### PR TITLE
perf(convolution): cache decoded IR + GraphicEQ IR synthesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Local benchmark configurations
+bench-config/
+bench-config-conv/

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -19,6 +19,9 @@
 
 #include "stdafx.h"
 #include <cmath>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
@@ -33,6 +36,121 @@
 using std::abs;
 using std::vector;
 using std::wstring;
+
+namespace
+{
+	// Cache of decoded impulse-response PCM, keyed by path + mtime + sample rate.
+	// Lets a config reload (or a second ConvolutionFilter using the same IR) skip
+	// the libsndfile read + interleave-to-planar pass. File I/O and the
+	// per-channel reshuffle dominate ConvolutionFilter initialization for large
+	// IRs; we keep the cache process-wide and unbounded since IRs rarely change
+	// inside a session and each entry is at most the file's PCM size.
+	struct IrCacheKey
+	{
+		std::wstring path;
+		unsigned long long mtime;
+		int sampleRate;
+
+		bool operator==(const IrCacheKey& o) const
+		{
+			return sampleRate == o.sampleRate && mtime == o.mtime && path == o.path;
+		}
+	};
+
+	struct IrCacheKeyHash
+	{
+		size_t operator()(const IrCacheKey& k) const noexcept
+		{
+			size_t h = std::hash<std::wstring>{}(k.path);
+			h ^= std::hash<unsigned long long>{}(k.mtime) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(k.sampleRate) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+			return h;
+		}
+	};
+
+	struct IrCacheEntry
+	{
+		unsigned channels = 0;
+		unsigned frames = 0;
+		// Channel-major IR samples; each inner vector has `frames` elements.
+		std::vector<std::vector<double>> buffers;
+	};
+
+	std::mutex& irCacheMutex()
+	{
+		static std::mutex m;
+		return m;
+	}
+
+	std::unordered_map<IrCacheKey, std::shared_ptr<const IrCacheEntry>, IrCacheKeyHash>& irCache()
+	{
+		static std::unordered_map<IrCacheKey, std::shared_ptr<const IrCacheEntry>, IrCacheKeyHash> c;
+		return c;
+	}
+
+	unsigned long long getMtime(const std::wstring& path)
+	{
+		WIN32_FILE_ATTRIBUTE_DATA attrs;
+		if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attrs))
+			return 0;
+		return (static_cast<unsigned long long>(attrs.ftLastWriteTime.dwHighDateTime) << 32)
+			| attrs.ftLastWriteTime.dwLowDateTime;
+	}
+
+	std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, double sampleRate)
+	{
+		const int sampleRateKey = static_cast<int>(sampleRate);
+		IrCacheKey key{ filename, getMtime(filename), sampleRateKey };
+
+		{
+			std::lock_guard<std::mutex> lock(irCacheMutex());
+			auto it = irCache().find(key);
+			if (it != irCache().end())
+				return it->second;
+		}
+
+		SF_INFO info{};
+		SNDFILE* in = sf_wchar_open(filename.c_str(), SFM_READ, &info);
+		if (in == nullptr)
+		{
+			LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(in));
+			return nullptr;
+		}
+		if (abs(sampleRate - info.samplerate) > 1.0)
+		{
+			LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
+			sf_close(in);
+			return nullptr;
+		}
+
+		const unsigned channels = static_cast<unsigned>(info.channels);
+		const unsigned frames = static_cast<unsigned>(info.frames);
+		std::vector<double> interleaved(static_cast<size_t>(frames) * channels);
+		sf_count_t numRead = 0;
+		while (numRead < info.frames)
+			numRead += sf_readf_double(in, interleaved.data() + numRead * channels, info.frames - numRead);
+		sf_close(in);
+
+		auto entry = std::make_shared<IrCacheEntry>();
+		entry->channels = channels;
+		entry->frames = frames;
+		entry->buffers.resize(channels);
+		for (unsigned c = 0; c < channels; ++c)
+		{
+			entry->buffers[c].resize(frames);
+			double* dst = entry->buffers[c].data();
+			const double* src = interleaved.data() + c;
+			for (unsigned i = 0; i < frames; ++i)
+				dst[i] = src[i * channels];
+		}
+
+		{
+			std::lock_guard<std::mutex> lock(irCacheMutex());
+			irCache().emplace(std::move(key), entry);
+		}
+		return entry;
+	}
+}
 
 ConvolutionFilter::ConvolutionFilter(wstring filename)
 {
@@ -119,57 +237,20 @@ void ConvolutionFilter::cleanup()
 
 void ConvolutionFilter::initializeFilters(unsigned frameCount)
 {
-	SF_INFO info;
+	auto ir = loadIrCached(filename, sampleRate);
+	if (!ir)
+		return;
 
-	SNDFILE* inFile = sf_wchar_open(filename.c_str(), SFM_READ, &info);
-	if (inFile == nullptr)
+	TraceF(L"Convolving using impulse response file %s (%u channels, %u frames)",
+		filename.c_str(), ir->channels, ir->frames);
+
+	fftw_make_planner_thread_safe();
+	filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	for (unsigned i = 0; i < channelCount; i++)
 	{
-		LogF(L"Error while reading impulse response file: %S", sf_strerror(inFile));
-	}
-	else if (abs(sampleRate - info.samplerate) > 1.0)
-	{
-		LogF(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
-	}
-	else
-	{
-		TraceF(L"Convolving using impulse response file %s", filename.c_str());
-		unsigned fileChannelCount = info.channels;
-		unsigned fileFrameCount = (unsigned)info.frames;
-
-		double* interleavedBuf = new double[fileFrameCount * fileChannelCount];
-
-		sf_count_t numRead = 0;
-		while (numRead < fileFrameCount)
-			numRead += sf_readf_double(inFile, interleavedBuf + numRead * fileChannelCount, fileFrameCount - numRead);
-
-		sf_close(inFile);
-		inFile = nullptr;
-
-		double** bufs = new double* [fileChannelCount];
-		for (unsigned i = 0; i < fileChannelCount; i++)
-		{
-			double* buf = new double[fileFrameCount];
-			double* p = interleavedBuf + i;
-			for (unsigned j = 0; j < fileFrameCount; j++)
-			{
-				buf[j] = p[j * fileChannelCount];
-			}
-
-			bufs[i] = buf;
-		}
-
-		fftw_make_planner_thread_safe();
-		filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
-		for (unsigned i = 0; i < channelCount; i++)
-		{
-			hcInitSingle(&filters[i], bufs[i % fileChannelCount], fileFrameCount, frameCount, 1);
-		}
-
-		for (unsigned i = 0; i < fileChannelCount; i++)
-		{
-			delete[] bufs[i];
-		}
-		delete[] bufs;
-		delete[] interleavedBuf;
+		// hcInitSingle reads the IR samples during planning but does not retain
+		// the pointer, so it is safe to feed it the shared cache buffer.
+		const std::vector<double>& src = ir->buffers[i % ir->channels];
+		hcInitSingle(&filters[i], const_cast<double*>(src.data()), static_cast<int>(ir->frames), static_cast<int>(frameCount), 1);
 	}
 }

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -20,6 +20,9 @@
 #include "stdafx.h"
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
@@ -33,6 +36,65 @@ using std::exp;
 using std::log;
 using std::pow;
 
+namespace
+{
+	// Cache for the impulse response GraphicEQFilter::initializeFilters synthesizes
+	// from the node list. The IR depends only on (nodes, sampleRate, filterLength)
+	// and is reused across channels and across config reloads that re-create the
+	// same GraphicEQFilter. Building the IR runs an FFT pair plus minimum-phase
+	// reconstruction; caching turns that into a vector copy on hit.
+	struct EqIrCacheKey
+	{
+		std::vector<FilterNode> nodes;
+		int sampleRate;
+		unsigned filterLength;
+
+		bool operator==(const EqIrCacheKey& o) const
+		{
+			if (sampleRate != o.sampleRate || filterLength != o.filterLength) return false;
+			if (nodes.size() != o.nodes.size()) return false;
+			for (size_t i = 0; i < nodes.size(); ++i)
+			{
+				if (nodes[i].freq != o.nodes[i].freq || nodes[i].dbGain != o.nodes[i].dbGain)
+					return false;
+			}
+			return true;
+		}
+	};
+
+	struct EqIrCacheKeyHash
+	{
+		size_t operator()(const EqIrCacheKey& k) const noexcept
+		{
+			size_t h = std::hash<int>{}(k.sampleRate);
+			h ^= std::hash<unsigned>{}(k.filterLength) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+			for (const auto& n : k.nodes)
+			{
+				h ^= std::hash<double>{}(n.freq) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+				h ^= std::hash<double>{}(n.dbGain) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+			}
+			return h;
+		}
+	};
+
+	struct EqIrCacheEntry
+	{
+		std::vector<double> ir;
+	};
+
+	std::mutex& eqIrCacheMutex()
+	{
+		static std::mutex m;
+		return m;
+	}
+
+	std::unordered_map<EqIrCacheKey, std::shared_ptr<const EqIrCacheEntry>, EqIrCacheKeyHash>& eqIrCache()
+	{
+		static std::unordered_map<EqIrCacheKey, std::shared_ptr<const EqIrCacheEntry>, EqIrCacheKeyHash> c;
+		return c;
+	}
+}
+
 GraphicEQFilter::GraphicEQFilter(const std::vector<FilterNode>& nodes, unsigned filterLength)
 	: ConvolutionFilter(L""), nodes(nodes), filterLength(filterLength)
 {
@@ -45,60 +107,77 @@ const std::vector<FilterNode>& GraphicEQFilter::getNodes()
 
 void GraphicEQFilter::initializeFilters(unsigned frameCount)
 {
+	EqIrCacheKey key{ nodes, static_cast<int>(sampleRate), filterLength };
+	std::shared_ptr<const EqIrCacheEntry> cached;
+	{
+		std::lock_guard<std::mutex> lock(eqIrCacheMutex());
+		auto it = eqIrCache().find(key);
+		if (it != eqIrCache().end())
+			cached = it->second;
+	}
+
+	if (!cached)
+	{
+		auto entry = std::make_shared<EqIrCacheEntry>();
+		entry->ir.resize(filterLength);
+
+		fftw_make_planner_thread_safe();
+		fftw_complex* timeData = fftw_alloc_complex(filterLength * 2);
+		fftw_complex* freqData = fftw_alloc_complex(filterLength * 2);
+		fftw_plan planForward = fftw_plan_dft_1d(filterLength * 2, timeData, freqData, FFTW_FORWARD, FFTW_ESTIMATE);
+		fftw_plan planReverse = fftw_plan_dft_1d(filterLength * 2, freqData, timeData, FFTW_BACKWARD, FFTW_ESTIMATE);
+
+		GainIterator gainIterator(nodes);
+		for (unsigned i = 0; i < filterLength; i++)
+		{
+			double freq = i * 1.0 * sampleRate / (filterLength * 2);
+			double dbGain = gainIterator.gainAt(freq);
+			double gain = pow(10.0, dbGain / 20.0);
+
+			freqData[i][0] = gain;
+			freqData[i][1] = 0;
+			freqData[2 * filterLength - i - 1][0] = gain;
+			freqData[2 * filterLength - i - 1][1] = 0;
+		}
+
+		mps(timeData, freqData, planForward, planReverse);
+
+		fftw_execute(planReverse);
+
+		for (unsigned i = 0; i < 2 * filterLength; i++)
+		{
+			timeData[i][0] /= 2 * filterLength;
+			timeData[i][1] /= 2 * filterLength;
+		}
+
+		for (unsigned i = 0; i < filterLength; i++)
+		{
+			double factor = 0.5 * (1 + cos(2 * M_PI * i * 1.0 / (2 * filterLength)));
+			timeData[i][0] *= factor;
+			timeData[i][1] *= factor;
+		}
+
+		for (unsigned i = 0; i < filterLength; i++)
+			entry->ir[i] = timeData[i][0];
+
+		fftw_free(timeData);
+		fftw_free(freqData);
+		fftw_destroy_plan(planForward);
+		fftw_destroy_plan(planReverse);
+
+		{
+			std::lock_guard<std::mutex> lock(eqIrCacheMutex());
+			eqIrCache().emplace(std::move(key), entry);
+		}
+		cached = entry;
+	}
+
 	fftw_make_planner_thread_safe();
-	fftw_complex* timeData = fftw_alloc_complex(filterLength * 2);
-	fftw_complex* freqData = fftw_alloc_complex(filterLength * 2);
-	fftw_plan planForward = fftw_plan_dft_1d(filterLength * 2, timeData, freqData, FFTW_FORWARD, FFTW_ESTIMATE);
-	fftw_plan planReverse = fftw_plan_dft_1d(filterLength * 2, freqData, timeData, FFTW_BACKWARD, FFTW_ESTIMATE);
-
-	GainIterator gainIterator(nodes);
-	for (unsigned i = 0; i < filterLength; i++)
-	{
-		double freq = i * 1.0 * sampleRate / (filterLength * 2);
-		double dbGain = gainIterator.gainAt(freq);
-		double gain = pow(10.0, dbGain / 20.0);
-
-		freqData[i][0] = gain;
-		freqData[i][1] = 0;
-		freqData[2 * filterLength - i - 1][0] = gain;
-		freqData[2 * filterLength - i - 1][1] = 0;
-	}
-
-	mps(timeData, freqData, planForward, planReverse);
-
-	fftw_execute(planReverse);
-
-	for (unsigned i = 0; i < 2 * filterLength; i++)
-	{
-		timeData[i][0] /= 2 * filterLength;
-		timeData[i][1] /= 2 * filterLength;
-	}
-
-	for (unsigned i = 0; i < filterLength; i++)
-	{
-		double factor = 0.5 * (1 + cos(2 * M_PI * i * 1.0 / (2 * filterLength)));
-		timeData[i][0] *= factor;
-		timeData[i][1] *= factor;
-	}
-
-	double* buf = new double[filterLength];
-	for (unsigned i = 0; i < filterLength; i++)
-	{
-		buf[i] = timeData[i][0];
-	}
-
-	fftw_free(timeData);
-	fftw_free(freqData);
-	fftw_destroy_plan(planForward);
-	fftw_destroy_plan(planReverse);
-
 	filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
-		hcInitSingle(&filters[i], buf, filterLength, frameCount, 1);
+		hcInitSingle(&filters[i], const_cast<double*>(cached->ir.data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);
 	}
-
-	delete[] buf;
 }
 
 // Minimum phase spectrum from coefficients


### PR DESCRIPTION
## Summary

Two process-wide IR caches that let a config reload (or a second filter
using the same IR) skip the expensive parts of
\`initializeFilters\`. Audit item P2-1.

### ConvolutionFilter
Keyed on **(path, mtime, sample rate)**. On a hit the filter goes straight
to \`hcInitSingle\` with the shared, already-deinterleaved buffer. On a
miss \`sf_wchar_open\`, \`sf_readf_double\`, and the interleaved →
channel-major reshuffle run exactly once, then publish into the cache.

### GraphicEQFilter
Keyed on **(nodes, sample rate, filterLength)**. The miss path still runs
the minimum-phase reconstruction plus the FFT pair (\`mps\` + forward +
reverse plans). The hit path is a vector reference into the cached IR.

### Notes
- The hot path (\`process()\`) is unchanged. The audit had FFTW wisdom
  done in PR [#14](https://github.com/115dkk/EqualizerAPO-XT/pull/14),
  so plan construction is already fast; the remaining boilerplate (file
  read, deinterleave, mps + FFT) is what this PR removes from a reload.
- Caches are unbounded for now. IRs change rarely inside a session and
  each entry is bounded by the IR's PCM size; if memory pressure becomes
  a concern we can wire in an LRU.
- \`HybridConvTests\` exercises both paths via real IR files; both pass
  after the change.

### Test plan
- [x] Common, Benchmark, HybridConvTests, EqualizerAPO.dll build clean
- [x] HybridConvTests passes
- [ ] CI matrix (sse2 / avx / avx2 / avx512 / avx10_1 / neon) green
- [ ] Manual: run an Editor session that toggles a Convolution IR on and
      off; confirm the second \`On\` is noticeably faster than the first
      (Process Monitor: no second \`ReadFile\` against the IR path)
- [ ] Manual: same with a GraphicEQ band whose node list is unchanged
      between reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)