### PR TITLE
fix(editor): restore Modern Card right header toolbar visibility

### DIFF
--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -336,7 +336,20 @@ int FilterTable::getPreferredWidth()
 	if (scrollArea == nullptr)
 		return width();
 
-	return scrollArea->viewport()->width();
+	// Use the scroll area's own outer width minus the vertical scrollbar - this
+	// is the actual on-screen visible area and is NOT affected by the inner
+	// widget's possibly-inflated size. Both viewport()->width() and
+	// maximumViewportSize() follow the inner widget when it grows past the
+	// window, which creates a feedback loop: a once-inflated card width
+	// permanently inflates the preferred width returned here, which in turn
+	// keeps the cards inflated.
+	int width = scrollArea->width();
+	if (QScrollBar* vBar = scrollArea->verticalScrollBar())
+		if (vBar->isVisible())
+			width -= vBar->sizeHint().width();
+	// Account for QScrollArea's own frame (default 1px each side).
+	width -= 2 * scrollArea->frameWidth();
+	return qMax(0, width);
 }
 
 void FilterTable::updateSizeHints()

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -5,6 +5,7 @@
 #include <QPainter>
 #include <QPropertyAnimation>
 #include <QRegularExpression>
+#include <QScrollArea>
 #include <QStyle>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -22,6 +23,11 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	QVBoxLayout* outerLayout = new QVBoxLayout(this);
 	outerLayout->setContentsMargins(8 + descriptor.depth * SkinManager::instance()->tokens().channelGroupIndent, 4, 8, 4);
 	outerLayout->setSpacing(0);
+	// Detach the layout's minimumSize from the children's: the body can contain
+	// legacy filter GUIs with huge content-driven sizeHints (DeviceFilterGUI,
+	// VST, Convolution, ...) and SetMinimumSize would propagate that up here
+	// and force every cell in FilterTable's grid to that width.
+	outerLayout->setSizeConstraint(QLayout::SetNoConstraint);
 
 	cardFrame = new QFrame(this);
 	cardFrame->setObjectName(QStringLiteral("FilterCardRow"));
@@ -120,6 +126,18 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	bodyStack = new QStackedWidget(cardFrame);
 	bodyStack->setObjectName(QStringLiteral("FilterCardBody"));
 	bodyStack->setAttribute(Qt::WA_StyledBackground, true);
+	// Stop an overgrown body editor (e.g. the legacy DeviceFilterGUI's
+	// QTreeWidget with sizeAdjustPolicy=AdjustToContents, or any other GUI that
+	// reports a content-driven sizeHint) from propagating its preferred width
+	// up through the card. Otherwise the card grows past the visible viewport
+	// and the right-side header toolbar (enable / + / - / ...) renders
+	// thousands of pixels off screen and becomes invisible.
+	// Ignored sizePolicy alone is not enough: it stops sizeHint propagation
+	// but the layout system still inherits the inner widgets' minimumSize.
+	// Pin the bodyStack's own minimumSize to 0 so the card frame's minimum
+	// width is driven by the header only.
+	bodyStack->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+	bodyStack->setMinimumSize(0, 0);
 	cardLayout->addWidget(bodyStack);
 
 	lineEdit = new QLineEdit(bodyStack);
@@ -132,9 +150,37 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 		QWidget* editorContainer = new QWidget(bodyStack);
 		editorContainer->setObjectName(QStringLiteral("FilterCardEditor"));
 		editorContainer->setAttribute(Qt::WA_StyledBackground, true);
+		// Match bodyStack: stop overgrown filter GUIs from inflating the card width.
+		editorContainer->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+		editorContainer->setMinimumSize(0, 0);
 		QVBoxLayout* editorLayout = new QVBoxLayout(editorContainer);
 		editorLayout->setContentsMargins(12, 10, 12, 12);
-		editorLayout->addWidget(gui);
+		// Wrap the legacy filter GUI in a borderless scroll area. Without this,
+		// any filter GUI that has a content-driven sizeHint (DeviceFilterGUI's
+		// QTreeWidget AdjustToContents, GraphicEQ / Convolution / VSTPlugin's
+		// internal AdjustToContents widgets) propagates a huge minimumSize up
+		// through editorContainer/bodyStack/cardFrame/FilterCardRow and the
+		// QGridLayout in FilterTable then forces every card column to that
+		// width, pushing the right-side header toolbar (enable / + / - / ...)
+		// thousands of pixels off screen.
+		QWidget* guiWidget = qobject_cast<QWidget*>(gui);
+		if (guiWidget != nullptr)
+		{
+			QScrollArea* guiScroll = new QScrollArea(editorContainer);
+			guiScroll->setObjectName(QStringLiteral("FilterCardEditorScroll"));
+			guiScroll->setFrameShape(QFrame::NoFrame);
+			guiScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+			guiScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+			guiScroll->setWidgetResizable(true);
+			guiScroll->setMinimumSize(0, 0);
+			guiScroll->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+			guiScroll->setWidget(guiWidget);
+			editorLayout->addWidget(guiScroll);
+		}
+		else
+		{
+			editorLayout->addWidget(gui);
+		}
 		bodyStack->addWidget(editorContainer);
 		bodyStack->setCurrentWidget(editorContainer);
 		connect(gui, SIGNAL(updateModel()), this, SLOT(updateModel()));
@@ -170,11 +216,32 @@ void FilterCardRow::editText()
 
 QSize FilterCardRow::sizeHint() const
 {
-	QSize size = QWidget::sizeHint();
-	int preferredWidth = table->getPreferredWidth();
-	if (size.width() < preferredWidth)
-		size.setWidth(preferredWidth);
-	return size;
+	// Use only the header's preferred width and the viewport - never the body's
+	// content-driven sizeHint. Some legacy filter GUIs (DeviceFilterGUI with
+	// QTreeWidget AdjustToContents, VST / Convolution / Stage editors) report
+	// a sizeHint matching their full content (thousands of pixels), which
+	// would otherwise inflate the entire QGridLayout column in FilterTable and
+	// push the right-side header toolbar far off screen.
+	int height = QWidget::sizeHint().height();
+	int width = headerWidget ? headerWidget->sizeHint().width() : QWidget::sizeHint().width();
+	if (layout() != nullptr)
+		width += layout()->contentsMargins().left() + layout()->contentsMargins().right();
+	int preferredWidth = table != nullptr ? table->getPreferredWidth() : 0;
+	if (width < preferredWidth)
+		width = preferredWidth;
+	return QSize(width, height);
+}
+
+QSize FilterCardRow::minimumSizeHint() const
+{
+	// Cap the cell's minimum width at a small constant so the QGridLayout in
+	// FilterTable does not inherit any content-driven minimum from a card's
+	// body editor. Without this, ONE row with a wide legacy filter GUI forces
+	// EVERY card column wide enough to push the right-side header toolbar far
+	// off screen. Height stays layout-driven so cards still vertically size to
+	// fit their bodies.
+	int height = QWidget::minimumSizeHint().height();
+	return QSize(0, height);
 }
 
 void FilterCardRow::paintEvent(QPaintEvent*)

--- a/Editor/widgets/FilterCardRow.h
+++ b/Editor/widgets/FilterCardRow.h
@@ -21,6 +21,7 @@ public:
 	QRect getHeaderRect() const;
 	void editText();
 	QSize sizeHint() const override;
+	QSize minimumSizeHint() const override;
 
 protected:
 	void paintEvent(QPaintEvent*) override;


### PR DESCRIPTION
## Summary

Modern Card 모드에서 모든 row의 우측 header toolbar 4 버튼 (⏻ enable, +, −, ⋯)이 화면 밖 수 천 픽셀 위치에 렌더되어 보이지도 클릭되지도 않던 버그를 수정합니다. 좌측 expand 토글만 작동했습니다.

## Root cause

3 계층이 얽힌 feedback loop:

1. **Legacy 필터 GUI**가 내부 `QTreeWidget`/`QGraphicsView`에 `sizeAdjustPolicy=AdjustToContents`를 설정 (DeviceFilterGUI, VST, Convolution, GraphicEQ ...). widget의 sizeHint가 전체 컨텐츠 너비 - Device row의 경우 수만 픽셀 - 와 같아집니다.

2. **FilterCardRow**가 gui를 card body에 raw로 감쌌습니다. 거대 minimumSize가 editorContainer → bodyStack → cardFrame → FilterCardRow → FilterTable의 `QGridLayout`까지 전파되어 단일 column의 모든 cell이 그 너비로 강제됩니다.

3. **`FilterTable::getPreferredWidth()`**가 `scrollArea->viewport()->width()`를 반환하는데, `setWidgetResizable(true)` 환경에서 viewport는 inner widget이 화면을 넘어 커지면 같이 커집니다. 한 번 카드가 inflated 되면 이후 모든 sizeHint 쿼리가 inflated 값을 반환하고 자체 회복이 불가능합니다.

## Fix

3 계층 전파를 모두 끊어, 한 row의 body가 거대해도 column 전체를 오염시키지 못하게 합니다:

- **`FilterTable::getPreferredWidth()`**: `scrollArea->width()` (실제 화면 가시 영역) 에서 수직 스크롤바·프레임을 뺀 값을 반환. viewport는 inner widget을 따라가므로 사용 안 함.
- **`FilterCardRow`**:
  - `outerLayout->setSizeConstraint(SetNoConstraint)`
  - `sizeHint()` / `minimumSizeHint()` 오버라이드 - 헤더 너비만 참조, body는 무시
  - `bodyStack`/`editorContainer`에 `QSizePolicy::Ignored` + `setMinimumSize(0, 0)`
- **Body 안에 borderless 가로 `QScrollArea`로 legacy gui 감싸기**: gui 자체는 여전히 거대한 sizeHint를 보고할 수 있지만 scroll area가 흡수해 card frame까지 전파되지 않음.

## 검증

computer-use MCP로 build → deploy → screenshot 사이클을 직접 돌려 확인:

- Device / Preamp / Include / Peaking / Comment / Channel / Stage / VST / Convolution 모든 row 타입에서 4 버튼 (⏻ + − ⋯) 정상 렌더
- Body editor들 (DeviceFilterGUI 테이블, PreampCardEditor gain dial, IncludeCardEditor path, BiQuadFilterGUI Center frequency / Gain / Q factor 3-dial) 정상 표시
- 진단 로그로 card geom 27166px → 2351px 로 감소 확인

## Test plan

- [ ] CI 모든 SIMD variant build 통과
- [ ] EditorLogicTests 통과 (FilterCardRow 직접 테스트는 없지만 회귀 없음 확인)
- [ ] Legacy TableEditor view (Modern Cards 비활성화)도 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)