### PR TITLE
fix(editor): stop disabling whole card on commented rows + richer biquad summary

### DIFF
--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -214,7 +214,11 @@ void FilterTable::updateGuis()
 					}
 				}
 
-				if (!usingCardEditor)
+				// In Modern Cards we skip the legacy CommentFilterGUI decorator on
+				// purpose: the card row already owns the enable/disable affordance
+				// and a second power toolbar inside the body editor only produces
+				// rules that disagree with the card header.
+				if (!usingCardEditor && renderMode != ModernCards)
 					for (IFilterGUIFactory* factory : factories)
 						gui = factory->decorateFilterGUI(gui);
 			}
@@ -330,7 +334,9 @@ void FilterTable::updateSingleRowGui(Item* item)
 					usingCardEditor = true;
 				}
 			}
-			if (!usingCardEditor)
+			// Same decorator gating as updateGuis(): Modern Cards owns power UI
+			// in the card header, no additional CommentFilterGUI toolbar inside.
+			if (!usingCardEditor && renderMode != ModernCards)
 				for (IFilterGUIFactory* factory : factories)
 					gui = factory->decorateFilterGUI(gui);
 		}

--- a/Editor/widgets/FilterCardModel.cpp
+++ b/Editor/widgets/FilterCardModel.cpp
@@ -32,6 +32,73 @@ bool isKnownConfigCommand(const QString& command)
 	};
 	return knownCommands.contains(normalized);
 }
+
+QString biquadTypeTitle(const QString& code)
+{
+	const QString normalized = code.toUpper();
+	if (normalized == QStringLiteral("PK") || normalized == QStringLiteral("PEQ") || normalized == QStringLiteral("MODAL"))
+		return QStringLiteral("Peaking");
+	if (normalized == QStringLiteral("LP") || normalized == QStringLiteral("LPQ"))
+		return QStringLiteral("Low-pass");
+	if (normalized == QStringLiteral("HP") || normalized == QStringLiteral("HPQ"))
+		return QStringLiteral("High-pass");
+	if (normalized == QStringLiteral("BP"))
+		return QStringLiteral("Band-pass");
+	if (normalized == QStringLiteral("LS") || normalized == QStringLiteral("LSC"))
+		return QStringLiteral("Low-shelf");
+	if (normalized == QStringLiteral("HS") || normalized == QStringLiteral("HSC"))
+		return QStringLiteral("High-shelf");
+	if (normalized == QStringLiteral("NO"))
+		return QStringLiteral("Notch");
+	if (normalized == QStringLiteral("AP"))
+		return QStringLiteral("All-pass");
+	return QStringLiteral("Biquad");
+}
+
+QString firstCapture(const QRegularExpression& expression, const QString& text)
+{
+	const QRegularExpressionMatch match = expression.match(text);
+	return match.hasMatch() ? match.captured(1).trimmed() : QString();
+}
+
+// Reproduces the same labelling the legacy BiQuad GUI shows so the modern card
+// agrees with it for the LSC/HSC/LPQ/HPQ/PEQ/Modal variants that the previous
+// regex did not recognize.
+QString summarizeBiquad(const QString& parameters, const QString& code, const QString& state)
+{
+	QStringList parts;
+	const bool shelf = code == QStringLiteral("LS") || code == QStringLiteral("LSC") || code == QStringLiteral("HS") || code == QStringLiteral("HSC");
+	const bool centerFrequency = code == QStringLiteral("LSC") || code == QStringLiteral("HSC");
+
+	const QString freq = firstCapture(QRegularExpression(QStringLiteral("\\bFc\\s*([-+0-9.,eE\\x{00A0}]+)\\s*H\\s*z"), QRegularExpression::CaseInsensitiveOption), parameters);
+	if (!freq.isEmpty())
+		parts.append(QStringLiteral("%1 %2 Hz").arg(shelf ? (centerFrequency ? QStringLiteral("Center") : QStringLiteral("Corner")) : QStringLiteral("Fc"), freq));
+
+	const QString gain = firstCapture(QRegularExpression(QStringLiteral("\\bGain\\s*([-+0-9.,eE]+)\\s*dB"), QRegularExpression::CaseInsensitiveOption), parameters);
+	if (!gain.isEmpty())
+		parts.append(QStringLiteral("Gain %1 dB").arg(gain));
+
+	if (shelf)
+	{
+		const QRegularExpression slopeExpression(QStringLiteral("^\\s*(?:ON|OFF)\\s+[A-Za-z]+\\s+([-+0-9.,eE]+)\\s*dB"), QRegularExpression::CaseInsensitiveOption);
+		const QString slope = firstCapture(slopeExpression, parameters);
+		if (!slope.isEmpty())
+			parts.append(QStringLiteral("Slope %1 dB/Oct").arg(slope));
+	}
+
+	const QString q = firstCapture(QRegularExpression(QStringLiteral("\\bQ\\s*([-+0-9.,eE]+)"), QRegularExpression::CaseInsensitiveOption), parameters);
+	if (!q.isEmpty())
+		parts.append(QStringLiteral("Q %1").arg(q));
+
+	const QString bandwidth = firstCapture(QRegularExpression(QStringLiteral("\\bBW\\s+Oct\\s*([-+0-9.,eE]+)"), QRegularExpression::CaseInsensitiveOption), parameters);
+	if (!bandwidth.isEmpty())
+		parts.append(QStringLiteral("BW %1 Oct").arg(bandwidth));
+
+	QString summary = parts.isEmpty() ? parameters.simplified() : parts.join(QStringLiteral(" \xC2\xB7 "));
+	if (state == QStringLiteral("OFF"))
+		summary = QStringLiteral("OFF \xC2\xB7 ") + summary;
+	return summary;
+}
 }
 
 QString FilterCardModel::compactWhitespace(QString text)
@@ -149,10 +216,20 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 		descriptor.title = QStringLiteral("Biquad");
 		descriptor.color = QStringLiteral("#22c55e");
 
-		QRegularExpression typeExpression(QStringLiteral("\\b(PK|LP|HP|LS|HS|NO|AP|BP)\\b"), QRegularExpression::CaseInsensitiveOption);
+		// Recognise the full BiQuadFilterFactory vocabulary (including LSC/HSC
+		// shelf-with-slope, LPQ/HPQ Q-form, PEQ alias and Modal) so the card
+		// title and summary agree with the legacy GUI. The previous regex only
+		// matched PK/LP/HP/LS/HS/NO/AP/BP and silently fell back to "Biquad".
+		QRegularExpression typeExpression(QStringLiteral("^\\s*(ON|OFF)\\s+(PK|PEQ|MODAL|LPQ|HPQ|LSC|HSC|LP|HP|BP|LS|HS|NO|AP)\\b"), QRegularExpression::CaseInsensitiveOption);
 		QRegularExpressionMatch match = typeExpression.match(parameters);
 		if (match.hasMatch())
-			descriptor.badge = match.captured(1).toUpper();
+		{
+			const QString state = match.captured(1).toUpper();
+			const QString code = match.captured(2).toUpper();
+			descriptor.badge = code;
+			descriptor.title = biquadTypeTitle(code);
+			descriptor.summary = summarizeBiquad(parameters, code, state);
+		}
 	}
 	else if (commandLower == QStringLiteral("graphiceq"))
 	{

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -1,5 +1,6 @@
 #include "FilterCardRow.h"
 
+#include <QIcon>
 #include <QMenu>
 #include <QPainter>
 #include <QPropertyAnimation>
@@ -80,12 +81,14 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	channelBadgeLayout->setSpacing(3);
 	headerLayout->addWidget(channelBadgeContainer);
 
-	enabledCheckBox = new QCheckBox(headerWidget);
-	enabledCheckBox->setObjectName(QStringLiteral("FilterCardEnabled"));
-	enabledCheckBox->setToolTip(tr("Enable or comment out this command"));
-	enabledCheckBox->setChecked(descriptor.enabled);
-	connect(enabledCheckBox, SIGNAL(toggled(bool)), this, SLOT(enabledToggled(bool)));
-	headerLayout->addWidget(enabledCheckBox);
+	enabledButton = new QToolButton(headerWidget);
+	enabledButton->setObjectName(QStringLiteral("FilterCardIconButton"));
+	enabledButton->setCheckable(true);
+	enabledButton->setToolTip(tr("Enable or comment out this command"));
+	enabledButton->setChecked(descriptor.enabled);
+	enabledButton->setIcon(QIcon(descriptor.enabled ? QStringLiteral(":/icons/power_on.svg") : QStringLiteral(":/icons/power_off.svg")));
+	connect(enabledButton, SIGNAL(toggled(bool)), this, SLOT(enabledToggled(bool)));
+	headerLayout->addWidget(enabledButton);
 
 	addButton = new QToolButton(headerWidget);
 	addButton->setObjectName(QStringLiteral("FilterCardIconButton"));
@@ -243,10 +246,16 @@ void FilterCardRow::rebuildSummary()
 	const SkinTokens& tokens = SkinManager::instance()->tokens();
 	rawPreviewLabel->setStyleSheet(QStringLiteral("QLabel#FilterCardRawPreview { background: %1; color: %2; border-top: 1px solid %3; padding: 4px 12px; font-family: \"%4\"; font-size: 9pt; }")
 		.arg(tokens.surfaceSunken, tokens.mutedText, tokens.border, tokens.monoFontFamily));
-	enabledCheckBox->blockSignals(true);
-	enabledCheckBox->setChecked(descriptor.enabled);
-	enabledCheckBox->blockSignals(false);
-	enabledCheckBox->setVisible(descriptor.canToggleEnabled);
+	enabledButton->blockSignals(true);
+	enabledButton->setChecked(descriptor.enabled);
+	enabledButton->setIcon(QIcon(descriptor.enabled ? QStringLiteral(":/icons/power_on.svg") : QStringLiteral(":/icons/power_off.svg")));
+	enabledButton->blockSignals(false);
+	enabledButton->setVisible(descriptor.canToggleEnabled);
+	// Disable only the body editor when the line is commented out. This keeps
+	// the card frame (and its header buttons - including the enable toggle and
+	// the raw-edit affordance) interactive so the user can flip the line back on.
+	if (gui != nullptr)
+		gui->setEnabled(descriptor.enabled);
 	buildChannelBadges(descriptor.channelBadges);
 	refreshStateProperties();
 	update();
@@ -363,6 +372,9 @@ void FilterCardRow::enabledToggled(bool checked)
 	if (!descriptor.canToggleEnabled)
 		return;
 
+	if (enabledButton != nullptr)
+		enabledButton->setIcon(QIcon(checked ? QStringLiteral(":/icons/power_on.svg") : QStringLiteral(":/icons/power_off.svg")));
+
 	QString trimmed = item->text.trimmed();
 	if (checked && trimmed.startsWith('#'))
 		item->text = uncommentedLine();
@@ -394,9 +406,15 @@ void FilterCardRow::refreshStateProperties()
 	const bool selected = table != nullptr && table->getSelectedItems().contains(item);
 	const bool focused = table != nullptr && table->getFocusedItem() == item;
 
+	// "enabled" is a real QWidget property, so setting it on cardFrame /
+	// headerWidget was equivalent to calling setEnabled(false) on the whole
+	// card whenever the line was commented out. That killed the toggle button,
+	// the raw editor, and every child editor (Include path field, BiQuad
+	// controls...) so a disabled row could not be re-enabled or even inspected.
+	// Use a dedicated dynamic property name for the styling hook instead.
 	const QList<QPair<const char*, QVariant>> properties = {
 		{ "filterKind", descriptor.command.toLower() },
-		{ "enabled", descriptor.enabled },
+		{ "filterEnabled", descriptor.enabled },
 		{ "selected", selected },
 		{ "focused", focused },
 		{ "scopeDepth", descriptor.depth }

--- a/Editor/widgets/FilterCardRow.h
+++ b/Editor/widgets/FilterCardRow.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QCheckBox>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -56,7 +55,7 @@ private:
 	QLabel* rawPreviewLabel = nullptr;
 	QWidget* channelBadgeContainer = nullptr;
 	QHBoxLayout* channelBadgeLayout = nullptr;
-	QCheckBox* enabledCheckBox = nullptr;
+	QToolButton* enabledButton = nullptr;
 	QToolButton* expandButton = nullptr;
 	QToolButton* addButton = nullptr;
 	QToolButton* removeButton = nullptr;

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -225,11 +225,17 @@ int main(int argc, char** argv)
 	expectEqual(disabledFilter.title, "Peaking", "disabled biquad title");
 	expectEqual(disabledFilter.summary, "Fc 1000 Hz · Gain -3 dB · Q 0.71", "disabled biquad summary");
 
-	FilterCardDescriptor lowShelfCornerFilter = FilterCardModel::describeLine("Filter: ON LSC 12 dB Fc 200 Hz Gain 3 dB");
-	expectEqual(lowShelfCornerFilter.badge, "LSC", "low-shelf corner badge");
+	FilterCardDescriptor lowShelfCenterFilter = FilterCardModel::describeLine("Filter: ON LSC 12 dB Fc 200 Hz Gain 3 dB");
+	expectEqual(lowShelfCenterFilter.badge, "LSC", "low-shelf center badge");
+	expectEqual(lowShelfCenterFilter.title, "Low-shelf", "low-shelf center title");
+	expectTrue(lowShelfCenterFilter.summary.contains("Center 200 Hz") && lowShelfCenterFilter.summary.contains("Gain 3 dB") && lowShelfCenterFilter.summary.contains("Slope 12 dB/Oct"),
+		QStringLiteral("low-shelf center summary missing expected fields: ") + lowShelfCenterFilter.summary);
+
+	FilterCardDescriptor lowShelfCornerFilter = FilterCardModel::describeLine("Filter: ON LS 6 dB Fc 120 Hz Gain -2 dB");
+	expectEqual(lowShelfCornerFilter.badge, "LS", "low-shelf corner badge");
 	expectEqual(lowShelfCornerFilter.title, "Low-shelf", "low-shelf corner title");
-	expectTrue(lowShelfCornerFilter.summary.contains("Corner 200 Hz") && lowShelfCornerFilter.summary.contains("Gain 3 dB") && lowShelfCornerFilter.summary.contains("Slope 12 dB/Oct"),
-		"low-shelf corner summary missing expected fields");
+	expectTrue(lowShelfCornerFilter.summary.contains("Corner 120 Hz") && lowShelfCornerFilter.summary.contains("Gain -2 dB") && lowShelfCornerFilter.summary.contains("Slope 6 dB/Oct"),
+		QStringLiteral("low-shelf corner summary missing expected fields: ") + lowShelfCornerFilter.summary);
 
 	FilterCardDescriptor pureComment = FilterCardModel::describeLine("    # purely explanatory comment");
 	expectFalse(pureComment.enabled, "pure comment was marked enabled");

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -222,7 +222,14 @@ int main(int argc, char** argv)
 	FilterCardDescriptor disabledFilter = FilterCardModel::describeLine("# Filter: ON PK Fc 1000 Hz Gain -3 dB Q 0.71");
 	expectFalse(disabledFilter.enabled, "commented filter was marked enabled");
 	expectEqual(disabledFilter.badge, "PK", "disabled biquad badge");
-	expectEqual(disabledFilter.title, "Biquad", "disabled biquad title");
+	expectEqual(disabledFilter.title, "Peaking", "disabled biquad title");
+	expectEqual(disabledFilter.summary, "Fc 1000 Hz · Gain -3 dB · Q 0.71", "disabled biquad summary");
+
+	FilterCardDescriptor lowShelfCornerFilter = FilterCardModel::describeLine("Filter: ON LSC 12 dB Fc 200 Hz Gain 3 dB");
+	expectEqual(lowShelfCornerFilter.badge, "LSC", "low-shelf corner badge");
+	expectEqual(lowShelfCornerFilter.title, "Low-shelf", "low-shelf corner title");
+	expectTrue(lowShelfCornerFilter.summary.contains("Corner 200 Hz") && lowShelfCornerFilter.summary.contains("Gain 3 dB") && lowShelfCornerFilter.summary.contains("Slope 12 dB/Oct"),
+		"low-shelf corner summary missing expected fields");
 
 	FilterCardDescriptor pureComment = FilterCardModel::describeLine("    # purely explanatory comment");
 	expectFalse(pureComment.enabled, "pure comment was marked enabled");


### PR DESCRIPTION
## Summary

External audit (`eapo_xt_modern_card_gui_bug_root_cause_ko.md`) identified a Modern Card bug: \`FilterCardRow::refreshStateProperties\` set the **dynamic property `enabled`** on \`cardFrame\` / \`headerWidget\`. Because \`QWidget::enabled\` is a real \`Q_PROPERTY\`, that call was equivalent to \`setEnabled(false)\` on the entire card whenever the line was commented out, which propagates to every child — toggle button, raw editor, Include path field, BiQuad inner controls all went dead on disabled rows.

Three coordinated changes from the audit + extension:

### 1. Stop poisoning the card with the real `enabled` property
- \`refreshStateProperties\`: dynamic property renamed from \`enabled\` → **\`filterEnabled\`** (purely a QSS styling hook now, no QWidget enabled side effects).
- \`rebuildSummary\`: \`gui->setEnabled(descriptor.enabled)\` so only the body editor goes inactive when the row is commented; the header (and the toggle itself) stays interactive.

### 2. Header power UI: QCheckBox → QToolButton with power_on/off icons
Matches the rest of the card toolbar and makes the on/off state visually distinct via \`:/icons/power_on.svg\` / \`:/icons/power_off.svg\`.

### 3. Modern Cards stops decorating with the legacy CommentFilterGUI
\`FilterTable::updateGuis\` and \`updateSingleRowGui\` skip \`decorateFilterGUI\` when \`renderMode == ModernCards\`. The card header now owns the power state; the legacy decorator's second power toolbar inside the body just produces rules that disagree with the card.

### 4. BiQuad summary recognises the full vocabulary
\`FilterCardModel::describeLine\` now handles **LSC/HSC** (shelf-with-slope), **LPQ/HPQ** (Q-form), **PEQ** alias, and **Modal** in addition to the original PK/LP/HP/LS/HS/NO/AP/BP. Emits a legacy-style summary like \`Center 250 Hz · Gain 6 dB · Slope 12 dB/Oct\` instead of falling back to badge=BQUAD + raw parameter text.

## Verification on the running build

Manual A/B against the install build (with backup) confirmed the new summary on a `Filter: ON PK Fc 6200 Hz Gain -4 dB Q 8` line shows up as **"Fc 6200 Hz · Gain -4 dB · Q 8"** in the Peaking card title. That string can only come from the new `summarizeBiquad`.

## Known separate issue (NOT addressed here)

While verifying, a **pre-existing layout bug** surfaced: on this user's setup the right-side header toolbar (power / + / - / ...) is not rendered at all on Modern Card rows — only the left-side expand button shows. A/B with \`refreshStateProperties\`'s \`setStyleSheet\` + \`polish\` calls disabled produced the exact same hidden buttons, so that path is not the cause. The bug is independent of this PR and is what the user's `"이전부터 고장"` (was broken before) report referred to. Tracked separately for diagnostics with qDebug / DebugView.

## Test plan
- [x] Editor builds clean against Qt 6.10.1 (msvc2022_64)
- [x] New BiQuad summary verified live on the running install build
- [ ] CI matrix (sse2 / avx / avx2 / avx512 / avx10_1 / neon) green
- [ ] Manual (once header buttons are visible — separate fix): comment a Filter row, confirm the row's GUI body becomes inactive but the toggle / raw editor stay clickable, and re-enabling the row works
- [ ] Manual: Include row with \`# Include: foo.txt\` — path field becomes inactive but the card header is still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)