### PR TITLE
Add stage-level profiler for the audio pipeline

### DIFF
--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -186,7 +186,8 @@ int main(int argc, char** argv)
 			if (!verbose)
 				cout << "\nLoading configuration took " << initTime * 1000.0 << " ms\n";
 
-			unsigned repeatCount = std::max(1u, repeatArg.getValue());
+			unsigned repeatCount = repeatArg.getValue();
+			if (repeatCount < 1) repeatCount = 1;
 			bool profileEnabled = profileArg.getValue();
 
 			if (profileEnabled)

--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -24,6 +24,9 @@
 #endif
 #include <cstdlib>
 #include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <string>
@@ -37,6 +40,7 @@
 #include "../helpers/StringHelper.h"
 #include "../helpers/PrecisionTimer.h"
 #include "../helpers/MemoryHelper.h"
+#include "../helpers/PerfProfile.h"
 
 using std::cerr;
 using std::cout;
@@ -62,6 +66,9 @@ int main(int argc, char** argv)
 
 		TCLAP::SwitchArg noPauseArg("", "nopause", "Do not wait for key press at the end", cmd);
 		TCLAP::SwitchArg verboseArg("v", "verbose", "Print trace and error messages to console instead of logfile", cmd);
+		TCLAP::SwitchArg profileArg("", "profile", "Enable per-stage performance instrumentation (FilterEngine + filter breakdown)", cmd);
+		TCLAP::ValueArg<unsigned> repeatArg("", "repeat", "Number of times to repeat the processing loop for averaging (Default: 1)", false, 1, "integer", cmd);
+		TCLAP::ValueArg<string> dumpCsvArg("", "dump-batches", "Path to a CSV file to write per-batch timings to", false, "", "string", cmd);
 		TCLAP::ValueArg<string> guidArg("", "guid", "Endpoint GUID to use when parsing configuration (Default: <empty>)", false, "", "string", cmd);
 		TCLAP::ValueArg<string> connectionnameArg("", "connectionname", "Connection name to use when parsing configuration (Default: File output)", false, "File output", "string", cmd);
 		TCLAP::ValueArg<string> devicenameArg("", "devicename", "Device name to use when parsing configuration (Default: Benchmark)", false, "Benchmark", "string", cmd);
@@ -179,19 +186,79 @@ int main(int argc, char** argv)
 			if (!verbose)
 				cout << "\nLoading configuration took " << initTime * 1000.0 << " ms\n";
 
-			cout << "\nProcessing " << frameCount << " frames from " << channelCount << " channel(s)\n";
+			unsigned repeatCount = std::max(1u, repeatArg.getValue());
+			bool profileEnabled = profileArg.getValue();
+
+			if (profileEnabled)
+			{
+				PerfProfile::reset();
+				PerfProfile::enable();
+			}
+
+			cout << "\nProcessing " << frameCount << " frames from " << channelCount << " channel(s)";
+			if (repeatCount > 1)
+				cout << " x" << repeatCount << " repetitions";
+			cout << "\n";
+
+			vector<double> batchTimes;
+			batchTimes.reserve(((size_t)frameCount / batchsize + 1) * repeatCount);
 
 			timer.start();
 
-			for (unsigned i = 0; i < frameCount; i += batchsize)
+			PrecisionTimer batchTimer;
+			for (unsigned r = 0; r < repeatCount; r++)
 			{
-				engine.process(buf2.data() + i * channelCount, buf.data() + i * channelCount, min(batchsize, frameCount - i));
+				for (unsigned i = 0; i < frameCount; i += batchsize)
+				{
+					unsigned actual = min(batchsize, frameCount - i);
+					batchTimer.start();
+					engine.process(buf2.data() + i * channelCount, buf.data() + i * channelCount, actual);
+					batchTimes.push_back(batchTimer.stop());
+				}
 			}
 
 			double time = timer.stop();
 
-			cout << frameCount * channelCount << " samples processed in " << time << " seconds\n";
-			cout << "This is equivalent to " << 100.0f * time / length << "% CPU load (one core) when processing in real time\n";
+			if (profileEnabled)
+				PerfProfile::disable();
+
+			double totalAudio = length * repeatCount;
+
+			cout << frameCount * channelCount * repeatCount << " samples processed in " << time << " seconds\n";
+			cout << "This is equivalent to " << 100.0f * time / totalAudio << "% CPU load (one core) when processing in real time\n";
+
+			if (!batchTimes.empty())
+			{
+				vector<double> sorted = batchTimes;
+				std::sort(sorted.begin(), sorted.end());
+				auto pick = [&](double pct) {
+					size_t n = sorted.size();
+					size_t idx = (size_t)(pct * (n - 1));
+					return sorted[idx];
+				};
+				double sum = std::accumulate(sorted.begin(), sorted.end(), 0.0);
+				double mean = sum / sorted.size();
+				cout << "Batch timings (n=" << sorted.size() << ", " << batchsize << " frames each, microseconds):\n";
+				cout << "  min:    " << sorted.front() * 1e6 << "\n";
+				cout << "  median: " << pick(0.50) * 1e6 << "\n";
+				cout << "  mean:   " << mean * 1e6 << "\n";
+				cout << "  p95:    " << pick(0.95) * 1e6 << "\n";
+				cout << "  p99:    " << pick(0.99) * 1e6 << "\n";
+				cout << "  max:    " << sorted.back() * 1e6 << "\n";
+			}
+
+			if (profileEnabled)
+				PerfProfile::report(cout);
+
+			string dumpCsvPath = dumpCsvArg.getValue();
+			if (!dumpCsvPath.empty())
+			{
+				std::ofstream csv(dumpCsvPath);
+				csv << "batch_index,seconds\n";
+				for (size_t i = 0; i < batchTimes.size(); i++)
+					csv << i << "," << batchTimes[i] << "\n";
+				cout << "\nPer-batch timings written to " << dumpCsvPath << "\n";
+			}
 
 			unsigned clipCount = 0;
 			float max = 0;

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -344,6 +344,7 @@
     <ClInclude Include="helpers\GainIterator.h" />
     <ClInclude Include="helpers\LogHelper.h" />
     <ClInclude Include="helpers\MemoryHelper.h" />
+    <ClInclude Include="helpers\PerfProfile.h" />
     <ClInclude Include="helpers\PrecisionTimer.h" />
     <ClInclude Include="helpers\RegistryHelper.h" />
     <ClInclude Include="helpers\ScopeGuard.h" />
@@ -408,6 +409,7 @@
     <ClCompile Include="helpers\GainIterator.cpp" />
     <ClCompile Include="helpers\LogHelper.cpp" />
     <ClCompile Include="helpers\MemoryHelper.cpp" />
+    <ClCompile Include="helpers\PerfProfile.cpp" />
     <ClCompile Include="helpers\RegistryHelper.cpp" />
     <ClCompile Include="helpers\StringHelper.cpp" />
     <ClCompile Include="helpers\VSTPluginInstance.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -95,6 +95,9 @@
     <ClInclude Include="helpers\MemoryHelper.h">
       <Filter>helpers</Filter>
     </ClInclude>
+    <ClInclude Include="helpers\PerfProfile.h">
+      <Filter>helpers</Filter>
+    </ClInclude>
     <ClInclude Include="helpers\PrecisionTimer.h">
       <Filter>helpers</Filter>
     </ClInclude>
@@ -242,6 +245,9 @@
       <Filter>helpers</Filter>
     </ClCompile>
     <ClCompile Include="helpers\MemoryHelper.cpp">
+      <Filter>helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="helpers\PerfProfile.cpp">
       <Filter>helpers</Filter>
     </ClCompile>
     <ClCompile Include="helpers\RegistryHelper.cpp">

--- a/FilterConfiguration.cpp
+++ b/FilterConfiguration.cpp
@@ -19,9 +19,11 @@
 
 #include "stdafx.h"
 #include <algorithm>
+#include <typeinfo>
 
 #include "FilterEngine.h"
 #include "FilterConfiguration.h"
+#include "helpers/PerfProfile.h"
 
 FilterConfiguration::FilterConfiguration(FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount)
 {
@@ -114,7 +116,15 @@ void FilterConfiguration::process(unsigned frameCount)
 				currentSamples2[j] = allSamples2[filterInfo->outChannels[j]];
 		}
 
-		filterInfo->filter->process(currentSamples2.data(), currentSamples.data(), frameCount);
+		if (PerfProfile::active())
+		{
+			PerfScope _ps(typeid(*filterInfo->filter).name());
+			filterInfo->filter->process(currentSamples2.data(), currentSamples.data(), frameCount);
+		}
+		else
+		{
+			filterInfo->filter->process(currentSamples2.data(), currentSamples.data(), frameCount);
+		}
 
 		if (!filterInfo->inPlace)
 		{

--- a/engine/FilterEngine.Process.cpp
+++ b/engine/FilterEngine.Process.cpp
@@ -40,6 +40,7 @@
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
 #include "helpers/ChannelHelper.h"
+#include "helpers/PerfProfile.h"
 #include "ConfigurationFileReader.h"
 #include "FilterEngine.h"
 #include "filters/ExpressionFilterFactory.h"
@@ -153,6 +154,8 @@ void convertDoubleToFloat(float* dest, const double* src, size_t count) {
 // Process interleaved audio (float*)
 void FilterEngine::process(float* output, float* input, unsigned frameCount)
 {
+	PerfScope _eapo_total("FilterEngine::process(float interleaved)");
+
 	if (currentConfig->isEmpty() && !nextConfig)
 	{
 		// Bypass mode: if no filters are active, just copy input to output if necessary.
@@ -167,24 +170,45 @@ void FilterEngine::process(float* output, float* input, unsigned frameCount)
 
 	// Conversion from float to double using SIMD
 	const unsigned inputSampleCount = inputChannelCount * frameCount;
-	convertFloatToDouble(inputBuf1D.data(), input, inputSampleCount);
+	{
+		PerfScope _ps("FilterEngine::convertFloatToDouble");
+		convertFloatToDouble(inputBuf1D.data(), input, inputSampleCount);
+	}
 
-	// The core processing logic remains unchanged
-	currentConfig->read(inputBuf1D.data(), frameCount);
-	currentConfig->process(frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::read(interleaved)");
+		currentConfig->read(inputBuf1D.data(), frameCount);
+	}
+	{
+		PerfScope _ps("FilterConfiguration::process(current)");
+		currentConfig->process(frameCount);
+	}
 
 	if (nextConfig)
 	{
-		nextConfig->read(inputBuf1D.data(), frameCount);
-		nextConfig->process(frameCount);
+		{
+			PerfScope _ps("FilterConfiguration::read(interleaved)");
+			nextConfig->read(inputBuf1D.data(), frameCount);
+		}
+		{
+			PerfScope _ps("FilterConfiguration::process(next)");
+			nextConfig->process(frameCount);
+		}
+		PerfScope _ps("FilterConfiguration::doTransition");
 		transitionCounter = currentConfig->doTransition(nextConfig.get(), frameCount, transitionCounter, transitionLength);
 	}
 
-	currentConfig->write(outputBuf1D.data(), frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::write(interleaved)");
+		currentConfig->write(outputBuf1D.data(), frameCount);
+	}
 
 	// Conversion from double back to float using SIMD
 	const unsigned outputSampleCount = outputChannelCount * frameCount;
-	convertDoubleToFloat(output, outputBuf1D.data(), outputSampleCount);
+	{
+		PerfScope _ps("FilterEngine::convertDoubleToFloat");
+		convertDoubleToFloat(output, outputBuf1D.data(), outputSampleCount);
+	}
 
 	finishTransitionIfReady();
 }
@@ -192,6 +216,8 @@ void FilterEngine::process(float* output, float* input, unsigned frameCount)
 // Process non-interleaved audio (float**)
 void FilterEngine::process(float** output, float** input, unsigned frameCount)
 {
+	PerfScope _eapo_total("FilterEngine::process(float planar)");
+
 	if (currentConfig->isEmpty() && !nextConfig)
 	{
 		// Bypass mode
@@ -204,36 +230,56 @@ void FilterEngine::process(float** output, float** input, unsigned frameCount)
 
 	resizeBuffers(frameCount);
 
-	// Optimized conversion for each channel
-	for (unsigned c = 0; c < inputChannelCount; c++) {
-		convertFloatToDouble(inputBuf2D[c].get(), input[c], frameCount);
+	{
+		PerfScope _ps("FilterEngine::convertFloatToDouble");
+		for (unsigned c = 0; c < inputChannelCount; c++) {
+			convertFloatToDouble(inputBuf2D[c].get(), input[c], frameCount);
+		}
 	}
 
-	// Core processing logic is the same
-	currentConfig->read(inputBuf2DPtrs.data(), frameCount);
-	currentConfig->process(frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::read(planar)");
+		currentConfig->read(inputBuf2DPtrs.data(), frameCount);
+	}
+	{
+		PerfScope _ps("FilterConfiguration::process(current)");
+		currentConfig->process(frameCount);
+	}
 
 	if (nextConfig)
 	{
-		nextConfig->read(inputBuf2DPtrs.data(), frameCount);
-		nextConfig->process(frameCount);
+		{
+			PerfScope _ps("FilterConfiguration::read(planar)");
+			nextConfig->read(inputBuf2DPtrs.data(), frameCount);
+		}
+		{
+			PerfScope _ps("FilterConfiguration::process(next)");
+			nextConfig->process(frameCount);
+		}
+		PerfScope _ps("FilterConfiguration::doTransition");
 		transitionCounter = currentConfig->doTransition(nextConfig.get(), frameCount, transitionCounter, transitionLength);
 	}
 
-	currentConfig->write(outputBuf2DPtrs.data(), frameCount);
-
-	// Optimized conversion back for each channel
-	for (unsigned c = 0; c < outputChannelCount; c++) {
-		convertDoubleToFloat(output[c], outputBuf2D[c].get(), frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::write(planar)");
+		currentConfig->write(outputBuf2DPtrs.data(), frameCount);
 	}
 
-	// Transition logic remains the same
+	{
+		PerfScope _ps("FilterEngine::convertDoubleToFloat");
+		for (unsigned c = 0; c < outputChannelCount; c++) {
+			convertDoubleToFloat(output[c], outputBuf2D[c].get(), frameCount);
+		}
+	}
+
 	finishTransitionIfReady();
 }
 
 // Process interleaved audio (double*) - native double precision without conversion
 void FilterEngine::process(double* output, double* input, unsigned frameCount)
 {
+	PerfScope _eapo_total("FilterEngine::process(double interleaved)");
+
 	if (currentConfig->isEmpty() && !nextConfig)
 	{
 		// Bypass mode: if no filters are active, just copy input to output if necessary.
@@ -243,18 +289,33 @@ void FilterEngine::process(double* output, double* input, unsigned frameCount)
 		return;
 	}
 
-	// Direct double-precision processing - no float conversion needed!
-	currentConfig->read(input, frameCount);
-	currentConfig->process(frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::read(interleaved)");
+		currentConfig->read(input, frameCount);
+	}
+	{
+		PerfScope _ps("FilterConfiguration::process(current)");
+		currentConfig->process(frameCount);
+	}
 
 	if (nextConfig)
 	{
-		nextConfig->read(input, frameCount);
-		nextConfig->process(frameCount);
+		{
+			PerfScope _ps("FilterConfiguration::read(interleaved)");
+			nextConfig->read(input, frameCount);
+		}
+		{
+			PerfScope _ps("FilterConfiguration::process(next)");
+			nextConfig->process(frameCount);
+		}
+		PerfScope _ps("FilterConfiguration::doTransition");
 		transitionCounter = currentConfig->doTransition(nextConfig.get(), frameCount, transitionCounter, transitionLength);
 	}
 
-	currentConfig->write(output, frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::write(interleaved)");
+		currentConfig->write(output, frameCount);
+	}
 
 	finishTransitionIfReady();
 }
@@ -262,6 +323,8 @@ void FilterEngine::process(double* output, double* input, unsigned frameCount)
 // Process non-interleaved audio (double**) - native double precision without conversion
 void FilterEngine::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _eapo_total("FilterEngine::process(double planar)");
+
 	if (currentConfig->isEmpty() && !nextConfig)
 	{
 		// Bypass mode
@@ -272,18 +335,33 @@ void FilterEngine::process(double** output, double** input, unsigned frameCount)
 		return;
 	}
 
-	// Direct double-precision processing - no float conversion needed!
-	currentConfig->read(input, frameCount);
-	currentConfig->process(frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::read(planar)");
+		currentConfig->read(input, frameCount);
+	}
+	{
+		PerfScope _ps("FilterConfiguration::process(current)");
+		currentConfig->process(frameCount);
+	}
 
 	if (nextConfig)
 	{
-		nextConfig->read(input, frameCount);
-		nextConfig->process(frameCount);
+		{
+			PerfScope _ps("FilterConfiguration::read(planar)");
+			nextConfig->read(input, frameCount);
+		}
+		{
+			PerfScope _ps("FilterConfiguration::process(next)");
+			nextConfig->process(frameCount);
+		}
+		PerfScope _ps("FilterConfiguration::doTransition");
 		transitionCounter = currentConfig->doTransition(nextConfig.get(), frameCount, transitionCounter, transitionLength);
 	}
 
-	currentConfig->write(output, frameCount);
+	{
+		PerfScope _ps("FilterConfiguration::write(planar)");
+		currentConfig->write(output, frameCount);
+	}
 
 	finishTransitionIfReady();
 }

--- a/helpers/PerfProfile.cpp
+++ b/helpers/PerfProfile.cpp
@@ -20,11 +20,19 @@
 #include "stdafx.h"
 #include "PerfProfile.h"
 #include <algorithm>
+#include <cstdint>
 #include <iomanip>
+#include <iostream>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 namespace PerfProfile
 {
@@ -35,14 +43,36 @@ namespace
 {
 	struct Entry
 	{
-		uint64_t count = 0;
+		std::uint64_t count = 0;
 		double total = 0.0;
 		double minVal = 0.0;
 		double maxVal = 0.0;
 	};
 
-	std::mutex s_mutex;
-	std::unordered_map<std::string, Entry> s_entries;
+	std::mutex& mutex_instance()
+	{
+		static std::mutex m;
+		return m;
+	}
+
+	std::unordered_map<std::string, Entry>& entries_instance()
+	{
+		static std::unordered_map<std::string, Entry> e;
+		return e;
+	}
+
+	LARGE_INTEGER qpc_frequency()
+	{
+		LARGE_INTEGER f;
+		QueryPerformanceFrequency(&f);
+		return f;
+	}
+}
+
+double qpc_to_seconds(std::int64_t delta)
+{
+	static LARGE_INTEGER freq = qpc_frequency();
+	return static_cast<double>(delta) / static_cast<double>(freq.QuadPart);
 }
 
 void enable()
@@ -57,14 +87,14 @@ void disable()
 
 void reset()
 {
-	std::lock_guard<std::mutex> lock(s_mutex);
-	s_entries.clear();
+	std::lock_guard<std::mutex> lock(mutex_instance());
+	entries_instance().clear();
 }
 
 void record(const char* label, double seconds)
 {
-	std::lock_guard<std::mutex> lock(s_mutex);
-	auto& entry = s_entries[label];
+	std::lock_guard<std::mutex> lock(mutex_instance());
+	auto& entry = entries_instance()[label];
 	if (entry.count == 0)
 	{
 		entry.minVal = seconds;
@@ -83,11 +113,12 @@ void report(std::ostream& os)
 {
 	std::vector<std::pair<std::string, Entry>> rows;
 	{
-		std::lock_guard<std::mutex> lock(s_mutex);
-		rows.assign(s_entries.begin(), s_entries.end());
+		std::lock_guard<std::mutex> lock(mutex_instance());
+		auto& entries = entries_instance();
+		rows.assign(entries.begin(), entries.end());
 	}
 
-	std::sort(rows.begin(), rows.end(), [](const auto& a, const auto& b) {
+	std::sort(rows.begin(), rows.end(), [](const std::pair<std::string, Entry>& a, const std::pair<std::string, Entry>& b) {
 		return a.second.total > b.second.total;
 	});
 
@@ -103,9 +134,9 @@ void report(std::ostream& os)
 
 	for (const auto& row : rows)
 	{
-		const auto& label = row.first;
-		const auto& entry = row.second;
-		double avg_us = entry.count > 0 ? (entry.total / entry.count) * 1e6 : 0.0;
+		const std::string& label = row.first;
+		const Entry& entry = row.second;
+		double avg_us = entry.count > 0 ? (entry.total / static_cast<double>(entry.count)) * 1e6 : 0.0;
 		os << "  " << std::left << std::setw(56) << label
 			<< std::right << std::setw(10) << entry.count
 			<< std::setw(14) << std::fixed << std::setprecision(3) << (entry.total * 1000.0)
@@ -117,4 +148,25 @@ void report(std::ostream& os)
 	os << "=================================================\n";
 }
 
+}
+
+PerfScope::PerfScope(const char* label)
+	: start_count_(0), label_(label), active_(PerfProfile::active())
+{
+	if (active_)
+	{
+		LARGE_INTEGER c;
+		QueryPerformanceCounter(&c);
+		start_count_ = c.QuadPart;
+	}
+}
+
+PerfScope::~PerfScope()
+{
+	if (active_)
+	{
+		LARGE_INTEGER c;
+		QueryPerformanceCounter(&c);
+		PerfProfile::record(label_, PerfProfile::qpc_to_seconds(c.QuadPart - start_count_));
+	}
 }

--- a/helpers/PerfProfile.cpp
+++ b/helpers/PerfProfile.cpp
@@ -1,0 +1,120 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2026  EqualizerAPO-XT contributors
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+#include "PerfProfile.h"
+#include <algorithm>
+#include <iomanip>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace PerfProfile
+{
+
+std::atomic<bool> g_active{false};
+
+namespace
+{
+	struct Entry
+	{
+		uint64_t count = 0;
+		double total = 0.0;
+		double minVal = 0.0;
+		double maxVal = 0.0;
+	};
+
+	std::mutex s_mutex;
+	std::unordered_map<std::string, Entry> s_entries;
+}
+
+void enable()
+{
+	g_active.store(true, std::memory_order_release);
+}
+
+void disable()
+{
+	g_active.store(false, std::memory_order_release);
+}
+
+void reset()
+{
+	std::lock_guard<std::mutex> lock(s_mutex);
+	s_entries.clear();
+}
+
+void record(const char* label, double seconds)
+{
+	std::lock_guard<std::mutex> lock(s_mutex);
+	auto& entry = s_entries[label];
+	if (entry.count == 0)
+	{
+		entry.minVal = seconds;
+		entry.maxVal = seconds;
+	}
+	else
+	{
+		if (seconds < entry.minVal) entry.minVal = seconds;
+		if (seconds > entry.maxVal) entry.maxVal = seconds;
+	}
+	entry.total += seconds;
+	entry.count++;
+}
+
+void report(std::ostream& os)
+{
+	std::vector<std::pair<std::string, Entry>> rows;
+	{
+		std::lock_guard<std::mutex> lock(s_mutex);
+		rows.assign(s_entries.begin(), s_entries.end());
+	}
+
+	std::sort(rows.begin(), rows.end(), [](const auto& a, const auto& b) {
+		return a.second.total > b.second.total;
+	});
+
+	os << "\n=== PerfProfile (sorted by total time) ===\n";
+	os << "  " << std::left << std::setw(56) << "Label"
+		<< std::right << std::setw(10) << "Calls"
+		<< std::setw(14) << "Total(ms)"
+		<< std::setw(12) << "Avg(us)"
+		<< std::setw(12) << "Min(us)"
+		<< std::setw(12) << "Max(us)"
+		<< "\n";
+	os << "  " << std::string(56 + 10 + 14 + 12 + 12 + 12, '-') << "\n";
+
+	for (const auto& row : rows)
+	{
+		const auto& label = row.first;
+		const auto& entry = row.second;
+		double avg_us = entry.count > 0 ? (entry.total / entry.count) * 1e6 : 0.0;
+		os << "  " << std::left << std::setw(56) << label
+			<< std::right << std::setw(10) << entry.count
+			<< std::setw(14) << std::fixed << std::setprecision(3) << (entry.total * 1000.0)
+			<< std::setw(12) << std::fixed << std::setprecision(2) << avg_us
+			<< std::setw(12) << std::fixed << std::setprecision(2) << (entry.minVal * 1e6)
+			<< std::setw(12) << std::fixed << std::setprecision(2) << (entry.maxVal * 1e6)
+			<< "\n";
+	}
+	os << "=================================================\n";
+}
+
+}

--- a/helpers/PerfProfile.h
+++ b/helpers/PerfProfile.h
@@ -20,14 +20,12 @@
 #pragma once
 
 #include <atomic>
-#include <ostream>
-#include "PrecisionTimer.h"
+#include <cstdint>
+#include <iosfwd>
 
 namespace PerfProfile
 {
 	// Active flag: relaxed atomic so the hot-path check is a single load with no fences.
-	// The release/uninstall build of EqualizerAPO.dll links the same translation units,
-	// so the flag stays off by default and Benchmark.exe is the only consumer that flips it.
 	extern std::atomic<bool> g_active;
 
 	inline bool active() noexcept
@@ -42,25 +40,18 @@ namespace PerfProfile
 	void report(std::ostream& os);
 }
 
+// RAII timer. Implementation lives in PerfProfile.cpp to avoid pulling
+// <windows.h> (via PrecisionTimer.h) into every translation unit that
+// only needs to declare a profile scope.
 class PerfScope
 {
-	PrecisionTimer timer_;
+	std::int64_t start_count_;
 	const char* label_;
 	bool active_;
 
 public:
-	explicit PerfScope(const char* label) noexcept
-		: label_(label), active_(PerfProfile::active())
-	{
-		if (active_)
-			timer_.start();
-	}
-
-	~PerfScope() noexcept
-	{
-		if (active_)
-			PerfProfile::record(label_, timer_.stop());
-	}
+	explicit PerfScope(const char* label);
+	~PerfScope();
 
 	PerfScope(const PerfScope&) = delete;
 	PerfScope& operator=(const PerfScope&) = delete;

--- a/helpers/PerfProfile.h
+++ b/helpers/PerfProfile.h
@@ -1,0 +1,67 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2026  EqualizerAPO-XT contributors
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <ostream>
+#include "PrecisionTimer.h"
+
+namespace PerfProfile
+{
+	// Active flag: relaxed atomic so the hot-path check is a single load with no fences.
+	// The release/uninstall build of EqualizerAPO.dll links the same translation units,
+	// so the flag stays off by default and Benchmark.exe is the only consumer that flips it.
+	extern std::atomic<bool> g_active;
+
+	inline bool active() noexcept
+	{
+		return g_active.load(std::memory_order_relaxed);
+	}
+
+	void enable();
+	void disable();
+	void reset();
+	void record(const char* label, double seconds);
+	void report(std::ostream& os);
+}
+
+class PerfScope
+{
+	PrecisionTimer timer_;
+	const char* label_;
+	bool active_;
+
+public:
+	explicit PerfScope(const char* label) noexcept
+		: label_(label), active_(PerfProfile::active())
+	{
+		if (active_)
+			timer_.start();
+	}
+
+	~PerfScope() noexcept
+	{
+		if (active_)
+			PerfProfile::record(label_, timer_.stop());
+	}
+
+	PerfScope(const PerfScope&) = delete;
+	PerfScope& operator=(const PerfScope&) = delete;
+};


### PR DESCRIPTION
## Summary
- Adds `PerfProfile` helper (`helpers/PerfProfile.{h,cpp}`) with an atomic activation flag and RAII `PerfScope`. The release DLL keeps a single relaxed atomic load on the hot path; only `Benchmark.exe` flips it on.
- `FilterEngine::process` (all 4 overloads: float/double × interleaved/planar) is wrapped per stage: `convertFloatToDouble`, `FilterConfiguration::read`, `FilterConfiguration::process` (current + next config), `FilterConfiguration::doTransition`, `FilterConfiguration::write`, `convertDoubleToFloat`.
- `FilterConfiguration::process` walks the filter chain through `typeid(*filter).name()`-named scopes so the report breaks down BiQuad vs Convolution vs ChannelFilter vs ... time.
- `Benchmark.cpp` gains three options:
  - `--profile`: activate the instrumentation and print the per-stage report
  - `--repeat N`: run the processing loop N times for averaging
  - `--dump-batches <csv>`: write raw per-batch timings to CSV
  - and prints min / median / mean / p95 / p99 / max batch latencies on every run.

## Why
Before chasing the BiQuad gather/scatter rewrite, DEINTERLEAVE SIMD, FFTW wisdom, or virtual-call fusion, we need to know where the time actually goes. The existing `Benchmark.exe` only printed total wall time, which can't attribute regressions or wins to a stage. This change is the measurement floor every later optimization PR will compare against.

## Test plan
- [ ] Build `Common`, `Benchmark`, `EqualizerAPO` (Release, win32 + x64 + ARM64) — confirms PerfProfile compiles under the SIMD matrix and that the DLL still links.
- [ ] `Benchmark.exe --nopause` (no profile flag) — confirm output is unchanged besides the new batch-percentile block, i.e. the release DLL hot path is unaffected when profiling is off.
- [ ] `Benchmark.exe --profile --nopause --repeat 5` against a real config file — verify the per-stage report lists FilterEngine stages and at least one filter type (e.g. `class BiQuadFilter`), and that totals sum to roughly the wall-clock time.
- [ ] `Benchmark.exe --profile --dump-batches out.csv --nopause` — verify CSV has one row per batch and that batch count matches `frameCount/batchsize × repeat`.

https://claude.ai/code/session_01UG9E52BXvXMudEDpkacnzz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UG9E52BXvXMudEDpkacnzz)_