### PR TITLE
Sweep Qt defaults out of Editor UI + migrate NSIS to Velopack

### DIFF
--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <QDrag>
 #include <QElapsedTimer>
+#include <QFrame>
 #include <QLabel>
 #include <QMimeData>
 #include <QPushButton>
@@ -92,33 +93,45 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 		version += QString(".%0").arg(REVISION);
 	setWindowTitle(tr("Equalizer APO %0 Configuration Editor").arg(version));
 
+	ui->mainToolBar->setObjectName(QStringLiteral("MainToolBar"));
+
 	QWidget* spacer = new QWidget;
+	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
 	spacer->setFixedWidth(10);
 	ui->mainToolBar->addWidget(spacer);
 
 	instantModeCheckBox = new QCheckBox(tr("Instant mode"));
+	instantModeCheckBox->setObjectName(QStringLiteral("InstantModeCheckBox"));
 	instantModeCheckBox->setChecked(true);
 	instantModeCheckBox->setToolTip(tr("Changes are saved immediately"));
 	connect(instantModeCheckBox, SIGNAL(toggled(bool)), this, SLOT(instantModeEnabled(bool)));
 	ui->mainToolBar->addWidget(instantModeCheckBox);
 
 	spacer = new QWidget;
+	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
 	spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	ui->mainToolBar->addWidget(spacer);
 
-	ui->mainToolBar->addWidget(new QLabel(tr("Device: ")));
+	QLabel* deviceLabel = new QLabel(tr("Device"));
+	deviceLabel->setObjectName(QStringLiteral("ToolBarLabel"));
+	ui->mainToolBar->addWidget(deviceLabel);
 
 	deviceComboBox = new QComboBox;
+	deviceComboBox->setObjectName(QStringLiteral("ToolBarComboBox"));
 	connect(deviceComboBox, QOverload<int>::of(&QComboBox::activated), this, &MainWindow::deviceSelected);
 	ui->mainToolBar->addWidget(deviceComboBox);
 
 	spacer = new QWidget;
+	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
 	spacer->setFixedWidth(10);
 	ui->mainToolBar->addWidget(spacer);
 
-	ui->mainToolBar->addWidget(new QLabel(tr("Channel configuration: ")));
+	QLabel* channelLabel = new QLabel(tr("Channels"));
+	channelLabel->setObjectName(QStringLiteral("ToolBarLabel"));
+	ui->mainToolBar->addWidget(channelLabel);
 
 	channelConfigurationComboBox = new QComboBox;
+	channelConfigurationComboBox->setObjectName(QStringLiteral("ToolBarComboBox"));
 	channelConfigurationComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 	ui->mainToolBar->addWidget(channelConfigurationComboBox);
 
@@ -152,8 +165,29 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 	ui->graphicsView->setScene(analysisPlotScene);
 	eqGraphView = new EqGraphView(ui->dockWidgetContents);
 	eqGraphView->setObjectName(QStringLiteral("ModernAnalysisGraph"));
-	ui->gridLayout_2->addWidget(eqGraphView, 0, 1, 2, 1);
+	ui->analysisDockLayout->insertWidget(1, eqGraphView, 1);
 	ui->graphicsView->hide();
+
+	ui->analysisControlBar->setObjectName(QStringLiteral("analysisControlBar"));
+	ui->analysisControlBar->setAttribute(Qt::WA_StyledBackground, true);
+	for (QLabel* label : { ui->startFromLabel, ui->analysisChannelLabel, ui->resolutionLabel })
+		label->setObjectName(QStringLiteral("AnalysisFormLabel"));
+	for (QComboBox* combo : { ui->startFromComboBox, ui->analysisChannelComboBox })
+		combo->setObjectName(QStringLiteral("AnalysisFormCombo"));
+	ui->resolutionSpinBox->setObjectName(QStringLiteral("AnalysisFormSpin"));
+	for (QFrame* chip : { ui->peakChip, ui->latencyChip, ui->initChip, ui->cpuChip })
+	{
+		chip->setObjectName(QStringLiteral("AnalysisStatChip"));
+		chip->setAttribute(Qt::WA_StyledBackground, true);
+	}
+	for (QLabel* label : { ui->peakGainLabel, ui->latencyLabel, ui->initTimeLabel, ui->cpuUsageLabel })
+		label->setObjectName(QStringLiteral("AnalysisStatLabel"));
+	for (QLabel* value : { ui->peakGainValueLabel, ui->latencyValueLabel, ui->initTimeValueLabel, ui->cpuUsageValueLabel })
+	{
+		value->setObjectName(QStringLiteral("AnalysisStatValue"));
+		value->setProperty("severity", QStringLiteral("normal"));
+	}
+	ui->tabWidget->setObjectName(QStringLiteral("MainTabWidget"));
 
 	analysisThread = new AnalysisThread;
 	analysisThread->start();

--- a/Editor/MainWindow.ui
+++ b/Editor/MainWindow.ui
@@ -117,64 +117,88 @@
   </widget>
   <widget class="QDockWidget" name="analysisDockWidget">
    <property name="windowTitle">
-    <string>Analysis panel</string>
+    <string>Graph</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>8</number>
    </attribute>
    <widget class="QWidget" name="dockWidgetContents">
-    <layout class="QGridLayout" name="gridLayout_2">
+    <layout class="QVBoxLayout" name="analysisDockLayout">
      <property name="leftMargin">
-      <number>1</number>
+      <number>10</number>
      </property>
      <property name="topMargin">
-      <number>0</number>
+      <number>6</number>
      </property>
      <property name="rightMargin">
-      <number>1</number>
+      <number>10</number>
      </property>
      <property name="bottomMargin">
-      <number>1</number>
+      <number>10</number>
      </property>
-     <property name="horizontalSpacing">
-      <number>1</number>
+     <property name="spacing">
+      <number>6</number>
      </property>
-     <property name="verticalSpacing">
-      <number>3</number>
-     </property>
-     <item row="0" column="0">
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Settings</string>
+     <item>
+      <widget class="QFrame" name="analysisControlBar">
+       <property name="frameShape">
+        <enum>QFrame::Shape::NoFrame</enum>
        </property>
-       <layout class="QGridLayout" name="gridLayout_3">
+       <layout class="QHBoxLayout" name="analysisControlLayout">
+        <property name="leftMargin">
+         <number>10</number>
+        </property>
         <property name="topMargin">
-         <number>3</number>
+         <number>6</number>
+        </property>
+        <property name="rightMargin">
+         <number>10</number>
         </property>
         <property name="bottomMargin">
-         <number>3</number>
+         <number>6</number>
         </property>
-        <property name="verticalSpacing">
-         <number>1</number>
+        <property name="spacing">
+         <number>8</number>
         </property>
-        <item row="3" column="0">
-         <widget class="QLabel" name="resolutionLabel">
+        <item>
+         <widget class="QLabel" name="startFromLabel">
           <property name="text">
-           <string>Resolution:</string>
+           <string>From</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item>
+         <widget class="QComboBox" name="startFromComboBox">
+          <item>
+           <property name="text">
+            <string notr="true">config.txt</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Current file</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
          <widget class="QLabel" name="analysisChannelLabel">
           <property name="text">
-           <string>Channel:</string>
+           <string>Channel</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item>
          <widget class="QComboBox" name="analysisChannelComboBox"/>
         </item>
-        <item row="3" column="1">
+        <item>
+         <widget class="QLabel" name="resolutionLabel">
+          <property name="text">
+           <string>Res</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="ExponentialSpinBox" name="resolutionSpinBox">
           <property name="correctionMode">
            <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
@@ -193,314 +217,184 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="startFromLabel">
-          <property name="text">
-           <string>Start from:</string>
+        <item>
+         <spacer name="analysisControlSpacer">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>1</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QFrame" name="peakChip">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <layout class="QHBoxLayout" name="peakChipLayout">
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>10</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="peakGainLabel">
+             <property name="text">
+              <string>Peak</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="peakGainValueLabel">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="startFromComboBox">
-          <item>
-           <property name="text">
-            <string notr="true">config.txt</string>
+        <item>
+         <widget class="QFrame" name="latencyChip">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <layout class="QHBoxLayout" name="latencyChipLayout">
+           <property name="leftMargin">
+            <number>10</number>
            </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Current file</string>
+           <property name="topMargin">
+            <number>3</number>
            </property>
-          </item>
+           <property name="rightMargin">
+            <number>10</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="latencyLabel">
+             <property name="text">
+              <string>Latency</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="latencyValueLabel">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QFrame" name="initChip">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <layout class="QHBoxLayout" name="initChipLayout">
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>10</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="initTimeLabel">
+             <property name="text">
+              <string>Init</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="initTimeValueLabel">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QFrame" name="cpuChip">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <layout class="QHBoxLayout" name="cpuChipLayout">
+           <property name="leftMargin">
+            <number>10</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>10</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="cpuUsageLabel">
+             <property name="text">
+              <string>CPU</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="cpuUsageValueLabel">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
        </layout>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="title">
-        <string>Estimated properties</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_4">
-        <property name="topMargin">
-         <number>6</number>
-        </property>
-        <item row="2" column="1">
-         <widget class="QLabel" name="initTimeValueLabel">
-          <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="cpuUsageLabel">
-          <property name="text">
-           <string>CPU usage:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="initTimeLabel">
-          <property name="text">
-           <string>Init. time:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLabel" name="cpuUsageValueLabel">
-          <property name="palette">
-           <palette>
-            <active>
-             <colorrole role="Midlight">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>127</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </active>
-            <inactive>
-             <colorrole role="Midlight">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>127</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </inactive>
-            <disabled>
-             <colorrole role="Midlight">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>127</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </disabled>
-           </palette>
-          </property>
-          <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="latencyValueLabel">
-          <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="latencyLabel">
-          <property name="text">
-           <string>Latency: </string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="peakGainlabel">
-          <property name="text">
-           <string>Peak gain:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="peakGainValueLabel">
-          <property name="palette">
-           <palette>
-            <active>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </active>
-            <inactive>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </inactive>
-            <disabled>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </disabled>
-           </palette>
-          </property>
-          <property name="text">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="0" column="1" rowspan="2">
+     <item>
       <widget class="AnalysisPlotView" name="graphicsView">
        <property name="mouseTracking">
         <bool>true</bool>
        </property>
        <property name="renderHints">
         <set>QPainter::RenderHint::Antialiasing|QPainter::RenderHint::TextAntialiasing</set>
+       </property>
+       <property name="visible">
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/Editor/MainWindowParts/MainWindow.Analysis.cpp
+++ b/Editor/MainWindowParts/MainWindow.Analysis.cpp
@@ -6,6 +6,7 @@
 #include <QPushButton>
 #include <QStandardItemModel>
 #include <QStringBuilder>
+#include <QStyle>
 #include <QScrollArea>
 #include <QFileInfo>
 #include <QFileDialog>
@@ -87,17 +88,27 @@ void MainWindow::updateAnalysisPanel()
 	if (eqGraphView != nullptr)
 		eqGraphView->setNodes(analysisPlotScene->getNodes(), static_cast<unsigned>(sampleRate), ui->analysisChannelComboBox->currentText());
 
+	auto setSeverity = [](QLabel* label, const char* severity)
+	{
+		if (label->property("severity").toString() == QLatin1String(severity))
+			return;
+		label->setProperty("severity", QString::fromLatin1(severity));
+		label->style()->unpolish(label);
+		label->style()->polish(label);
+		label->update();
+	};
+
 	double peakGain = analysisThread->getPeakGain();
 	ui->peakGainValueLabel->setText(tr("%0 dB").arg(peakGain, 0, 'f', 1));
-	ui->peakGainValueLabel->setForegroundRole(peakGain > 0 ? QPalette::Dark : QPalette::WindowText);
+	setSeverity(ui->peakGainValueLabel, peakGain > 0 ? "critical" : "normal");
 
 	ui->latencyValueLabel->setText(tr("%0 ms (%1 s.)").arg(latency * 1000.0 / sampleRate, 0, 'f', 1).arg(latency));
 
 	ui->initTimeValueLabel->setText(tr("%0 ms").arg(analysisThread->getInitializationTime(), 0, 'f', 1));
 
 	double cpuUsage = analysisThread->getProcessingTime() * 100.0 / (analysisThread->getProcessedFrames() * 1000.0 / sampleRate);
-	ui->cpuUsageValueLabel->setText(tr("%0 % (one core)").arg(cpuUsage, 0, 'f', 1));
-	ui->cpuUsageValueLabel->setForegroundRole(cpuUsage >= 20 ? (cpuUsage >= 50 ? QPalette::Dark : QPalette::Midlight) : QPalette::WindowText);
+	ui->cpuUsageValueLabel->setText(tr("%0 %").arg(cpuUsage, 0, 'f', 1));
+	setSeverity(ui->cpuUsageValueLabel, cpuUsage >= 50 ? "critical" : (cpuUsage >= 20 ? "warning" : "normal"));
 
 	analysisThread->endGetResult();
 }

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -37,8 +37,16 @@ void SkinManager::applySkin(const QString& newSkinId, bool dark)
 	currentTokens = loadTokens(skinId, darkMode);
 
 	QFile file(qssPath(skinId, darkMode));
-	if (file.open(QFile::ReadOnly))
+	if (!file.open(QFile::ReadOnly))
+	{
+		QFile fallback(qssPath(QStringLiteral("glassy"), darkMode));
+		if (fallback.open(QFile::ReadOnly))
+			qApp->setStyleSheet(QString::fromUtf8(fallback.readAll()));
+	}
+	else
+	{
 		qApp->setStyleSheet(QString::fromUtf8(file.readAll()));
+	}
 
 	emit skinChanged(currentTokens);
 }

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -21,10 +21,13 @@
 #include <QApplication>
 #include <QDir>
 #include <QCommandLineParser>
+#include <QPalette>
 #include <QSettings>
+#include <QStyleFactory>
 #include <QStyleHints>
 #include "CustomStyle.h"
 #include "MainWindow.h"
+#include "SkinManager.h"
 #include "helpers/RegistryHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 
@@ -45,11 +48,41 @@ int main(int argc, char* argv[])
 	do
 	{
 		QApplication application(argc, argv);
-		if(GUIHelper::isDarkMode())
-			application.setStyle("fusion");
-		application.setStyle(new CustomStyle(application.style()));
+		application.setStyle(new CustomStyle(QStyleFactory::create(QStringLiteral("Fusion"))));
 
 		QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+		{
+			QString skinId = settings.value(QStringLiteral("interface/skin"), QStringLiteral("glassy")).toString();
+			bool dark = settings.value(QStringLiteral("interface/dark"), GUIHelper::isDarkMode()).toBool();
+			SkinManager::instance()->applySkin(skinId, dark);
+			const SkinTokens& tokens = SkinManager::instance()->tokens();
+			QPalette palette = application.palette();
+			QColor background(tokens.background);
+			QColor surface(tokens.surface);
+			QColor card(tokens.card);
+			QColor text(tokens.text);
+			QColor accent(tokens.accent);
+			palette.setColor(QPalette::Window, background);
+			palette.setColor(QPalette::WindowText, text);
+			palette.setColor(QPalette::Base, surface);
+			palette.setColor(QPalette::AlternateBase, card);
+			palette.setColor(QPalette::Text, text);
+			palette.setColor(QPalette::Button, card);
+			palette.setColor(QPalette::ButtonText, text);
+			palette.setColor(QPalette::ToolTipBase, card);
+			palette.setColor(QPalette::ToolTipText, text);
+			palette.setColor(QPalette::Highlight, accent);
+			palette.setColor(QPalette::HighlightedText, dark ? QColor(QStringLiteral("#0c0c16")) : QColor(QStringLiteral("#ffffff")));
+			palette.setColor(QPalette::PlaceholderText, QColor(tokens.mutedText));
+			palette.setColor(QPalette::Light, card.lighter(120));
+			palette.setColor(QPalette::Midlight, card.lighter(105));
+			palette.setColor(QPalette::Mid, surface);
+			palette.setColor(QPalette::Dark, background.darker(120));
+			palette.setColor(QPalette::Shadow, background.darker(160));
+			palette.setColor(QPalette::Link, accent);
+			palette.setColor(QPalette::LinkVisited, accent.darker(110));
+			application.setPalette(palette);
+		}
 
 		QVariant languageValue = settings.value("language");
 		if (languageValue.isValid())

--- a/Editor/skins/glassy_dark.qss
+++ b/Editor/skins/glassy_dark.qss
@@ -1,59 +1,808 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Glassy Dark
+   Tokens: bg #0c0c16 / surface #12121e / card #1a1a28 / cardHover #222236
+           text #e8e8f4 / mutedText #8888a8 / border #2a2a3c
+           accent #3B82F6 / borderRadius 16 / row 40
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #f8fafc;
+}
+
+QWidget {
     background: #0c0c16;
     color: #e8e8f4;
-    font-family: "Segoe UI";
+    font-family: "Segoe UI", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    font-size: 10pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
+
+QMainWindow,
+QDialog {
+    background: #0c0c16;
+}
+
+QMainWindow::separator {
+    background: #1a1a28;
+    width: 4px;
+    height: 4px;
+}
+
+QToolTip {
+    background: #1a1a28;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 8px;
+    padding: 6px 10px;
+}
+
+/* ===== Menu Bar / Menus ===== */
+QMenuBar {
     background: #12121e;
     color: #e8e8f4;
-    border: 1px solid rgba(255,255,255,0.07);
+    padding: 4px 6px;
+    border: 0;
+    border-bottom: 1px solid #2a2a3c;
 }
-QMenu::item:selected, QToolButton:hover, QPushButton:hover {
-    background: rgba(255,255,255,0.07);
+QMenuBar::item {
+    background: transparent;
+    padding: 6px 12px;
+    border-radius: 10px;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
+QMenuBar::item:selected,
+QMenuBar::item:pressed {
+    background: rgba(59, 130, 246, 0.22);
+    color: #e8e8f4;
+}
+
+QMenu {
+    background: #1a1a28;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 12px;
+    padding: 6px;
+}
+QMenu::item {
+    background: transparent;
+    padding: 6px 22px 6px 22px;
+    border-radius: 8px;
+    min-width: 140px;
+}
+QMenu::item:selected {
+    background: rgba(59, 130, 246, 0.25);
+    color: #e8e8f4;
+}
+QMenu::item:disabled {
+    color: #5a5a72;
+}
+QMenu::separator {
+    height: 1px;
+    background: #2a2a3c;
+    margin: 6px 8px;
+}
+QMenu::indicator {
+    width: 14px;
+    height: 14px;
+    margin-left: 4px;
+}
+QMenu::indicator:checked {
+    background: #3B82F6;
+    border-radius: 3px;
+}
+QMenu::icon {
+    padding-left: 8px;
+}
+
+/* ===== Toolbars ===== */
+QToolBar {
+    background: #12121e;
+    border: 0;
+    border-bottom: 1px solid #2a2a3c;
+    padding: 4px 6px;
+    spacing: 4px;
+}
+QToolBar::separator {
+    background: #2a2a3c;
+    width: 1px;
+    margin: 6px 8px;
+}
+QToolBar::handle {
+    background: #2a2a3c;
+    width: 6px;
+    margin: 4px 2px;
+    border-radius: 3px;
+}
+QToolButton {
+    background: transparent;
+    color: #e8e8f4;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 4px 8px;
+    min-height: 22px;
+}
+QToolButton:hover {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+QToolButton:pressed,
+QToolButton:checked {
+    background: rgba(59, 130, 246, 0.25);
+    border: 1px solid rgba(59, 130, 246, 0.5);
+}
+QToolButton::menu-indicator {
+    image: none;
+    width: 0;
+    height: 0;
+}
+
+QLabel#ToolBarLabel {
+    color: #8888a8;
+    background: transparent;
+    padding: 0 4px 0 8px;
+    font-weight: 600;
+}
+
+/* ===== Push Buttons ===== */
+QPushButton {
+    background: #1a1a28;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 10px;
+    padding: 6px 14px;
+    min-height: 22px;
+}
+QPushButton:hover {
+    background: #222236;
+    border-color: rgba(59, 130, 246, 0.45);
+}
+QPushButton:pressed {
+    background: rgba(59, 130, 246, 0.3);
+    border-color: #3B82F6;
+}
+QPushButton:default {
+    border: 1px solid #3B82F6;
+}
+QPushButton:disabled {
+    color: #5a5a72;
+    background: #14141f;
+    border-color: #1f1f2c;
+}
+
+/* ===== Inputs ===== */
+QLineEdit,
+QPlainTextEdit,
+QTextEdit,
+QAbstractSpinBox {
     background: #08080f;
     color: #e8e8f4;
-    border: 1px solid rgba(255,255,255,0.07);
-    border-radius: 8px;
+    border: 1px solid #2a2a3c;
+    border-radius: 10px;
+    padding: 4px 8px;
+    selection-background-color: #3B82F6;
+    selection-color: #f8fafc;
 }
+QLineEdit:focus,
+QPlainTextEdit:focus,
+QTextEdit:focus,
+QAbstractSpinBox:focus {
+    border: 1px solid #3B82F6;
+    background: #0e0e18;
+}
+QLineEdit:disabled,
+QAbstractSpinBox:disabled {
+    color: #5a5a72;
+    background: #0a0a14;
+}
+
+QAbstractSpinBox::up-button,
+QAbstractSpinBox::down-button {
+    subcontrol-origin: border;
+    background: #1a1a28;
+    width: 18px;
+    border-left: 1px solid #2a2a3c;
+}
+QAbstractSpinBox::up-button {
+    subcontrol-position: top right;
+    border-top-right-radius: 9px;
+}
+QAbstractSpinBox::down-button {
+    subcontrol-position: bottom right;
+    border-bottom-right-radius: 9px;
+    border-top: 1px solid #2a2a3c;
+}
+QAbstractSpinBox::up-button:hover,
+QAbstractSpinBox::down-button:hover {
+    background: rgba(59, 130, 246, 0.22);
+}
+QAbstractSpinBox::up-arrow {
+    image: none;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-bottom: 5px solid #8888a8;
+    width: 0;
+    height: 0;
+}
+QAbstractSpinBox::down-arrow {
+    image: none;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid #8888a8;
+    width: 0;
+    height: 0;
+}
+QAbstractSpinBox::up-arrow:hover,
+QAbstractSpinBox::down-arrow:hover {
+    border-bottom-color: #e8e8f4;
+    border-top-color: #e8e8f4;
+}
+
+/* ===== Combo Box ===== */
+QComboBox {
+    background: #1a1a28;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 10px;
+    padding: 4px 28px 4px 10px;
+    min-height: 22px;
+}
+QComboBox:hover {
+    border-color: rgba(59, 130, 246, 0.45);
+    background: #222236;
+}
+QComboBox:focus,
+QComboBox:on {
+    border: 1px solid #3B82F6;
+}
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 22px;
+    border: 0;
+    background: transparent;
+}
+QComboBox::down-arrow {
+    image: none;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #8888a8;
+    margin-right: 8px;
+}
+QComboBox::down-arrow:on {
+    border-top-color: #3B82F6;
+}
+QComboBox QAbstractItemView {
+    background: #1a1a28;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 12px;
+    padding: 4px;
+    outline: 0;
+    selection-background-color: rgba(59, 130, 246, 0.28);
+    selection-color: #e8e8f4;
+}
+QComboBox QAbstractItemView::item {
+    padding: 6px 10px;
+    border-radius: 8px;
+    min-height: 22px;
+}
+QComboBox QAbstractItemView::item:selected {
+    background: rgba(59, 130, 246, 0.28);
+    color: #e8e8f4;
+}
+
+/* ===== Check / Radio ===== */
+QCheckBox,
+QRadioButton {
+    color: #e8e8f4;
+    background: transparent;
+    spacing: 8px;
+    padding: 2px;
+}
+QCheckBox:disabled,
+QRadioButton:disabled {
+    color: #5a5a72;
+}
+QCheckBox::indicator,
+QRadioButton::indicator {
+    width: 16px;
+    height: 16px;
+    background: #08080f;
+    border: 1px solid #2a2a3c;
+}
+QCheckBox::indicator { border-radius: 4px; }
+QRadioButton::indicator { border-radius: 8px; }
+QCheckBox::indicator:hover,
+QRadioButton::indicator:hover {
+    border-color: #3B82F6;
+}
+QCheckBox::indicator:checked,
+QRadioButton::indicator:checked {
+    background: #3B82F6;
+    border-color: #3B82F6;
+}
+QCheckBox::indicator:checked:disabled,
+QRadioButton::indicator:checked:disabled {
+    background: #2a2a3c;
+    border-color: #2a2a3c;
+}
+
+/* ===== Scroll Bars ===== */
+QScrollBar:vertical {
+    background: transparent;
+    width: 12px;
+    margin: 4px 2px 4px 2px;
+    border: 0;
+}
+QScrollBar::handle:vertical {
+    background: rgba(255, 255, 255, 0.10);
+    min-height: 32px;
+    border-radius: 4px;
+}
+QScrollBar::handle:vertical:hover {
+    background: rgba(59, 130, 246, 0.45);
+}
+QScrollBar::handle:vertical:pressed {
+    background: #3B82F6;
+}
+QScrollBar:horizontal {
+    background: transparent;
+    height: 12px;
+    margin: 2px 4px 2px 4px;
+    border: 0;
+}
+QScrollBar::handle:horizontal {
+    background: rgba(255, 255, 255, 0.10);
+    min-width: 32px;
+    border-radius: 4px;
+}
+QScrollBar::handle:horizontal:hover {
+    background: rgba(59, 130, 246, 0.45);
+}
+QScrollBar::handle:horizontal:pressed {
+    background: #3B82F6;
+}
+QScrollBar::add-line,
+QScrollBar::sub-line {
+    background: transparent;
+    border: 0;
+    width: 0;
+    height: 0;
+}
+QScrollBar::add-page,
+QScrollBar::sub-page {
+    background: transparent;
+}
+QScrollBar::up-arrow,
+QScrollBar::down-arrow,
+QScrollBar::left-arrow,
+QScrollBar::right-arrow {
+    background: transparent;
+    width: 0;
+    height: 0;
+}
+
+/* ===== ScrollArea / AbstractScrollArea ===== */
+QAbstractScrollArea {
+    background: #0c0c16;
+    color: #e8e8f4;
+    border: 0;
+}
+QScrollArea {
+    background: #0c0c16;
+    border: 0;
+}
+QScrollArea > QWidget > QWidget {
+    background: #0c0c16;
+}
+
+/* ===== Dock Widgets ===== */
+QDockWidget {
+    color: #e8e8f4;
+    background: #0c0c16;
+    titlebar-close-icon: none;
+    titlebar-normal-icon: none;
+}
+QDockWidget::title {
+    background: #12121e;
+    color: #8888a8;
+    text-align: left;
+    padding: 6px 12px;
+    border: 0;
+    border-bottom: 1px solid #2a2a3c;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QDockWidget::close-button,
+QDockWidget::float-button {
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    padding: 2px;
+    icon-size: 12px;
+}
+QDockWidget::close-button:hover,
+QDockWidget::float-button:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+/* ===== Tab Widget / Tab Bar ===== */
+QTabWidget::pane {
+    background: #0c0c16;
+    border: 0;
+    border-top: 1px solid #2a2a3c;
+    top: -1px;
+}
+QTabBar {
+    background: #0c0c16;
+    border: 0;
+    qproperty-drawBase: 0;
+}
+QTabBar::tab {
+    background: transparent;
+    color: #8888a8;
+    padding: 8px 18px;
+    border: 0;
+    border-radius: 0;
+    min-width: 80px;
+    margin: 0;
+}
+QTabBar::tab:hover {
+    color: #e8e8f4;
+    background: rgba(255, 255, 255, 0.04);
+}
+QTabBar::tab:selected {
+    color: #e8e8f4;
+    background: #12121e;
+    border-top: 2px solid #3B82F6;
+}
+QTabBar::tab:!selected {
+    border-bottom: 1px solid #2a2a3c;
+}
+QTabBar::close-button {
+    image: none;
+    background: transparent;
+    border-radius: 6px;
+    padding: 2px;
+    margin: 2px;
+    subcontrol-position: right;
+}
+QTabBar::close-button:hover {
+    background: rgba(239, 68, 68, 0.35);
+}
+QTabBar QToolButton {
+    background: #12121e;
+    border: 1px solid #2a2a3c;
+    border-radius: 6px;
+    margin: 4px 2px;
+}
+
+/* ===== Group Box ===== */
+QGroupBox {
+    background: #12121e;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 12px;
+    margin-top: 14px;
+    padding: 14px 12px 10px 12px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0 8px;
+    color: #8888a8;
+    background: #0c0c16;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+/* ===== Headers / Item Views ===== */
+QHeaderView {
+    background: #12121e;
+    color: #8888a8;
+    border: 0;
+}
+QHeaderView::section {
+    background: #12121e;
+    color: #8888a8;
+    border: 0;
+    border-right: 1px solid #2a2a3c;
+    border-bottom: 1px solid #2a2a3c;
+    padding: 6px 10px;
+    font-weight: 600;
+}
+QHeaderView::section:hover {
+    color: #e8e8f4;
+}
+QTreeView,
+QListView,
+QTableView {
+    background: #0c0c16;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 10px;
+    alternate-background-color: #12121e;
+    selection-background-color: rgba(59, 130, 246, 0.28);
+    selection-color: #e8e8f4;
+    gridline-color: #2a2a3c;
+}
+QTreeView::item,
+QListView::item,
+QTableView::item {
+    padding: 4px 6px;
+    border-radius: 6px;
+}
+QTreeView::item:hover,
+QListView::item:hover,
+QTableView::item:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+QTreeView::item:selected,
+QListView::item:selected,
+QTableView::item:selected {
+    background: rgba(59, 130, 246, 0.28);
+    color: #e8e8f4;
+}
+QTreeView::branch {
+    background: transparent;
+}
+
+/* ===== Sliders ===== */
+QSlider::groove:horizontal {
+    background: #2a2a3c;
+    height: 4px;
+    border-radius: 2px;
+    margin: 0 6px;
+}
+QSlider::sub-page:horizontal {
+    background: #3B82F6;
+    height: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:horizontal {
+    background: #e8e8f4;
+    border: 2px solid #3B82F6;
+    width: 14px;
+    height: 14px;
+    margin: -6px 0;
+    border-radius: 9px;
+}
+QSlider::handle:horizontal:hover {
+    background: #f8fafc;
+}
+QSlider::groove:vertical {
+    background: #2a2a3c;
+    width: 4px;
+    border-radius: 2px;
+    margin: 6px 0;
+}
+QSlider::sub-page:vertical {
+    background: #2a2a3c;
+    width: 4px;
+    border-radius: 2px;
+}
+QSlider::add-page:vertical {
+    background: #3B82F6;
+    width: 4px;
+    border-radius: 2px;
+}
+QSlider::handle:vertical {
+    background: #e8e8f4;
+    border: 2px solid #3B82F6;
+    width: 14px;
+    height: 14px;
+    margin: 0 -6px;
+    border-radius: 9px;
+}
+
+/* ===== Splitter ===== */
+QSplitter::handle {
+    background: #2a2a3c;
+}
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+/* ===== Status Bar ===== */
+QStatusBar {
+    background: #12121e;
+    color: #8888a8;
+    border: 0;
+    border-top: 1px solid #2a2a3c;
+}
+QStatusBar::item {
+    border: 0;
+}
+
+/* ===== Progress Bar ===== */
+QProgressBar {
+    background: #08080f;
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 8px;
+    text-align: center;
+}
+QProgressBar::chunk {
+    background: #3B82F6;
+    border-radius: 6px;
+}
+
+/* ===== Frame separators ===== */
+QFrame[frameShape="4"], /* HLine */
+QFrame[frameShape="5"]  /* VLine */ {
+    background: #2a2a3c;
+    border: 0;
+}
+
+/* ====================================================================
+   Application-specific object names
+   ==================================================================== */
+
+/* ===== Analysis Dock Control Bar ===== */
+QFrame#analysisControlBar {
+    background: #12121e;
+    border: 1px solid #2a2a3c;
+    border-radius: 14px;
+}
+QLabel#AnalysisFormLabel {
+    color: #8888a8;
+    background: transparent;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 0 4px;
+}
+QComboBox#AnalysisFormCombo {
+    min-width: 110px;
+}
+QFrame#AnalysisStatChip {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 10px;
+}
+QLabel#AnalysisStatLabel {
+    color: #8888a8;
+    background: transparent;
+    font-weight: 600;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QLabel#AnalysisStatValue {
+    color: #e8e8f4;
+    background: transparent;
+    font-weight: 700;
+    font-family: "Consolas", "JetBrains Mono", monospace;
+}
+QLabel#AnalysisStatValue[severity="warning"] { color: #f59e0b; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #ef4444; }
+
+QWidget#ModernAnalysisGraph {
+    background: #08080f;
+    border: 1px solid #2a2a3c;
+    border-radius: 14px;
+}
+
+/* ===== Filter Card Components ===== */
 QFrame#FilterCardRow {
-    background: rgba(255,255,255,0.045);
-    border: 1px solid rgba(255,255,255,0.07);
+    background: #1a1a28;
+    border: 1px solid #2a2a3c;
     border-radius: 16px;
 }
 QWidget#FilterCardHeader {
-    background: rgba(255,255,255,0.03);
-    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.03);
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
 }
-QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: rgba(255,255,255,0.02);
+QWidget#FilterCardBody,
+QWidget#FilterCardEditor {
+    background: rgba(255, 255, 255, 0.02);
     border-bottom-left-radius: 16px;
     border-bottom-right-radius: 16px;
 }
 QLabel#FilterTypeBadge {
     color: white;
     border-radius: 10px;
-    font-weight: 700;
-    padding: 2px 6px;
+    font-weight: 800;
+    padding: 2px 8px;
+    min-height: 18px;
+    font-size: 9pt;
+    letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #e8e8f4; font-weight: 600; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #8888a8; }
-QToolButton#FilterCardIconButton {
-    background: rgba(255,255,255,0.04);
+QLabel#FilterCardTitle {
     color: #e8e8f4;
-    border: 1px solid rgba(255,255,255,0.07);
-    border-radius: 6px;
-    min-width: 22px;
-    min-height: 22px;
+    background: transparent;
+    font-weight: 700;
+    font-size: 10pt;
+}
+QLabel#FilterCardSummary,
+QLabel#FilterCardRawText {
+    color: #8888a8;
+    background: transparent;
+}
+QLabel#FilterCardNumber {
+    color: #8888a8;
+    background: transparent;
+    font-family: "Consolas", monospace;
+    font-weight: 700;
+}
+QToolButton#FilterCardIconButton {
+    background: rgba(255, 255, 255, 0.04);
+    color: #e8e8f4;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 8px;
+    min-width: 24px;
+    min-height: 24px;
+    padding: 2px 4px;
+    font-weight: 700;
 }
 QToolButton#FilterCardIconButton:hover {
-    background: rgba(59,130,246,0.20);
+    background: rgba(59, 130, 246, 0.20);
+    border-color: rgba(59, 130, 246, 0.4);
 }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
+QToolButton#FilterCardIconButton:checked {
+    background: rgba(59, 130, 246, 0.30);
+    border-color: #3B82F6;
 }
-QLabel#EditableValue {
+QLineEdit#FilterCardRawEditor {
+    background: #08080f;
+    border: 1px solid #3B82F6;
+    border-radius: 10px;
     padding: 6px 10px;
 }
+QCheckBox#FilterCardEnabled {
+    background: transparent;
+}
+
+/* ===== Card Editors ===== */
+QWidget#PreampCardEditor,
+QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock,
+QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus,
+QLabel#PreampCardCaption {
+    background: transparent;
+    border: 0;
+}
+QLabel#PreampCardCaption {
+    color: #8888a8;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+}
+QLabel#EditableValue {
+    background: rgba(255, 255, 255, 0.04);
+    color: #e8e8f4;
+    border: 1px solid #2a2a3c;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-family: "Consolas", monospace;
+    font-weight: 700;
+}
+QLineEdit#EditableValueEditor {
+    background: #08080f;
+    border: 1px solid #3B82F6;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-family: "Consolas", monospace;
+    font-weight: 700;
+}
+QLineEdit#IncludeCardPath {
+    background: #08080f;
+    border: 1px solid #2a2a3c;
+    border-radius: 8px;
+    padding: 6px 10px;
+}
+QLabel#IncludeCardStatus {
+    color: #ef4444;
+    font-size: 9pt;
+}
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/glassy_light.qss
+++ b/Editor/skins/glassy_light.qss
@@ -1,59 +1,456 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Glassy Light
+   Tokens: bg #eef0f6 / surface #e4e7ee / card #ffffff / cardHover #f6f7fb
+           text #1a1a2e / mutedText #6a6a8a / border #d7d9e4
+           accent #3B82F6 / borderRadius 16 / row 40
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #ffffff;
+}
+
+QWidget {
     background: #eef0f6;
     color: #1a1a2e;
-    font-family: "Segoe UI";
+    font-family: "Segoe UI", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    font-size: 10pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
+
+QMainWindow,
+QDialog {
+    background: #eef0f6;
+}
+
+QMainWindow::separator {
+    background: #d7d9e4;
+    width: 4px;
+    height: 4px;
+}
+
+QToolTip {
+    background: #ffffff;
+    color: #1a1a2e;
+    border: 1px solid #d7d9e4;
+    border-radius: 8px;
+    padding: 6px 10px;
+}
+
+QMenuBar {
     background: #e4e7ee;
     color: #1a1a2e;
-    border: 1px solid rgba(0,0,0,0.07);
+    padding: 4px 6px;
+    border: 0;
+    border-bottom: 1px solid #d7d9e4;
 }
-QMenu::item:selected, QToolButton:hover, QPushButton:hover {
-    background: rgba(255,255,255,0.8);
+QMenuBar::item {
+    background: transparent;
+    padding: 6px 12px;
+    border-radius: 10px;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
+QMenuBar::item:selected,
+QMenuBar::item:pressed {
+    background: rgba(59, 130, 246, 0.18);
+    color: #1a1a2e;
+}
+
+QMenu {
+    background: #ffffff;
+    color: #1a1a2e;
+    border: 1px solid #d7d9e4;
+    border-radius: 12px;
+    padding: 6px;
+}
+QMenu::item {
+    background: transparent;
+    padding: 6px 22px;
+    border-radius: 8px;
+    min-width: 140px;
+}
+QMenu::item:selected {
+    background: rgba(59, 130, 246, 0.18);
+    color: #1a1a2e;
+}
+QMenu::item:disabled {
+    color: #a0a0b4;
+}
+QMenu::separator {
+    height: 1px;
+    background: #d7d9e4;
+    margin: 6px 8px;
+}
+QMenu::indicator {
+    width: 14px;
+    height: 14px;
+    margin-left: 4px;
+}
+QMenu::indicator:checked {
+    background: #3B82F6;
+    border-radius: 3px;
+}
+
+QToolBar {
+    background: #e4e7ee;
+    border: 0;
+    border-bottom: 1px solid #d7d9e4;
+    padding: 4px 6px;
+    spacing: 4px;
+}
+QToolBar::separator {
+    background: #d7d9e4;
+    width: 1px;
+    margin: 6px 8px;
+}
+QToolButton {
+    background: transparent;
+    color: #1a1a2e;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    padding: 4px 8px;
+    min-height: 22px;
+}
+QToolButton:hover {
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(0, 0, 0, 0.07);
+}
+QToolButton:pressed,
+QToolButton:checked {
+    background: rgba(59, 130, 246, 0.18);
+    border: 1px solid rgba(59, 130, 246, 0.5);
+}
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel {
+    color: #6a6a8a;
+    background: transparent;
+    padding: 0 4px 0 8px;
+    font-weight: 600;
+}
+
+QPushButton {
+    background: #ffffff;
+    color: #1a1a2e;
+    border: 1px solid #d7d9e4;
+    border-radius: 10px;
+    padding: 6px 14px;
+    min-height: 22px;
+}
+QPushButton:hover { background: #f6f7fb; border-color: rgba(59, 130, 246, 0.5); }
+QPushButton:pressed { background: rgba(59, 130, 246, 0.16); border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #a0a0b4; background: #f6f7fb; border-color: #e6e8ee; }
+
+QLineEdit,
+QPlainTextEdit,
+QTextEdit,
+QAbstractSpinBox {
     background: #f6f7fb;
     color: #1a1a2e;
-    border: 1px solid rgba(0,0,0,0.07);
-    border-radius: 8px;
+    border: 1px solid #d7d9e4;
+    border-radius: 10px;
+    padding: 4px 8px;
+    selection-background-color: #3B82F6;
+    selection-color: #ffffff;
 }
+QLineEdit:focus,
+QPlainTextEdit:focus,
+QTextEdit:focus,
+QAbstractSpinBox:focus {
+    border: 1px solid #3B82F6;
+    background: #ffffff;
+}
+QLineEdit:disabled,
+QAbstractSpinBox:disabled { color: #a0a0b4; background: #ececf2; }
+
+QAbstractSpinBox::up-button,
+QAbstractSpinBox::down-button {
+    subcontrol-origin: border;
+    background: #f6f7fb;
+    width: 18px;
+    border-left: 1px solid #d7d9e4;
+}
+QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 9px; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 9px; border-top: 1px solid #d7d9e4; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.16); }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-bottom: 5px solid #6a6a8a;
+}
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid #6a6a8a;
+}
+
+QComboBox {
+    background: #ffffff;
+    color: #1a1a2e;
+    border: 1px solid #d7d9e4;
+    border-radius: 10px;
+    padding: 4px 28px 4px 10px;
+    min-height: 22px;
+}
+QComboBox:hover { border-color: rgba(59, 130, 246, 0.5); background: #f6f7fb; }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #6a6a8a;
+    margin-right: 8px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #ffffff;
+    color: #1a1a2e;
+    border: 1px solid #d7d9e4;
+    border-radius: 12px;
+    padding: 4px;
+    outline: 0;
+    selection-background-color: rgba(59, 130, 246, 0.18);
+    selection-color: #1a1a2e;
+}
+QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 22px; }
+QComboBox QAbstractItemView::item:selected { background: rgba(59, 130, 246, 0.18); color: #1a1a2e; }
+
+QCheckBox, QRadioButton { color: #1a1a2e; background: transparent; spacing: 8px; padding: 2px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #a0a0b4; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 16px; height: 16px;
+    background: #ffffff;
+    border: 1px solid #c0c4d0;
+}
+QCheckBox::indicator { border-radius: 4px; }
+QRadioButton::indicator { border-radius: 8px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 12px; margin: 4px 2px; border: 0; }
+QScrollBar::handle:vertical { background: rgba(0, 0, 0, 0.12); min-height: 32px; border-radius: 4px; }
+QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:vertical:pressed { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 12px; margin: 2px 4px; border: 0; }
+QScrollBar::handle:horizontal { background: rgba(0, 0, 0, 0.12); min-width: 32px; border-radius: 4px; }
+QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:horizontal:pressed { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #eef0f6; color: #1a1a2e; border: 0; }
+QScrollArea { background: #eef0f6; border: 0; }
+QScrollArea > QWidget > QWidget { background: #eef0f6; }
+
+QDockWidget {
+    color: #1a1a2e; background: #eef0f6;
+    titlebar-close-icon: none; titlebar-normal-icon: none;
+}
+QDockWidget::title {
+    background: #e4e7ee;
+    color: #6a6a8a;
+    text-align: left;
+    padding: 6px 12px;
+    border: 0;
+    border-bottom: 1px solid #d7d9e4;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QDockWidget::close-button, QDockWidget::float-button {
+    background: transparent; border: 0; border-radius: 6px; padding: 2px; icon-size: 12px;
+}
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: rgba(0, 0, 0, 0.08); }
+
+QTabWidget::pane { background: #eef0f6; border: 0; border-top: 1px solid #d7d9e4; top: -1px; }
+QTabBar { background: #eef0f6; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #6a6a8a;
+    padding: 8px 18px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+}
+QTabBar::tab:hover { color: #1a1a2e; background: rgba(0, 0, 0, 0.04); }
+QTabBar::tab:selected {
+    color: #1a1a2e; background: #ffffff;
+    border-top: 2px solid #3B82F6;
+}
+QTabBar::tab:!selected { border-bottom: 1px solid #d7d9e4; }
+QTabBar::close-button {
+    image: none; background: transparent; border-radius: 6px;
+    padding: 2px; margin: 2px; subcontrol-position: right;
+}
+QTabBar::close-button:hover { background: rgba(239, 68, 68, 0.25); }
+QTabBar QToolButton { background: #ffffff; border: 1px solid #d7d9e4; border-radius: 6px; margin: 4px 2px; }
+
+QGroupBox {
+    background: #ffffff;
+    color: #1a1a2e;
+    border: 1px solid #d7d9e4;
+    border-radius: 12px;
+    margin-top: 14px;
+    padding: 14px 12px 10px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 8px; color: #6a6a8a; background: #eef0f6;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+
+QHeaderView { background: #e4e7ee; color: #6a6a8a; border: 0; }
+QHeaderView::section {
+    background: #e4e7ee; color: #6a6a8a; border: 0;
+    border-right: 1px solid #d7d9e4;
+    border-bottom: 1px solid #d7d9e4;
+    padding: 6px 10px; font-weight: 600;
+}
+QTreeView, QListView, QTableView {
+    background: #ffffff; color: #1a1a2e;
+    border: 1px solid #d7d9e4; border-radius: 10px;
+    alternate-background-color: #f6f7fb;
+    selection-background-color: rgba(59, 130, 246, 0.18);
+    selection-color: #1a1a2e;
+    gridline-color: #d7d9e4;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 6px; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: rgba(0, 0, 0, 0.04); }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: rgba(59, 130, 246, 0.18); color: #1a1a2e; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #d7d9e4; height: 4px; border-radius: 2px; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 4px; border-radius: 2px; }
+QSlider::handle:horizontal {
+    background: #ffffff; border: 2px solid #3B82F6;
+    width: 14px; height: 14px; margin: -6px 0; border-radius: 9px;
+}
+QSlider::handle:horizontal:hover { background: #f6f7fb; }
+QSlider::groove:vertical { background: #d7d9e4; width: 4px; border-radius: 2px; margin: 6px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 4px; border-radius: 2px; }
+QSlider::sub-page:vertical { background: #d7d9e4; width: 4px; border-radius: 2px; }
+QSlider::handle:vertical {
+    background: #ffffff; border: 2px solid #3B82F6;
+    width: 14px; height: 14px; margin: 0 -6px; border-radius: 9px;
+}
+
+QSplitter::handle { background: #d7d9e4; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #e4e7ee; color: #6a6a8a; border: 0; border-top: 1px solid #d7d9e4; }
+QStatusBar::item { border: 0; }
+
+QProgressBar {
+    background: #f6f7fb; color: #1a1a2e;
+    border: 1px solid #d7d9e4; border-radius: 8px;
+    text-align: center;
+}
+QProgressBar::chunk { background: #3B82F6; border-radius: 6px; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #d7d9e4; border: 0; }
+
+/* Analysis Dock */
+QFrame#analysisControlBar {
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid #d7d9e4;
+    border-radius: 14px;
+}
+QLabel#AnalysisFormLabel {
+    color: #6a6a8a; background: transparent;
+    font-weight: 600; text-transform: uppercase; letter-spacing: 1px; padding: 0 4px;
+}
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip {
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 10px;
+}
+QLabel#AnalysisStatLabel {
+    color: #6a6a8a; background: transparent;
+    font-weight: 600; font-size: 9pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QLabel#AnalysisStatValue {
+    color: #1a1a2e; background: transparent;
+    font-weight: 700; font-family: "Consolas", "JetBrains Mono", monospace;
+}
+QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
+
+QWidget#ModernAnalysisGraph {
+    background: #f6f7fb;
+    border: 1px solid #d7d9e4;
+    border-radius: 14px;
+}
+
+/* Filter Cards */
 QFrame#FilterCardRow {
-    background: rgba(255,255,255,0.65);
-    border: 1px solid rgba(0,0,0,0.07);
+    background: #ffffff;
+    border: 1px solid #d7d9e4;
     border-radius: 16px;
 }
 QWidget#FilterCardHeader {
-    background: rgba(255,255,255,0.4);
-    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.4);
+    border-top-left-radius: 16px; border-top-right-radius: 16px;
 }
 QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: rgba(255,255,255,0.3);
-    border-bottom-left-radius: 16px;
-    border-bottom-right-radius: 16px;
+    background: rgba(255, 255, 255, 0.6);
+    border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;
 }
 QLabel#FilterTypeBadge {
-    color: white;
-    border-radius: 10px;
-    font-weight: 700;
-    padding: 2px 6px;
+    color: white; border-radius: 10px;
+    font-weight: 800; padding: 2px 8px; min-height: 18px;
+    font-size: 9pt; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #1a1a2e; font-weight: 600; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #6a6a8a; }
+QLabel#FilterCardTitle { color: #1a1a2e; background: transparent; font-weight: 700; font-size: 10pt; }
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #6a6a8a; background: transparent; }
+QLabel#FilterCardNumber {
+    color: #6a6a8a; background: transparent;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
 QToolButton#FilterCardIconButton {
-    background: rgba(255,255,255,0.45);
+    background: rgba(255, 255, 255, 0.5);
     color: #1a1a2e;
-    border: 1px solid rgba(0,0,0,0.07);
-    border-radius: 6px;
-    min-width: 22px;
-    min-height: 22px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 8px;
+    min-width: 24px; min-height: 24px;
+    padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover {
-    background: rgba(59,130,246,0.12);
+QToolButton#FilterCardIconButton:hover { background: rgba(59, 130, 246, 0.14); border-color: rgba(59, 130, 246, 0.5); }
+QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.22); border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor {
+    background: #f6f7fb; border: 1px solid #3B82F6;
+    border-radius: 10px; padding: 6px 10px;
 }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption {
+    color: #6a6a8a; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 1px; font-size: 9pt;
 }
 QLabel#EditableValue {
+    background: rgba(0, 0, 0, 0.04); color: #1a1a2e;
+    border: 1px solid #d7d9e4; border-radius: 8px;
     padding: 6px 10px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #f6f7fb; border: 1px solid #3B82F6;
+    border-radius: 8px; padding: 6px 10px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath {
+    background: #f6f7fb; border: 1px solid #d7d9e4;
+    border-radius: 8px; padding: 6px 10px;
+}
+QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/industrial_dark.qss
+++ b/Editor/skins/industrial_dark.qss
@@ -1,50 +1,272 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Industrial Dark
+   Tokens: bg #08080c / surface #0e0e14 / card #151520 / cardHover #1a1a28
+           text #b0b0c8 / mutedText #606078 / border #2a2a3a
+           accent #3B82F6 / borderRadius 2 / row 30
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #f8fafc;
+}
+
+QWidget {
     background: #08080c;
     color: #b0b0c8;
-    font-family: "Segoe UI";
+    font-family: "Segoe UI", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    font-size: 9pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
-    background: #0e0e14;
-    color: #b0b0c8;
-    border: 1px solid #2a2a3a;
+
+QMainWindow, QDialog { background: #08080c; }
+QMainWindow::separator { background: #2a2a3a; width: 1px; height: 1px; }
+
+QToolTip { background: #151520; color: #b0b0c8; border: 1px solid #2a2a3a; border-radius: 2px; padding: 4px 8px; }
+
+QMenuBar { background: #0e0e14; color: #b0b0c8; padding: 2px 4px; border: 0; border-bottom: 1px solid #2a2a3a; }
+QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 2px; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: #1a1a28; color: #ffffff; }
+
+QMenu { background: #151520; color: #b0b0c8; border: 1px solid #2a2a3a; border-radius: 2px; padding: 2px; }
+QMenu::item { background: transparent; padding: 5px 22px; border-radius: 2px; min-width: 140px; }
+QMenu::item:selected { background: #1a1a28; color: #ffffff; }
+QMenu::item:disabled { color: #404054; }
+QMenu::separator { height: 1px; background: #2a2a3a; margin: 4px 6px; }
+QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
+QMenu::indicator:checked { background: #3B82F6; }
+
+QToolBar { background: #0e0e14; border: 0; border-bottom: 1px solid #2a2a3a; padding: 2px 4px; spacing: 2px; }
+QToolBar::separator { background: #2a2a3a; width: 1px; margin: 4px 6px; }
+QToolButton {
+    background: transparent; color: #b0b0c8;
+    border: 1px solid transparent; border-radius: 2px;
+    padding: 3px 8px; min-height: 22px;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
-    background: #050508;
-    color: #b0b0c8;
-    border: 1px solid #2a2a3a;
-    border-radius: 2px;
+QToolButton:hover { background: #151520; border: 1px solid #2a2a3a; }
+QToolButton:pressed, QToolButton:checked { background: #1a3358; border: 1px solid #3B82F6; }
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel { color: #606078; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+
+QPushButton {
+    background: #151520; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    padding: 4px 14px; min-height: 22px;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QFrame#FilterCardRow {
-    background: #151520;
-    border: 1px solid #2a2a3a;
-    border-radius: 2px;
+QPushButton:hover { background: #1a1a28; border-color: #3B82F6; }
+QPushButton:pressed { background: #1a3358; border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #404054; background: #0e0e14; border-color: #1a1a28; }
+
+QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
+    background: #050508; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    padding: 3px 8px;
+    selection-background-color: #3B82F6; selection-color: #f8fafc;
 }
-QWidget#FilterCardHeader, QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: #0e0e14;
-    border-radius: 2px;
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid #3B82F6; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #404054; background: #08080c; }
+
+QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
+    subcontrol-origin: border; background: #0e0e14;
+    width: 16px; border-left: 1px solid #2a2a3a;
 }
+QAbstractSpinBox::up-button { subcontrol-position: top right; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid #2a2a3a; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #1a1a28; }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent; border-bottom: 4px solid #606078;
+}
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 4px solid #606078;
+}
+
+QComboBox {
+    background: #151520; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    padding: 3px 28px 3px 10px; min-height: 22px;
+}
+QComboBox:hover { background: #1a1a28; border-color: #3B82F6; }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 5px solid #606078; margin-right: 8px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #151520; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    padding: 2px; outline: 0;
+    selection-background-color: #1a1a28; selection-color: #ffffff;
+}
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 22px; }
+
+QCheckBox, QRadioButton { color: #b0b0c8; background: transparent; spacing: 8px; padding: 2px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #404054; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px; height: 14px; background: #050508; border: 1px solid #2a2a3a;
+}
+QCheckBox::indicator { border-radius: 2px; }
+QRadioButton::indicator { border-radius: 7px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:vertical { background: #2a2a3a; min-height: 32px; border-radius: 2px; }
+QScrollBar::handle:vertical:hover { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:horizontal { background: #2a2a3a; min-width: 32px; border-radius: 2px; }
+QScrollBar::handle:horizontal:hover { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #08080c; color: #b0b0c8; border: 0; }
+QScrollArea { background: #08080c; border: 0; }
+QScrollArea > QWidget > QWidget { background: #08080c; }
+
+QDockWidget { color: #b0b0c8; background: #08080c; titlebar-close-icon: none; titlebar-normal-icon: none; }
+QDockWidget::title {
+    background: #0e0e14; color: #606078;
+    text-align: left; padding: 4px 10px;
+    border: 0; border-bottom: 1px solid #2a2a3a;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 2px; padding: 2px; icon-size: 12px; }
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: #1a1a28; }
+
+QTabWidget::pane { background: #08080c; border: 0; border-top: 1px solid #2a2a3a; top: -1px; }
+QTabBar { background: #08080c; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #606078;
+    padding: 6px 16px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+}
+QTabBar::tab:hover { color: #b0b0c8; background: #0e0e14; }
+QTabBar::tab:selected { color: #ffffff; background: #0e0e14; border-top: 2px solid #3B82F6; }
+QTabBar::tab:!selected { border-bottom: 1px solid #2a2a3a; }
+QTabBar::close-button { image: none; background: transparent; border-radius: 2px; padding: 2px; margin: 2px; subcontrol-position: right; }
+QTabBar::close-button:hover { background: #5a1a1a; }
+QTabBar QToolButton { background: #0e0e14; border: 1px solid #2a2a3a; border-radius: 2px; margin: 4px 2px; }
+
+QGroupBox {
+    background: #0e0e14; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    margin-top: 14px; padding: 14px 10px 10px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 6px; color: #606078; background: #08080c;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+
+QHeaderView { background: #0e0e14; color: #606078; border: 0; }
+QHeaderView::section {
+    background: #0e0e14; color: #606078; border: 0;
+    border-right: 1px solid #2a2a3a; border-bottom: 1px solid #2a2a3a;
+    padding: 4px 10px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QTreeView, QListView, QTableView {
+    background: #08080c; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    alternate-background-color: #0a0a10;
+    selection-background-color: #1a1a28; selection-color: #ffffff;
+    gridline-color: #2a2a3a;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 2px; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #12121c; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: #1a1a28; color: #ffffff; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #2a2a3a; height: 2px; border-radius: 1px; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 2px; border-radius: 1px; }
+QSlider::handle:horizontal { background: #b0b0c8; border: 1px solid #3B82F6; width: 12px; height: 12px; margin: -6px 0; border-radius: 1px; }
+QSlider::groove:vertical { background: #2a2a3a; width: 2px; border-radius: 1px; margin: 6px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 2px; border-radius: 1px; }
+QSlider::sub-page:vertical { background: #2a2a3a; width: 2px; border-radius: 1px; }
+QSlider::handle:vertical { background: #b0b0c8; border: 1px solid #3B82F6; width: 12px; height: 12px; margin: 0 -6px; border-radius: 1px; }
+
+QSplitter::handle { background: #2a2a3a; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #0e0e14; color: #606078; border: 0; border-top: 1px solid #2a2a3a; }
+QStatusBar::item { border: 0; }
+
+QProgressBar { background: #050508; color: #b0b0c8; border: 1px solid #2a2a3a; border-radius: 2px; text-align: center; }
+QProgressBar::chunk { background: #3B82F6; border-radius: 1px; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #2a2a3a; border: 0; }
+
+QFrame#analysisControlBar { background: #0e0e14; border: 1px solid #2a2a3a; border-radius: 2px; }
+QLabel#AnalysisFormLabel {
+    color: #606078; background: transparent;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
+}
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip { background: #151520; border: 1px solid #2a2a3a; border-radius: 2px; }
+QLabel#AnalysisStatLabel {
+    color: #606078; background: transparent;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 2px;
+}
+QLabel#AnalysisStatValue { color: #b0b0c8; background: transparent; font-weight: 700; font-family: "Consolas", monospace; }
+QLabel#AnalysisStatValue[severity="warning"] { color: #f59e0b; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #ef4444; }
+
+QWidget#ModernAnalysisGraph { background: #050508; border: 1px solid #2a2a3a; border-radius: 2px; }
+
+QFrame#FilterCardRow { background: #151520; border: 1px solid #2a2a3a; border-radius: 2px; }
+QWidget#FilterCardHeader { background: #0e0e14; border-radius: 2px; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #0e0e14; border-radius: 2px; }
 QLabel#FilterTypeBadge {
-    background: transparent;
-    border: 1px solid;
-    border-radius: 1px;
-    font-weight: 700;
-    padding: 1px 5px;
+    background: transparent; color: #b0b0c8;
+    border: 1px solid #b0b0c8; border-radius: 1px;
+    font-weight: 700; padding: 1px 6px; min-height: 18px;
+    font-size: 8pt; text-transform: uppercase; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #b0b0c8; font-weight: 700; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #606078; }
+QLabel#FilterCardTitle { color: #b0b0c8; background: transparent; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #606078; background: transparent; }
+QLabel#FilterCardNumber { color: #606078; background: transparent; font-family: "Consolas", monospace; font-weight: 700; }
 QToolButton#FilterCardIconButton {
-    background: #08080c;
-    color: #b0b0c8;
-    border: 1px solid #2a2a3a;
-    border-radius: 1px;
-    min-width: 22px;
-    min-height: 22px;
+    background: #08080c; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 1px;
+    min-width: 24px; min-height: 24px; padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: #1a1a28; }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
+QToolButton#FilterCardIconButton:hover { background: #1a1a28; border-color: #3B82F6; }
+QToolButton#FilterCardIconButton:checked { background: #1a3358; border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor { background: #050508; border: 1px solid #3B82F6; border-radius: 2px; padding: 4px 8px; }
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption {
+    color: #606078; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 2px; font-size: 8pt;
 }
 QLabel#EditableValue {
-    padding: 6px 10px;
+    background: #08080c; color: #b0b0c8;
+    border: 1px solid #2a2a3a; border-radius: 2px;
+    padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #050508; border: 1px solid #3B82F6;
+    border-radius: 2px; padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath { background: #050508; border: 1px solid #2a2a3a; border-radius: 2px; padding: 4px 8px; }
+QLabel#IncludeCardStatus { color: #ef4444; font-size: 8pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/industrial_light.qss
+++ b/Editor/skins/industrial_light.qss
@@ -1,50 +1,268 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Industrial Light
+   Tokens: bg #e0e0e8 / surface #d4d4de / card #ecece4 / cardHover #f0f0f8
+           text #1a1a28 / mutedText #5a5a70 / border #b0b0c0
+           accent #3B82F6 / borderRadius 2 / row 30
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #ffffff;
+}
+
+QWidget {
     background: #e0e0e8;
     color: #1a1a28;
-    font-family: "Segoe UI";
+    font-family: "Segoe UI", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    font-size: 9pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
-    background: #d4d4de;
-    color: #1a1a28;
-    border: 1px solid #b0b0c0;
+
+QMainWindow, QDialog { background: #e0e0e8; }
+QMainWindow::separator { background: #b0b0c0; width: 1px; height: 1px; }
+
+QToolTip { background: #ecece4; color: #1a1a28; border: 1px solid #b0b0c0; border-radius: 2px; padding: 4px 8px; }
+
+QMenuBar { background: #d4d4de; color: #1a1a28; padding: 2px 4px; border: 0; border-bottom: 1px solid #b0b0c0; }
+QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 2px; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: #c0c0d0; color: #000000; }
+
+QMenu { background: #ecece4; color: #1a1a28; border: 1px solid #b0b0c0; border-radius: 2px; padding: 2px; }
+QMenu::item { background: transparent; padding: 5px 22px; border-radius: 2px; min-width: 140px; }
+QMenu::item:selected { background: #d4d4de; color: #000000; }
+QMenu::item:disabled { color: #9090a0; }
+QMenu::separator { height: 1px; background: #b0b0c0; margin: 4px 6px; }
+QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
+QMenu::indicator:checked { background: #3B82F6; }
+
+QToolBar { background: #d4d4de; border: 0; border-bottom: 1px solid #b0b0c0; padding: 2px 4px; spacing: 2px; }
+QToolBar::separator { background: #b0b0c0; width: 1px; margin: 4px 6px; }
+QToolButton { background: transparent; color: #1a1a28; border: 1px solid transparent; border-radius: 2px; padding: 3px 8px; min-height: 22px; }
+QToolButton:hover { background: #c8c8d4; border: 1px solid #b0b0c0; }
+QToolButton:pressed, QToolButton:checked { background: #c4d4f0; border: 1px solid #3B82F6; }
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel { color: #5a5a70; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+
+QPushButton {
+    background: #ecece4; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    padding: 4px 14px; min-height: 22px;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
-    background: #f2f2f8;
-    color: #1a1a28;
-    border: 1px solid #b0b0c0;
-    border-radius: 2px;
+QPushButton:hover { background: #f0f0f8; border-color: #3B82F6; }
+QPushButton:pressed { background: #c4d4f0; border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #9090a0; background: #dadade; border-color: #c4c4d0; }
+
+QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
+    background: #f2f2f8; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    padding: 3px 8px;
+    selection-background-color: #3B82F6; selection-color: #ffffff;
 }
-QFrame#FilterCardRow {
-    background: #ecece4;
-    border: 1px solid #b0b0c0;
-    border-radius: 2px;
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid #3B82F6; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #9090a0; background: #d8d8e0; }
+
+QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
+    subcontrol-origin: border; background: #d4d4de;
+    width: 16px; border-left: 1px solid #b0b0c0;
 }
-QWidget#FilterCardHeader, QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: #d8d8e2;
-    border-radius: 2px;
+QAbstractSpinBox::up-button { subcontrol-position: top right; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid #b0b0c0; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #c0c0d0; }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent; border-bottom: 4px solid #5a5a70;
 }
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 4px solid #5a5a70;
+}
+
+QComboBox {
+    background: #ecece4; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    padding: 3px 28px 3px 10px; min-height: 22px;
+}
+QComboBox:hover { background: #f0f0f8; border-color: #3B82F6; }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 5px solid #5a5a70; margin-right: 8px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #ecece4; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    padding: 2px; outline: 0;
+    selection-background-color: #d4d4de; selection-color: #000000;
+}
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 22px; }
+
+QCheckBox, QRadioButton { color: #1a1a28; background: transparent; spacing: 8px; padding: 2px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #9090a0; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px; height: 14px; background: #f2f2f8; border: 1px solid #b0b0c0;
+}
+QCheckBox::indicator { border-radius: 2px; }
+QRadioButton::indicator { border-radius: 7px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:vertical { background: #b0b0c0; min-height: 32px; border-radius: 2px; }
+QScrollBar::handle:vertical:hover { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:horizontal { background: #b0b0c0; min-width: 32px; border-radius: 2px; }
+QScrollBar::handle:horizontal:hover { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #e0e0e8; color: #1a1a28; border: 0; }
+QScrollArea { background: #e0e0e8; border: 0; }
+QScrollArea > QWidget > QWidget { background: #e0e0e8; }
+
+QDockWidget { color: #1a1a28; background: #e0e0e8; titlebar-close-icon: none; titlebar-normal-icon: none; }
+QDockWidget::title {
+    background: #d4d4de; color: #5a5a70;
+    text-align: left; padding: 4px 10px;
+    border: 0; border-bottom: 1px solid #b0b0c0;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 2px; padding: 2px; icon-size: 12px; }
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: #c0c0d0; }
+
+QTabWidget::pane { background: #e0e0e8; border: 0; border-top: 1px solid #b0b0c0; top: -1px; }
+QTabBar { background: #e0e0e8; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #5a5a70;
+    padding: 6px 16px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+}
+QTabBar::tab:hover { color: #1a1a28; background: #d4d4de; }
+QTabBar::tab:selected { color: #000000; background: #ecece4; border-top: 2px solid #3B82F6; }
+QTabBar::tab:!selected { border-bottom: 1px solid #b0b0c0; }
+QTabBar::close-button { image: none; background: transparent; border-radius: 2px; padding: 2px; margin: 2px; subcontrol-position: right; }
+QTabBar::close-button:hover { background: #f4baba; }
+QTabBar QToolButton { background: #ecece4; border: 1px solid #b0b0c0; border-radius: 2px; margin: 4px 2px; }
+
+QGroupBox {
+    background: #ecece4; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    margin-top: 14px; padding: 14px 10px 10px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 6px; color: #5a5a70; background: #e0e0e8;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+
+QHeaderView { background: #d4d4de; color: #5a5a70; border: 0; }
+QHeaderView::section {
+    background: #d4d4de; color: #5a5a70; border: 0;
+    border-right: 1px solid #b0b0c0; border-bottom: 1px solid #b0b0c0;
+    padding: 4px 10px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QTreeView, QListView, QTableView {
+    background: #ecece4; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    alternate-background-color: #e8e8e0;
+    selection-background-color: #d4d4de; selection-color: #000000;
+    gridline-color: #b0b0c0;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 2px; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #e0e0d8; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: #d4d4de; color: #000000; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #b0b0c0; height: 2px; border-radius: 1px; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 2px; border-radius: 1px; }
+QSlider::handle:horizontal { background: #1a1a28; border: 1px solid #3B82F6; width: 12px; height: 12px; margin: -6px 0; border-radius: 1px; }
+QSlider::groove:vertical { background: #b0b0c0; width: 2px; border-radius: 1px; margin: 6px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 2px; border-radius: 1px; }
+QSlider::sub-page:vertical { background: #b0b0c0; width: 2px; border-radius: 1px; }
+QSlider::handle:vertical { background: #1a1a28; border: 1px solid #3B82F6; width: 12px; height: 12px; margin: 0 -6px; border-radius: 1px; }
+
+QSplitter::handle { background: #b0b0c0; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #d4d4de; color: #5a5a70; border: 0; border-top: 1px solid #b0b0c0; }
+QStatusBar::item { border: 0; }
+
+QProgressBar { background: #f2f2f8; color: #1a1a28; border: 1px solid #b0b0c0; border-radius: 2px; text-align: center; }
+QProgressBar::chunk { background: #3B82F6; border-radius: 1px; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #b0b0c0; border: 0; }
+
+QFrame#analysisControlBar { background: #d4d4de; border: 1px solid #b0b0c0; border-radius: 2px; }
+QLabel#AnalysisFormLabel {
+    color: #5a5a70; background: transparent;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
+}
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip { background: #e8e8e0; border: 1px solid #b0b0c0; border-radius: 2px; }
+QLabel#AnalysisStatLabel {
+    color: #5a5a70; background: transparent;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 2px;
+}
+QLabel#AnalysisStatValue { color: #1a1a28; background: transparent; font-weight: 700; font-family: "Consolas", monospace; }
+QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
+
+QWidget#ModernAnalysisGraph { background: #f2f2f8; border: 1px solid #b0b0c0; border-radius: 2px; }
+
+QFrame#FilterCardRow { background: #ecece4; border: 1px solid #b0b0c0; border-radius: 2px; }
+QWidget#FilterCardHeader { background: #d8d8e2; border-radius: 2px; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #d8d8e2; border-radius: 2px; }
 QLabel#FilterTypeBadge {
-    background: transparent;
-    border: 1px solid;
-    border-radius: 1px;
-    font-weight: 700;
-    padding: 1px 5px;
+    background: transparent; color: #1a1a28;
+    border: 1px solid #1a1a28; border-radius: 1px;
+    font-weight: 700; padding: 1px 6px; min-height: 18px;
+    font-size: 8pt; text-transform: uppercase; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #1a1a28; font-weight: 700; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #5a5a70; }
+QLabel#FilterCardTitle { color: #1a1a28; background: transparent; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #5a5a70; background: transparent; }
+QLabel#FilterCardNumber { color: #5a5a70; background: transparent; font-family: "Consolas", monospace; font-weight: 700; }
 QToolButton#FilterCardIconButton {
-    background: #d8d8e2;
-    color: #1a1a28;
-    border: 1px solid #b0b0c0;
-    border-radius: 1px;
-    min-width: 22px;
-    min-height: 22px;
+    background: #d8d8e2; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 1px;
+    min-width: 24px; min-height: 24px; padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: #f0f0f8; }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
+QToolButton#FilterCardIconButton:hover { background: #f0f0f8; border-color: #3B82F6; }
+QToolButton#FilterCardIconButton:checked { background: #c4d4f0; border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor { background: #f2f2f8; border: 1px solid #3B82F6; border-radius: 2px; padding: 4px 8px; }
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption {
+    color: #5a5a70; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 2px; font-size: 8pt;
 }
 QLabel#EditableValue {
-    padding: 6px 10px;
+    background: #e8e8e0; color: #1a1a28;
+    border: 1px solid #b0b0c0; border-radius: 2px;
+    padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #f2f2f8; border: 1px solid #3B82F6;
+    border-radius: 2px; padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath { background: #f2f2f8; border: 1px solid #b0b0c0; border-radius: 2px; padding: 4px 8px; }
+QLabel#IncludeCardStatus { color: #dc2626; font-size: 8pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/minimal_dark.qss
+++ b/Editor/skins/minimal_dark.qss
@@ -1,52 +1,329 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Minimal Dark
+   Tokens: bg #191919 / surface #1f1f1f / card #262626 / cardHover #2c2c2c
+           text #cccccc / mutedText #777777 / border #3c3c3c
+           accent #3B82F6 / borderRadius 0 / row 32 / font Consolas
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #f8fafc;
+}
+
+QWidget {
     background: #191919;
     color: #cccccc;
-    font-family: "Consolas";
+    font-family: "Consolas", "JetBrains Mono", "DejaVu Sans Mono", "Noto Sans Mono CJK KR", monospace;
+    font-size: 10pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
-    background: #1f1f1f;
-    color: #cccccc;
-    border: 1px solid #3c3c3c;
+
+QMainWindow, QDialog { background: #191919; }
+QMainWindow::separator { background: #3c3c3c; width: 1px; height: 1px; }
+
+QToolTip {
+    background: #1f1f1f; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    padding: 4px 8px;
 }
-QMenu::item:selected, QToolButton:hover, QPushButton:hover {
-    background: #2c2c2c;
+
+QMenuBar {
+    background: #1f1f1f; color: #cccccc;
+    padding: 2px 4px; border: 0; border-bottom: 1px solid #3c3c3c;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
-    background: #0e0e0e;
-    color: #cccccc;
-    border: 1px solid #3c3c3c;
-    border-radius: 0;
+QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 0; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: #2c2c2c; color: #ffffff; }
+
+QMenu {
+    background: #1f1f1f; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0; padding: 2px;
 }
+QMenu::item { background: transparent; padding: 4px 22px; border-radius: 0; min-width: 140px; }
+QMenu::item:selected { background: #2c2c2c; color: #ffffff; }
+QMenu::item:disabled { color: #555555; }
+QMenu::separator { height: 1px; background: #3c3c3c; margin: 4px 6px; }
+QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
+QMenu::indicator:checked { background: #3B82F6; }
+
+QToolBar {
+    background: #1f1f1f; border: 0; border-bottom: 1px solid #3c3c3c;
+    padding: 2px 4px; spacing: 2px;
+}
+QToolBar::separator { background: #3c3c3c; width: 1px; margin: 4px 6px; }
+QToolButton {
+    background: transparent; color: #cccccc;
+    border: 1px solid transparent; border-radius: 0;
+    padding: 3px 8px; min-height: 22px;
+}
+QToolButton:hover { background: #2c2c2c; border: 1px solid #3c3c3c; }
+QToolButton:pressed, QToolButton:checked { background: #2a3a55; border: 1px solid #3B82F6; }
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel {
+    color: #777777; background: transparent; padding: 0 4px 0 8px;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+
+QPushButton {
+    background: #262626; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    padding: 4px 14px; min-height: 22px;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+}
+QPushButton:hover { background: #2c2c2c; border-color: #3B82F6; }
+QPushButton:pressed { background: #1a3358; border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #555555; background: #1f1f1f; border-color: #2c2c2c; }
+
+QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
+    background: #0e0e0e; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    padding: 4px 8px;
+    selection-background-color: #3B82F6; selection-color: #f8fafc;
+}
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid #3B82F6; background: #0a0a0a; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #555555; background: #141414; }
+
+QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
+    subcontrol-origin: border; background: #1f1f1f;
+    width: 16px; border-left: 1px solid #3c3c3c;
+}
+QAbstractSpinBox::up-button { subcontrol-position: top right; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid #3c3c3c; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #2c2c2c; }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent;
+    border-bottom: 4px solid #777777;
+}
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent;
+    border-top: 4px solid #777777;
+}
+
+QComboBox {
+    background: #262626; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    padding: 4px 28px 4px 10px; min-height: 22px;
+}
+QComboBox:hover { background: #2c2c2c; border-color: #3B82F6; }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 5px solid #777777; margin-right: 8px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #1f1f1f; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    padding: 2px; outline: 0;
+    selection-background-color: #2c2c2c; selection-color: #ffffff;
+}
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 0; min-height: 22px; }
+
+QCheckBox, QRadioButton { color: #cccccc; background: transparent; spacing: 8px; padding: 2px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #555555; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px; height: 14px; background: #0e0e0e; border: 1px solid #3c3c3c;
+}
+QCheckBox::indicator { border-radius: 0; }
+QRadioButton::indicator { border-radius: 7px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:vertical { background: #3c3c3c; min-height: 32px; border-radius: 0; }
+QScrollBar::handle:vertical:hover { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:horizontal { background: #3c3c3c; min-width: 32px; border-radius: 0; }
+QScrollBar::handle:horizontal:hover { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #191919; color: #cccccc; border: 0; }
+QScrollArea { background: #191919; border: 0; }
+QScrollArea > QWidget > QWidget { background: #191919; }
+
+QDockWidget { color: #cccccc; background: #191919; titlebar-close-icon: none; titlebar-normal-icon: none; }
+QDockWidget::title {
+    background: #1f1f1f; color: #777777;
+    text-align: left; padding: 4px 10px;
+    border: 0; border-bottom: 1px solid #3c3c3c;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+QDockWidget::close-button, QDockWidget::float-button {
+    background: transparent; border: 0; border-radius: 0; padding: 2px; icon-size: 12px;
+}
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: #2c2c2c; }
+
+QTabWidget::pane { background: #191919; border: 0; border-top: 1px solid #3c3c3c; top: -1px; }
+QTabBar { background: #191919; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #777777;
+    padding: 6px 16px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+}
+QTabBar::tab:hover { color: #cccccc; background: #1f1f1f; }
+QTabBar::tab:selected { color: #ffffff; background: #1f1f1f; border-top: 2px solid #3B82F6; }
+QTabBar::tab:!selected { border-bottom: 1px solid #3c3c3c; }
+QTabBar::close-button {
+    image: none; background: transparent; border-radius: 0;
+    padding: 2px; margin: 2px; subcontrol-position: right;
+}
+QTabBar::close-button:hover { background: #5a1a1a; }
+QTabBar QToolButton { background: #1f1f1f; border: 1px solid #3c3c3c; border-radius: 0; margin: 4px 2px; }
+
+QGroupBox {
+    background: #1f1f1f; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    margin-top: 14px; padding: 14px 10px 10px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 6px; color: #777777; background: #191919;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+
+QHeaderView { background: #1f1f1f; color: #777777; border: 0; }
+QHeaderView::section {
+    background: #1f1f1f; color: #777777; border: 0;
+    border-right: 1px solid #3c3c3c; border-bottom: 1px solid #3c3c3c;
+    padding: 4px 10px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QTreeView, QListView, QTableView {
+    background: #191919; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    alternate-background-color: #1c1c1c;
+    selection-background-color: #2c2c2c; selection-color: #ffffff;
+    gridline-color: #3c3c3c;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 0; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #222222; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: #2c2c2c; color: #ffffff; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #3c3c3c; height: 2px; border-radius: 0; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 2px; border-radius: 0; }
+QSlider::handle:horizontal {
+    background: #cccccc; border: 1px solid #3B82F6;
+    width: 12px; height: 12px; margin: -6px 0; border-radius: 0;
+}
+QSlider::groove:vertical { background: #3c3c3c; width: 2px; border-radius: 0; margin: 6px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 2px; border-radius: 0; }
+QSlider::sub-page:vertical { background: #3c3c3c; width: 2px; border-radius: 0; }
+QSlider::handle:vertical {
+    background: #cccccc; border: 1px solid #3B82F6;
+    width: 12px; height: 12px; margin: 0 -6px; border-radius: 0;
+}
+
+QSplitter::handle { background: #3c3c3c; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #1f1f1f; color: #777777; border: 0; border-top: 1px solid #3c3c3c; }
+QStatusBar::item { border: 0; }
+
+QProgressBar {
+    background: #0e0e0e; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    text-align: center;
+}
+QProgressBar::chunk { background: #3B82F6; border-radius: 0; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #3c3c3c; border: 0; }
+
+QFrame#analysisControlBar {
+    background: #1f1f1f; border: 1px solid #3c3c3c; border-radius: 0;
+}
+QLabel#AnalysisFormLabel {
+    color: #777777; background: transparent;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
+}
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip {
+    background: #262626; border: 1px solid #3c3c3c; border-radius: 0;
+}
+QLabel#AnalysisStatLabel {
+    color: #777777; background: transparent;
+    font-weight: 700; font-size: 9pt;
+    text-transform: uppercase; letter-spacing: 2px;
+}
+QLabel#AnalysisStatValue {
+    color: #cccccc; background: transparent;
+    font-weight: 700; font-family: "Consolas", monospace;
+}
+QLabel#AnalysisStatValue[severity="warning"] { color: #f59e0b; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #ef4444; }
+
+QWidget#ModernAnalysisGraph {
+    background: #0e0e0e; border: 1px solid #3c3c3c; border-radius: 0;
+}
+
 QFrame#FilterCardRow {
-    background: #262626;
-    border: 1px solid #2e2e2e;
-    border-radius: 0;
+    background: #262626; border: 1px solid #2e2e2e; border-radius: 0;
 }
-QWidget#FilterCardHeader, QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: #1f1f1f;
-    border-radius: 0;
-}
+QWidget#FilterCardHeader { background: #1f1f1f; border-radius: 0; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #1f1f1f; border-radius: 0; }
 QLabel#FilterTypeBadge {
-    background: transparent;
-    border: 1px solid;
-    border-radius: 0;
-    font-weight: 700;
-    padding: 1px 5px;
+    background: transparent; color: #cccccc;
+    border: 1px solid #cccccc; border-radius: 0;
+    font-weight: 700; padding: 1px 6px; min-height: 18px;
+    font-size: 9pt; text-transform: uppercase; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #cccccc; font-weight: 700; text-transform: uppercase; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #777777; }
+QLabel#FilterCardTitle {
+    color: #cccccc; background: transparent;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #777777; background: transparent; }
+QLabel#FilterCardNumber {
+    color: #777777; background: transparent;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
 QToolButton#FilterCardIconButton {
-    background: #1a1a1a;
-    color: #cccccc;
-    border: 1px solid #3c3c3c;
-    border-radius: 0;
-    min-width: 22px;
-    min-height: 22px;
+    background: #1a1a1a; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    min-width: 24px; min-height: 24px;
+    padding: 2px 4px; font-weight: 700;
 }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
+QToolButton#FilterCardIconButton:hover { background: #2c2c2c; border-color: #3B82F6; }
+QToolButton#FilterCardIconButton:checked { background: #1a3358; border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor {
+    background: #0e0e0e; border: 1px solid #3B82F6;
+    border-radius: 0; padding: 4px 8px;
+}
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption {
+    color: #777777; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 2px; font-size: 9pt;
 }
 QLabel#EditableValue {
-    padding: 6px 10px;
+    background: #1a1a1a; color: #cccccc;
+    border: 1px solid #3c3c3c; border-radius: 0;
+    padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #0e0e0e; border: 1px solid #3B82F6;
+    border-radius: 0; padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath {
+    background: #0e0e0e; border: 1px solid #3c3c3c;
+    border-radius: 0; padding: 4px 8px;
+}
+QLabel#IncludeCardStatus { color: #ef4444; font-size: 9pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/minimal_light.qss
+++ b/Editor/skins/minimal_light.qss
@@ -1,52 +1,268 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Minimal Light
+   Tokens: bg #f0f0f0 / surface #e6e6e6 / card #fafafa / cardHover #f0f0f0
+           text #1a1a1a / mutedText #666666 / border #c0c0c0
+           accent #3B82F6 / borderRadius 0 / row 32 / font Consolas
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #ffffff;
+}
+
+QWidget {
     background: #f0f0f0;
     color: #1a1a1a;
-    font-family: "Consolas";
+    font-family: "Consolas", "JetBrains Mono", "DejaVu Sans Mono", "Noto Sans Mono CJK KR", monospace;
+    font-size: 10pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
-    background: #e6e6e6;
-    color: #1a1a1a;
-    border: 1px solid #c0c0c0;
+
+QMainWindow, QDialog { background: #f0f0f0; }
+QMainWindow::separator { background: #c0c0c0; width: 1px; height: 1px; }
+
+QToolTip { background: #fafafa; color: #1a1a1a; border: 1px solid #c0c0c0; border-radius: 0; padding: 4px 8px; }
+
+QMenuBar { background: #e6e6e6; color: #1a1a1a; padding: 2px 4px; border: 0; border-bottom: 1px solid #c0c0c0; }
+QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 0; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: #d0d0d0; color: #000000; }
+
+QMenu { background: #fafafa; color: #1a1a1a; border: 1px solid #c0c0c0; border-radius: 0; padding: 2px; }
+QMenu::item { background: transparent; padding: 4px 22px; border-radius: 0; min-width: 140px; }
+QMenu::item:selected { background: #e0e0e0; color: #000000; }
+QMenu::item:disabled { color: #999999; }
+QMenu::separator { height: 1px; background: #c0c0c0; margin: 4px 6px; }
+QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
+QMenu::indicator:checked { background: #3B82F6; }
+
+QToolBar { background: #e6e6e6; border: 0; border-bottom: 1px solid #c0c0c0; padding: 2px 4px; spacing: 2px; }
+QToolBar::separator { background: #c0c0c0; width: 1px; margin: 4px 6px; }
+QToolButton { background: transparent; color: #1a1a1a; border: 1px solid transparent; border-radius: 0; padding: 3px 8px; min-height: 22px; }
+QToolButton:hover { background: #d8d8d8; border: 1px solid #c0c0c0; }
+QToolButton:pressed, QToolButton:checked { background: #c4d4f0; border: 1px solid #3B82F6; }
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel { color: #666666; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+
+QPushButton {
+    background: #fafafa; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    padding: 4px 14px; min-height: 22px;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QMenu::item:selected, QToolButton:hover, QPushButton:hover {
-    background: #fafafa;
+QPushButton:hover { background: #f0f0f0; border-color: #3B82F6; }
+QPushButton:pressed { background: #c4d4f0; border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #999999; background: #ececec; border-color: #d8d8d8; }
+
+QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
+    background: #ffffff; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    padding: 4px 8px;
+    selection-background-color: #3B82F6; selection-color: #ffffff;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
-    background: #ffffff;
-    color: #1a1a1a;
-    border: 1px solid #c0c0c0;
-    border-radius: 0;
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid #3B82F6; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #999999; background: #ececec; }
+
+QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
+    subcontrol-origin: border; background: #e6e6e6;
+    width: 16px; border-left: 1px solid #c0c0c0;
 }
-QFrame#FilterCardRow {
-    background: #fafafa;
-    border: 1px solid #d8d8d8;
-    border-radius: 0;
+QAbstractSpinBox::up-button { subcontrol-position: top right; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid #c0c0c0; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #d0d0d0; }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent; border-bottom: 4px solid #666666;
 }
-QWidget#FilterCardHeader, QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: #f0f0f0;
-    border-radius: 0;
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 4px solid #666666;
 }
+
+QComboBox {
+    background: #fafafa; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    padding: 4px 28px 4px 10px; min-height: 22px;
+}
+QComboBox:hover { background: #f0f0f0; border-color: #3B82F6; }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 5px solid #666666; margin-right: 8px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #fafafa; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    padding: 2px; outline: 0;
+    selection-background-color: #e0e0e0; selection-color: #000000;
+}
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 0; min-height: 22px; }
+
+QCheckBox, QRadioButton { color: #1a1a1a; background: transparent; spacing: 8px; padding: 2px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #999999; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 14px; height: 14px; background: #ffffff; border: 1px solid #c0c0c0;
+}
+QCheckBox::indicator { border-radius: 0; }
+QRadioButton::indicator { border-radius: 7px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:vertical { background: #c0c0c0; min-height: 32px; border-radius: 0; }
+QScrollBar::handle:vertical:hover { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 10px; margin: 2px; border: 0; }
+QScrollBar::handle:horizontal { background: #c0c0c0; min-width: 32px; border-radius: 0; }
+QScrollBar::handle:horizontal:hover { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #f0f0f0; color: #1a1a1a; border: 0; }
+QScrollArea { background: #f0f0f0; border: 0; }
+QScrollArea > QWidget > QWidget { background: #f0f0f0; }
+
+QDockWidget { color: #1a1a1a; background: #f0f0f0; titlebar-close-icon: none; titlebar-normal-icon: none; }
+QDockWidget::title {
+    background: #e6e6e6; color: #666666;
+    text-align: left; padding: 4px 10px;
+    border: 0; border-bottom: 1px solid #c0c0c0;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 0; padding: 2px; icon-size: 12px; }
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: #d0d0d0; }
+
+QTabWidget::pane { background: #f0f0f0; border: 0; border-top: 1px solid #c0c0c0; top: -1px; }
+QTabBar { background: #f0f0f0; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #666666;
+    padding: 6px 16px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+}
+QTabBar::tab:hover { color: #1a1a1a; background: #e6e6e6; }
+QTabBar::tab:selected { color: #000000; background: #fafafa; border-top: 2px solid #3B82F6; }
+QTabBar::tab:!selected { border-bottom: 1px solid #c0c0c0; }
+QTabBar::close-button { image: none; background: transparent; border-radius: 0; padding: 2px; margin: 2px; subcontrol-position: right; }
+QTabBar::close-button:hover { background: #f4baba; }
+QTabBar QToolButton { background: #fafafa; border: 1px solid #c0c0c0; border-radius: 0; margin: 4px 2px; }
+
+QGroupBox {
+    background: #fafafa; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    margin-top: 14px; padding: 14px 10px 10px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 6px; color: #666666; background: #f0f0f0;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
+}
+
+QHeaderView { background: #e6e6e6; color: #666666; border: 0; }
+QHeaderView::section {
+    background: #e6e6e6; color: #666666; border: 0;
+    border-right: 1px solid #c0c0c0; border-bottom: 1px solid #c0c0c0;
+    padding: 4px 10px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QTreeView, QListView, QTableView {
+    background: #fafafa; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    alternate-background-color: #f0f0f0;
+    selection-background-color: #e0e0e0; selection-color: #000000;
+    gridline-color: #c0c0c0;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 0; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #ebebeb; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: #e0e0e0; color: #000000; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #c0c0c0; height: 2px; border-radius: 0; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 2px; border-radius: 0; }
+QSlider::handle:horizontal { background: #1a1a1a; border: 1px solid #3B82F6; width: 12px; height: 12px; margin: -6px 0; border-radius: 0; }
+QSlider::groove:vertical { background: #c0c0c0; width: 2px; border-radius: 0; margin: 6px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 2px; border-radius: 0; }
+QSlider::sub-page:vertical { background: #c0c0c0; width: 2px; border-radius: 0; }
+QSlider::handle:vertical { background: #1a1a1a; border: 1px solid #3B82F6; width: 12px; height: 12px; margin: 0 -6px; border-radius: 0; }
+
+QSplitter::handle { background: #c0c0c0; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #e6e6e6; color: #666666; border: 0; border-top: 1px solid #c0c0c0; }
+QStatusBar::item { border: 0; }
+
+QProgressBar { background: #ffffff; color: #1a1a1a; border: 1px solid #c0c0c0; border-radius: 0; text-align: center; }
+QProgressBar::chunk { background: #3B82F6; border-radius: 0; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #c0c0c0; border: 0; }
+
+QFrame#analysisControlBar { background: #fafafa; border: 1px solid #c0c0c0; border-radius: 0; }
+QLabel#AnalysisFormLabel {
+    color: #666666; background: transparent;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
+}
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip { background: #f0f0f0; border: 1px solid #c0c0c0; border-radius: 0; }
+QLabel#AnalysisStatLabel {
+    color: #666666; background: transparent;
+    font-weight: 700; font-size: 9pt;
+    text-transform: uppercase; letter-spacing: 2px;
+}
+QLabel#AnalysisStatValue { color: #1a1a1a; background: transparent; font-weight: 700; font-family: "Consolas", monospace; }
+QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
+
+QWidget#ModernAnalysisGraph { background: #ffffff; border: 1px solid #c0c0c0; border-radius: 0; }
+
+QFrame#FilterCardRow { background: #fafafa; border: 1px solid #d0d0d0; border-radius: 0; }
+QWidget#FilterCardHeader { background: #f0f0f0; border-radius: 0; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #f0f0f0; border-radius: 0; }
 QLabel#FilterTypeBadge {
-    background: transparent;
-    border: 1px solid;
-    border-radius: 0;
-    font-weight: 700;
-    padding: 1px 5px;
+    background: transparent; color: #1a1a1a;
+    border: 1px solid #1a1a1a; border-radius: 0;
+    font-weight: 700; padding: 1px 6px; min-height: 18px;
+    font-size: 9pt; text-transform: uppercase; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #1a1a1a; font-weight: 700; text-transform: uppercase; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #666666; }
+QLabel#FilterCardTitle { color: #1a1a1a; background: transparent; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #666666; background: transparent; }
+QLabel#FilterCardNumber { color: #666666; background: transparent; font-family: "Consolas", monospace; font-weight: 700; }
 QToolButton#FilterCardIconButton {
-    background: #eaeaea;
-    color: #1a1a1a;
-    border: 1px solid #c0c0c0;
-    border-radius: 0;
-    min-width: 22px;
-    min-height: 22px;
+    background: #f0f0f0; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    min-width: 24px; min-height: 24px; padding: 2px 4px; font-weight: 700;
 }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
+QToolButton#FilterCardIconButton:hover { background: #e0e0e0; border-color: #3B82F6; }
+QToolButton#FilterCardIconButton:checked { background: #c4d4f0; border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor { background: #ffffff; border: 1px solid #3B82F6; border-radius: 0; padding: 4px 8px; }
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption {
+    color: #666666; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 2px; font-size: 9pt;
 }
 QLabel#EditableValue {
-    padding: 6px 10px;
+    background: #ffffff; color: #1a1a1a;
+    border: 1px solid #c0c0c0; border-radius: 0;
+    padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #ffffff; border: 1px solid #3B82F6;
+    border-radius: 0; padding: 4px 8px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath { background: #ffffff; border: 1px solid #c0c0c0; border-radius: 0; padding: 4px 8px; }
+QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -1,54 +1,256 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Soft Dark
+   Tokens: bg #161620 / surface #1e1e2a / card #262636 / cardHover #2c2c3e
+           text #eeeefc / mutedText #9090ac / border #34344a
+           accent #3B82F6 / borderRadius 18 / row 44
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #f8fafc;
+}
+
+QWidget {
     background: #161620;
     color: #eeeefc;
-    font-family: "Segoe UI";
+    font-family: "Segoe UI", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    font-size: 10pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
-    background: #1e1e2a;
-    color: #eeeefc;
-    border: 1px solid #34344a;
+
+QMainWindow, QDialog { background: #161620; }
+QMainWindow::separator { background: #1e1e2a; width: 6px; height: 6px; }
+
+QToolTip { background: #262636; color: #eeeefc; border: 1px solid #34344a; border-radius: 10px; padding: 6px 12px; }
+
+QMenuBar { background: #1e1e2a; color: #eeeefc; padding: 6px 8px; border: 0; border-bottom: 1px solid #34344a; }
+QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 12px; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.22); color: #eeeefc; }
+
+QMenu { background: #262636; color: #eeeefc; border: 1px solid #34344a; border-radius: 14px; padding: 6px; }
+QMenu::item { background: transparent; padding: 8px 22px; border-radius: 10px; min-width: 140px; }
+QMenu::item:selected { background: rgba(59, 130, 246, 0.25); color: #eeeefc; }
+QMenu::item:disabled { color: #5a5a72; }
+QMenu::separator { height: 1px; background: #34344a; margin: 6px 8px; }
+QMenu::indicator { width: 14px; height: 14px; margin-left: 4px; }
+QMenu::indicator:checked { background: #3B82F6; border-radius: 4px; }
+
+QToolBar { background: #1e1e2a; border: 0; border-bottom: 1px solid #34344a; padding: 6px 8px; spacing: 6px; }
+QToolBar::separator { background: #34344a; width: 1px; margin: 6px 8px; }
+QToolButton { background: transparent; color: #eeeefc; border: 1px solid transparent; border-radius: 12px; padding: 5px 12px; min-height: 26px; }
+QToolButton:hover { background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.06); }
+QToolButton:pressed, QToolButton:checked { background: rgba(59, 130, 246, 0.25); border: 1px solid rgba(59, 130, 246, 0.55); }
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel { color: #9090ac; background: transparent; padding: 0 4px 0 10px; font-weight: 600; }
+
+QPushButton {
+    background: #262636; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 12px;
+    padding: 8px 18px; min-height: 24px;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
-    background: #101018;
-    color: #eeeefc;
-    border: 1px solid #34344a;
-    border-radius: 12px;
+QPushButton:hover { background: #2c2c3e; border-color: rgba(59, 130, 246, 0.55); }
+QPushButton:pressed { background: rgba(59, 130, 246, 0.32); border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #5a5a72; background: #1a1a26; border-color: #2a2a38; }
+
+QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
+    background: #101018; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 12px;
+    padding: 6px 12px;
+    selection-background-color: #3B82F6; selection-color: #f8fafc;
 }
-QFrame#FilterCardRow {
-    background: #262636;
-    border: 1px solid #34344a;
-    border-radius: 18px;
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid #3B82F6; background: #14141c; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #5a5a72; background: #14141c; }
+
+QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
+    subcontrol-origin: border; background: #262636;
+    width: 22px; border-left: 1px solid #34344a;
 }
-QWidget#FilterCardHeader {
-    background: #1e1e2a;
-    border-radius: 18px;
+QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 11px; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 11px; border-top: 1px solid #34344a; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.25); }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 5px solid #9090ac;
 }
-QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: #222232;
-    border-bottom-left-radius: 18px;
-    border-bottom-right-radius: 18px;
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 5px solid #9090ac;
 }
+
+QComboBox {
+    background: #262636; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 12px;
+    padding: 6px 30px 6px 14px; min-height: 24px;
+}
+QComboBox:hover { background: #2c2c3e; border-color: rgba(59, 130, 246, 0.55); }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 26px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 5px solid #9090ac; margin-right: 10px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #262636; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 14px;
+    padding: 6px; outline: 0;
+    selection-background-color: rgba(59, 130, 246, 0.28); selection-color: #eeeefc;
+}
+QComboBox QAbstractItemView::item { padding: 8px 12px; border-radius: 10px; min-height: 26px; }
+
+QCheckBox, QRadioButton { color: #eeeefc; background: transparent; spacing: 10px; padding: 4px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #5a5a72; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 18px; height: 18px; background: #101018; border: 1px solid #34344a;
+}
+QCheckBox::indicator { border-radius: 6px; }
+QRadioButton::indicator { border-radius: 9px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 14px; margin: 6px 2px; border: 0; }
+QScrollBar::handle:vertical { background: rgba(255, 255, 255, 0.10); min-height: 36px; border-radius: 6px; }
+QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:vertical:pressed { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 14px; margin: 2px 6px; border: 0; }
+QScrollBar::handle:horizontal { background: rgba(255, 255, 255, 0.10); min-width: 36px; border-radius: 6px; }
+QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:horizontal:pressed { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #161620; color: #eeeefc; border: 0; }
+QScrollArea { background: #161620; border: 0; }
+QScrollArea > QWidget > QWidget { background: #161620; }
+
+QDockWidget { color: #eeeefc; background: #161620; titlebar-close-icon: none; titlebar-normal-icon: none; }
+QDockWidget::title {
+    background: #1e1e2a; color: #9090ac;
+    text-align: left; padding: 8px 14px;
+    border: 0; border-bottom: 1px solid #34344a;
+    font-weight: 600; letter-spacing: 1px;
+}
+QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 8px; padding: 2px; icon-size: 12px; }
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: rgba(255, 255, 255, 0.08); }
+
+QTabWidget::pane { background: #161620; border: 0; border-top: 1px solid #34344a; top: -1px; }
+QTabBar { background: #161620; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #9090ac;
+    padding: 10px 22px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+}
+QTabBar::tab:hover { color: #eeeefc; background: rgba(255, 255, 255, 0.04); }
+QTabBar::tab:selected { color: #eeeefc; background: #1e1e2a; border-top: 3px solid #3B82F6; }
+QTabBar::tab:!selected { border-bottom: 1px solid #34344a; }
+QTabBar::close-button { image: none; background: transparent; border-radius: 8px; padding: 2px; margin: 4px; subcontrol-position: right; }
+QTabBar::close-button:hover { background: rgba(239, 68, 68, 0.35); }
+QTabBar QToolButton { background: #1e1e2a; border: 1px solid #34344a; border-radius: 8px; margin: 6px 2px; }
+
+QGroupBox {
+    background: #1e1e2a; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 14px;
+    margin-top: 16px; padding: 16px 14px 12px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 8px; color: #9090ac; background: #161620;
+    font-weight: 600; letter-spacing: 1px;
+}
+
+QHeaderView { background: #1e1e2a; color: #9090ac; border: 0; }
+QHeaderView::section {
+    background: #1e1e2a; color: #9090ac; border: 0;
+    border-right: 1px solid #34344a; border-bottom: 1px solid #34344a;
+    padding: 8px 12px; font-weight: 600;
+}
+QTreeView, QListView, QTableView {
+    background: #161620; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 12px;
+    alternate-background-color: #1e1e2a;
+    selection-background-color: rgba(59, 130, 246, 0.28); selection-color: #eeeefc;
+    gridline-color: #34344a;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 6px 8px; border-radius: 8px; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: rgba(255, 255, 255, 0.05); }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: rgba(59, 130, 246, 0.28); color: #eeeefc; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #34344a; height: 6px; border-radius: 3px; margin: 0 8px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 6px; border-radius: 3px; }
+QSlider::handle:horizontal { background: #eeeefc; border: 2px solid #3B82F6; width: 16px; height: 16px; margin: -6px 0; border-radius: 10px; }
+QSlider::groove:vertical { background: #34344a; width: 6px; border-radius: 3px; margin: 8px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 6px; border-radius: 3px; }
+QSlider::sub-page:vertical { background: #34344a; width: 6px; border-radius: 3px; }
+QSlider::handle:vertical { background: #eeeefc; border: 2px solid #3B82F6; width: 16px; height: 16px; margin: 0 -6px; border-radius: 10px; }
+
+QSplitter::handle { background: #34344a; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #1e1e2a; color: #9090ac; border: 0; border-top: 1px solid #34344a; }
+QStatusBar::item { border: 0; }
+
+QProgressBar { background: #101018; color: #eeeefc; border: 1px solid #34344a; border-radius: 10px; text-align: center; }
+QProgressBar::chunk { background: #3B82F6; border-radius: 8px; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #34344a; border: 0; }
+
+QFrame#analysisControlBar { background: #1e1e2a; border: 1px solid #34344a; border-radius: 18px; }
+QLabel#AnalysisFormLabel { color: #9090ac; background: transparent; font-weight: 600; padding: 0 6px; }
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip { background: #262636; border: 1px solid #34344a; border-radius: 14px; }
+QLabel#AnalysisStatLabel { color: #9090ac; background: transparent; font-weight: 600; font-size: 9pt; letter-spacing: 1px; }
+QLabel#AnalysisStatValue { color: #eeeefc; background: transparent; font-weight: 700; font-family: "Consolas", "JetBrains Mono", monospace; }
+QLabel#AnalysisStatValue[severity="warning"] { color: #f59e0b; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #ef4444; }
+
+QWidget#ModernAnalysisGraph { background: #101018; border: 1px solid #34344a; border-radius: 16px; }
+
+QFrame#FilterCardRow { background: #262636; border: 1px solid #34344a; border-radius: 18px; }
+QWidget#FilterCardHeader { background: #1e1e2a; border-top-left-radius: 18px; border-top-right-radius: 18px; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #222232; border-bottom-left-radius: 18px; border-bottom-right-radius: 18px; }
 QLabel#FilterTypeBadge {
-    color: white;
-    border-radius: 12px;
-    font-weight: 700;
-    padding: 2px 7px;
+    color: white; border-radius: 12px;
+    font-weight: 700; padding: 3px 10px; min-height: 20px;
+    font-size: 9pt; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #eeeefc; font-weight: 600; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #9090ac; }
+QLabel#FilterCardTitle { color: #eeeefc; background: transparent; font-weight: 600; font-size: 10pt; }
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #9090ac; background: transparent; }
+QLabel#FilterCardNumber { color: #9090ac; background: transparent; font-family: "Consolas", monospace; font-weight: 600; }
 QToolButton#FilterCardIconButton {
-    background: #1e1e2a;
-    color: #eeeefc;
-    border: 1px solid #34344a;
-    border-radius: 8px;
-    min-width: 22px;
-    min-height: 22px;
+    background: #1e1e2a; color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 10px;
+    min-width: 26px; min-height: 26px; padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: #2c2c3e; }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
-}
+QToolButton#FilterCardIconButton:hover { background: #2c2c3e; border-color: rgba(59, 130, 246, 0.55); }
+QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.30); border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor { background: #101018; border: 1px solid #3B82F6; border-radius: 10px; padding: 8px 12px; }
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption { color: #9090ac; font-weight: 600; letter-spacing: 1px; font-size: 9pt; }
 QLabel#EditableValue {
-    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.04); color: #eeeefc;
+    border: 1px solid #34344a; border-radius: 10px;
+    padding: 8px 12px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #101018; border: 1px solid #3B82F6;
+    border-radius: 10px; padding: 8px 12px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath { background: #101018; border: 1px solid #34344a; border-radius: 10px; padding: 8px 12px; }
+QLabel#IncludeCardStatus { color: #ef4444; font-size: 9pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -1,54 +1,256 @@
-QMainWindow, QWidget {
+/* ====================================================================
+   Skin: Soft Light
+   Tokens: bg #f7f7fa / surface #efeff4 / card #ffffff / cardHover #f8f8fc
+           text #1c1c2c / mutedText #707088 / border #e2e2ec
+           accent #3B82F6 / borderRadius 18 / row 44
+   ==================================================================== */
+
+* {
+    outline: 0;
+    selection-background-color: #3B82F6;
+    selection-color: #ffffff;
+}
+
+QWidget {
     background: #f7f7fa;
     color: #1c1c2c;
-    font-family: "Segoe UI";
+    font-family: "Segoe UI", "Noto Sans KR", "Malgun Gothic", sans-serif;
+    font-size: 10pt;
 }
-QMenuBar, QMenu, QToolBar, QDockWidget, QTabWidget::pane {
-    background: #efeff4;
-    color: #1c1c2c;
-    border: 1px solid #e2e2ec;
+
+QMainWindow, QDialog { background: #f7f7fa; }
+QMainWindow::separator { background: #efeff4; width: 6px; height: 6px; }
+
+QToolTip { background: #ffffff; color: #1c1c2c; border: 1px solid #e2e2ec; border-radius: 10px; padding: 6px 12px; }
+
+QMenuBar { background: #efeff4; color: #1c1c2c; padding: 6px 8px; border: 0; border-bottom: 1px solid #e2e2ec; }
+QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 12px; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.18); color: #1c1c2c; }
+
+QMenu { background: #ffffff; color: #1c1c2c; border: 1px solid #e2e2ec; border-radius: 14px; padding: 6px; }
+QMenu::item { background: transparent; padding: 8px 22px; border-radius: 10px; min-width: 140px; }
+QMenu::item:selected { background: rgba(59, 130, 246, 0.18); color: #1c1c2c; }
+QMenu::item:disabled { color: #a0a0b4; }
+QMenu::separator { height: 1px; background: #e2e2ec; margin: 6px 8px; }
+QMenu::indicator { width: 14px; height: 14px; margin-left: 4px; }
+QMenu::indicator:checked { background: #3B82F6; border-radius: 4px; }
+
+QToolBar { background: #efeff4; border: 0; border-bottom: 1px solid #e2e2ec; padding: 6px 8px; spacing: 6px; }
+QToolBar::separator { background: #e2e2ec; width: 1px; margin: 6px 8px; }
+QToolButton { background: transparent; color: #1c1c2c; border: 1px solid transparent; border-radius: 12px; padding: 5px 12px; min-height: 26px; }
+QToolButton:hover { background: rgba(0, 0, 0, 0.04); border: 1px solid rgba(0, 0, 0, 0.06); }
+QToolButton:pressed, QToolButton:checked { background: rgba(59, 130, 246, 0.18); border: 1px solid rgba(59, 130, 246, 0.55); }
+QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+
+QLabel#ToolBarLabel { color: #707088; background: transparent; padding: 0 4px 0 10px; font-weight: 600; }
+
+QPushButton {
+    background: #ffffff; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 12px;
+    padding: 8px 18px; min-height: 24px;
 }
-QScrollArea, QAbstractScrollArea, QLineEdit, QComboBox, QSpinBox {
-    background: #fefefe;
-    color: #1c1c2c;
-    border: 1px solid #e2e2ec;
-    border-radius: 12px;
+QPushButton:hover { background: #f8f8fc; border-color: rgba(59, 130, 246, 0.55); }
+QPushButton:pressed { background: rgba(59, 130, 246, 0.16); border-color: #3B82F6; }
+QPushButton:default { border: 1px solid #3B82F6; }
+QPushButton:disabled { color: #a0a0b4; background: #f4f4f8; border-color: #ececf0; }
+
+QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
+    background: #fefefe; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 12px;
+    padding: 6px 12px;
+    selection-background-color: #3B82F6; selection-color: #ffffff;
 }
-QFrame#FilterCardRow {
-    background: #ffffff;
-    border: 1px solid #e2e2ec;
-    border-radius: 18px;
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid #3B82F6; background: #ffffff; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #a0a0b4; background: #f0f0f4; }
+
+QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
+    subcontrol-origin: border; background: #efeff4;
+    width: 22px; border-left: 1px solid #e2e2ec;
 }
-QWidget#FilterCardHeader {
-    background: #efeff4;
-    border-radius: 18px;
+QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 11px; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 11px; border-top: 1px solid #e2e2ec; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.16); }
+QAbstractSpinBox::up-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 4px solid transparent; border-right: 4px solid transparent; border-bottom: 5px solid #707088;
 }
-QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: #f2f2f7;
-    border-bottom-left-radius: 18px;
-    border-bottom-right-radius: 18px;
+QAbstractSpinBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 5px solid #707088;
 }
+
+QComboBox {
+    background: #ffffff; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 12px;
+    padding: 6px 30px 6px 14px; min-height: 24px;
+}
+QComboBox:hover { background: #f8f8fc; border-color: rgba(59, 130, 246, 0.55); }
+QComboBox:focus, QComboBox:on { border: 1px solid #3B82F6; }
+QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 26px; border: 0; background: transparent; }
+QComboBox::down-arrow {
+    image: none; width: 0; height: 0;
+    border-left: 5px solid transparent; border-right: 5px solid transparent;
+    border-top: 5px solid #707088; margin-right: 10px;
+}
+QComboBox::down-arrow:on { border-top-color: #3B82F6; }
+QComboBox QAbstractItemView {
+    background: #ffffff; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 14px;
+    padding: 6px; outline: 0;
+    selection-background-color: rgba(59, 130, 246, 0.18); selection-color: #1c1c2c;
+}
+QComboBox QAbstractItemView::item { padding: 8px 12px; border-radius: 10px; min-height: 26px; }
+
+QCheckBox, QRadioButton { color: #1c1c2c; background: transparent; spacing: 10px; padding: 4px; }
+QCheckBox:disabled, QRadioButton:disabled { color: #a0a0b4; }
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 18px; height: 18px; background: #ffffff; border: 1px solid #cfcfde;
+}
+QCheckBox::indicator { border-radius: 6px; }
+QRadioButton::indicator { border-radius: 9px; }
+QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: #3B82F6; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: #3B82F6; border-color: #3B82F6; }
+
+QScrollBar:vertical { background: transparent; width: 14px; margin: 6px 2px; border: 0; }
+QScrollBar::handle:vertical { background: rgba(0, 0, 0, 0.10); min-height: 36px; border-radius: 6px; }
+QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:vertical:pressed { background: #3B82F6; }
+QScrollBar:horizontal { background: transparent; height: 14px; margin: 2px 6px; border: 0; }
+QScrollBar::handle:horizontal { background: rgba(0, 0, 0, 0.10); min-width: 36px; border-radius: 6px; }
+QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:horizontal:pressed { background: #3B82F6; }
+QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
+QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
+QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+
+QAbstractScrollArea { background: #f7f7fa; color: #1c1c2c; border: 0; }
+QScrollArea { background: #f7f7fa; border: 0; }
+QScrollArea > QWidget > QWidget { background: #f7f7fa; }
+
+QDockWidget { color: #1c1c2c; background: #f7f7fa; titlebar-close-icon: none; titlebar-normal-icon: none; }
+QDockWidget::title {
+    background: #efeff4; color: #707088;
+    text-align: left; padding: 8px 14px;
+    border: 0; border-bottom: 1px solid #e2e2ec;
+    font-weight: 600; letter-spacing: 1px;
+}
+QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 8px; padding: 2px; icon-size: 12px; }
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: rgba(0, 0, 0, 0.06); }
+
+QTabWidget::pane { background: #f7f7fa; border: 0; border-top: 1px solid #e2e2ec; top: -1px; }
+QTabBar { background: #f7f7fa; border: 0; qproperty-drawBase: 0; }
+QTabBar::tab {
+    background: transparent; color: #707088;
+    padding: 10px 22px; border: 0; border-radius: 0;
+    min-width: 80px; margin: 0;
+}
+QTabBar::tab:hover { color: #1c1c2c; background: rgba(0, 0, 0, 0.04); }
+QTabBar::tab:selected { color: #1c1c2c; background: #ffffff; border-top: 3px solid #3B82F6; }
+QTabBar::tab:!selected { border-bottom: 1px solid #e2e2ec; }
+QTabBar::close-button { image: none; background: transparent; border-radius: 8px; padding: 2px; margin: 4px; subcontrol-position: right; }
+QTabBar::close-button:hover { background: rgba(239, 68, 68, 0.25); }
+QTabBar QToolButton { background: #ffffff; border: 1px solid #e2e2ec; border-radius: 8px; margin: 6px 2px; }
+
+QGroupBox {
+    background: #ffffff; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 14px;
+    margin-top: 16px; padding: 16px 14px 12px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin; subcontrol-position: top left;
+    padding: 0 8px; color: #707088; background: #f7f7fa;
+    font-weight: 600; letter-spacing: 1px;
+}
+
+QHeaderView { background: #efeff4; color: #707088; border: 0; }
+QHeaderView::section {
+    background: #efeff4; color: #707088; border: 0;
+    border-right: 1px solid #e2e2ec; border-bottom: 1px solid #e2e2ec;
+    padding: 8px 12px; font-weight: 600;
+}
+QTreeView, QListView, QTableView {
+    background: #ffffff; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 12px;
+    alternate-background-color: #f8f8fc;
+    selection-background-color: rgba(59, 130, 246, 0.18); selection-color: #1c1c2c;
+    gridline-color: #e2e2ec;
+}
+QTreeView::item, QListView::item, QTableView::item { padding: 6px 8px; border-radius: 8px; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: rgba(0, 0, 0, 0.04); }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: rgba(59, 130, 246, 0.18); color: #1c1c2c; }
+QTreeView::branch { background: transparent; }
+
+QSlider::groove:horizontal { background: #e2e2ec; height: 6px; border-radius: 3px; margin: 0 8px; }
+QSlider::sub-page:horizontal { background: #3B82F6; height: 6px; border-radius: 3px; }
+QSlider::handle:horizontal { background: #ffffff; border: 2px solid #3B82F6; width: 16px; height: 16px; margin: -6px 0; border-radius: 10px; }
+QSlider::groove:vertical { background: #e2e2ec; width: 6px; border-radius: 3px; margin: 8px 0; }
+QSlider::add-page:vertical { background: #3B82F6; width: 6px; border-radius: 3px; }
+QSlider::sub-page:vertical { background: #e2e2ec; width: 6px; border-radius: 3px; }
+QSlider::handle:vertical { background: #ffffff; border: 2px solid #3B82F6; width: 16px; height: 16px; margin: 0 -6px; border-radius: 10px; }
+
+QSplitter::handle { background: #e2e2ec; }
+QSplitter::handle:horizontal { width: 1px; }
+QSplitter::handle:vertical { height: 1px; }
+QSplitter::handle:hover { background: #3B82F6; }
+
+QStatusBar { background: #efeff4; color: #707088; border: 0; border-top: 1px solid #e2e2ec; }
+QStatusBar::item { border: 0; }
+
+QProgressBar { background: #fefefe; color: #1c1c2c; border: 1px solid #e2e2ec; border-radius: 10px; text-align: center; }
+QProgressBar::chunk { background: #3B82F6; border-radius: 8px; }
+
+QFrame[frameShape="4"], QFrame[frameShape="5"] { background: #e2e2ec; border: 0; }
+
+QFrame#analysisControlBar { background: #ffffff; border: 1px solid #e2e2ec; border-radius: 18px; }
+QLabel#AnalysisFormLabel { color: #707088; background: transparent; font-weight: 600; padding: 0 6px; }
+QComboBox#AnalysisFormCombo { min-width: 110px; }
+QFrame#AnalysisStatChip { background: #efeff4; border: 1px solid #e2e2ec; border-radius: 14px; }
+QLabel#AnalysisStatLabel { color: #707088; background: transparent; font-weight: 600; font-size: 9pt; letter-spacing: 1px; }
+QLabel#AnalysisStatValue { color: #1c1c2c; background: transparent; font-weight: 700; font-family: "Consolas", "JetBrains Mono", monospace; }
+QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
+
+QWidget#ModernAnalysisGraph { background: #fefefe; border: 1px solid #e2e2ec; border-radius: 16px; }
+
+QFrame#FilterCardRow { background: #ffffff; border: 1px solid #e2e2ec; border-radius: 18px; }
+QWidget#FilterCardHeader { background: #efeff4; border-top-left-radius: 18px; border-top-right-radius: 18px; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #f2f2f7; border-bottom-left-radius: 18px; border-bottom-right-radius: 18px; }
 QLabel#FilterTypeBadge {
-    color: white;
-    border-radius: 12px;
-    font-weight: 700;
-    padding: 2px 7px;
+    color: white; border-radius: 12px;
+    font-weight: 700; padding: 3px 10px; min-height: 20px;
+    font-size: 9pt; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: #1c1c2c; font-weight: 600; }
-QLabel#FilterCardSummary, QLabel#FilterCardNumber, QLabel#FilterCardRawText { color: #707088; }
+QLabel#FilterCardTitle { color: #1c1c2c; background: transparent; font-weight: 600; font-size: 10pt; }
+QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: #707088; background: transparent; }
+QLabel#FilterCardNumber { color: #707088; background: transparent; font-family: "Consolas", monospace; font-weight: 600; }
 QToolButton#FilterCardIconButton {
-    background: #efeff4;
-    color: #1c1c2c;
-    border: 1px solid #e2e2ec;
-    border-radius: 8px;
-    min-width: 22px;
-    min-height: 22px;
+    background: #efeff4; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 10px;
+    min-width: 26px; min-height: 26px; padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: #f8f8fc; }
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor, QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph {
-    background: transparent;
-    border: none;
-}
+QToolButton#FilterCardIconButton:hover { background: #f8f8fc; border-color: rgba(59, 130, 246, 0.55); }
+QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.22); border-color: #3B82F6; }
+QLineEdit#FilterCardRawEditor { background: #fefefe; border: 1px solid #3B82F6; border-radius: 10px; padding: 8px 12px; }
+QCheckBox#FilterCardEnabled { background: transparent; }
+
+QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
+QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
+QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+QLabel#PreampCardCaption { color: #707088; font-weight: 600; letter-spacing: 1px; font-size: 9pt; }
 QLabel#EditableValue {
-    padding: 6px 10px;
+    background: #efeff4; color: #1c1c2c;
+    border: 1px solid #e2e2ec; border-radius: 10px;
+    padding: 8px 12px;
+    font-family: "Consolas", monospace; font-weight: 700;
 }
+QLineEdit#EditableValueEditor {
+    background: #fefefe; border: 1px solid #3B82F6;
+    border-radius: 10px; padding: 8px 12px;
+    font-family: "Consolas", monospace; font-weight: 700;
+}
+QLineEdit#IncludeCardPath { background: #fefefe; border: 1px solid #e2e2ec; border-radius: 10px; padding: 8px 12px; }
+QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/widgets/EqGraphView.cpp
+++ b/Editor/widgets/EqGraphView.cpp
@@ -67,7 +67,15 @@ void EqGraphView::paintEvent(QPaintEvent*)
 
 	const SkinTokens& tokens = SkinManager::instance()->tokens();
 	QRectF graphRect = rect().adjusted(18, 16, -18, -28);
-	painter.fillRect(rect(), QColor(tokens.graph));
+
+	QRectF bgRect = QRectF(rect()).adjusted(0.5, 0.5, -0.5, -0.5);
+	qreal radius = qMax(0, tokens.borderRadius - 2);
+	QPainterPath bgPath;
+	bgPath.addRoundedRect(bgRect, radius, radius);
+	painter.fillPath(bgPath, QColor(tokens.graph));
+	painter.setPen(QPen(QColor(tokens.border), 1));
+	painter.drawPath(bgPath);
+	painter.setClipPath(bgPath);
 
 	QPen gridPen(QColor(tokens.border), 1);
 	gridPen.setCosmetic(true);

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -22,6 +22,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 
 	cardFrame = new QFrame(this);
 	cardFrame->setObjectName(QStringLiteral("FilterCardRow"));
+	cardFrame->setAttribute(Qt::WA_StyledBackground, true);
 	cardFrame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 	outerLayout->addWidget(cardFrame);
 
@@ -31,6 +32,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 
 	headerWidget = new QWidget(cardFrame);
 	headerWidget->setObjectName(QStringLiteral("FilterCardHeader"));
+	headerWidget->setAttribute(Qt::WA_StyledBackground, true);
 	headerWidget->setMinimumHeight(SkinManager::instance()->tokens().rowHeight);
 	cardLayout->addWidget(headerWidget);
 
@@ -107,6 +109,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 
 	bodyStack = new QStackedWidget(cardFrame);
 	bodyStack->setObjectName(QStringLiteral("FilterCardBody"));
+	bodyStack->setAttribute(Qt::WA_StyledBackground, true);
 	cardLayout->addWidget(bodyStack);
 
 	lineEdit = new QLineEdit(bodyStack);
@@ -118,6 +121,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	{
 		QWidget* editorContainer = new QWidget(bodyStack);
 		editorContainer->setObjectName(QStringLiteral("FilterCardEditor"));
+		editorContainer->setAttribute(Qt::WA_StyledBackground, true);
 		QVBoxLayout* editorLayout = new QVBoxLayout(editorContainer);
 		editorLayout->setContentsMargins(12, 10, 12, 12);
 		editorLayout->addWidget(gui);


### PR DESCRIPTION
## Summary

This PR now contains two related streams of work, kept as separate commits so each phase is reviewable on its own:

### 1. UI overhaul — sweep Qt defaults out of the Editor (commit `7ccb75a`)

The screen mixed modern filter cards with windowsvista menus, toolbars, group boxes and scroll bars. Root causes:

- `main.cpp` only switched to Fusion in dark mode, so light mode rendered with the native Windows style under our QSS.
- Each skin's QSS only styled a handful of widgets, leaving everything else (`QMenuBar`, `QMenu`, `QToolBar`, `QToolButton`, `QPushButton`, `QAbstractSpinBox`, `QComboBox` dropdown/items, `QScrollBar`, `QDockWidget::title`, `QTabBar`, `QGroupBox::title`, `QHeaderView`, `QSlider`, `QSplitter`, `QStatusBar`, `QToolTip`, `QProgressBar`, `QCheckBox/QRadioButton::indicator`) to fall back to whatever Qt's default style picked.
- `MainWindow.ui` hard-coded `QPalette` colors on the analysis labels (red/orange Peak Gain & CPU usage), which beat anything the QSS tried to do.
- The old "Settings" / "Estimated properties" `QGroupBox` column in the analysis dock didn't match the design at all.

Fix:

- Always wrap Fusion in `CustomStyle`; load the saved skin's QSS and derive a `QPalette` from its tokens before `MainWindow` shows.
- Rewrite all eight skin files end-to-end (~250–800 lines each) to cover every standard Qt widget plus the application-specific object names. Force `Qt::WA_StyledBackground` on the frame widgets that QSS needs to paint.
- Drop the `QGroupBox` left column. Replace it with a compact control bar: `From / Channel / Res` followed by `Peak / Latency / Init / CPU` chips. Severity colors are driven by a dynamic `severity` property the QSS selects against.
- `EqGraphView::paintEvent` clips to a rounded background so the graph picks up the skin's border-radius.

### 2. NSIS → Velopack migration (commits `7729ca4`, `f51262c`, `ecf0351`, `15efded`, `a982e7e`)

The previous CI wrapped the NSIS Setup.exe inside a Velopack package — double install, NSIS .exe extracted inside the install dir. Five-phase migration per `NSIS_to_Velopack_Migration.md`:

- **Phase 1** — `helpers/ApoRegistration{.h,.cpp}` wraps every NSIS install / uninstall step (regsvr32, HKLM registry writes, DisableProtectedAudioDG, config dir ACL via icacls, AudioSrv start/stop, per-device APO removal, legacy NSIS install detection + config migration). All steps are headless and bounded by `waitForProcess` so they fit Velopack's 15/30 s hook windows.
- **Phase 2** — Editor's `main()` parses `--veloapp-install / --veloapp-updated / --veloapp-obsolete / --veloapp-uninstall` before any Qt init, dispatches to `ApoRegistration`, and exits with the result code. On normal launches with `VELOPACK_FIRSTRUN` set, skips `doChecks()` and spawns `DeviceSelector.exe /i` so the user can pick a device.
- **Phase 3** — `create-release` now depends on `build` directly, downloads `EqualizerAPO-*` artifacts, relocates Qt plugin folders under `qt/` (Editor calls `addLibraryPath("qt")`), copies `Setup/config/*.txt` and the `.url` shortcuts, and `vpk pack`s the result with Editor.exe as `--mainExe`. NSIS `Setup-*.exe` is no longer wrapped.
- **Phase 4** — `helpers/VelopackBootstrap{.h,.cpp}` centralizes Velopack runtime detection (`VELOPACK_FIRSTRUN`, `VELOPACK_RESTART`, `<root>\current\Editor.exe` layout, sibling `Update.exe`) and provides `triggerBackgroundUpdate(repo)` to spawn `Update.exe --silent --update <github url>` detached. Editor calls it on startup so Velopack stages the new version while the user works.
- **Phase 5** — Removes the `create-installer` CI job, all four `.nsi` scripts, the vendored `Setup/lib{32,64,ARM64}` Qt + runtime DLLs, NSIS calls in `build.bat`, UpdateChecker's `-i / -u` scheduled-task options, and `helpers/TaskSchedulerHelper.{h,cpp}`. `Setup/config` and the `.url` shortcuts stay. Agent.md and Wiki/Developer.txt are refreshed.

## Test plan

Linux container; the real verification has to run on Windows in CI. Manual smoke tests after the Windows build:

**UI overhaul:**
- [ ] Launch in light mode — no native Windows chrome on menubar, toolbar, tab bar, scroll bars, dock title.
- [ ] Launch in dark mode — same.
- [ ] Cycle `View → Interface → Minimal / Glassy / Industrial / Soft` + toggle `Dark theme`; every widget repaints to the chosen skin.
- [ ] Open the analysis panel — `From / Channel / Res` controls and `Peak / Latency / Init / CPU` chips render in the new compact bar. Force >0 dB peak and >50% CPU to confirm the severity property turns the values amber / red.
- [ ] Load a config with channel scopes and includes — filter cards render correctly including the indent decoration.

**Velopack migration:**
- [ ] CI builds without `create-installer`; `create-release` produces a Velopack `Setup.exe` + `.nupkg` per channel without wrapping a NSIS exe.
- [ ] Install the Setup.exe on a clean VM and verify EqualizerAPO.dll lands in the install dir, HKLM registry keys are written, `DisableProtectedAudioDG` is set, and DeviceSelector pops up on first launch (`VELOPACK_FIRSTRUN`).
- [ ] Uninstall via Add/Remove Programs — DeviceSelector `/u` runs (via Velopack hook → ApoRegistration::uninstall), APO is removed from every device, registry is cleaned.
- [ ] Push a newer release; on the next Editor launch, confirm `Update.exe --silent --update` runs in background and the new version is applied on the launch after that.
- [ ] Confirm no scheduled task named `EqualizerAPOUpdateChecker` is created (it would have been by the deleted UpdateChecker `-i` path).

https://claude.ai/code/session_01UG9E52BXvXMudEDpkacnzz