### PR TITLE
fix(apo): restore audio passthrough when sample format is not IEEE_FLOAT 32/64

### DIFF
--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -25,6 +25,7 @@ SOURCES += main.cpp\
 	../helpers/RegistryHelper.cpp \
 	../helpers/ServiceHelper.cpp \
 	../helpers/ApoRegistration.cpp \
+	../helpers/AudioFormatProbe.cpp \
 	../helpers/VelopackBootstrap.cpp \
 	../parser/LogicalOperators.cpp \
 	IFilterGUIFactory.cpp \
@@ -181,6 +182,7 @@ HEADERS  += \
 	../helpers/RegistryHelper.h \
 	../helpers/ServiceHelper.h \
 	../helpers/ApoRegistration.h \
+	../helpers/AudioFormatProbe.h \
 	../helpers/VelopackBootstrap.h \
 	../parser/LogicalOperators.h \
 	IFilterGUIFactory.h \

--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -40,6 +40,7 @@
 #include "helpers/StringHelper.h"
 #include "helpers/LogHelper.h"
 #include "helpers/ChannelHelper.h"
+#include "helpers/AudioFormatProbe.h"
 #include "Editor/helpers/GUIChannelHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "version.h"
@@ -125,6 +126,14 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 	deviceComboBox->setObjectName(QStringLiteral("ToolBarComboBox"));
 	connect(deviceComboBox, QOverload<int>::of(&QComboBox::activated), this, &MainWindow::deviceSelected);
 	ui->mainToolBar->addWidget(deviceComboBox);
+
+	deviceFormatBadge = new QLabel(QString());
+	deviceFormatBadge->setObjectName(QStringLiteral("DeviceFormatBadge"));
+	deviceFormatBadge->setAttribute(Qt::WA_StyledBackground, true);
+	deviceFormatBadge->setProperty("severity", QStringLiteral("normal"));
+	deviceFormatBadge->setVisible(false);
+	deviceFormatBadge->setToolTip(tr("Whether EqualizerAPO is processing this device's stream natively, or forwarding it without applying filters."));
+	ui->mainToolBar->addWidget(deviceFormatBadge);
 
 	spacer = new QWidget;
 	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
@@ -253,6 +262,42 @@ void MainWindow::doChecks()
 		{
 			runDeviceSelector();
 			return;
+		}
+	}
+
+	// Scan every installed endpoint and warn once if any of them currently
+	// uses a stream format we cannot process natively. The APO still passes
+	// audio through in that case, but no filters are applied — without this
+	// warning the user would just see "EQ has no effect" with no explanation.
+	{
+		QStringList passthroughDevices;
+		auto inspect = [&passthroughDevices](const QList<shared_ptr<AbstractAPOInfo>>& list)
+		{
+			for (const shared_ptr<AbstractAPOInfo>& info : list)
+			{
+				if (info == nullptr || !info->isInstalled())
+					continue;
+				AudioFormatProbe::Result r = AudioFormatProbe::probe(info->getDeviceGuid());
+				if (AudioFormatProbe::isPassthrough(r.status))
+				{
+					QString label = QString::fromStdWString(info->getConnectionName())
+						+ " - " + QString::fromStdWString(info->getDeviceName())
+						+ "  (" + QString::fromStdWString(r.subtypeDescription)
+						+ ", " + QString::number(r.containerBytes * 8) + "-bit)";
+					passthroughDevices.append(label);
+				}
+			}
+		};
+		inspect(outputDevices);
+		inspect(inputDevices);
+		if (!passthroughDevices.isEmpty())
+		{
+			QMessageBox::warning(this,
+				tr("EQ inactive on some devices"),
+				tr("EqualizerAPO can only process IEEE_FLOAT 32/64-bit streams natively. The following installed devices currently use a different format, "
+				   "so audio passes through them without any filter being applied:\n\n%0\n\nThis is not a crash — sound still reaches the device, but no EQ. "
+				   "Switch the device's default format to a 32-bit IEEE_FLOAT one in Sound Settings if you need filtering on them.")
+				.arg(passthroughDevices.join('\n')));
 		}
 	}
 

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -105,6 +105,7 @@ private:
 	void executeStartAnalysis();
 	FilterTable* addTab(QString title, QString tooltip, QString configPath, QList<QString> lines);
 	void getDeviceAndChannelMask(std::shared_ptr<AbstractAPOInfo>* selectedDevice, int* channelMask);
+	void updateDeviceFormatBadge(const std::shared_ptr<AbstractAPOInfo>& apoInfo);
 	bool askForClose(int tabIndex);
 	void loadPreferences();
 	void savePreferences();
@@ -123,6 +124,7 @@ private:
 	QCheckBox* instantModeCheckBox;
 	QLabel* dirtyStatusLabel = nullptr;
 	QComboBox* deviceComboBox;
+	QLabel* deviceFormatBadge = nullptr;
 	QComboBox* channelConfigurationComboBox;
 	QList<std::shared_ptr<AbstractAPOInfo>> outputDevices;
 	QList<std::shared_ptr<AbstractAPOInfo>> inputDevices;

--- a/Editor/MainWindowParts/MainWindow.Device.cpp
+++ b/Editor/MainWindowParts/MainWindow.Device.cpp
@@ -3,6 +3,7 @@
 #include <QElapsedTimer>
 #include <QLabel>
 #include <QMimeData>
+#include <QStyle>
 #include <QPushButton>
 #include <QStandardItemModel>
 #include <QStringBuilder>
@@ -20,6 +21,7 @@
 #include "helpers/StringHelper.h"
 #include "helpers/LogHelper.h"
 #include "helpers/ChannelHelper.h"
+#include "helpers/AudioFormatProbe.h"
 #include "Editor/helpers/GUIChannelHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "version.h"
@@ -42,6 +44,8 @@ void MainWindow::deviceSelected(int index)
 	shared_ptr<AbstractAPOInfo> apoInfo = deviceComboBox->itemData(index).value<shared_ptr<AbstractAPOInfo>>();
 	if (apoInfo == nullptr)
 		apoInfo = defaultOutputDevice;
+
+	updateDeviceFormatBadge(apoInfo);
 
 	channelConfigurationComboBox->clear();
 
@@ -143,6 +147,60 @@ FilterTable* MainWindow::addTab(QString title, QString tooltip, QString configPa
 	ui->tabWidget->setTabToolTip(tabIndex, tooltip);
 
 	return filterTable;
+}
+
+void MainWindow::updateDeviceFormatBadge(const shared_ptr<AbstractAPOInfo>& apoInfo)
+{
+	if (deviceFormatBadge == nullptr)
+		return;
+
+	if (apoInfo == nullptr)
+	{
+		deviceFormatBadge->setVisible(false);
+		deviceFormatBadge->setText(QString());
+		return;
+	}
+
+	AudioFormatProbe::Result r = AudioFormatProbe::probe(apoInfo->getDeviceGuid());
+
+	QString label;
+	QString severity = QStringLiteral("normal");
+	QString tooltip;
+	switch (r.status)
+	{
+	case AudioFormatProbe::Status::ActiveFloat32:
+		label = tr("EQ active · 32-bit float");
+		severity = QStringLiteral("normal");
+		tooltip = tr("EqualizerAPO is processing this stream natively (IEEE_FLOAT 32-bit, %0 Hz, %1 ch).")
+			.arg(r.sampleRate).arg(r.channelCount);
+		break;
+	case AudioFormatProbe::Status::ActiveFloat64:
+		label = tr("EQ active · 64-bit float");
+		severity = QStringLiteral("normal");
+		tooltip = tr("EqualizerAPO is processing this stream natively (IEEE_FLOAT 64-bit, %0 Hz, %1 ch).")
+			.arg(r.sampleRate).arg(r.channelCount);
+		break;
+	case AudioFormatProbe::Status::Passthrough:
+		label = tr("Passthrough · EQ inactive");
+		severity = QStringLiteral("warning");
+		tooltip = tr("This device's stream format is %0 (%1-bit container). EqualizerAPO only processes IEEE_FLOAT 32/64-bit streams natively, "
+			"so audio is forwarded without any filter being applied. Switch the device's default format to a 32-bit IEEE_FLOAT one in "
+			"Sound Settings if you need filtering on this device.")
+			.arg(QString::fromStdWString(r.subtypeDescription)).arg(r.containerBytes * 8);
+		break;
+	case AudioFormatProbe::Status::Unknown:
+	default:
+		deviceFormatBadge->setVisible(false);
+		deviceFormatBadge->setText(QString());
+		return;
+	}
+
+	deviceFormatBadge->setText(label);
+	deviceFormatBadge->setToolTip(tooltip);
+	deviceFormatBadge->setProperty("severity", severity);
+	deviceFormatBadge->style()->unpolish(deviceFormatBadge);
+	deviceFormatBadge->style()->polish(deviceFormatBadge);
+	deviceFormatBadge->setVisible(true);
 }
 
 void MainWindow::getDeviceAndChannelMask(shared_ptr<AbstractAPOInfo>* selectedDevice, int* channelMask)

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -34,11 +34,19 @@ namespace
 {
 	EqualizerAPO::ApoSampleFormat detectSampleFormat(const UNCOMPRESSEDAUDIOFORMAT& f)
 	{
+		// Windows audio engine normally hands system-effect APOs IEEE_FLOAT samples
+		// even when the endpoint runs an integer format underneath. We only need to
+		// match the container size to pick the right reinterpret. Validating the
+		// exact dwValidBitsPerSample value is too strict — some virtual devices
+		// (CABLE Input, loopback adapters, etc.) report non-canonical valid-bit
+		// counts even though the container is plain 32-bit float. Rejecting them
+		// here used to fall through to silent output and made the device sound
+		// dead. See git 309e9e8 regression.
 		if (IsEqualGUID(f.guidFormatType, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT))
 		{
-			if (f.dwBytesPerSampleContainer == 4 && f.dwValidBitsPerSample == 32)
+			if (f.dwBytesPerSampleContainer == 4)
 				return EqualizerAPO::ApoSampleFormat::Float32;
-			if (f.dwBytesPerSampleContainer == 8 && f.dwValidBitsPerSample == 64)
+			if (f.dwBytesPerSampleContainer == 8)
 				return EqualizerAPO::ApoSampleFormat::Float64;
 		}
 		return EqualizerAPO::ApoSampleFormat::Unsupported;
@@ -428,6 +436,18 @@ HRESULT EqualizerAPO::LockForProcess(UINT32 u32NumInputConnections,
 	outputSampleFormat = detectSampleFormat(outFormat);
 	TraceF(L"Resolved APO sample formats: in=%d, out=%d", static_cast<int>(inputSampleFormat), static_cast<int>(outputSampleFormat));
 
+	// Loud warning so the user can see in TraceLog.txt why a device sounds dry:
+	// when the format is something we cannot natively process the engine is
+	// bypassed and the input is forwarded straight to the output without any
+	// filtering. This is still preferable to going silent.
+	if (inputSampleFormat == ApoSampleFormat::Unsupported || outputSampleFormat == ApoSampleFormat::Unsupported)
+	{
+		LogF(L"Connection format is not IEEE_FLOAT 32/64 (in container=%u valid=%u, out container=%u valid=%u). "
+			L"APO will passthrough audio without applying filters for this stream.",
+			inFormat.dwBytesPerSampleContainer, inFormat.dwValidBitsPerSample,
+			outFormat.dwBytesPerSampleContainer, outFormat.dwValidBitsPerSample);
+	}
+
 	if (childCfg != nullptr)
 	{
 		hr = childCfg->LockForProcess(u32NumInputConnections, ppInputConnections, u32NumOutputConnections,
@@ -582,9 +602,13 @@ void EqualizerAPO::APOProcess(UINT32 u32NumInputConnections,
 		}
 
 		// The APO is registered with APO_FLAG_BITSPERSAMPLE_MUST_MATCH, so input
-		// and output formats agree. Branch on the input format to pick the native
-		// path: legacy float32 (the dominant case on Windows) or true float64.
-		if (inputSampleFormat == ApoSampleFormat::Float64)
+		// and output formats should agree on container size. Only take the native
+		// path when both sides resolved to the same supported format — otherwise
+		// fall through to the passthrough branch so we never reinterpret integer
+		// samples as float.
+		const bool nativePathSafe = (inputSampleFormat == outputSampleFormat)
+			&& (inputSampleFormat != ApoSampleFormat::Unsupported);
+		if (nativePathSafe && inputSampleFormat == ApoSampleFormat::Float64)
 		{
 			double* inputFrames = reinterpret_cast<double*>(ppInputConnections[0]->pBuffer);
 			double* outputFrames = reinterpret_cast<double*>(ppOutputConnections[0]->pBuffer);
@@ -595,7 +619,7 @@ void EqualizerAPO::APOProcess(UINT32 u32NumInputConnections,
 				u32NumInputConnections, ppInputConnections,
 				u32NumOutputConnections, ppOutputConnections);
 		}
-		else if (inputSampleFormat == ApoSampleFormat::Float32)
+		else if (nativePathSafe && inputSampleFormat == ApoSampleFormat::Float32)
 		{
 			float* inputFrames = reinterpret_cast<float*>(ppInputConnections[0]->pBuffer);
 			float* outputFrames = reinterpret_cast<float*>(ppOutputConnections[0]->pBuffer);
@@ -608,15 +632,38 @@ void EqualizerAPO::APOProcess(UINT32 u32NumInputConnections,
 		}
 		else
 		{
-			// Unsupported connection format: emit silent output of the requested
-			// frame count and let the caller detect via BUFFER_SILENT. Writing
-			// garbage by reinterpreting an unknown buffer is worse.
-			const size_t outBytes = bytesPerSample(outputSampleFormat);
-			if (outBytes > 0)
-				memset(reinterpret_cast<void*>(ppOutputConnections[0]->pBuffer), 0,
-					static_cast<size_t>(frameCount) * outputChannelCount * outBytes);
+			// Unsupported or mismatched connection format: do NOT process, but
+			// still let audio reach the device. The APO is registered with
+			// APO_FLAG_INPLACE, so a conformant host hands us the same buffer
+			// for input and output — the samples already sit at outBuf untouched
+			// and we just have to mark the buffer valid. Emitting BUFFER_SILENT
+			// here was the cause of the "APO installed → device goes mute"
+			// regression (git 309e9e8).
+			//
+			// If a host does call us with distinct in/out buffers we cannot
+			// safely copy the bytes through because we do not know the exact
+			// input container size when the format is unsupported, and copying
+			// the wrong number of bytes would either truncate the signal or
+			// read past the input buffer. In that rare case we fall back to
+			// silence — it is still better than emitting random memory, and
+			// such a host is non-compliant given APO_FLAG_INPLACE anyway.
+			void* inBuf = reinterpret_cast<void*>(ppInputConnections[0]->pBuffer);
+			void* outBuf = reinterpret_cast<void*>(ppOutputConnections[0]->pBuffer);
 			ppOutputConnections[0]->u32ValidFrameCount = frameCount;
-			ppOutputConnections[0]->u32BufferFlags = BUFFER_SILENT;
+			if (inBuf == outBuf)
+			{
+				ppOutputConnections[0]->u32BufferFlags = isSilentInput ? BUFFER_SILENT : BUFFER_VALID;
+			}
+			else
+			{
+				const size_t outBytes = bytesPerSample(outputSampleFormat);
+				if (outBytes > 0)
+				{
+					memset(outBuf, 0,
+						static_cast<size_t>(frameCount) * outputChannelCount * outBytes);
+				}
+				ppOutputConnections[0]->u32BufferFlags = BUFFER_SILENT;
+			}
 		}
 
 		break;

--- a/helpers/AudioFormatProbe.cpp
+++ b/helpers/AudioFormatProbe.cpp
@@ -1,0 +1,141 @@
+/*
+	This file is part of EqualizerAPO, a system-wide equalizer.
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "AudioFormatProbe.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <Unknwn.h>
+#define INITGUID
+#include <mmdeviceapi.h>
+#include <Audioclient.h>
+#include <mmreg.h>
+#include <ksmedia.h>
+
+namespace
+{
+	// Minimal RAII to release COM pointers without pulling in wrl/comptr.
+	template<typename T>
+	struct ComPtr
+	{
+		T* p = nullptr;
+		~ComPtr() { if (p) p->Release(); }
+		T** operator&() { return &p; }
+		T* operator->() const { return p; }
+		operator T*() const { return p; }
+	};
+
+	std::wstring formatSubtypeName(const GUID& sub)
+	{
+		if (IsEqualGUID(sub, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT))
+			return L"IEEE_FLOAT";
+		if (IsEqualGUID(sub, KSDATAFORMAT_SUBTYPE_PCM))
+			return L"PCM";
+		return L"Other";
+	}
+}
+
+namespace AudioFormatProbe
+{
+
+Result probe(const std::wstring& deviceGuid)
+{
+	Result result;
+
+	// IMMDeviceEnumerator/IAudioClient are usable from a regular STA/MTA
+	// process. CoInitializeEx is assumed to have been called by the host
+	// (Qt does this implicitly via the GUI event loop).
+	ComPtr<IMMDeviceEnumerator> enumerator;
+	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
+		CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&enumerator));
+	if (FAILED(hr) || enumerator.p == nullptr)
+		return result;
+
+	ComPtr<IMMDevice> device;
+	hr = enumerator->GetDevice(deviceGuid.c_str(), &device);
+	if (FAILED(hr) || device.p == nullptr)
+		return result;
+
+	ComPtr<IAudioClient> client;
+	hr = device->Activate(__uuidof(IAudioClient), CLSCTX_INPROC_SERVER, nullptr,
+		reinterpret_cast<void**>(&client));
+	if (FAILED(hr) || client.p == nullptr)
+		return result;
+
+	WAVEFORMATEX* mixFormat = nullptr;
+	hr = client->GetMixFormat(&mixFormat);
+	if (FAILED(hr) || mixFormat == nullptr)
+		return result;
+
+	result.containerBytes = mixFormat->wBitsPerSample / 8;
+	result.sampleRate = mixFormat->nSamplesPerSec;
+	result.channelCount = mixFormat->nChannels;
+	result.validBits = mixFormat->wBitsPerSample;
+
+	GUID subFormat = {};
+	if (mixFormat->wFormatTag == WAVE_FORMAT_EXTENSIBLE
+		&& mixFormat->cbSize >= sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX))
+	{
+		WAVEFORMATEXTENSIBLE* ext = reinterpret_cast<WAVEFORMATEXTENSIBLE*>(mixFormat);
+		subFormat = ext->SubFormat;
+		if (ext->Samples.wValidBitsPerSample != 0)
+			result.validBits = ext->Samples.wValidBitsPerSample;
+	}
+	else if (mixFormat->wFormatTag == WAVE_FORMAT_IEEE_FLOAT)
+	{
+		subFormat = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
+	}
+	else if (mixFormat->wFormatTag == WAVE_FORMAT_PCM)
+	{
+		subFormat = KSDATAFORMAT_SUBTYPE_PCM;
+	}
+
+	result.isFloat = IsEqualGUID(subFormat, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) != 0;
+	result.subtypeDescription = formatSubtypeName(subFormat);
+
+	if (result.isFloat)
+	{
+		if (result.containerBytes == 4)
+			result.status = Status::ActiveFloat32;
+		else if (result.containerBytes == 8)
+			result.status = Status::ActiveFloat64;
+		else
+			result.status = Status::Passthrough;
+	}
+	else
+	{
+		result.status = Status::Passthrough;
+	}
+
+	CoTaskMemFree(mixFormat);
+	return result;
+}
+
+std::wstring describe(const Result& r)
+{
+	switch (r.status)
+	{
+	case Status::ActiveFloat32:
+		return L"EQ active (IEEE_FLOAT 32-bit)";
+	case Status::ActiveFloat64:
+		return L"EQ active (IEEE_FLOAT 64-bit)";
+	case Status::Passthrough:
+	{
+		std::wstring desc = L"Passthrough — EQ inactive (";
+		desc += r.subtypeDescription;
+		desc += L", container " + std::to_wstring(r.containerBytes * 8) + L"-bit)";
+		return desc;
+	}
+	case Status::Unknown:
+	default:
+		return L"";
+	}
+}
+
+}  // namespace AudioFormatProbe

--- a/helpers/AudioFormatProbe.h
+++ b/helpers/AudioFormatProbe.h
@@ -1,0 +1,54 @@
+/*
+	This file is part of EqualizerAPO, a system-wide equalizer.
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#pragma once
+
+#include <string>
+
+// Probe a Windows audio endpoint to find out whether EqualizerAPO can
+// natively process its stream or will fall back to passthrough.
+//
+// Background: the APO only processes streams whose connection format is
+// IEEE_FLOAT with a 4-byte (float32) or 8-byte (float64) container. Any
+// other subtype (PCM integer, AC-3, etc.) is forwarded unchanged through
+// the passthrough path so audio still reaches the device. The Editor uses
+// this helper to surface that distinction in the UI — the user otherwise
+// has no way to tell that filters are silently inactive on a given device.
+namespace AudioFormatProbe
+{
+	enum class Status
+	{
+		Unknown,            // Could not query the device (offline, no permission, etc.)
+		ActiveFloat32,      // IEEE_FLOAT, 4-byte container — EQ applied natively
+		ActiveFloat64,      // IEEE_FLOAT, 8-byte container — EQ applied natively
+		Passthrough,        // Any other format — APO forwards untouched
+	};
+
+	struct Result
+	{
+		Status status = Status::Unknown;
+		unsigned containerBytes = 0;
+		unsigned validBits = 0;
+		unsigned sampleRate = 0;
+		unsigned channelCount = 0;
+		bool isFloat = false;
+		std::wstring subtypeDescription;  // human-readable, e.g. "IEEE_FLOAT", "PCM"
+	};
+
+	// Query the given endpoint's current mix format via IMMDevice / IAudioClient.
+	// deviceGuid must be the endpoint ID string ("{...}"). Returns Status::Unknown
+	// if the endpoint cannot be queried.
+	Result probe(const std::wstring& deviceGuid);
+
+	// Short one-line description suitable for a status-bar label or tooltip.
+	std::wstring describe(const Result& r);
+
+	// True when the EQ chain is bypassed for this stream.
+	inline bool isPassthrough(Status s) { return s == Status::Passthrough; }
+}

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define MAJOR 1
 #define MINOR 5
-#define REVISION 4
+#define REVISION 5

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define MAJOR 1
 #define MINOR 5
-#define REVISION 3
+#define REVISION 4


### PR DESCRIPTION
## Summary

- `detectSampleFormat`이 `dwValidBitsPerSample == 32 || 64`까지 강제하면서, CABLE Input 등 일부 가상 디바이스의 비-canonical valid bit 보고에 대해 `Unsupported`로 떨어뜨렸고, `APOProcess`가 `BUFFER_SILENT`를 내보내 디바이스가 무음이 되는 regression(`309e9e8`)을 수정합니다.
- 분류는 IEEE_FLOAT subtype + container size로만 합니다. native float32/float64 경로는 입력과 출력 포맷이 같은 supported로 해석될 때만 탑니다.
- Unsupported/mismatched 시에는 `APO_FLAG_INPLACE` 보장을 활용해 buffer를 그대로 통과시키고 `BUFFER_VALID`로 표시합니다. 입/출력 buffer가 서로 다른 비정상 호스트는 안전을 위해 silence fallback으로 갑니다.
- `LockForProcess`에 unsupported 포맷 경고 로그를 추가해, 필터가 적용되지 않는 스트림은 TraceLog에서 추적 가능합니다.

## Test plan

- [ ] CI matrix(sse2/avx/avx2/avx512/avx10_1/neon) 전체 빌드 통과
- [ ] CABLE Input(VB-Audio Virtual Cable)에 APO install 후, 음원 재생 시 CABLE Output에 신호가 정상적으로 도달하는지 확인
- [ ] 일반 디바이스(스피커, 헤드폰)에 APO install 시 기존 EQ 처리가 그대로 동작하는지 확인
- [ ] `EnableTrace=true` 설정 시 TraceLog.txt에 unsupported 포맷 경고가 기록되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)