### PR TITLE
perf(editor): cut GUI/analysis overhead + defer Velopack

### DIFF
--- a/Editor/AnalysisPlotScene.cpp
+++ b/Editor/AnalysisPlotScene.cpp
@@ -31,8 +31,10 @@ AnalysisPlotScene::AnalysisPlotScene(QObject* parent)
 
 void AnalysisPlotScene::setFreqData(fftw_complex* freqData, int frameCount, unsigned sampleRate)
 {
+	const int count = frameCount / 2;
 	nodes.clear();
-	for (int i = 0; i < frameCount / 2; i++)
+	nodes.reserve(count);
+	for (int i = 0; i < count; i++)
 	{
 		double freq = (i * 1.0 / frameCount) * sampleRate;
 		// GainIterator can't handle 0 Hz node
@@ -40,7 +42,7 @@ void AnalysisPlotScene::setFreqData(fftw_complex* freqData, int frameCount, unsi
 			freq = 0.001;
 		double gain = sqrt(freqData[i][0] * freqData[i][0] + freqData[i][1] * freqData[i][1]);
 		double dbGain = log10(gain) * 20;
-		nodes.push_back(FilterNode(freq, dbGain));
+		nodes.emplace_back(freq, dbGain);
 	}
 
 	update();

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -26,6 +26,7 @@
 #include <QComboBox>
 #include <QDir>
 #include <QActionGroup>
+#include <QTimer>
 
 #include "FilterTable.h"
 #include "DeviceAPOInfo.h"
@@ -101,6 +102,7 @@ private slots:
 	void on_actionResetAllFileSpecificPreferences_triggered();
 
 private:
+	void executeStartAnalysis();
 	FilterTable* addTab(QString title, QString tooltip, QString configPath, QList<QString> lines);
 	void getDeviceAndChannelMask(std::shared_ptr<AbstractAPOInfo>* selectedDevice, int* channelMask);
 	bool askForClose(int tabIndex);
@@ -128,6 +130,7 @@ private:
 	AnalysisPlotScene* analysisPlotScene;
 	EqGraphView* eqGraphView = nullptr;
 	AnalysisThread* analysisThread = nullptr;
+	QTimer* analysisDebounceTimer = nullptr;
 	bool restart = false;
 	bool noSavePreferences = false;
 	bool noSaveFilePreferences = false;

--- a/Editor/MainWindowParts/MainWindow.Analysis.cpp
+++ b/Editor/MainWindowParts/MainWindow.Analysis.cpp
@@ -132,6 +132,27 @@ void MainWindow::startAnalysis()
 	if (!ui->analysisDockWidget->isVisible())
 		return;
 
+	// Debounce: instant-mode saves, slider drags, channel/resolution changes, and
+	// tab switches each call startAnalysis. AnalysisThread::setParameters already
+	// keeps only the most recent parameters via wakeAll, but the actual analysis
+	// run (engine init + up to ten seconds of impulse processing) does not abort
+	// mid-flight. Adding a short coalesce window cuts redundant runs while a
+	// user is still dragging.
+	static constexpr int kAnalysisDebounceMs = 120;
+	if (analysisDebounceTimer == nullptr)
+	{
+		analysisDebounceTimer = new QTimer(this);
+		analysisDebounceTimer->setSingleShot(true);
+		connect(analysisDebounceTimer, &QTimer::timeout, this, &MainWindow::executeStartAnalysis);
+	}
+	analysisDebounceTimer->start(kAnalysisDebounceMs);
+}
+
+void MainWindow::executeStartAnalysis()
+{
+	if (!ui->analysisDockWidget->isVisible())
+		return;
+
 	shared_ptr<AbstractAPOInfo> selectedDevice;
 
 	int channelMask;

--- a/Editor/MainWindowParts/MainWindow.Edit.cpp
+++ b/Editor/MainWindowParts/MainWindow.Edit.cpp
@@ -14,6 +14,7 @@
 #include <QMessageBox>
 #include <QProcess>
 #include <QSettings>
+#include <QTimer>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -54,7 +55,31 @@ void MainWindow::linesChanged()
 		QString configPath = filterTable->getConfigPath();
 		if (configPath.length() > 0)
 		{
-			save(filterTable, configPath);
+			// Debounce instant-mode saves. Dragging a knob or typing in a value
+			// previously triggered a full file write per change; coalesce all
+			// changes within a short window into a single save.
+			static constexpr int kSaveDebounceMs = 200;
+			const QString timerObjectName = QStringLiteral("__instantModeSaveTimer");
+			QTimer* timer = filterTable->findChild<QTimer*>(timerObjectName, Qt::FindDirectChildrenOnly);
+			if (!timer)
+			{
+				timer = new QTimer(filterTable);
+				timer->setObjectName(timerObjectName);
+				timer->setSingleShot(true);
+				// Capturing filterTable is safe: the timer is its child, so the
+				// timer cannot outlive the FilterTable. Re-resolve the path on
+				// fire because the FilterTable's config path can change while
+				// the debounce window is pending.
+				connect(timer, &QTimer::timeout, this, [this, filterTable]() {
+					QString currentPath = filterTable->getConfigPath();
+					if (currentPath.length() > 0)
+					{
+						save(filterTable, currentPath);
+						updateDirtyStatus();
+					}
+				});
+			}
+			timer->start(kSaveDebounceMs);
 			updateDirtyStatus();
 			return;
 		}

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -29,6 +29,7 @@
 #include <QSettings>
 #include <QStyleFactory>
 #include <QStyleHints>
+#include <QTimer>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -334,7 +335,15 @@ int main(int argc, char* argv[])
 			w.doChecks();
 
 		if (VelopackBootstrap::isVelopackInstall() && !firstRun)
-			VelopackBootstrap::triggerBackgroundUpdate(QStringLiteral("115dkk/EqualizerAPO-XT").toStdWString());
+		{
+			// Defer the background update so it does not race with audio service
+			// work or a Device Selector launch right after the Editor opens.
+			// 60s is long enough that the initial GUI paint, config load, and
+			// device enumeration are all comfortably finished.
+			QTimer::singleShot(60000, qApp, []() {
+				VelopackBootstrap::triggerBackgroundUpdate(QStringLiteral("115dkk/EqualizerAPO-XT").toStdWString());
+			});
+		}
 
 		result = application.exec();
 

--- a/Editor/widgets/EqGraphView.cpp
+++ b/Editor/widgets/EqGraphView.cpp
@@ -44,13 +44,21 @@ void EqGraphView::setNodes(const std::vector<FilterNode>& nodes, unsigned sample
 	currentNodes = nodes;
 	currentSampleRate = sampleRate;
 	currentChannel = channel.isEmpty() ? QStringLiteral("All") : channel;
+	curveDirty = true;
 	update();
 }
 
 void EqGraphView::setChannel(const QString& channel)
 {
+	// Only the label changes; the cached curve geometry stays valid.
 	currentChannel = channel;
 	update();
+}
+
+void EqGraphView::resizeEvent(QResizeEvent* event)
+{
+	QWidget::resizeEvent(event);
+	curveDirty = true;
 }
 
 QString EqGraphView::channel() const
@@ -94,21 +102,55 @@ void EqGraphView::paintEvent(QPaintEvent*)
 		painter.drawLine(QPointF(x, graphRect.top()), QPointF(x, graphRect.bottom()));
 	}
 
-	GainIterator gainIterator(currentNodes);
-	QVector<double> sampledDb;
-	sampledDb.reserve(qMax(2, static_cast<int>(graphRect.width())));
-	double maxAbsDb = 0.0;
-	for (int x = static_cast<int>(graphRect.left()); x <= static_cast<int>(graphRect.right()); x++)
+	const bool geometryChanged = (cachedSize != size()) || (cachedGraphRect != graphRect);
+	if (curveDirty || geometryChanged)
 	{
-		const double db = gainIterator.gainAt(xToHz(graphRect, x));
-		const double finiteDb = std::isfinite(db) ? db : -120.0;
-		sampledDb.append(finiteDb);
-		maxAbsDb = std::max(maxAbsDb, std::abs(finiteDb));
+		GainIterator gainIterator(currentNodes);
+		QVector<double> sampledDb;
+		sampledDb.reserve(qMax(2, static_cast<int>(graphRect.width())));
+		double maxAbsDb = 0.0;
+		for (int x = static_cast<int>(graphRect.left()); x <= static_cast<int>(graphRect.right()); x++)
+		{
+			const double db = gainIterator.gainAt(xToHz(graphRect, x));
+			const double finiteDb = std::isfinite(db) ? db : -120.0;
+			sampledDb.append(finiteDb);
+			maxAbsDb = std::max(maxAbsDb, std::abs(finiteDb));
+		}
+
+		const double rangeDb = qBound(12.0, std::ceil(maxAbsDb / 6.0) * 6.0, 60.0);
+		cachedMinDb = -rangeDb;
+		cachedMaxDb = rangeDb;
+		cachedZeroY = dbToY(graphRect, 0.0, cachedMinDb, cachedMaxDb);
+
+		cachedCurve = QPainterPath();
+		bool first = true;
+		for (int i = 0; i < sampledDb.size(); i++)
+		{
+			const double x = graphRect.left() + i;
+			const double y = dbToY(graphRect, sampledDb[i], cachedMinDb, cachedMaxDb);
+			if (first)
+			{
+				cachedCurve.moveTo(x, y);
+				first = false;
+			}
+			else
+			{
+				cachedCurve.lineTo(x, y);
+			}
+		}
+
+		cachedFill = cachedCurve;
+		cachedFill.lineTo(graphRect.right(), cachedZeroY);
+		cachedFill.lineTo(graphRect.left(), cachedZeroY);
+		cachedFill.closeSubpath();
+
+		cachedSize = size();
+		cachedGraphRect = graphRect;
+		curveDirty = false;
 	}
 
-	const double rangeDb = qBound(12.0, std::ceil(maxAbsDb / 6.0) * 6.0, 60.0);
-	const double minDb = -rangeDb;
-	const double maxDb = rangeDb;
+	const double minDb = cachedMinDb;
+	const double maxDb = cachedMaxDb;
 	for (int db = static_cast<int>(minDb); db <= static_cast<int>(maxDb); db += 6)
 	{
 		double y = dbToY(graphRect, db, minDb, maxDb);
@@ -118,38 +160,17 @@ void EqGraphView::paintEvent(QPaintEvent*)
 	QPen zeroPen(QColor(tokens.accent), 1.4);
 	zeroPen.setCosmetic(true);
 	painter.setPen(zeroPen);
-	double zeroY = dbToY(graphRect, 0.0, minDb, maxDb);
+	const double zeroY = cachedZeroY;
 	painter.drawLine(QPointF(graphRect.left(), zeroY), QPointF(graphRect.right(), zeroY));
 
-	QPainterPath curve;
-	bool first = true;
-	for (int i = 0; i < sampledDb.size(); i++)
-	{
-		const double x = graphRect.left() + i;
-		const double y = dbToY(graphRect, sampledDb[i], minDb, maxDb);
-		if (first)
-		{
-			curve.moveTo(x, y);
-			first = false;
-		}
-		else
-		{
-			curve.lineTo(x, y);
-		}
-	}
-
-	QPainterPath fillPath = curve;
-	fillPath.lineTo(graphRect.right(), zeroY);
-	fillPath.lineTo(graphRect.left(), zeroY);
-	fillPath.closeSubpath();
 	QColor fill(tokens.accent);
 	fill.setAlpha(SkinManager::instance()->isDark() ? 30 : 18);
-	painter.fillPath(fillPath, fill);
+	painter.fillPath(cachedFill, fill);
 
 	QPen curvePen(QColor(tokens.accent), 2.4, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
 	curvePen.setCosmetic(true);
 	painter.setPen(curvePen);
-	painter.drawPath(curve);
+	painter.drawPath(cachedCurve);
 
 	painter.setPen(QColor(tokens.mutedText));
 	QFont labelFont = font();

--- a/Editor/widgets/EqGraphView.h
+++ b/Editor/widgets/EqGraphView.h
@@ -2,6 +2,9 @@
 
 #include <vector>
 
+#include <QPainterPath>
+#include <QRectF>
+#include <QSize>
 #include <QWidget>
 
 #include "helpers/GainIterator.h"
@@ -20,9 +23,22 @@ public:
 
 protected:
 	void paintEvent(QPaintEvent*) override;
+	void resizeEvent(QResizeEvent* event) override;
 
 private:
 	std::vector<FilterNode> currentNodes;
 	QString currentChannel = QStringLiteral("All");
 	unsigned currentSampleRate = 0;
+
+	// Cached curve geometry. Rebuilt only when the node set or the widget
+	// dimensions change; skin or channel-label changes reuse the cached path
+	// (they only affect pen colour and overlay text).
+	bool curveDirty = true;
+	QSize cachedSize;
+	QRectF cachedGraphRect;
+	QPainterPath cachedCurve;
+	QPainterPath cachedFill;
+	double cachedMinDb = 0.0;
+	double cachedMaxDb = 0.0;
+	double cachedZeroY = 0.0;
 };

--- a/helpers/GainIterator.cpp
+++ b/helpers/GainIterator.cpp
@@ -26,10 +26,8 @@ using std::log;
 using std::vector;
 
 GainIterator::GainIterator(const vector<FilterNode>& nodes)
+	: nodes(nodes), nodeLeft(nullptr), nodeRight(nullptr), logLeft(0.0), logRightMinusLeft(0.0)
 {
-	this->nodes = nodes;
-	nodeLeft = nullptr;
-	nodeRight = nullptr;
 }
 
 double GainIterator::gainAt(double freq)
@@ -37,7 +35,7 @@ double GainIterator::gainAt(double freq)
 	if (nodeLeft == nullptr && nodeRight == nullptr || nodeLeft != nullptr && freq < nodeLeft->freq)
 	{
 		FilterNode findNode(freq, 0);
-		vector<FilterNode>::iterator it = lower_bound(nodes.begin(), nodes.end(), findNode);
+		vector<FilterNode>::const_iterator it = lower_bound(nodes.begin(), nodes.end(), findNode);
 		if (it != nodes.begin())
 			nodeLeft = &*(it - 1);
 		if (it != nodes.end())
@@ -51,7 +49,7 @@ double GainIterator::gainAt(double freq)
 	}
 	else if (nodeRight != nullptr && freq > nodeRight->freq)
 	{
-		vector<FilterNode>::iterator it = nodes.begin() + (nodeRight - &*nodes.begin());
+		vector<FilterNode>::const_iterator it = nodes.begin() + (nodeRight - &*nodes.begin());
 		while (it != nodes.end() && freq > it->freq)
 		{
 			it++;

--- a/helpers/GainIterator.h
+++ b/helpers/GainIterator.h
@@ -32,7 +32,7 @@ struct FilterNode
 		this->dbGain = dbGain;
 	}
 
-	bool operator<(FilterNode other)
+	bool operator<(FilterNode other) const
 	{
 		return freq < other.freq;
 	}
@@ -41,13 +41,19 @@ struct FilterNode
 class GainIterator
 {
 public:
+	// Holds a reference to the caller's node vector. The caller must keep the
+	// vector alive for the lifetime of the iterator. This avoids copying the
+	// (often 100k+ node) vector that would otherwise happen once per paint.
 	GainIterator(const std::vector<FilterNode>& nodes);
 	double gainAt(double freq);
 
+	GainIterator(const GainIterator&) = delete;
+	GainIterator& operator=(const GainIterator&) = delete;
+
 private:
-	std::vector<FilterNode> nodes;
-	FilterNode* nodeLeft;
-	FilterNode* nodeRight;
+	const std::vector<FilterNode>& nodes;
+	const FilterNode* nodeLeft;
+	const FilterNode* nodeRight;
 	double logLeft;
 	double logRightMinusLeft;
 };


### PR DESCRIPTION
## Summary

Follow-up to [#14](https://github.com/115dkk/EqualizerAPO-XT/pull/14). The
hot-path DSP/RT work landed there; this PR moves to the GUI responsiveness
items (audit P1-7..11) and the small startup quality-of-life change for
Velopack.

### GUI / analysis responsiveness
- **GainIterator stops copying its node vector.** Now holds a `const std::vector<FilterNode>&` to the caller's data, marked non-copyable, with `FilterNode::operator<` made `const` so it works through `const_iterator`. AnalysisPlotScene / EqGraphView / GraphicEQ GUIs handed 100k+ nodes per construction; for the 262144-resolution analysis view this fired on every paint.
- **AnalysisPlotScene::setFreqData reserves up-front and emplace_backs.** Cuts the inner-loop reallocation/copy churn that happens on each analysis result.
- **EqGraphView caches the QPainterPath of the curve and fill.** Cache invalidates only on node change or resize. Skin and channel-label changes reuse the cached geometry. Sampling already ran at one pixel per column, so the audit's downsample requirement is in place.
- **Instant-mode save debounce (200 ms).** Knob drags and typing in values previously triggered a full file write per change; now coalesce into one save after the burst settles. Timer is parented to the FilterTable for automatic lifetime.
- **Analysis debounce (120 ms).** `MainWindow::startAnalysis` schedules through a single QTimer; the actual run moves into `executeStartAnalysis`. `AnalysisThread::setParameters` already kept only the last parameters via `wakeAll`, but the actual analysis pass (engine init + impulse run) is not abortable mid-flight; the debounce keeps it from being re-started on every drag tick.

### Velopack startup
- **`triggerBackgroundUpdate` deferred 60 s.** Was launched immediately from `Editor/main.cpp` right before `application.exec()`, racing with audio service work and Device Selector launches in the same opening second. `QTimer::singleShot(60s, qApp, ...)` lets the initial paint, config load, and device enumeration settle first.

## Test plan
- [x] Editor builds clean against Qt 6.10.1 (msvc2022_64) after each change
- [x] `HybridConvTests` still passes (no DSP-side changes here)
- [ ] CI matrix (sse2 / avx / avx2 / avx512 / avx10_1 / neon) green
- [ ] Manual: launch Editor with a multi-tab config, drag a knob, confirm only one save fires after the drag ends and analysis runs once after the debounce
- [ ] Manual: launch Velopack-packaged Editor, confirm Update.exe starts ~60 s after window opens (Sysinternals Process Monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)