### PR TITLE
perf(editor): refresh only the toggled row on enabled toggle

### DIFF
--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -268,3 +268,91 @@ void FilterTable::updateGuis()
 	qDebug("Create took %d ms", timer.elapsed());
 	update();
 }
+
+void FilterTable::updateSingleRowGui(Item* item)
+{
+	int rowIndex = items.indexOf(item);
+	if (rowIndex < 0 || gridLayout == nullptr)
+		return;
+
+	// Save GUI preferences before tearing down.
+	if (item->gui != nullptr)
+	{
+		item->prefs.clear();
+		item->gui->storePreferences(item->prefs);
+	}
+
+	QLayoutItem* slot = gridLayout->itemAtPosition(rowIndex, 0);
+	if (slot == nullptr || slot->widget() == nullptr)
+	{
+		// No widget in that slot; fall back to a full refresh so we don't
+		// silently leave the row stale.
+		updateGuis();
+		return;
+	}
+
+	QWidget* oldRow = slot->widget();
+	gridLayout->removeWidget(oldRow);
+	oldRow->deleteLater();
+
+	// Reparse the line and rebuild the GUI exactly the way updateGuis() does,
+	// using the same factory chain. Factory startOfFile/endOfFile is skipped
+	// intentionally: a single in-place edit (enabled toggle) does not change
+	// the surrounding file's structural context, so the include/depth state
+	// the factories track stays valid.
+	QString line = item->text;
+	IFilterGUI* gui = nullptr;
+	bool usingCardEditor = false;
+	int colonPos = line.indexOf(':');
+	if (colonPos != -1)
+	{
+		QString key = line.mid(0, colonPos).trimmed();
+		QString value = line.mid(colonPos + 1);
+
+		QString factoryKey = key;
+		QString factoryValue = value;
+		for (IFilterGUIFactory* factory : factories)
+		{
+			gui = factory->createFilterGUI(factoryKey, factoryValue);
+			if (gui != nullptr || factoryKey == "")
+				break;
+		}
+
+		if (gui != nullptr)
+		{
+			if (renderMode == ModernCards)
+			{
+				IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
+				if (cardGui != nullptr)
+				{
+					delete gui;
+					gui = cardGui;
+					usingCardEditor = true;
+				}
+			}
+			if (!usingCardEditor)
+				for (IFilterGUIFactory* factory : factories)
+					gui = factory->decorateFilterGUI(gui);
+		}
+	}
+
+	QVector<int> rowDepths = FilterCardModel::calculateDepths(getLines());
+	int depth = rowIndex < rowDepths.size() ? rowDepths[rowIndex] : 0;
+	QWidget* rowWidget = renderMode == ModernCards
+		? static_cast<QWidget*>(new FilterCardRow(this, rowIndex + 1, item, gui, depth))
+		: static_cast<QWidget*>(new FilterTableRow(this, rowIndex + 1, item, gui));
+	gridLayout->addWidget(rowWidget, rowIndex, 0);
+
+	item->gui = gui;
+	if (gui != nullptr)
+	{
+		gui->loadPreferences(item->prefs);
+		if (renderMode != ModernCards)
+			connect(gui, SIGNAL(updateModel()), this, SLOT(updateModel()));
+		connect(gui, SIGNAL(updateChannels()), this, SLOT(updateChannels()));
+	}
+
+	propagateChannels();
+	disableWheelForWidgets();
+	update();
+}

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -67,6 +67,10 @@ public:
 	void initialize(QScrollArea* scrollArea, const QList<std::shared_ptr<AbstractAPOInfo>>& outputDevices, const QList<std::shared_ptr<AbstractAPOInfo>>& inputDevices);
 	void updateDeviceAndChannelMask(std::shared_ptr<AbstractAPOInfo> selectedDevice, int selectedChannelMask);
 	void updateGuis();
+	// Re-create the GUI widget for a single row in place. Used for cheap
+	// edits like the enabled toggle, which used to trigger a full updateGuis
+	// (delete + rebuild every row in the file).
+	void updateSingleRowGui(Item* item);
 	void propagateChannels();
 	QList<QString> getLines();
 	void setLines(const QString& configPath, const QList<QString>& lines);

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -371,8 +371,12 @@ void FilterCardRow::enabledToggled(bool checked)
 
 	table->updateModel();
 	FilterTable* targetTable = table;
-	QTimer::singleShot(0, targetTable, [targetTable]() {
-		targetTable->updateGuis();
+	FilterTable::Item* targetItem = item;
+	// In-place refresh: only the toggled row's GUI needs to change. Falling
+	// back to a full updateGuis() on a 500+ row config was the dominant
+	// source of toggle latency.
+	QTimer::singleShot(0, targetTable, [targetTable, targetItem]() {
+		targetTable->updateSingleRowGui(targetItem);
 	});
 }
 


### PR DESCRIPTION
## Summary

\`FilterCardRow::enabledToggled\` used to schedule a full \`FilterTable::updateGuis\` on every toggle. updateGuis deletes every row widget in the file and rebuilds them — for a config with 500+ rows that's the dominant source of toggle latency.

This PR adds \`FilterTable::updateSingleRowGui(Item*)\` that re-creates the GUI widget for one row in place using the same factory chain as updateGuis. The toggle now uses it instead of the full rebuild.

### What this PR does NOT change
- The factory \`startOfFile\` / \`endOfFile\` hooks are intentionally not re-run. The only caller (the enabled toggle on a filter row) cannot move the file's structural context: \`canToggleEnabled\` is already gated in \`FilterCardEditorDescriptor\` to non-nesting filters, so \`If\` / \`Stage\` nesting and \`Include\` depth are preserved by definition.
- depth recomputation is still run via \`FilterCardModel::calculateDepths(getLines())\` against the full line list, so the new row gets the correct depth in the modern-cards layout.
- propagateChannels is still called so downstream rows see the new channel state.

### Safety fallback
If the row's grid slot is empty for any reason (e.g. mid-edit race), the code falls back to a full \`updateGuis()\` so we never silently leave a stale widget behind.

## Test plan
- [x] Editor builds clean against Qt 6.10.1 (msvc2022_64)
- [ ] CI matrix (sse2 / avx / avx2 / avx512 / avx10_1 / neon) green
- [ ] **Manual: open a config with 100+ filters in Modern Cards mode, toggle a single filter's enabled checkbox, confirm:**
  - The toggled row visibly switches between active and commented styling
  - Other rows are NOT re-created (no flash, scroll position preserved, focus preserved)
  - The line in the underlying config switches between \`Filter: ...\` and \`# Filter: ...\` (instant mode save still fires)
- [ ] **Manual: toggle within a nested \`If: ... / Stage: ...\` block - depth indentation of the toggled row stays correct after the refresh**
- [ ] **Manual: revert path - toggle in legacy LegacyRows render mode also works**

🤖 Generated with [Claude Code](https://claude.com/claude-code)