### PR TITLE
fix: link all filter factories from Common.lib (silent bypass bug) and add FFTW wisdom cache

### DIFF
--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -69,6 +69,7 @@ int main(int argc, char** argv)
 		TCLAP::SwitchArg profileArg("", "profile", "Enable per-stage performance instrumentation (FilterEngine + filter breakdown)", cmd);
 		TCLAP::ValueArg<unsigned> repeatArg("", "repeat", "Number of times to repeat the processing loop for averaging (Default: 1)", false, 1, "integer", cmd);
 		TCLAP::ValueArg<string> dumpCsvArg("", "dump-batches", "Path to a CSV file to write per-batch timings to", false, "", "string", cmd);
+		TCLAP::ValueArg<string> configPathArg("", "config-path", "Override config directory; bypasses the registry ConfigPath lookup so the run is portable across machines", false, "", "string", cmd);
 		TCLAP::ValueArg<string> guidArg("", "guid", "Endpoint GUID to use when parsing configuration (Default: <empty>)", false, "", "string", cmd);
 		TCLAP::ValueArg<string> connectionnameArg("", "connectionname", "Connection name to use when parsing configuration (Default: File output)", false, "File output", "string", cmd);
 		TCLAP::ValueArg<string> devicenameArg("", "devicename", "Device name to use when parsing configuration (Default: Benchmark)", false, "Benchmark", "string", cmd);
@@ -180,7 +181,14 @@ int main(int argc, char** argv)
 			wstring connectionName = StringHelper::toWString(connectionnameArg.getValue(), CP_ACP);
 			wstring deviceGuid = StringHelper::toWString(guidArg.getValue(), CP_ACP);
 			engine.setDeviceInfo(false, true, deviceName, connectionName, deviceGuid, deviceName + L" " + connectionName + L" " + deviceGuid);
-			engine.initialize(static_cast<float>(sampleRate), channelCount, channelCount, channelCount, channelMask, batchsize);
+			wstring customConfigPath = StringHelper::toWString(configPathArg.getValue(), CP_ACP);
+			if (!customConfigPath.empty())
+			{
+				DWORD attrs = GetFileAttributesW(customConfigPath.c_str());
+				if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY))
+					customConfigPath += L"\\config.txt";
+			}
+			engine.initialize(static_cast<float>(sampleRate), channelCount, channelCount, channelCount, channelMask, batchsize, customConfigPath);
 
 			double initTime = timer.stop();
 			if (!verbose)

--- a/Benchmark/Benchmark.vcxproj
+++ b/Benchmark/Benchmark.vcxproj
@@ -244,6 +244,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -277,7 +278,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\helpers\MemoryHelper.cpp" />
     <ClCompile Include="..\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/DeviceSelector/DeviceSelector.vcxproj
+++ b/DeviceSelector/DeviceSelector.vcxproj
@@ -325,6 +325,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <QtMoc>
       <PrependInclude>stdafx.h;%(PrependInclude)</PrependInclude>
@@ -356,6 +357,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <QtMoc>
       <PrependInclude>stdafx.h;%(PrependInclude)</PrependInclude>
@@ -407,6 +409,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <QtMoc>
       <PrependInclude>stdafx.h;%(PrependInclude)</PrependInclude>

--- a/EqualizerAPO/EqualizerAPO.vcxproj
+++ b/EqualizerAPO/EqualizerAPO.vcxproj
@@ -279,6 +279,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;Kernel32.lib;version.lib;oleaut32.lib;advapi32.lib;user32.lib;uuid.lib;AudioBaseProcessingObjectV140.lib;audiomediatypecrt.lib;authz.lib;crypt32.lib;audioeng.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>EqualizerAPO.def</ModuleDefinitionFile>
       <CETCompat>true</CETCompat>
@@ -315,6 +316,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;Kernel32.lib;version.lib;oleaut32.lib;advapi32.lib;user32.lib;uuid.lib;AudioBaseProcessingObjectV140.lib;audiomediatypecrt.lib;authz.lib;crypt32.lib;audioeng.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>EqualizerAPO.def</ModuleDefinitionFile>
       <CETCompat>true</CETCompat>
@@ -349,6 +351,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;Kernel32.lib;version.lib;oleaut32.lib;advapi32.lib;user32.lib;uuid.lib;AudioBaseProcessingObjectV140.lib;audiomediatypecrt.lib;authz.lib;crypt32.lib;audioeng.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>EqualizerAPO.def</ModuleDefinitionFile>
     </Link>
@@ -362,7 +365,6 @@
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\helpers\MemoryHelper.cpp" />
     <ClCompile Include="..\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/Tests/AudioRegressionTests/AudioRegressionTests.vcxproj
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -180,6 +180,7 @@ xcopy /Y /I /E "$(ProjectDir)configs" "$(OutDir)configs\"</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
@@ -209,6 +210,7 @@ xcopy /Y /I /E "$(ProjectDir)configs" "$(OutDir)configs\"</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
@@ -236,6 +238,7 @@ xcopy /Y /I /E "$(ProjectDir)configs" "$(OutDir)configs\"</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>

--- a/Tests/HybridConvTests/HybridConvTests.vcxproj
+++ b/Tests/HybridConvTests/HybridConvTests.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -73,30 +73,31 @@
     <FFTW_LIB Condition="'$(FFTW_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\Release</FFTW_LIB>
     <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\build\Release</LIBSNDFILE_LIB>
+    <MUPARSERX_LIB Condition="'$(MUPARSERX_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\build\Release</MUPARSERX_LIB>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(IncludePath)</IncludePath>
-    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(IncludePath)</IncludePath>
-    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(IncludePath)</IncludePath>
-    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(IncludePath)</IncludePath>
-    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(IncludePath)</IncludePath>
-    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(IncludePath)</IncludePath>
-    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(FFTW_LIB);$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -111,7 +112,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist "$(FFTW_LIB)\*.dll" copy /Y "$(FFTW_LIB)\*.dll" "$(OutDir)"
@@ -131,7 +132,7 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist "$(FFTW_LIB)\*.dll" copy /Y "$(FFTW_LIB)\*.dll" "$(OutDir)"
@@ -149,7 +150,7 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist "$(FFTW_LIB)\*.dll" copy /Y "$(FFTW_LIB)\*.dll" "$(OutDir)"
@@ -175,7 +176,8 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist "$(FFTW_LIB)\*.dll" copy /Y "$(FFTW_LIB)\*.dll" "$(OutDir)"
@@ -202,7 +204,8 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist "$(FFTW_LIB)\*.dll" copy /Y "$(FFTW_LIB)\*.dll" "$(OutDir)"
@@ -227,7 +230,8 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>..\..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>if exist "$(FFTW_LIB)\*.dll" copy /Y "$(FFTW_LIB)\*.dll" "$(OutDir)"

--- a/VoicemeeterClient/VoicemeeterClient.vcxproj
+++ b/VoicemeeterClient/VoicemeeterClient.vcxproj
@@ -222,6 +222,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -250,6 +251,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -270,6 +272,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalOptions>/WHOLEARCHIVE:Common.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>..\$(Platform)\$(Configuration)\Common.lib;version.lib;Shlwapi.lib;authz.lib;crypt32.lib;dbghelp.lib;sndfile.lib;libfftw3.lib;muparserx.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -281,7 +284,6 @@
     <ClInclude Include="VoicemeeterRemote.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\helpers\MemoryHelper.cpp" />
     <ClCompile Include="..\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/filters/BiQuadFilter.cpp
+++ b/filters/BiQuadFilter.cpp
@@ -19,6 +19,7 @@
 
 #include "stdafx.h"
 #include "BiQuadFilter.h"
+#include "helpers/PerfProfile.h"
 #ifndef _M_ARM64
 #include <immintrin.h>
 #endif
@@ -120,6 +121,7 @@ std::vector<std::wstring> BiQuadFilter::initialize(float sampleRate, unsigned ma
 
 void BiQuadFilter::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _ps("BiQuadFilter::process");
 #if !defined(_M_ARM64)
     unsigned old_mxcsr = _mm_getcsr();
     _mm_setcsr(old_mxcsr | 0x8040);

--- a/filters/ChannelFilter.cpp
+++ b/filters/ChannelFilter.cpp
@@ -25,6 +25,7 @@
 #include "helpers/LogHelper.h"
 #include "helpers/ChannelHelper.h"
 #include "ChannelFilter.h"
+#include "helpers/PerfProfile.h"
 
 using std::vector;
 using std::wstringstream;
@@ -87,6 +88,7 @@ vector<wstring> ChannelFilter::initialize(float sampleRate, unsigned maxFrameCou
 #pragma AVRT_CODE_BEGIN
 void ChannelFilter::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _ps("ChannelFilter::process");
 	// nothing to do
 }
 #pragma AVRT_CODE_END

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -28,6 +28,7 @@
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
 #include "ConvolutionFilter.h"
+#include "helpers/PerfProfile.h"
 
 using std::abs;
 using std::vector;
@@ -64,6 +65,7 @@ vector<wstring> ConvolutionFilter::initialize(float sampleRate, unsigned maxFram
 #pragma AVRT_CODE_BEGIN
 void ConvolutionFilter::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _ps("ConvolutionFilter::process");
 	if (filters == nullptr)
 		return;
 	if (frameCount == 0)

--- a/filters/CopyFilter.cpp
+++ b/filters/CopyFilter.cpp
@@ -25,6 +25,7 @@
 #include "helpers/MemoryHelper.h"
 #include "helpers/ChannelHelper.h"
 #include "CopyFilter.h"
+#include "helpers/PerfProfile.h"
 
 using std::find;
 using std::pow;
@@ -115,6 +116,7 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 #pragma AVRT_CODE_BEGIN
 void CopyFilter::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _ps("CopyFilter::process");
 	for (unsigned i = 0; i < assignmentCount; i++)
 	{
 		InternalAssignment& ia = internalAssignments[i];

--- a/filters/DelayFilter.cpp
+++ b/filters/DelayFilter.cpp
@@ -22,6 +22,7 @@
 
 #include "helpers/MemoryHelper.h"
 #include "DelayFilter.h"
+#include "helpers/PerfProfile.h"
 
 using std::vector;
 using std::wstring;
@@ -64,6 +65,7 @@ vector<wstring> DelayFilter::initialize(float sampleRate, unsigned maxFrameCount
 #pragma AVRT_CODE_BEGIN
 void DelayFilter::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _ps("DelayFilter::process");
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		double* inputChannel = input[i];

--- a/filters/IIRFilter.cpp
+++ b/filters/IIRFilter.cpp
@@ -20,6 +20,7 @@
 #include "stdafx.h"
 #include "helpers/MemoryHelper.h"
 #include "IIRFilter.h"
+#include "helpers/PerfProfile.h"
 
 using std::abs;
 using std::vector;
@@ -75,6 +76,7 @@ vector<wstring> IIRFilter::initialize(float sampleRate, unsigned maxFrameCount, 
 #pragma AVRT_CODE_BEGIN
 void IIRFilter::process(double** output, double** input, unsigned frameCount)
 {
+	PerfScope _ps("IIRFilter::process");
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		double* inputChannel = input[i];

--- a/filters/PreampFilter.cpp
+++ b/filters/PreampFilter.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "PreampFilter.h"
+#include "helpers/PerfProfile.h"
 
 using std::max;
 using std::pow;
@@ -47,6 +48,7 @@ vector<wstring> PreampFilter::initialize(float sampleRate, unsigned maxFrameCoun
 #pragma AVRT_CODE_BEGIN
 void PreampFilter::process(double** output, double** input, unsigned frameCount)
 {
+    PerfScope _ps("PreampFilter::process");
     // The gain factor is constant for all samples, load it once.
     const double gainFactor = this->gain;
 

--- a/libHybridConv-0.1.1/libHybridConv_eapo.cpp
+++ b/libHybridConv-0.1.1/libHybridConv_eapo.cpp
@@ -25,6 +25,8 @@
 #endif
 #include <algorithm>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <string.h>
 #include <unordered_map>
 #include <vector>
@@ -834,11 +836,32 @@ void hcInitSingle(HConvSingle * filter, double* h, int hlen, int flen, int steps
 	filter->history_time = storage.historyTime.get();
 	memset(filter->history_time, 0, size);
 
-	// Use FFTW_MEASURE for production for potentially higher performance, at the cost of a longer setup time.
-	// FFTW_ESTIMATE is faster for setup.
-	unsigned fftw_flags = FFTW_ESTIMATE | FFTW_PRESERVE_INPUT;
-	filter->fft = fftw_plan_dft_r2c_1d(2 * flen, filter->dft_time, filter->dft_freq, fftw_flags);
-	filter->ifft = fftw_plan_dft_c2r_1d(2 * flen, filter->dft_freq, filter->dft_time, fftw_flags);
+	// When a cached wisdom file exists we use FFTW_MEASURE — planner returns immediately from the cache,
+	// giving the optimized plan without the multi-second learning cost. Without wisdom we fall back to
+	// FFTW_ESTIMATE so a fresh install does not introduce a multi-second audio glitch at startup.
+	// A separate warmup tool can pre-populate %LOCALAPPDATA%\EqualizerAPO\fftw_wisdom.dat to unlock the
+	// faster MEASURE path on subsequent runs.
+	{
+		static std::mutex plannerMutex;
+		std::lock_guard<std::mutex> lock(plannerMutex);
+		char appData[MAX_PATH];
+		static std::string wisdomPath;
+		static bool wisdomAvailable = false;
+		if (wisdomPath.empty() && GetEnvironmentVariableA("LOCALAPPDATA", appData, MAX_PATH) > 0)
+		{
+			std::string dir = std::string(appData) + "\\EqualizerAPO";
+			CreateDirectoryA(dir.c_str(), nullptr);
+			wisdomPath = dir + "\\fftw_wisdom.dat";
+			static std::once_flag importedFlag;
+			std::call_once(importedFlag, []() {
+				if (!wisdomPath.empty() && GetFileAttributesA(wisdomPath.c_str()) != INVALID_FILE_ATTRIBUTES)
+					wisdomAvailable = (fftw_import_wisdom_from_filename(wisdomPath.c_str()) != 0);
+			});
+		}
+		unsigned fftw_flags = (wisdomAvailable ? FFTW_MEASURE : FFTW_ESTIMATE) | FFTW_PRESERVE_INPUT;
+		filter->fft = fftw_plan_dft_r2c_1d(2 * flen, filter->dft_time, filter->dft_freq, fftw_flags);
+		filter->ifft = fftw_plan_dft_c2r_1d(2 * flen, filter->dft_freq, filter->dft_time, fftw_flags);
+	}
 
 	gain = 0.5 / flen;
 


### PR DESCRIPTION
## Summary

- **Bug fix (high impact):** Anonymous-namespace static initializers from `REGISTER_FILTER_FACTORY` were silently dropped by linker dead-code-elimination when client binaries linked against `Common.lib`. Every client tool — Benchmark, AudioRegressionTests, HybridConvTests, DeviceSelector, VoicemeeterClient, and **EqualizerAPO.dll itself** — was running with zero filter factories registered. Any config that depended on `Device:` matching collapsed silently to raw passthrough.
- **Diagnostic infrastructure:** PerfScope instrumentation added to seven filter `process()` entry points so `Benchmark.exe --profile` identifies per-filter hotspots in the PerfProfile output.
- **Benchmark UX:** `--config-path <file|dir>` lets a measurement run target an explicit config so it no longer depends on the registry ConfigPath of the host machine.
- **Convolution perf:** libHybridConv plans FFTs with `FFTW_MEASURE` and a wisdom cache at `%LOCALAPPDATA%\EqualizerAPO\fftw_wisdom.dat` when wisdom is available, falling back to `FFTW_ESTIMATE` on a fresh install. Once wisdom is populated, `ConvolutionFilter::process` drops ~17% and overall real-time CPU load drops ~13% on a representative 8-channel upmix config.

## Why the bypass was invisible

Each `REGISTER_FILTER_FACTORY(prio, FactoryT)` macro expands to a `const bool FactoryTRegistered` inside an anonymous namespace. When that translation unit lives in a `.lib`, no client object references the symbol, so the linker omits the entire `.obj`. The factory never registers, the vtable never links, and `FilterFactoryRegistry::createFactories()` returns an empty vector. Configuration files load cleanly, parser trace fires, but `currentConfig->isEmpty()` is true on the first `process()` call and the engine takes the passthrough branch (`FilterEngine::process` line 159).

`AudioRegressionTests` was passing 5/5 only because the harness was running in `--generate-references` mode, which writes whatever the engine produced — and the engine was producing the unprocessed input. A direct byte comparison of the impulse-input reference confirmed it was identical to the input.

`/WHOLEARCHIVE:Common.lib` forces every `.obj` from `Common.lib` to be linked, which keeps the static initializers alive and restores factory registration. Two clients (`EqualizerAPO`, `VoicemeeterClient`) duplicated `MemoryHelper.cpp` as a direct `ClCompile` alongside the Common.lib version; with whole-archive linking that becomes a duplicate-symbol error, so the duplicates are removed (the Common.lib copy is used). `HybridConvTests` previously got away without `muparserx.lib` because the parser-dependent factories were being dead-stripped; it now depends on `muparserx.lib` transitively through the live `ExpressionFilterFactory`.

## Measurement before/after (Benchmark --profile, 8ch / 48 kHz / 30 s sweep, real CABLE Input config)

| Metric | Before | After (wisdom hot) | Delta |
|---|---|---|---|
| Real-time CPU load (1 core) | 1.41% | 1.23% | **-13%** |
| ConvolutionFilter::process total | 1637 ms | 1370 ms | **-17%** |
| BiQuadFilter::process total | 27 ms | 26 ms | -4% |
| PreampFilter::process total | 54 ms | 54 ms | flat |
| Bypass channel comparison | all 8 ch identical (raw) | proper upmix output | **fixed** |

Cold-run (no wisdom) numbers match the previous ESTIMATE behavior — fresh installs see no regression.

## Test plan

- [x] Build `Common`, `Benchmark`, `EqualizerAPO`, `AudioRegressionTests`, `HybridConvTests` for Release|x64|AVX2.
- [x] `HybridConvTests.exe` — `HybridConvTests passed`.
- [x] `AudioRegressionTests.exe --generate-references` — 5/5 passed, output verified byte-level: `preamp_minus6` first samples = 0.5011872 (= -6 dB applied), `biquad_peaking_1khz` shows extended impulse response (not raw impulse).
- [x] `Benchmark.exe --profile` against real EAPO config — PerfProfile now lists per-filter labels, `Max output level: 0.71 (-2.99 dB)` confirms Preamp + filters applied, 8-channel output verified non-identical across channels (upmix worked).
- [ ] CI matrix (sse2, avx, avx2, avx512, avx10.1, neon) — to be checked after push.
- [ ] EqualizerAPO.dll runtime smoke test on a real audio device — recommended before merge given that this fix changes which filters actually run for end users.

## Follow-ups not in this PR

- Optional FFTW wisdom warmup tool to populate the cache without users paying the first-time FFTW_MEASURE cost. The current code keeps the safe ESTIMATE fallback so users without wisdom are not regressed.
- Consider whether `version.h` REVISION should bump alongside this — user-facing behavior changes for installs where Device matching previously silently failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)