### PR TITLE
Grant audiodg (LOCAL SERVICE) access to the APO install dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,7 +187,6 @@ node_modules/
 orleans.codegen.cs
 deps/
 Qt/
-tools/
 build-*/
 DeviceSelector/translations/DeviceSelector_*.qm
 UpdateChecker/translations/UpdateChecker_*.qm

--- a/helpers/ApoRegistration.cpp
+++ b/helpers/ApoRegistration.cpp
@@ -169,21 +169,43 @@ ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 		return Result::RegistryFailed;
 	}
 
+	// audiodg.exe runs as LOCAL SERVICE (*S-1-5-19) and loads EqualizerAPO.dll
+	// via the COM InprocServer32 path written below. When Velopack installs the
+	// app under %LocalAppData% the default ACL only grants the installing user
+	// and Administrators, so the audio engine fails to map the DLL and Windows
+	// reports the device as access-denied / invalidated from outside (the
+	// symptom users see is GetMixFormat / Initialize returning E_ACCESSDENIED
+	// in DeviceSelector). Widen the ACL on the whole install root for both
+	// LOCAL SERVICE (RX recursive) and Users (RX recursive) before any APO
+	// registration takes effect.
+	std::wstring icacls = joinPath(systemPath(), L"icacls.exe");
+	std::wstring installAclArgs = L"\"" + installDir + L"\" "
+		L"/grant *S-1-5-19:(OI)(CI)RX "
+		L"/grant *S-1-5-32-545:(OI)(CI)RX "
+		L"/T /C /Q";
+	int rc = waitForProcess(icacls, installAclArgs, 30000);
+	if (rc != 0)
+		logLine(L"WARN", L"icacls (install root) returned %d, continuing", rc);
+
 	std::wstring regsvr32 = joinPath(systemPath(), L"regsvr32.exe");
 	std::wstring registerArgs = L"/s \"" + joinPath(installDir, L"EqualizerAPO.dll") + L"\"";
-	int rc = waitForProcess(regsvr32, registerArgs, 30000);
+	rc = waitForProcess(regsvr32, registerArgs, 30000);
 	if (rc != 0)
 	{
 		logLine(L"ERR", L"regsvr32 returned %d", rc);
 		return Result::RegistrationFailed;
 	}
 
+	// Config dir gets Users:F so the user can edit configs, and LOCAL SERVICE
+	// modify (M) so audiodg can read/write trace logs from the APO.
 	std::wstring configDir = joinPath(installDir, L"config");
-	std::wstring icacls = joinPath(systemPath(), L"icacls.exe");
-	std::wstring aclArgs = L"\"" + configDir + L"\" /grant *S-1-5-32-545:(OI)(CI)F /T /C /Q";
-	rc = waitForProcess(icacls, aclArgs, 30000);
+	std::wstring configAclArgs = L"\"" + configDir + L"\" "
+		L"/grant *S-1-5-32-545:(OI)(CI)F "
+		L"/grant *S-1-5-19:(OI)(CI)M "
+		L"/T /C /Q";
+	rc = waitForProcess(icacls, configAclArgs, 30000);
 	if (rc != 0)
-		logLine(L"WARN", L"icacls returned %d, continuing", rc);
+		logLine(L"WARN", L"icacls (config dir) returned %d, continuing", rc);
 
 	// Velopack's vpk pack only emits a shortcut for --mainExe (Editor.exe).
 	// DeviceSelector is the elevated companion that performs per-device APO

--- a/tools/Diagnose-EqualizerAPO.ps1
+++ b/tools/Diagnose-EqualizerAPO.ps1
@@ -1,0 +1,212 @@
+<#
+.SYNOPSIS
+    Read-only diagnostics for EqualizerAPO-XT installs.
+    Dumps install path, ACLs, COM registration, MMDevices APO chains, and
+    flags the conditions that cause "GetMixFormat / Initialize access denied"
+    in Device Selector.
+
+.DESCRIPTION
+    Run from any PowerShell. Elevation is not required - this script does not
+    modify the system.
+
+    The most common failure mode on a Velopack install is:
+      audiodg.exe (LOCAL SERVICE) cannot read EqualizerAPO.dll because the
+      DLL lives under %LocalAppData% and the default ACL only grants the
+      installing user and Administrators. The DLL load fails inside the
+      audio engine, so any IAudioClient call against the affected device
+      returns E_ACCESSDENIED (Korean: "액세스가 거부되었습니다").
+
+    Use Repair-EqualizerAPO.ps1 (elevated) to apply the LOCAL SERVICE / Users
+    ACL grants if this diagnostics report flags the install root as broken.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Diagnose-EqualizerAPO.ps1
+
+.EXAMPLE
+    .\Diagnose-EqualizerAPO.ps1 > eapo-report.txt
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Continue'
+
+$preGuid  = '{eacd2258-fcac-4ff4-b36d-419e924a6d79}'
+$postGuid = '{ec1cc9ce-faed-4822-828a-82a81a6f018f}'
+
+function Write-Section { param([string]$Title) "`n=== $Title ===" }
+
+function Get-RegValueSafe {
+    param([string]$Path, [string]$Name)
+    try { (Get-Item -LiteralPath $Path -ErrorAction Stop).GetValue($Name) }
+    catch { $null }
+}
+
+function Test-LocalServiceAccess {
+    param([string]$Path)
+    if (-not $Path -or -not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+    $acl = Get-Acl -LiteralPath $Path
+    $hasLs = $acl.Access | Where-Object {
+        $_.IdentityReference.Value -like '*LOCAL SERVICE*' -and
+        $_.AccessControlType -eq 'Allow'
+    }
+    $hasUsersRx = $acl.Access | Where-Object {
+        $_.IdentityReference.Value -like '*\Users' -and
+        $_.AccessControlType -eq 'Allow' -and
+        (($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::ReadAndExecute) -ne 0)
+    }
+    [PSCustomObject]@{
+        LocalServiceAllowed = [bool]$hasLs
+        UsersReadAndExecute = [bool]$hasUsersRx
+    }
+}
+
+Write-Section 'Environment'
+"Time:           $(Get-Date -Format o)"
+"Current user:   $([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)"
+"Is elevated:    $(([Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))"
+"PowerShell:     $($PSVersionTable.PSVersion)"
+"OS:             $((Get-CimInstance Win32_OperatingSystem).Caption) ($((Get-CimInstance Win32_OperatingSystem).Version))"
+
+Write-Section 'EqualizerAPO registry'
+$appReg          = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO'
+$installPath     = Get-RegValueSafe $appReg 'InstallPath'
+$configPath      = Get-RegValueSafe $appReg 'ConfigPath'
+$enableTrace     = Get-RegValueSafe $appReg 'EnableTrace'
+$disableProtAdg  = Get-RegValueSafe 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Audio' 'DisableProtectedAudioDG'
+
+"InstallPath:              $installPath"
+"ConfigPath:               $configPath"
+"EnableTrace:              $enableTrace"
+"DisableProtectedAudioDG:  $disableProtAdg"
+
+if (-not $installPath) {
+    Write-Warning "EqualizerAPO is not registered on this machine. Run the installer first."
+    return
+}
+
+Write-Section 'APO COM registration'
+foreach ($pair in @(@{Name='PreMix'; Guid=$preGuid}, @{Name='PostMix'; Guid=$postGuid})) {
+    $clsidPath = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\$($pair.Guid)\InprocServer32"
+    $dll = Get-RegValueSafe $clsidPath ''
+    "$($pair.Name) InprocServer32: $dll"
+    if ($dll) {
+        "  DLL exists:            $(Test-Path -LiteralPath $dll)"
+        if (-not (Test-Path -LiteralPath $dll)) {
+            Write-Warning "$($pair.Name) APO DLL is missing on disk. Re-run install."
+        }
+    }
+}
+
+Write-Section 'Install location class'
+$profileDir   = [Environment]::GetFolderPath('UserProfile')
+$localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+$inProfile    = $installPath.StartsWith($profileDir,   [StringComparison]::OrdinalIgnoreCase) -or
+                $installPath.StartsWith($localAppData, [StringComparison]::OrdinalIgnoreCase)
+if ($inProfile) {
+    Write-Warning "InstallPath lives under the installing user's profile. audiodg.exe (LOCAL SERVICE) must be granted RX on this tree, otherwise the APO will fail to load."
+} else {
+    "InstallPath is outside the user's profile."
+}
+
+Write-Section 'Install root ACL'
+"Path: $installPath"
+$installAcl = Test-LocalServiceAccess $installPath
+if ($null -ne $installAcl) {
+    "LOCAL SERVICE allowed: $($installAcl.LocalServiceAllowed)"
+    "Users RX:              $($installAcl.UsersReadAndExecute)"
+    if (-not $installAcl.LocalServiceAllowed) {
+        Write-Warning "MISSING: LOCAL SERVICE grant on install root. audiodg.exe cannot load EqualizerAPO.dll. This causes GetMixFormat / Initialize access denied."
+    }
+    if (-not $installAcl.UsersReadAndExecute) {
+        Write-Warning "MISSING: Users RX on install root. Editor/DeviceSelector may not start for non-admin users."
+    }
+} else {
+    Write-Warning "Install root does not exist: $installPath"
+}
+
+Write-Section 'Config dir ACL'
+if ($configPath) {
+    "Path: $configPath"
+    $configAcl = Test-LocalServiceAccess $configPath
+    if ($null -ne $configAcl) {
+        "LOCAL SERVICE allowed: $($configAcl.LocalServiceAllowed)"
+        "Users RX:              $($configAcl.UsersReadAndExecute)"
+        if (-not $configAcl.LocalServiceAllowed) {
+            Write-Warning "MISSING: LOCAL SERVICE grant on config dir. audiodg cannot read config.txt and the APO will run with empty filters."
+        }
+    } else {
+        Write-Warning "Config dir does not exist: $configPath"
+    }
+}
+
+Write-Section 'EqualizerAPO APO chains on devices'
+$fxGuidNames = @(
+    @{Name='LFX'; Id='{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},1'},
+    @{Name='GFX'; Id='{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},2'},
+    @{Name='SFX'; Id='{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},5'},
+    @{Name='MFX'; Id='{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},6'},
+    @{Name='EFX'; Id='{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},7'}
+)
+$mmRoots = @(
+    'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render',
+    'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Capture'
+)
+
+$attached = @()
+foreach ($root in $mmRoots) {
+    if (-not (Test-Path -LiteralPath $root)) { continue }
+    foreach ($dev in Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue) {
+        $fx = Join-Path $dev.PSPath 'FxProperties'
+        if (-not (Test-Path -LiteralPath $fx)) { continue }
+        $slots = @()
+        foreach ($f in $fxGuidNames) {
+            $v = Get-RegValueSafe $fx $f.Id
+            if ($v -and ($v -ieq $preGuid -or $v -ieq $postGuid)) {
+                $slot = if ($v -ieq $preGuid) { "$($f.Name)=PreMix" } else { "$($f.Name)=PostMix" }
+                $slots += $slot
+            }
+        }
+        if ($slots.Count -gt 0) {
+            $props      = Join-Path $dev.PSPath 'Properties'
+            $connection = Get-RegValueSafe $props '{a45c254e-df1c-4efd-8020-67d146a850e0},2'
+            $deviceName = Get-RegValueSafe $props '{b3f8fa53-0004-438e-9003-51a46e139bfc},6'
+            $attached += [PSCustomObject]@{
+                Kind       = Split-Path $root -Leaf
+                Device     = $deviceName
+                Connection = $connection
+                Slots      = ($slots -join ', ')
+            }
+        }
+    }
+}
+if ($attached.Count -eq 0) {
+    "No devices currently have EqualizerAPO in their APO chain."
+} else {
+    $attached | Format-Table -AutoSize | Out-String -Width 220
+}
+
+Write-Section 'audiodg.exe state'
+$audiodg = Get-Process -Name audiodg -ErrorAction SilentlyContinue
+if ($audiodg) {
+    $audiodg | Select-Object Id, StartTime, ProcessName | Format-Table -AutoSize | Out-String
+} else {
+    "audiodg.exe is not running (audio engine is idle)."
+}
+
+Write-Section 'Suggested next step'
+if ($installAcl -and -not $installAcl.LocalServiceAllowed) {
+@"
+The install root is missing LOCAL SERVICE access. To repair an existing
+install without reinstalling, run from an ELEVATED PowerShell:
+
+  .\Repair-EqualizerAPO.ps1
+
+That script applies the same ACL grants the install hook would apply on a
+clean install, then restarts Audiosrv so audiodg picks up the change.
+"@
+} else {
+    "No obvious ACL problems detected. If Device Selector still reports access denied, capture an ETW trace (logman) or ProcMon trace filtered to audiodg.exe and Path containing EqualizerAPO."
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,34 @@
+# tools/
+
+EqualizerAPO-XT 설치 진단과 복구를 위한 PowerShell 헬퍼.
+
+## Diagnose-EqualizerAPO.ps1
+
+읽기 전용 진단 스크립트입니다. 설치 경로, ACL, COM 등록 상태, MMDevices의 APO 체인을 덤프하고 Device Selector에서 "GetMixFormat / Initialize 액세스 거부"가 발생하는 조건이 있는지 점검합니다. 권한 상승 없이 실행할 수 있습니다.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\Diagnose-EqualizerAPO.ps1
+# 결과를 파일로 저장하려면:
+.\Diagnose-EqualizerAPO.ps1 > eapo-report.txt
+```
+
+스크립트가 "MISSING: LOCAL SERVICE grant on install root"를 경고하면 audiodg.exe가 APO DLL을 읽지 못해 audio engine이 device를 invalidated 상태로 만든 경우입니다. 이 경우 `Repair-EqualizerAPO.ps1`을 elevated PowerShell에서 실행하면 됩니다.
+
+## Repair-EqualizerAPO.ps1
+
+기존 설치본을 재설치 없이 복구합니다. install hook이 적용하는 것과 동일한 ACL을 install root와 config dir에 다시 적용하고, Audiosrv를 재시작해 audiodg가 새 ACL로 APO를 다시 로드하게 합니다. **elevated PowerShell**이 필요합니다.
+
+```powershell
+# 관리자 권한 PowerShell에서
+powershell -ExecutionPolicy Bypass -File .\Repair-EqualizerAPO.ps1
+```
+
+`-SkipServiceRestart`를 주면 ACL만 손보고 Audiosrv는 건드리지 않습니다. 이 경우 수동으로 재시작하거나 재부팅해야 audiodg가 변경된 ACL을 본다.
+
+이 스크립트는 install hook fix(v0.3 이후)가 들어가기 전에 설치한 사용자가 재설치 없이 문제를 해결할 수 있도록 두는 것입니다. v0.3 이후로 새로 설치한 사용자는 install hook이 동일한 ACL을 자동으로 적용하므로 이 스크립트가 필요하지 않습니다.
+
+## 배경
+
+`audiodg.exe`는 LOCAL SERVICE 계정으로 실행되어 APO COM 객체를 로드합니다. Velopack은 EqualizerAPO를 `%LocalAppData%\EqualizerAPO-XT-*\current\` 아래에 설치하는데, 이 사용자 프로필 하위 트리의 기본 ACL은 설치한 사용자와 Administrators만 접근을 허용합니다. LOCAL SERVICE에는 권한이 없으므로 audiodg가 EqualizerAPO.dll을 읽지 못하고, audio engine이 device를 invalidated 상태로 만들어 후속 `IAudioClient::GetMixFormat`과 `Initialize` 호출이 `E_ACCESSDENIED`(액세스가 거부되었습니다)를 반환합니다. 한 device 안에서 install mode 세 가지(SFX/EFX, SFX/MFX, LFX/GFX)를 차례로 시도하므로 오류 다이얼로그가 여러 개 쌓이는 것이 보입니다.
+
+`helpers/ApoRegistration.cpp`의 `install()`이 v0.3부터 install root에 LOCAL SERVICE RX, config dir에 LOCAL SERVICE M을 grant하도록 보강되어, 새 설치에서는 이 문제가 발생하지 않습니다.

--- a/tools/Repair-EqualizerAPO.ps1
+++ b/tools/Repair-EqualizerAPO.ps1
@@ -1,0 +1,102 @@
+<#
+.SYNOPSIS
+    Repairs an existing EqualizerAPO-XT install whose APO DLL is unreadable
+    to audiodg.exe (LOCAL SERVICE), without reinstalling.
+
+.DESCRIPTION
+    Applies the same ACL grants the install hook would set on a clean install:
+      - install root: LOCAL SERVICE RX recursive, Users RX recursive
+      - config dir:   Users F recursive, LOCAL SERVICE M recursive
+    Then restarts Audiosrv so the audio engine reloads the APO with the
+    corrected ACL.
+
+    Must be run elevated. If the install hook on a fresh install already
+    applies these grants (as of the v0.3 fix), this script is only needed
+    for installs that predate that fix.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Repair-EqualizerAPO.ps1
+
+.NOTES
+    Restarting Audiosrv interrupts any active audio playback for a few seconds.
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [switch]$SkipServiceRestart
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Elevated {
+    $current = [Security.Principal.WindowsPrincipal]::new(
+        [Security.Principal.WindowsIdentity]::GetCurrent())
+    if (-not $current.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw "This script must be run from an elevated PowerShell. Right-click PowerShell > Run as administrator."
+    }
+}
+
+function Invoke-Icacls {
+    param(
+        [string]$Path,
+        [string[]]$Grants
+    )
+    $args = @("`"$Path`"")
+    foreach ($g in $Grants) { $args += '/grant'; $args += $g }
+    $args += '/T'; $args += '/C'; $args += '/Q'
+    Write-Host "  icacls $($args -join ' ')"
+    $output = & icacls.exe @args 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "icacls returned $LASTEXITCODE for $Path"
+        $output | ForEach-Object { Write-Warning "    $_" }
+    }
+}
+
+Assert-Elevated
+
+$apoRegPath = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO'
+if (-not (Test-Path $apoRegPath)) {
+    throw "EqualizerAPO is not registered. Install it first."
+}
+
+$installPath = (Get-ItemProperty $apoRegPath -Name InstallPath -ErrorAction Stop).InstallPath
+$configPath  = (Get-ItemProperty $apoRegPath -Name ConfigPath  -ErrorAction Stop).ConfigPath
+
+if (-not (Test-Path -LiteralPath $installPath)) {
+    throw "InstallPath does not exist: $installPath"
+}
+
+Write-Host "InstallPath: $installPath"
+Write-Host "ConfigPath:  $configPath"
+
+if ($PSCmdlet.ShouldProcess($installPath, 'Grant LOCAL SERVICE RX recursive')) {
+    Write-Host ""
+    Write-Host "Granting LOCAL SERVICE (RX) and Users (RX) on install root..."
+    Invoke-Icacls -Path $installPath -Grants @(
+        '*S-1-5-19:(OI)(CI)RX',
+        '*S-1-5-32-545:(OI)(CI)RX'
+    )
+}
+
+if ($configPath -and (Test-Path -LiteralPath $configPath)) {
+    if ($PSCmdlet.ShouldProcess($configPath, 'Grant Users F + LOCAL SERVICE M recursive')) {
+        Write-Host ""
+        Write-Host "Granting Users (F) and LOCAL SERVICE (M) on config dir..."
+        Invoke-Icacls -Path $configPath -Grants @(
+            '*S-1-5-32-545:(OI)(CI)F',
+            '*S-1-5-19:(OI)(CI)M'
+        )
+    }
+}
+
+if (-not $SkipServiceRestart) {
+    if ($PSCmdlet.ShouldProcess('Audiosrv', 'Restart so audiodg reloads the APO')) {
+        Write-Host ""
+        Write-Host "Restarting Audiosrv..."
+        Restart-Service -Name Audiosrv -Force
+        Write-Host "Done. Open Device Selector and re-run the APO installation check."
+    }
+} else {
+    Write-Host ""
+    Write-Host "Skipped Audiosrv restart. Restart it manually (or reboot) for audiodg to pick up the new ACL."
+}


### PR DESCRIPTION
## Summary

PR [#8](https://github.com/115dkk/EqualizerAPO-XT/pull/8)이 머지되며 install hook self-elevation과 DeviceSelector Start Menu 단축키가 main에 들어갔지만, 그 직후에 만든 진짜 root-cause fix 두 commit이 PR이 닫힌 뒤 push되어 머지되지 못했습니다. 이 PR이 그 둘을 가져옵니다.

- `helpers/ApoRegistration.cpp`: install 루트에 LOCAL SERVICE / Users RX recursive, config 디렉터리에 LOCAL SERVICE M recursive를 부여하도록 보강.
- `tools/Diagnose-EqualizerAPO.ps1`, `tools/Repair-EqualizerAPO.ps1`, `tools/README.md`: 진단/복구 PowerShell 헬퍼와 문서.

## Why this is urgent

머지된 PR #8 직후 CI가 `v1.4.3-main.41` release를 만들었습니다. 그 release에는 install hook self-elevation은 들어 있지만 ACL grant는 빠져 있어, **사용자는 새 빌드를 받아도 여전히 GetMixFormat / Initialize 액세스 거부를 보게 됩니다.** PR #8 머지 후 사용자 머신에서 ACL 진단을 다시 돌려 root cause를 확정했고, 그 결과 install root에 LOCAL SERVICE 권한이 없다는 사실이 명백해졌습니다.

## Root cause

`audiodg.exe`는 LOCAL SERVICE(`*S-1-5-19`)로 실행되어 COM InprocServer32 경로의 EqualizerAPO.dll을 로드합니다. Velopack은 앱을 `%LocalAppData%\EqualizerAPO-XT-*\current\` 아래에 설치하는데, 이 사용자 프로필 하위 트리의 기본 ACL은 설치한 사용자와 Administrators만 허용합니다. LOCAL SERVICE에 권한이 없으므로 audiodg는 DLL 파일 자체를 열지 못하고, audio engine은 device를 invalidated 상태로 만들며, 이후 모든 `IAudioClient::GetMixFormat`/`Initialize` 호출이 `E_ACCESSDENIED`를 돌려줍니다. DeviceSelector는 한 device 안에서 install mode 세 가지(SFX/EFX, SFX/MFX, LFX/GFX)를 차례로 시도하기 때문에 에러 다이얼로그가 여러 개 쌓이는 것이 보입니다.

기존 install hook의 icacls는 `installDir\config`만 손대고 install 루트와 EqualizerAPO.dll에는 권한을 추가하지 않았습니다. SYSTEM은 FullControl을 가지지만 audiodg는 SYSTEM이 아닙니다.

## Changes

- [helpers/ApoRegistration.cpp](helpers/ApoRegistration.cpp): `install()`에서 regsvr32 호출 전에 install 루트에 `LOCAL SERVICE RX` + `Users RX`를 recursive로 부여하고, regsvr32 후에는 config 디렉터리에 `Users F` + `LOCAL SERVICE M`을 recursive로 부여합니다. ACL grant가 COM 등록보다 먼저 일어나므로 audio engine이 InprocServer32를 처음 인식할 때부터 DLL이 읽힙니다. trace logging이 활성화되면 APO가 config 폴더에 쓰기를 하므로 LOCAL SERVICE에는 modify(M)을 줍니다.
- [tools/Diagnose-EqualizerAPO.ps1](tools/Diagnose-EqualizerAPO.ps1): 권한 상승 없이 돌아가는 진단 스크립트. InstallPath, ACL, COM 등록 상태, MMDevices APO 체인을 덤프하고 LOCAL SERVICE 권한 부재를 명시적으로 경고합니다.
- [tools/Repair-EqualizerAPO.ps1](tools/Repair-EqualizerAPO.ps1): elevated PowerShell에서 실행하는 복구 스크립트. install root와 config dir에 동일 ACL을 재적용하고 Audiosrv를 재시작합니다. 이 fix 이전에 설치한 사용자가 재설치 없이 빠져나올 수 있도록 두는 용도입니다.
- [tools/README.md](tools/README.md): 두 스크립트 사용법과 배경 설명.
- [.gitignore](.gitignore): 옛 `tools/` ignore 패턴을 제거(이 repo에서 build artifact가 `tools/`로 가는 일이 없습니다).

## Verification

- Common.lib와 EditorLogicTests가 v143 toolset으로 깨끗하게 빌드되고 단위 테스트 통과.
- `Diagnose-EqualizerAPO.ps1`을 PR #8이 머지된 빌드가 설치된 머신에서 돌려 본 결과 `MISSING: LOCAL SERVICE grant on install root` 경고가 정확히 출력되고, 영향받는 device 목록(VB-Audio Virtual Cable, DDRC 2x4n)도 정확히 잡았습니다.

## Test plan

- [x] Common + EditorLogicTests rebuild and unit tests pass
- [x] Diagnose-EqualizerAPO.ps1 produces the expected warnings on the broken install
- [ ] Manual verification on the user's machine: run `tools\Repair-EqualizerAPO.ps1` from elevated PowerShell on the existing install and re-run DeviceSelector check; access-denied should disappear
- [ ] CI matrix builds pass on this branch
- [ ] After merge, the new release's installer should leave a freshly-installed Velopack install with LOCAL SERVICE access on the install root from the start

🤖 Generated with [Claude Code](https://claude.com/claude-code)