### PR TITLE
fix(editor): Modern Card 변형 진단으로 발견된 3건 일괄 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,6 @@ paket-files/
 # Local benchmark configurations
 bench-config/
 bench-config-conv/
+
+# Local Modern Card variant visual-check sample (Task #32)
+_card_variants_demo.txt

--- a/Editor/widgets/ChBadge.cpp
+++ b/Editor/widgets/ChBadge.cpp
@@ -85,12 +85,21 @@ void ChBadge::paintEvent(QPaintEvent*)
 	}
 	else
 	{
-		painter.setPen(Qt::NoPen);
-		painter.setBrush(color);
+		// Filled style: tone down the saturated channel colour to a soft chip
+		// (low-alpha fill + matching outline). The fully-saturated brush used
+		// to read like a warning indicator next to neutral header controls,
+		// even though the row was in a perfectly normal selection state.
+		QColor fill = color;
+		fill.setAlpha(SkinManager::instance()->isDark() ? 70 : 48);
+		QPen pen(color, 1.0);
+		painter.setPen(pen);
+		painter.setBrush(fill);
 	}
 
 	painter.drawRoundedRect(badgeRect, radius, radius);
-	painter.setPen(isVirtualChannel() || tokens.badgeStyle == SkinTokens::OutlineOnly || tokens.badgeStyle == SkinTokens::WireframeBorder ? color : Qt::white);
+	// Text always uses the channel colour now; with the muted filled chip the
+	// pure-white glyph on a soft pastel background became hard to read.
+	painter.setPen(color);
 	QFont badgeFont = font();
 	badgeFont.setBold(true);
 	badgeFont.setPointSizeF(qMax(7.5, badgeFont.pointSizeF() - 1.0));

--- a/Editor/widgets/FilterCardModel.cpp
+++ b/Editor/widgets/FilterCardModel.cpp
@@ -169,6 +169,18 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 	descriptor.depth = depth;
 	descriptor.enabled = !line.trimmed().startsWith('#');
 
+	// Blank / whitespace-only lines (including the trailing newline that almost
+	// every config file ends with) used to fall through to the generic "TXT
+	// Text" branch and produce a full-height card with an empty title. Mark
+	// them as a dedicated spacer so the row widget can render a thin separator
+	// instead of an empty card.
+	if (line.trimmed().isEmpty())
+	{
+		descriptor.type = QStringLiteral("spacer");
+		descriptor.canToggleEnabled = false;
+		return descriptor;
+	}
+
 	if (isPureCommentLine(line))
 	{
 		QString trimmed = line.trimmed();
@@ -209,8 +221,13 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 		descriptor.title = QStringLiteral("Delay");
 		descriptor.color = QStringLiteral("#14b8a6");
 	}
-	else if (commandLower == QStringLiteral("filter"))
+	else if (commandLower == QStringLiteral("filter") || commandLower.startsWith(QStringLiteral("filter ")))
 	{
+		// EAPO syntax allows numbered filter lines such as `Filter 1:`, `Filter 99:`
+		// (commonly emitted by REW, Room EQ Wizard, Dirac, and other tools). The
+		// exact-match check that used to live here treated `Filter 1` as a generic
+		// text command, which stripped the type-specific badge/title/summary off
+		// every BiQuad card produced by those tools.
 		descriptor.type = QStringLiteral("biquad");
 		descriptor.badge = QStringLiteral("BQUAD");
 		descriptor.title = QStringLiteral("Biquad");

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -216,6 +216,14 @@ void FilterCardRow::editText()
 
 QSize FilterCardRow::sizeHint() const
 {
+	// Blank lines collapse to a thin spacer; no header, no body, just a few
+	// pixels of breathing room so visual grouping in the config survives.
+	if (descriptor.type == QStringLiteral("spacer"))
+	{
+		int preferredWidth = table != nullptr ? table->getPreferredWidth() : 0;
+		return QSize(preferredWidth, 10);
+	}
+
 	// Use only the header's preferred width and the viewport - never the body's
 	// content-driven sizeHint. Some legacy filter GUIs (DeviceFilterGUI with
 	// QTreeWidget AdjustToContents, VST / Convolution / Stage editors) report
@@ -234,6 +242,11 @@ QSize FilterCardRow::sizeHint() const
 
 QSize FilterCardRow::minimumSizeHint() const
 {
+	// Spacer rows force a small fixed height so QGridLayout does not promote
+	// them up to the body-driven minimum of neighbouring cards.
+	if (descriptor.type == QStringLiteral("spacer"))
+		return QSize(0, 10);
+
 	// Cap the cell's minimum width at a small constant so the QGridLayout in
 	// FilterTable does not inherit any content-driven minimum from a card's
 	// body editor. Without this, ONE row with a wide legacy filter GUI forces
@@ -300,6 +313,26 @@ void FilterCardRow::paintEvent(QPaintEvent*)
 void FilterCardRow::rebuildSummary()
 {
 	descriptor = FilterCardModel::describeLine(item->text, descriptor.depth);
+
+	// Blank lines render as a thin spacer: no header, no body, no raw preview.
+	// The card frame itself stays visible (so its background fills the gap and
+	// scope-rail painting still works for indented blocks) but is collapsed
+	// to a small fixed height by sizeHint() / minimumSizeHint() below.
+	const bool isSpacer = descriptor.type == QStringLiteral("spacer");
+	if (headerWidget != nullptr)
+		headerWidget->setVisible(!isSpacer);
+	if (bodyStack != nullptr)
+		bodyStack->setVisible(!isSpacer && expandButton != nullptr && expandButton->isChecked());
+	if (isSpacer)
+	{
+		if (rawPreviewLabel != nullptr)
+			rawPreviewLabel->setVisible(false);
+		refreshStateProperties();
+		updateGeometry();
+		update();
+		return;
+	}
+
 	typeBadge->setText(descriptor.badge);
 	bool outlineBadge = SkinManager::instance()->tokens().badgeStyle == SkinTokens::OutlineOnly || SkinManager::instance()->tokens().badgeStyle == SkinTokens::WireframeBorder;
 	typeBadge->setStyleSheet(QStringLiteral("color:%1; border-color:%2; background-color:%3;")

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define MAJOR 1
 #define MINOR 5
-#define REVISION 2
+#define REVISION 3


### PR DESCRIPTION
## Summary

14개 filter factory + BiQuad 10개 subtype + disabled/comment 변형을 모두 띄워 시각 검수한 결과(task #32) 디자인 결함 5건을 발견했고, 그 중 코드 수정이 필요한 3건을 일괄 처리합니다.

### A. BiQuad `Filter N:` 형식 인식 복원 (Critical)
`FilterCardModel.cpp:212`의 `commandLower == \"filter\"` 정확 매칭이 REW·Room EQ Wizard·Dirac 등이 export하는 숫자 prefix 형식(`Filter 1:`, `Filter 99:`)을 generic \"TXT Filter N\" 카드로 떨어뜨려, PK/LP/HP/LS/HS/NO/AP/BP 등 type-specific badge·title·summary가 사라지는 광범위한 결함이었습니다. `isKnownConfigCommand`와 동일하게 `startsWith` 패턴으로 확장합니다.

### B. 빈 줄을 thin spacer로 처리 (UX)
의도적 빈 줄과 모든 config 파일 끝의 trailing newline이 generic \"TXT Text\" 카드로 렌더링되며 빈 카드를 만들었습니다. `describeLine`에 `type = \"spacer\"` 분기를 추가하고, FilterCardRow는 spacer일 때 header·body·raw 모두 hide하고 sizeHint를 10px로 줄여 카드 사이 시각적 그룹핑만 남깁니다.

### C. Channel/Copy 채널 뱃지 색상 톤 다운 (UX)
선택된 L/R 채널을 강한 빨간/주황 알약으로 표시해 헤더 옆에서 경고 indicator처럼 읽혔습니다. filled style을 low-alpha fill + 1px outline + 채널색 글자의 soft chip으로 바꿉니다.

### 검수에서 제외된 2건
- **Disabled 카드 toolbar**: 첫 진단의 \"+ - ⋯ 안 보임\"은 작은 해상도 + disabled muted styling에서의 시각적 착시. zoom 재확인 결과 모두 정상.
- **VST/Include badge 색**: 코드상 VST=#a855f7(보라), Include=#64748b(회색, Device와 동일 control 카테고리). zoom 재확인 결과 의도된 표현.

## Test plan

- [x] Editor build (nmake release) 성공
- [x] Sample config(`_card_variants_demo.txt`) 로드 후 모든 BiQuad subtype이 type-specific green badge로 표시
- [x] disabled `# Filter 11:` 라인도 PK Peaking badge + summary 표시
- [x] Channel/Copy 카드 우측의 채널 뱃지(L, R)가 soft outline 톤으로 표시
- [x] 파일 끝 trailing newline에서 빈 \"TXT Text\" 카드가 사라짐
- [x] 사용자 실제 config(`config.txt`) 정상 표시(regression)
- [ ] CI matrix(sse2, avx, avx2, avx512, avx10_1, neon) 전체 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)