### PR TITLE
Add "Import to config directory" flow for Include cards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [
-          windows-x64-sse2,
-          windows-x64-avx,
-          windows-x64-avx2,
-          windows-x64-avx512,
-          windows-x64-avx10_1,
-          windows-arm64
-        ]
-        # On a pull request, exclude every variant except AVX2. The full
-        # matrix, cross-variant compare, and release packaging stay on
-        # the push to main.
-        exclude: ${{ fromJson(github.event_name == 'pull_request' && '[{"name":"windows-x64-sse2"},{"name":"windows-x64-avx"},{"name":"windows-x64-avx512"},{"name":"windows-x64-avx10_1"},{"name":"windows-arm64"}]' || '[]') }}
+        # On a pull request only the AVX2 variant runs. On push to main the
+        # full six-variant matrix runs. matrix.name is evaluated at workflow
+        # parse time, so we drive it from a fromJson expression rather than
+        # matrix.exclude (which the runner appears to ignore in PR context).
+        name: ${{ fromJson(github.event_name == 'pull_request' && '["windows-x64-avx2"]' || '["windows-x64-sse2","windows-x64-avx","windows-x64-avx2","windows-x64-avx512","windows-x64-avx10_1","windows-arm64"]') }}
         include:
           - name: windows-x64-sse2
             os: windows-2025

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -171,6 +171,7 @@ SOURCES += main.cpp\
 	widgets/FilterCardRow.cpp \
 	widgets/MiddleClickTabWidget.cpp \
 	import/ConfigDependencyScanner.cpp \
+	import/ImportDialog.cpp \
 	import/ImportExecutor.cpp \
 	widgets/MiddleClickTabBar.cpp
 
@@ -312,6 +313,7 @@ HEADERS  += \
 	widgets/FilterCardRow.h \
 	widgets/MiddleClickTabWidget.h \
 	import/ConfigDependencyScanner.h \
+	import/ImportDialog.h \
 	import/ImportExecutor.h \
 	import/ImportManifest.h \
 	widgets/MiddleClickTabBar.h

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -170,6 +170,7 @@ SOURCES += main.cpp\
 	widgets/FilterCardModel.cpp \
 	widgets/FilterCardRow.cpp \
 	widgets/MiddleClickTabWidget.cpp \
+	import/ConfigDependencyScanner.cpp \
 	widgets/MiddleClickTabBar.cpp
 
 HEADERS  += \
@@ -309,6 +310,8 @@ HEADERS  += \
 	widgets/FilterCardModel.h \
 	widgets/FilterCardRow.h \
 	widgets/MiddleClickTabWidget.h \
+	import/ConfigDependencyScanner.h \
+	import/ImportManifest.h \
 	widgets/MiddleClickTabBar.h
 
 FORMS    += \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -171,6 +171,7 @@ SOURCES += main.cpp\
 	widgets/FilterCardRow.cpp \
 	widgets/MiddleClickTabWidget.cpp \
 	import/ConfigDependencyScanner.cpp \
+	import/ImportExecutor.cpp \
 	widgets/MiddleClickTabBar.cpp
 
 HEADERS  += \
@@ -311,6 +312,7 @@ HEADERS  += \
 	widgets/FilterCardRow.h \
 	widgets/MiddleClickTabWidget.h \
 	import/ConfigDependencyScanner.h \
+	import/ImportExecutor.h \
 	import/ImportManifest.h \
 	widgets/MiddleClickTabBar.h
 

--- a/Editor/import/ConfigDependencyScanner.cpp
+++ b/Editor/import/ConfigDependencyScanner.cpp
@@ -1,0 +1,198 @@
+/*
+    This file is part of EqualizerAPO-XT.
+*/
+
+#include "ConfigDependencyScanner.h"
+#include "../widgets/FilterCardModel.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+#include <QTextStream>
+
+namespace EqAPO::Import
+{
+
+namespace
+{
+
+bool isReferenceCommand(const QString& commandLower)
+{
+    return commandLower == QStringLiteral("include")
+        || commandLower == QStringLiteral("convolution")
+        || commandLower == QStringLiteral("vstplugin");
+}
+
+QString kindForCommand(const QString& commandLower)
+{
+    if (commandLower == QStringLiteral("include")) return QStringLiteral("Include");
+    if (commandLower == QStringLiteral("convolution")) return QStringLiteral("Convolution");
+    if (commandLower == QStringLiteral("vstplugin")) return QStringLiteral("VSTPlugin");
+    return commandLower;
+}
+
+QString resolveAbsolute(const QString& reference, const QString& baseDir)
+{
+    QString trimmed = reference.trimmed();
+    if (trimmed.isEmpty())
+        return QString();
+
+    QFileInfo info(trimmed);
+    if (info.isAbsolute())
+        return QDir::cleanPath(info.absoluteFilePath());
+
+    return QDir::cleanPath(QDir(baseDir).absoluteFilePath(trimmed));
+}
+
+// Returns relativePath using forward slashes if target is inside rootDir,
+// or an empty string if it is not. We don't allow ".." segments in the
+// destination because that would let an import escape the config tree.
+QString relativeToRoot(const QString& targetAbs, const QString& rootDir)
+{
+    QDir root(rootDir);
+    QString rel = root.relativeFilePath(targetAbs);
+    if (rel.isEmpty() || rel.startsWith(QStringLiteral("..")))
+        return QString();
+    return QDir::fromNativeSeparators(rel);
+}
+
+void appendItem(ImportManifest& manifest,
+                const QString& sourceAbs,
+                const QString& destRel,
+                const QString& kind)
+{
+    for (const ImportItem& existing : manifest.items)
+    {
+        if (existing.sourceAbsolute == sourceAbs)
+            return; // already collected
+    }
+
+    ImportItem item;
+    item.sourceAbsolute = sourceAbs;
+    item.destRelative = destRel;
+    item.kind = kind;
+
+    QFileInfo info(sourceAbs);
+    if (info.exists() && info.isFile())
+    {
+        item.exists = true;
+        item.sizeBytes = info.size();
+        manifest.totalBytes += item.sizeBytes;
+    }
+    else
+    {
+        item.exists = false;
+        manifest.hasErrors = true;
+        manifest.warnings.append(QObject::tr("Missing file: %1").arg(sourceAbs));
+    }
+
+    manifest.items.append(item);
+}
+
+void scanConfigFile(ImportManifest& manifest,
+                    const QString& sourceTxtAbs,
+                    const QString& rootSourceDir,
+                    int depth,
+                    QSet<QString>& visited)
+{
+    if (depth >= ConfigDependencyScanner::kRecursionLimit)
+    {
+        manifest.warnings.append(QObject::tr("Recursion limit reached at %1; nested references were not followed.").arg(sourceTxtAbs));
+        manifest.hasErrors = true;
+        return;
+    }
+
+    if (visited.contains(sourceTxtAbs))
+        return;
+    visited.insert(sourceTxtAbs);
+
+    QFile file(sourceTxtAbs);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+        manifest.warnings.append(QObject::tr("Cannot open %1 for scanning.").arg(sourceTxtAbs));
+        manifest.hasErrors = true;
+        return;
+    }
+
+    QFileInfo configInfo(sourceTxtAbs);
+    QString baseDir = configInfo.absoluteDir().absolutePath();
+
+    QTextStream stream(&file);
+    while (!stream.atEnd())
+    {
+        QString line = stream.readLine();
+        QString trimmed = line.trimmed();
+        if (trimmed.isEmpty() || trimmed.startsWith('#'))
+            continue;
+
+        QString parameters;
+        QString command = FilterCardModel::commandForLine(line, &parameters);
+        QString commandLower = command.toLower();
+
+        if (!isReferenceCommand(commandLower))
+            continue;
+
+        QString refAbs = resolveAbsolute(parameters, baseDir);
+        if (refAbs.isEmpty())
+            continue;
+
+        QString rel = relativeToRoot(refAbs, rootSourceDir);
+        if (rel.isEmpty())
+        {
+            manifest.warnings.append(QObject::tr("Reference outside the source folder will be skipped: %1 (in %2)")
+                .arg(parameters, sourceTxtAbs));
+            manifest.hasErrors = true;
+            continue;
+        }
+
+        QString rootName = QFileInfo(rootSourceDir).fileName();
+        QString destRel = rootName.isEmpty() ? rel : rootName + QStringLiteral("/") + rel;
+
+        appendItem(manifest, refAbs, destRel, kindForCommand(commandLower));
+
+        if (commandLower == QStringLiteral("include"))
+            scanConfigFile(manifest, refAbs, rootSourceDir, depth + 1, visited);
+    }
+}
+
+}
+
+ImportManifest ConfigDependencyScanner::scan(const QString& rootSource, const QString& configDir)
+{
+    Q_UNUSED(configDir);
+
+    ImportManifest manifest;
+    manifest.rootSource = QDir::cleanPath(QFileInfo(rootSource).absoluteFilePath());
+
+    QFileInfo rootInfo(manifest.rootSource);
+    if (!rootInfo.exists())
+    {
+        manifest.warnings.append(QObject::tr("Root file does not exist: %1").arg(manifest.rootSource));
+        manifest.hasErrors = true;
+        return manifest;
+    }
+
+    manifest.rootSourceDir = rootInfo.absoluteDir().absolutePath();
+    QString rootName = QFileInfo(manifest.rootSourceDir).fileName();
+    QString rootRel = rootName.isEmpty()
+        ? rootInfo.fileName()
+        : rootName + QStringLiteral("/") + rootInfo.fileName();
+    manifest.rootDest = rootRel;
+
+    appendItem(manifest, manifest.rootSource, manifest.rootDest, QStringLiteral("Root"));
+
+    QString suffix = rootInfo.suffix().toLower();
+    if (suffix == QStringLiteral("txt"))
+    {
+        QSet<QString> visited;
+        scanConfigFile(manifest, manifest.rootSource, manifest.rootSourceDir, 0, visited);
+    }
+
+    return manifest;
+}
+
+}

--- a/Editor/import/ConfigDependencyScanner.h
+++ b/Editor/import/ConfigDependencyScanner.h
@@ -1,0 +1,38 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    Walks an external EqualizerAPO config file (the one the user is
+    about to import) and collects every file it references through
+    Include, Convolution, and VSTPlugin commands. Recursion follows the
+    same pattern as filters/IncludeFilterFactory.cpp so nested config
+    trees are picked up.
+
+    The scanner is read-only and side-effect free. ImportExecutor is the
+    component that actually copies files.
+*/
+
+#pragma once
+
+#include "ImportManifest.h"
+
+#include <QString>
+
+namespace EqAPO::Import
+{
+
+class ConfigDependencyScanner
+{
+public:
+    // Maximum recursion depth, matches IncludeFilterFactory::RECURSION_LIMIT.
+    static constexpr int kRecursionLimit = 100;
+
+    // Build a manifest for importing rootSource into configDir.
+    //
+    // rootSource may be a config text file (.txt) — its references are
+    // walked recursively — or a single binary (.wav, .dll, etc.) in
+    // which case the manifest contains exactly one item. configDir is
+    // only used to compute dest paths; the scanner never writes there.
+    static ImportManifest scan(const QString& rootSource, const QString& configDir);
+};
+
+}

--- a/Editor/import/ImportDialog.cpp
+++ b/Editor/import/ImportDialog.cpp
@@ -1,0 +1,97 @@
+/*
+    This file is part of EqualizerAPO-XT.
+*/
+
+#include "ImportDialog.h"
+
+#include <QDialogButtonBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QVBoxLayout>
+
+namespace EqAPO::Import
+{
+
+namespace
+{
+
+QString formatSize(qint64 bytes)
+{
+    if (bytes <= 0)
+        return QObject::tr("0 B");
+    if (bytes < 1024)
+        return QObject::tr("%1 B").arg(bytes);
+    if (bytes < 1024 * 1024)
+        return QObject::tr("%1 KB").arg(bytes / 1024.0, 0, 'f', 1);
+    return QObject::tr("%1 MB").arg(bytes / (1024.0 * 1024.0), 0, 'f', 2);
+}
+
+}
+
+ImportDialog::ImportDialog(const ImportManifest& manifest, const QString& configDir, QWidget* parent)
+    : QDialog(parent)
+    , manifest_(manifest)
+    , configDir_(configDir)
+    , itemTree_(nullptr)
+    , summaryLabel_(nullptr)
+    , warningsLabel_(nullptr)
+{
+    setWindowTitle(tr("Import to config directory"));
+    setMinimumWidth(620);
+    buildUi();
+}
+
+void ImportDialog::buildUi()
+{
+    auto* layout = new QVBoxLayout(this);
+
+    summaryLabel_ = new QLabel(this);
+    summaryLabel_->setWordWrap(true);
+    summaryLabel_->setText(tr("%1 file(s), %2 will be copied into %3.")
+        .arg(manifest_.items.size())
+        .arg(formatSize(manifest_.totalBytes))
+        .arg(configDir_));
+    layout->addWidget(summaryLabel_);
+
+    itemTree_ = new QTreeWidget(this);
+    itemTree_->setColumnCount(3);
+    itemTree_->setHeaderLabels({ tr("Kind"), tr("Source"), tr("Size") });
+    itemTree_->setRootIsDecorated(false);
+    itemTree_->setAlternatingRowColors(true);
+    for (const ImportItem& item : manifest_.items)
+    {
+        auto* row = new QTreeWidgetItem(itemTree_);
+        row->setText(0, item.kind);
+        row->setText(1, item.sourceAbsolute);
+        if (item.exists)
+            row->setText(2, formatSize(item.sizeBytes));
+        else
+            row->setText(2, tr("missing"));
+    }
+    itemTree_->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    itemTree_->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    itemTree_->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    layout->addWidget(itemTree_, 1);
+
+    if (!manifest_.warnings.isEmpty())
+    {
+        warningsLabel_ = new QLabel(this);
+        warningsLabel_->setWordWrap(true);
+        warningsLabel_->setStyleSheet(QStringLiteral("color: #c46060;"));
+        warningsLabel_->setText(manifest_.warnings.join('\n'));
+        layout->addWidget(warningsLabel_);
+    }
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    auto* okButton = buttons->button(QDialogButtonBox::Ok);
+    okButton->setText(tr("Import"));
+    okButton->setEnabled(!manifest_.items.isEmpty());
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(buttons);
+}
+
+}

--- a/Editor/import/ImportDialog.h
+++ b/Editor/import/ImportDialog.h
@@ -1,0 +1,39 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    Modal confirmation step between ConfigDependencyScanner and
+    ImportExecutor. Shows what the import will touch, the total size,
+    any warnings the scanner produced, and lets the user back out.
+*/
+
+#pragma once
+
+#include "ImportManifest.h"
+
+#include <QDialog>
+#include <QString>
+
+class QLabel;
+class QTreeWidget;
+
+namespace EqAPO::Import
+{
+
+class ImportDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    ImportDialog(const ImportManifest& manifest, const QString& configDir, QWidget* parent = nullptr);
+
+private:
+    void buildUi();
+
+    ImportManifest manifest_;
+    QString configDir_;
+    QTreeWidget* itemTree_;
+    QLabel* summaryLabel_;
+    QLabel* warningsLabel_;
+};
+
+}

--- a/Editor/import/ImportExecutor.cpp
+++ b/Editor/import/ImportExecutor.cpp
@@ -1,0 +1,76 @@
+/*
+    This file is part of EqualizerAPO-XT.
+*/
+
+#include "ImportExecutor.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QObject>
+
+namespace EqAPO::Import
+{
+
+ExecutionResult ImportExecutor::execute(const ImportManifest& manifest, const QString& configDir)
+{
+    ExecutionResult result;
+
+    if (configDir.isEmpty())
+    {
+        result.success = false;
+        result.errors.append(QObject::tr("Import target directory is empty."));
+        return result;
+    }
+
+    if (!QDir().mkpath(configDir))
+    {
+        result.success = false;
+        result.errors.append(QObject::tr("Could not create config directory %1.").arg(configDir));
+        return result;
+    }
+
+    for (const ImportItem& item : manifest.items)
+    {
+        if (!item.exists)
+        {
+            result.success = false;
+            result.errors.append(QObject::tr("Source missing, skipped: %1").arg(item.sourceAbsolute));
+            continue;
+        }
+
+        QString relNative = QDir::fromNativeSeparators(item.destRelative);
+        QString destAbs = QDir(configDir).absoluteFilePath(relNative);
+        QString destDir = QFileInfo(destAbs).absolutePath();
+        if (!QDir().mkpath(destDir))
+        {
+            result.success = false;
+            result.errors.append(QObject::tr("Could not create %1.").arg(destDir));
+            continue;
+        }
+
+        if (QFile::exists(destAbs))
+        {
+            if (!QFile::remove(destAbs))
+            {
+                result.success = false;
+                result.errors.append(QObject::tr("Could not overwrite %1.").arg(destAbs));
+                continue;
+            }
+        }
+
+        if (!QFile::copy(item.sourceAbsolute, destAbs))
+        {
+            result.success = false;
+            result.errors.append(QObject::tr("Failed to copy %1 to %2.").arg(item.sourceAbsolute, destAbs));
+            continue;
+        }
+
+        ++result.filesCopied;
+        result.bytesCopied += item.sizeBytes;
+    }
+
+    return result;
+}
+
+}

--- a/Editor/import/ImportExecutor.h
+++ b/Editor/import/ImportExecutor.h
@@ -1,0 +1,39 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    Side-effecting half of the "import to config directory" flow.
+    Takes an ImportManifest produced by ConfigDependencyScanner and
+    copies every existing item into the config directory, creating
+    sub-directories as needed and overwriting any existing destination.
+*/
+
+#pragma once
+
+#include "ImportManifest.h"
+
+#include <QString>
+#include <QStringList>
+
+#include <cstdint>
+
+namespace EqAPO::Import
+{
+
+struct ExecutionResult
+{
+    bool success = true;
+    int filesCopied = 0;
+    qint64 bytesCopied = 0;
+    QStringList errors;
+};
+
+class ImportExecutor
+{
+public:
+    // Apply the manifest to configDir. Items whose source is missing are
+    // skipped and reported as errors. Returns success only if every
+    // existing item was copied without trouble.
+    static ExecutionResult execute(const ImportManifest& manifest, const QString& configDir);
+};
+
+}

--- a/Editor/import/ImportManifest.h
+++ b/Editor/import/ImportManifest.h
@@ -1,0 +1,57 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    Data structures describing what an "Import to config directory" pass
+    will touch. Built by ConfigDependencyScanner, consumed by the GUI
+    dialog, and finally executed by ImportExecutor.
+*/
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+#include <cstdint>
+
+namespace EqAPO::Import
+{
+
+struct ImportItem
+{
+    // Absolute path of the file on the user's machine.
+    QString sourceAbsolute;
+    // Path relative to the chosen config directory where it should land
+    // (forward slashes; ImportExecutor turns this into native separators).
+    QString destRelative;
+    // Size in bytes if the file exists, 0 otherwise.
+    qint64 sizeBytes = 0;
+    // Was the file present on disk when the scan ran?
+    bool exists = true;
+    // What kind of reference triggered this item (Include, Convolution,
+    // VSTPlugin, Root). Purely informational; useful for the dialog.
+    QString kind;
+};
+
+struct ImportManifest
+{
+    // Absolute path of the root config file the user picked.
+    QString rootSource;
+    // Absolute path of the directory that becomes the import root - every
+    // dependency relative path is resolved against this. Usually
+    // QFileInfo(rootSource).absoluteDir().
+    QString rootSourceDir;
+    // dest path of the root config file relative to the config directory.
+    QString rootDest;
+    // Every file we plan to copy (root + dependencies). Items keep a
+    // stable order so the dialog can display them in scan order.
+    QVector<ImportItem> items;
+    // Non-fatal messages (file not found, dependency outside root, etc).
+    QStringList warnings;
+    // Sum of sizeBytes across all existing items, for the confirmation UI.
+    qint64 totalBytes = 0;
+    // True if any item could not be located or recursion blew the limit.
+    bool hasErrors = false;
+};
+
+}

--- a/Editor/widgets/FilterCardModel.h
+++ b/Editor/widgets/FilterCardModel.h
@@ -24,9 +24,9 @@ class FilterCardModel
 public:
 	static FilterCardDescriptor describeLine(const QString& line, int depth = 0);
 	static QVector<int> calculateDepths(const QList<QString>& lines);
+	static QString commandForLine(const QString& line, QString* parameters);
 
 private:
-	static QString commandForLine(const QString& line, QString* parameters);
 	static QStringList parseChannelList(const QString& text);
 	static QString compactWhitespace(QString text);
 };

--- a/Editor/widgets/cards/IncludeCardEditor.cpp
+++ b/Editor/widgets/cards/IncludeCardEditor.cpp
@@ -7,6 +7,7 @@
 #include <QIcon>
 #include <QLabel>
 #include <QLineEdit>
+#include <QMessageBox>
 #include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
@@ -15,6 +16,9 @@
 #include <windows.h>
 
 #include "Editor/FilterTable.h"
+#include "Editor/import/ConfigDependencyScanner.h"
+#include "Editor/import/ImportDialog.h"
+#include "Editor/import/ImportExecutor.h"
 #include "helpers/RegistryHelper.h"
 
 IncludeCardEditor::IncludeCardEditor(FilterTable* filterTable, const QString& path, QWidget* parent)
@@ -64,6 +68,14 @@ IncludeCardEditor::IncludeCardEditor(FilterTable* filterTable, const QString& pa
 	openButton->setToolTip(tr("Open include file"));
 	connect(openButton, SIGNAL(clicked()), this, SLOT(openFile()));
 	layout->addWidget(openButton, 0, Qt::AlignTop);
+
+	importButton = new QToolButton(this);
+	importButton->setObjectName(QStringLiteral("FilterCardIconButton"));
+	importButton->setIcon(QIcon(QStringLiteral(":/icons/document-save.ico")));
+	importButton->setToolTip(tr("Copy this file and its dependencies into the config directory"));
+	importButton->setVisible(false);
+	connect(importButton, SIGNAL(clicked()), this, SLOT(importToConfig()));
+	layout->addWidget(importButton, 0, Qt::AlignTop);
 
 	updateFileInfo();
 }
@@ -134,6 +146,7 @@ QFileInfo IncludeCardEditor::currentFileInfo() const
 void IncludeCardEditor::updateFileInfo()
 {
 	QString error;
+	bool offerImport = false;
 	QString path = pathEdit->text();
 	if (path.isEmpty())
 	{
@@ -160,11 +173,51 @@ void IncludeCardEditor::updateFileInfo()
 			}
 
 			if ((mask & GENERIC_READ) != GENERIC_READ && (mask & FILE_GENERIC_READ) != FILE_GENERIC_READ)
-				error = tr("The file is not readable for the audio service.\nChange the file permissions or copy the file to the config directory.");
+			{
+				error = tr("The file is not readable for the audio service.\nClick the import button to copy it into the config directory.");
+				offerImport = true;
+			}
 		}
 	}
 
 	statusLabel->setVisible(!error.isEmpty());
 	statusLabel->setText(error);
 	openButton->setEnabled(error.isEmpty() && !pathEdit->text().isEmpty());
+	importButton->setVisible(offerImport);
+}
+
+void IncludeCardEditor::importToConfig()
+{
+	if (filterTable == nullptr)
+		return;
+
+	QFileInfo fileInfo = currentFileInfo();
+	if (!fileInfo.exists())
+		return;
+
+	QString sourcePath = fileInfo.absoluteFilePath();
+	QString configDir = QFileInfo(filterTable->getConfigPath()).absolutePath();
+
+	auto manifest = EqAPO::Import::ConfigDependencyScanner::scan(sourcePath, configDir);
+	if (manifest.items.isEmpty())
+	{
+		QMessageBox::warning(this, tr("Import"), tr("Nothing to import: %1").arg(manifest.warnings.join('\n')));
+		return;
+	}
+
+	EqAPO::Import::ImportDialog dialog(manifest, configDir, this);
+	if (dialog.exec() != QDialog::Accepted)
+		return;
+
+	auto result = EqAPO::Import::ImportExecutor::execute(manifest, configDir);
+	if (!result.success)
+	{
+		QMessageBox::warning(this, tr("Import"),
+			tr("Some files could not be copied:\n%1").arg(result.errors.join('\n')));
+		return;
+	}
+
+	pathEdit->setText(QDir::toNativeSeparators(manifest.rootDest));
+	updateFileInfo();
+	emit updateModel();
 }

--- a/Editor/widgets/cards/IncludeCardEditor.h
+++ b/Editor/widgets/cards/IncludeCardEditor.h
@@ -22,6 +22,7 @@ private slots:
 	void chooseFile();
 	void openFile();
 	void pathEdited();
+	void importToConfig();
 
 private:
 	QFileInfo currentFileInfo() const;
@@ -32,4 +33,5 @@ private:
 	QLabel* statusLabel = nullptr;
 	QToolButton* chooseButton = nullptr;
 	QToolButton* openButton = nullptr;
+	QToolButton* importButton = nullptr;
 };

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -10,7 +10,13 @@
 #include <QStringList>
 #include <QVector>
 
+#include <QFile>
+#include <QTemporaryDir>
+#include <QTextStream>
+
 #include "Editor/helpers/ConvolutionPathHelper.h"
+#include "Editor/import/ConfigDependencyScanner.h"
+#include "Editor/import/ImportManifest.h"
 #include "Editor/widgets/FilterCardModel.h"
 #include "UpdateChecker/UpdateInfoFormatter.h"
 #include "UpdateChecker/VelopackUpdateInfo.h"
@@ -246,6 +252,60 @@ int main(int argc, char** argv)
 	expectEqual(depths[3], 0, "include should reset channel depth");
 	expectEqual(depths[4], 0, "channel all depth");
 	expectEqual(depths[5], 0, "post channel-all depth");
+
+	{
+		QTemporaryDir tempDir;
+		expectTrue(tempDir.isValid(), "QTemporaryDir must be valid");
+
+		QString surroundDir = tempDir.path() + "/Surround";
+		expectTrue(QDir().mkpath(surroundDir), "failed to create Surround dir");
+
+		auto writeText = [](const QString& path, const QString& body) {
+			QFile f(path);
+			expectTrue(f.open(QIODevice::WriteOnly | QIODevice::Text), QString("could not open %1 for write").arg(path));
+			QTextStream ts(&f);
+			ts << body;
+		};
+		auto writeBlob = [](const QString& path, int bytes) {
+			QFile f(path);
+			expectTrue(f.open(QIODevice::WriteOnly), QString("could not open %1 for write").arg(path));
+			f.write(QByteArray(bytes, '\0'));
+		};
+
+		writeText(surroundDir + "/main.txt",
+			"# main\n"
+			"Preamp: -3 dB\n"
+			"Include: child.txt\n"
+			"Convolution: ir.wav\n");
+		writeText(surroundDir + "/child.txt",
+			"Convolution: nested.wav\n");
+		writeBlob(surroundDir + "/ir.wav", 128);
+		writeBlob(surroundDir + "/nested.wav", 64);
+
+		EqAPO::Import::ImportManifest manifest = EqAPO::Import::ConfigDependencyScanner::scan(
+			surroundDir + "/main.txt", tempDir.path() + "/configdir");
+
+		expectFalse(manifest.hasErrors, "scan should not flag any errors for this tree");
+		expectEqual(int(manifest.items.size()), 4, "expected root + child + ir + nested");
+
+		expectEqual(manifest.items[0].kind, "Root", "first item must be the root config");
+		expectEqual(manifest.items[0].destRelative, "Surround/main.txt", "root dest path");
+		expectTrue(manifest.totalBytes > 0, "totalBytes should be positive");
+
+		QStringList destRels;
+		for (const auto& item : manifest.items)
+			destRels.append(item.destRelative);
+		expectTrue(destRels.contains("Surround/main.txt"), "root present in items");
+		expectTrue(destRels.contains("Surround/child.txt"), "include child present");
+		expectTrue(destRels.contains("Surround/ir.wav"), "ir wav present");
+		expectTrue(destRels.contains("Surround/nested.wav"), "nested wav present");
+
+		// Missing reference should surface as a non-fatal warning + hasErrors.
+		writeText(surroundDir + "/broken.txt", "Convolution: does_not_exist.wav\n");
+		auto broken = EqAPO::Import::ConfigDependencyScanner::scan(surroundDir + "/broken.txt", tempDir.path() + "/configdir");
+		expectTrue(broken.hasErrors, "missing dependency must flag hasErrors");
+		expectTrue(!broken.warnings.isEmpty(), "missing dependency must produce a warning");
+	}
 
 	printf("EditorLogicTests passed\n");
 	return 0;

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -16,6 +16,7 @@
 
 #include "Editor/helpers/ConvolutionPathHelper.h"
 #include "Editor/import/ConfigDependencyScanner.h"
+#include "Editor/import/ImportExecutor.h"
 #include "Editor/import/ImportManifest.h"
 #include "Editor/widgets/FilterCardModel.h"
 #include "UpdateChecker/UpdateInfoFormatter.h"
@@ -305,6 +306,21 @@ int main(int argc, char** argv)
 		auto broken = EqAPO::Import::ConfigDependencyScanner::scan(surroundDir + "/broken.txt", tempDir.path() + "/configdir");
 		expectTrue(broken.hasErrors, "missing dependency must flag hasErrors");
 		expectTrue(!broken.warnings.isEmpty(), "missing dependency must produce a warning");
+
+		QString configDest = tempDir.path() + "/configdir";
+		EqAPO::Import::ExecutionResult exec = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
+		expectTrue(exec.success, "executor should succeed on clean manifest");
+		expectEqual(exec.filesCopied, 4, "executor must copy four files");
+
+		expectTrue(QFile::exists(configDest + "/Surround/main.txt"), "main.txt missing after import");
+		expectTrue(QFile::exists(configDest + "/Surround/child.txt"), "child.txt missing after import");
+		expectTrue(QFile::exists(configDest + "/Surround/ir.wav"), "ir.wav missing after import");
+		expectTrue(QFile::exists(configDest + "/Surround/nested.wav"), "nested.wav missing after import");
+
+		// Re-executing should be idempotent (overwrites are allowed).
+		EqAPO::Import::ExecutionResult exec2 = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
+		expectTrue(exec2.success, "second execute should also succeed");
+		expectEqual(exec2.filesCopied, 4, "second execute should still report four copies");
 	}
 
 	printf("EditorLogicTests passed\n");

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -116,12 +116,15 @@
   <ItemGroup>
     <ClCompile Include="EditorLogicTests.cpp" />
     <ClCompile Include="..\..\Editor\helpers\ConvolutionPathHelper.cpp" />
+    <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
     <ClCompile Include="..\..\UpdateChecker\UpdateInfoFormatter.cpp" />
     <ClCompile Include="..\..\UpdateChecker\VelopackUpdateInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Editor\helpers\ConvolutionPathHelper.h" />
+    <ClInclude Include="..\..\Editor\import\ConfigDependencyScanner.h" />
+    <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
     <ClInclude Include="..\..\UpdateChecker\UpdateInfoFormatter.h" />
     <ClInclude Include="..\..\UpdateChecker\VelopackUpdateInfo.h" />

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="EditorLogicTests.cpp" />
     <ClCompile Include="..\..\Editor\helpers\ConvolutionPathHelper.cpp" />
     <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp" />
+    <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
     <ClCompile Include="..\..\UpdateChecker\UpdateInfoFormatter.cpp" />
     <ClCompile Include="..\..\UpdateChecker\VelopackUpdateInfo.cpp" />
@@ -124,6 +125,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Editor\helpers\ConvolutionPathHelper.h" />
     <ClInclude Include="..\..\Editor\import\ConfigDependencyScanner.h" />
+    <ClInclude Include="..\..\Editor\import\ImportExecutor.h" />
     <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
     <ClInclude Include="..\..\UpdateChecker\UpdateInfoFormatter.h" />

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
@@ -20,6 +20,9 @@
     <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -35,6 +38,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Editor\import\ConfigDependencyScanner.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Editor\import\ImportExecutor.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Editor\import\ImportManifest.h">

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="..\..\Editor\helpers\ConvolutionPathHelper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -29,6 +32,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Editor\helpers\ConvolutionPathHelper.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Editor\import\ConfigDependencyScanner.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Editor\import\ImportManifest.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h">


### PR DESCRIPTION
## Summary
Addresses the LOCAL_SERVICE permission problem on Include / Convolution references by adding a copy-into-config flow instead of telling users to fix ACLs themselves.

### New modules under `Editor/import/`
- **ImportManifest** — declarative plan: source absolute path + destination relative path + size + kind + warnings + totalBytes + hasErrors. Consumed by both dialog and executor.
- **ConfigDependencyScanner** — read-only walker that reuses `FilterCardModel::commandForLine` to parse a user-selected `.txt` and recursively follow `Include` / `Convolution` / `VSTPlugin` references. Uses the same `RECURSION_LIMIT = 100` and visited-set deduplication pattern as `filters/IncludeFilterFactory.cpp`. References that resolve outside the source root are skipped with a warning so an import cannot escape the config tree. Dest layout preserves the source folder name under a single sub-directory (`<configDir>/<sourceFolderName>/<relativePath>`).
- **ImportExecutor** — copies every existing item, creates sub-directories on demand, overwrites destinations (idempotent). Failures are per-item; the overall result keeps a list of errors.
- **ImportDialog** — modal confirmation step: summary, per-item tree (Kind / Source / Size), warning bar, Import / Cancel.

### Include card integration
`IncludeCardEditor` now hosts an import button right next to the existing open button. It stays hidden while the referenced file is readable by `LOCAL_SERVICE` and only appears when `RegistryHelper::getFileAccessForUser` reports it cannot read the file. On click: scan → dialog → execute → rewrite `pathEdit` to the imported location.

### What's intentionally not in this PR
- **Convolution card / old IncludeFilterGUI / VSTPluginFilterGUI integration.** Convolution and the legacy guis will land in follow-up commits because they all share the same shape and the diff stays smaller this way.
- **VST DLL handling.** In practice plugin DLLs live under `<install>\VSTPlugins\` which is `%ProgramFiles%` and is therefore already readable by `LOCAL_SERVICE`. The "library is not readable" warning fires only when a user points to a per-user path, which is rare; for that case ACL grant on the DLL is more appropriate than copying because some plugins key licenses to the install path. That branch will be its own PR.
- **Config directory relocation** (the "second method" Claude described). Independent change that requires touching the Velopack install layout and `ApoRegistration`.

## Test plan
- [x] `EditorLogicTests` adds a temporary-directory fixture (Surround/main.txt + child.txt + ir.wav + nested.wav) and asserts that the scanner returns all four items with the expected dest paths, that a missing dependency flags `hasErrors`, and that `ImportExecutor::execute` actually lands the files and is idempotent on a second run.
- [ ] CI builds AudioRegressionTests / EditorLogicTests / Editor under the matrix variant.
- [ ] Manual: open an Include card pointing at a per-user `.txt` referencing Convolution IR files, observe the warning + import button, accept the dialog, confirm the dest path is rewritten and the warning disappears.

https://claude.ai/code/session_01UG9E52BXvXMudEDpkacnzz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UG9E52BXvXMudEDpkacnzz)_