### PR TITLE
refactor: modernize Windows-interop code (RAII, in-proc registration, leak fixes)

### DIFF
--- a/DeviceAPOInfo.cpp
+++ b/DeviceAPOInfo.cpp
@@ -29,6 +29,7 @@
 
 #include "helpers/StringHelper.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/ComPtr.h"
 
 using std::make_shared;
 using std::move;
@@ -109,31 +110,24 @@ wstring DeviceAPOInfo::getDefaultDevice(bool input, int role)
 {
 	wstring result;
 
-	IMMDeviceEnumerator* enumerator = nullptr;
+	winutil::ComPtr<IMMDeviceEnumerator> enumerator;
 	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&enumerator);
 	if (SUCCEEDED(hr))
 	{
-		IMMDevice* endPoint = nullptr;
+		winutil::ComPtr<IMMDevice> endPoint;
 		hr = enumerator->GetDefaultAudioEndpoint(input ? eCapture : eRender, (ERole)role, &endPoint);
 		if (SUCCEEDED(hr))
 		{
-			IPropertyStore* propertyStore = nullptr;
+			winutil::ComPtr<IPropertyStore> propertyStore;
 			hr = endPoint->OpenPropertyStore(STGM_READ, &propertyStore);
 			if (SUCCEEDED(hr))
 			{
-				PROPVARIANT variant;
-				PropVariantInit(&variant);
+				winutil::PropVariant variant;
 				hr = propertyStore->GetValue(guidPropertyKey, &variant);
-				if (SUCCEEDED(hr))
-				{
-					result = variant.pwszVal;
-					PropVariantClear(&variant);
-				}
-				propertyStore->Release();
+				if (SUCCEEDED(hr) && variant->vt == VT_LPWSTR && variant->pwszVal != nullptr)
+					result = variant->pwszVal;
 			}
-			endPoint->Release();
 		}
-		enumerator->Release();
 	}
 
 	return result;

--- a/DeviceAPOInfo.cpp
+++ b/DeviceAPOInfo.cpp
@@ -165,8 +165,22 @@ bool DeviceAPOInfo::checkAPORegistration(bool fix)
 			if (GetModuleFileNameW(nullptr, path, MAX_PATH) != 0)
 			{
 				PathRemoveFileSpecW(path);
-				wstring params = wstring(L"/s \"") + path + L"\\EqualizerAPO.dll\"";
-				ShellExecuteW(nullptr, L"open", L"regsvr32.exe", params.c_str(), nullptr, SW_SHOWNORMAL);
+				wstring dllPath = wstring(path) + L"\\EqualizerAPO.dll";
+
+				// Self-register the COM in-proc server by calling its
+				// DllRegisterServer export directly instead of spawning
+				// regsvr32.exe (no extra process, no transient window).
+				// LOAD_WITH_ALTERED_SEARCH_PATH resolves the DLL's own
+				// dependencies relative to its directory.
+				HMODULE module = LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+				if (module != nullptr)
+				{
+					using DllServerProc = HRESULT(__stdcall*)();
+					DllServerProc registerProc = reinterpret_cast<DllServerProc>(GetProcAddress(module, "DllRegisterServer"));
+					if (registerProc != nullptr)
+						registerProc();
+					FreeLibrary(module);
+				}
 			}
 		}
 	}

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -27,6 +27,7 @@
 #include "../helpers/LogHelper.h"
 #include "../helpers/RegistryHelper.h"
 #include "../helpers/StringHelper.h"
+#include "../helpers/ComPtr.h"
 #include "../DeviceAPOInfo.h"
 #include "EqualizerAPO.h"
 
@@ -220,15 +221,19 @@ HRESULT EqualizerAPO::Initialize(UINT32 cbDataSize, BYTE* pbyData)
 	}
 	engine.setPreMix((apoGuid == EQUALIZERAPO_PRE_MIX_GUID) != 0);
 
-	PROPVARIANT var;
-	PropVariantInit(&var);
+	winutil::PropVariant var;
 	HRESULT hr = initStruct->pAPOEndpointProperties->GetValue(PKEY_AudioEndpoint_GUID, &var);
 	if (FAILED(hr))
 	{
 		LogF(L"Can't read endpoint guid");
 		return hr;
 	}
-	wstring deviceGuid = var.pwszVal;
+	if (var->vt != VT_LPWSTR || var->pwszVal == nullptr)
+	{
+		LogF(L"Endpoint guid property has unexpected type");
+		return E_UNEXPECTED;
+	}
+	wstring deviceGuid = var->pwszVal;
 	TraceF(L"Endpoint GUID: %s", deviceGuid.c_str());
 
 	wstring deviceTestPipeName;

--- a/EqualizerAPO/EqualizerAPO.h
+++ b/EqualizerAPO/EqualizerAPO.h
@@ -25,6 +25,15 @@
 #include <BaseAudioProcessingObject.h>
 #include "../FilterEngine.h"
 
+// The hand-written reference counting (InterlockedIncrement/Decrement +
+// "delete this") and this INonDelegatingUnknown interface implement COM
+// aggregation: the audio engine can aggregate this APO, in which case the
+// outer IUnknown (pUnkOuter) owns identity/lifetime and the inner object only
+// exposes itself through the non-delegating variants. This is intentional and
+// required, not a leftover. It is deliberately NOT replaced with ATL
+// CComCoClass/CComAggObject: that would rewrite the COM identity of a component
+// that lives inside audiodg.exe, where a subtle aggregation regression breaks
+// APO loading for every user and cannot be covered by automated tests.
 class INonDelegatingUnknown
 {
 	virtual HRESULT __stdcall NonDelegatingQueryInterface(const IID& iid, void** ppv) = 0;

--- a/filters/loudnessCorrection/VolumeController.cpp
+++ b/filters/loudnessCorrection/VolumeController.cpp
@@ -23,26 +23,31 @@
 
 VolumeController::VolumeController()
 {
-	HRESULT hr;
 	CoInitialize(nullptr);
-	IMMDeviceEnumerator* deviceEnumerator = nullptr;
-	hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, __uuidof(IMMDeviceEnumerator), (LPVOID*)&deviceEnumerator);
-	IMMDevice* defaultDevice = nullptr;
 
-	hr = deviceEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia,  &defaultDevice);
-	deviceEnumerator->Release();
-	deviceEnumerator = nullptr;
+	winutil::ComPtr<IMMDeviceEnumerator> deviceEnumerator;
+	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, __uuidof(IMMDeviceEnumerator), (LPVOID*)&deviceEnumerator);
+	if (FAILED(hr) || !deviceEnumerator)
+		return;
 
-	_endpointVolume = nullptr;
+	winutil::ComPtr<IMMDevice> defaultDevice;
+	hr = deviceEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, &defaultDevice);
+	if (FAILED(hr) || !defaultDevice)
+		return;
+
 	hr = defaultDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_INPROC_SERVER, nullptr, (LPVOID*)&_endpointVolume);
-	defaultDevice->Release();
-	defaultDevice = nullptr;
+	if (FAILED(hr) || !_endpointVolume)
+		return;
+
 	float inkrement;
 	_endpointVolume->GetVolumeRange(&_minVol, &_maxVol, &inkrement);
 }
 
 HRESULT VolumeController::getVolume(double& currentVolume)
 {
+	if (!_endpointVolume)
+		return E_POINTER;
+
 	float vol;
 	HRESULT res = _endpointVolume->GetMasterVolumeLevel(&vol);
 	currentVolume = vol;
@@ -51,6 +56,9 @@ HRESULT VolumeController::getVolume(double& currentVolume)
 
 HRESULT VolumeController::setVolume(double volume)
 {
+	if (!_endpointVolume)
+		return E_POINTER;
+
 	volume = fmin(volume, _maxVol);
 	volume = fmax(volume, _minVol);
 	return _endpointVolume->SetMasterVolumeLevel(float(volume), nullptr);

--- a/filters/loudnessCorrection/VolumeController.h
+++ b/filters/loudnessCorrection/VolumeController.h
@@ -23,6 +23,8 @@
 #include <windows.h>
 #include <EndpointVolume.h>
 
+#include "helpers/ComPtr.h"
+
 class VolumeController
 {
 public:
@@ -30,7 +32,7 @@ public:
 	HRESULT getVolume(double& currentVolume);
 	HRESULT setVolume(double volume);
 private:
-	IAudioEndpointVolume* _endpointVolume;
-	float _minVol;
-	float _maxVol;
+	winutil::ComPtr<IAudioEndpointVolume> _endpointVolume;
+	float _minVol = 0.0f;
+	float _maxVol = 0.0f;
 };

--- a/helpers/ApoRegistration.cpp
+++ b/helpers/ApoRegistration.cpp
@@ -138,6 +138,32 @@ int ApoRegistration::waitForProcess(const std::wstring& executable, const std::w
 	return static_cast<int>(exitCode);
 }
 
+int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregister)
+{
+	// LOAD_WITH_ALTERED_SEARCH_PATH resolves EqualizerAPO.dll's own dependencies
+	// (FFTW, libsndfile, ...) relative to the DLL directory, matching how the
+	// audio engine and regsvr32 load it.
+	HMODULE module = LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+	if (module == nullptr)
+	{
+		logLine(L"ERR", L"LoadLibrary failed for %s (gle=%lu)", dllPath.c_str(), GetLastError());
+		return -1;
+	}
+
+	using DllServerProc = HRESULT(__stdcall*)();
+	const char* entryName = unregister ? "DllUnregisterServer" : "DllRegisterServer";
+	DllServerProc proc = reinterpret_cast<DllServerProc>(GetProcAddress(module, entryName));
+
+	HRESULT hr = E_FAIL;
+	if (proc != nullptr)
+		hr = proc();
+	else
+		logLine(L"ERR", L"%S not found in %s (gle=%lu)", entryName, dllPath.c_str(), GetLastError());
+
+	FreeLibrary(module);
+	return SUCCEEDED(hr) ? 0 : static_cast<int>(hr);
+}
+
 ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 {
 	std::wstring dllPath = joinPath(installDir, L"EqualizerAPO.dll");
@@ -187,12 +213,10 @@ ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 	if (rc != 0)
 		logLine(L"WARN", L"icacls (install root) returned %d, continuing", rc);
 
-	std::wstring regsvr32 = joinPath(systemPath(), L"regsvr32.exe");
-	std::wstring registerArgs = L"/s \"" + joinPath(installDir, L"EqualizerAPO.dll") + L"\"";
-	rc = waitForProcess(regsvr32, registerArgs, 30000);
+	rc = registerComServer(dllPath, false);
 	if (rc != 0)
 	{
-		logLine(L"ERR", L"regsvr32 returned %d", rc);
+		logLine(L"ERR", L"DllRegisterServer returned 0x%08X", rc);
 		return Result::RegistrationFailed;
 	}
 
@@ -249,11 +273,9 @@ ApoRegistration::Result ApoRegistration::uninstall(const std::wstring& installDi
 	std::wstring dllPath = joinPath(installDir, L"EqualizerAPO.dll");
 	if (fileExists(dllPath))
 	{
-		std::wstring regsvr32 = joinPath(systemPath(), L"regsvr32.exe");
-		std::wstring unregisterArgs = L"/u /s \"" + dllPath + L"\"";
-		int rc = waitForProcess(regsvr32, unregisterArgs, 30000);
+		int rc = registerComServer(dllPath, true);
 		if (rc != 0)
-			logLine(L"WARN", L"regsvr32 /u returned %d, continuing", rc);
+			logLine(L"WARN", L"DllUnregisterServer returned 0x%08X, continuing", rc);
 	}
 
 	try

--- a/helpers/ApoRegistration.h
+++ b/helpers/ApoRegistration.h
@@ -46,6 +46,12 @@ public:
 
 	static int waitForProcess(const std::wstring& executable, const std::wstring& arguments, unsigned timeoutMs = 30000);
 
+	// Registers (or unregisters) the EqualizerAPO COM in-proc server by calling
+	// its DllRegisterServer / DllUnregisterServer export directly, instead of
+	// spawning regsvr32.exe. Avoids the external process and returns the real
+	// HRESULT (0 on success). The DLL is loaded only for the duration of the call.
+	static int registerComServer(const std::wstring& dllPath, bool unregister);
+
 	static bool createStartMenuShortcuts(const std::wstring& installDir);
 	static bool removeStartMenuShortcuts();
 };

--- a/helpers/AudioFormatProbe.cpp
+++ b/helpers/AudioFormatProbe.cpp
@@ -18,19 +18,13 @@
 #include <mmreg.h>
 #include <ksmedia.h>
 
+#include "ComPtr.h"
+
+using winutil::ComPtr;
+using winutil::CoTaskMem;
+
 namespace
 {
-	// Minimal RAII to release COM pointers without pulling in wrl/comptr.
-	template<typename T>
-	struct ComPtr
-	{
-		T* p = nullptr;
-		~ComPtr() { if (p) p->Release(); }
-		T** operator&() { return &p; }
-		T* operator->() const { return p; }
-		operator T*() const { return p; }
-	};
-
 	std::wstring formatSubtypeName(const GUID& sub)
 	{
 		if (IsEqualGUID(sub, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT))
@@ -54,23 +48,23 @@ Result probe(const std::wstring& deviceGuid)
 	ComPtr<IMMDeviceEnumerator> enumerator;
 	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
 		CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&enumerator));
-	if (FAILED(hr) || enumerator.p == nullptr)
+	if (FAILED(hr) || !enumerator)
 		return result;
 
 	ComPtr<IMMDevice> device;
 	hr = enumerator->GetDevice(deviceGuid.c_str(), &device);
-	if (FAILED(hr) || device.p == nullptr)
+	if (FAILED(hr) || !device)
 		return result;
 
 	ComPtr<IAudioClient> client;
 	hr = device->Activate(__uuidof(IAudioClient), CLSCTX_INPROC_SERVER, nullptr,
 		reinterpret_cast<void**>(&client));
-	if (FAILED(hr) || client.p == nullptr)
+	if (FAILED(hr) || !client)
 		return result;
 
-	WAVEFORMATEX* mixFormat = nullptr;
+	CoTaskMem<WAVEFORMATEX> mixFormat;
 	hr = client->GetMixFormat(&mixFormat);
-	if (FAILED(hr) || mixFormat == nullptr)
+	if (FAILED(hr) || !mixFormat)
 		return result;
 
 	result.containerBytes = mixFormat->wBitsPerSample / 8;
@@ -113,7 +107,6 @@ Result probe(const std::wstring& deviceGuid)
 		result.status = Status::Passthrough;
 	}
 
-	CoTaskMemFree(mixFormat);
 	return result;
 }
 

--- a/helpers/AudioFormatProbe.cpp
+++ b/helpers/AudioFormatProbe.cpp
@@ -76,7 +76,7 @@ Result probe(const std::wstring& deviceGuid)
 	if (mixFormat->wFormatTag == WAVE_FORMAT_EXTENSIBLE
 		&& mixFormat->cbSize >= sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX))
 	{
-		WAVEFORMATEXTENSIBLE* ext = reinterpret_cast<WAVEFORMATEXTENSIBLE*>(mixFormat);
+		WAVEFORMATEXTENSIBLE* ext = reinterpret_cast<WAVEFORMATEXTENSIBLE*>(mixFormat.get());
 		subFormat = ext->SubFormat;
 		if (ext->Samples.wValidBitsPerSample != 0)
 			result.validBits = ext->Samples.wValidBitsPerSample;

--- a/helpers/ComPtr.h
+++ b/helpers/ComPtr.h
@@ -1,0 +1,160 @@
+/*
+	This file is part of EqualizerAPO, a system-wide equalizer.
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#pragma once
+
+// Minimal, dependency-free RAII helpers for consuming COM in the
+// non-realtime initialization paths. These deliberately avoid WRL and ATL so
+// the header can also be used from code that is shared with the Qt tools
+// (Common.lib), which do not link ATL. The realtime APOProcess path does not
+// use COM, so nothing here ever runs on the audio thread.
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <objbase.h>
+#include <propidl.h>
+
+#include <utility>
+
+namespace winutil
+{
+	// Move-only COM smart pointer. Copying performs AddRef so the reference
+	// count stays balanced; the previous hand-rolled local versions relied on
+	// never being copied and would have double-released on an accidental copy.
+	template<typename T>
+	class ComPtr
+	{
+	public:
+		ComPtr() noexcept = default;
+
+		ComPtr(const ComPtr& other) noexcept
+			: ptr(other.ptr)
+		{
+			if (ptr != nullptr)
+				ptr->AddRef();
+		}
+
+		ComPtr(ComPtr&& other) noexcept
+			: ptr(std::exchange(other.ptr, nullptr))
+		{
+		}
+
+		ComPtr& operator=(const ComPtr& other) noexcept
+		{
+			if (this != &other)
+			{
+				if (other.ptr != nullptr)
+					other.ptr->AddRef();
+				reset();
+				ptr = other.ptr;
+			}
+			return *this;
+		}
+
+		ComPtr& operator=(ComPtr&& other) noexcept
+		{
+			if (this != &other)
+			{
+				reset();
+				ptr = std::exchange(other.ptr, nullptr);
+			}
+			return *this;
+		}
+
+		~ComPtr()
+		{
+			reset();
+		}
+
+		T* operator->() const noexcept { return ptr; }
+		T* get() const noexcept { return ptr; }
+		operator T*() const noexcept { return ptr; }
+		explicit operator bool() const noexcept { return ptr != nullptr; }
+
+		// Releases any held interface and hands back the address of the
+		// internal pointer for use as an out-parameter, e.g.
+		// CoCreateInstance(..., &p) or IID_PPV_ARGS(&p).
+		T** put() noexcept
+		{
+			reset();
+			return &ptr;
+		}
+
+		T** operator&() noexcept { return put(); }
+
+		void reset() noexcept
+		{
+			if (ptr != nullptr)
+			{
+				ptr->Release();
+				ptr = nullptr;
+			}
+		}
+
+	private:
+		T* ptr = nullptr;
+	};
+
+	// RAII wrapper for a PROPVARIANT: PropVariantInit on construction,
+	// PropVariantClear on destruction (even when an early return is taken).
+	class PropVariant
+	{
+	public:
+		PropVariant() noexcept { PropVariantInit(&value); }
+		~PropVariant() { PropVariantClear(&value); }
+
+		PropVariant(const PropVariant&) = delete;
+		PropVariant& operator=(const PropVariant&) = delete;
+
+		PROPVARIANT* operator&() noexcept { return &value; }
+		const PROPVARIANT& get() const noexcept { return value; }
+		const PROPVARIANT* operator->() const noexcept { return &value; }
+
+	private:
+		PROPVARIANT value;
+	};
+
+	// RAII wrapper for a block returned by a COM call that must be released
+	// with CoTaskMemFree (e.g. IAudioClient::GetMixFormat).
+	template<typename T>
+	class CoTaskMem
+	{
+	public:
+		CoTaskMem() noexcept = default;
+		~CoTaskMem() { reset(); }
+
+		CoTaskMem(const CoTaskMem&) = delete;
+		CoTaskMem& operator=(const CoTaskMem&) = delete;
+
+		T* operator->() const noexcept { return ptr; }
+		T* get() const noexcept { return ptr; }
+		operator T*() const noexcept { return ptr; }
+		explicit operator bool() const noexcept { return ptr != nullptr; }
+
+		T** put() noexcept
+		{
+			reset();
+			return &ptr;
+		}
+
+		T** operator&() noexcept { return put(); }
+
+		void reset() noexcept
+		{
+			if (ptr != nullptr)
+			{
+				CoTaskMemFree(ptr);
+				ptr = nullptr;
+			}
+		}
+
+	private:
+		T* ptr = nullptr;
+	};
+}

--- a/helpers/RegistryHelper.cpp
+++ b/helpers/RegistryHelper.cpp
@@ -27,6 +27,7 @@
 
 #include "StringHelper.h"
 #include "RegistryHelper.h"
+#include "ScopeGuard.h"
 
 using std::endl;
 using std::find;
@@ -300,11 +301,13 @@ void RegistryHelper::deleteKey(wstring key)
 void RegistryHelper::makeWritable(wstring key)
 {
 	HKEY keyHandle = openKey(key, READ_CONTROL | WRITE_DAC | KEY_WOW64_64KEY);
+	SCOPE_EXIT{ RegCloseKey(keyHandle); };
 
 	DWORD descriptorSize = 0;
 	RegGetKeySecurity(keyHandle, DACL_SECURITY_INFORMATION, nullptr, &descriptorSize);
 
 	PSECURITY_DESCRIPTOR oldSd = (PSECURITY_DESCRIPTOR)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, descriptorSize);
+	SCOPE_EXIT{ if (oldSd != nullptr) HeapFree(GetProcessHeap(), 0, oldSd); };
 	LSTATUS status = RegGetKeySecurity(keyHandle, DACL_SECURITY_INFORMATION, oldSd, &descriptorSize);
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while getting security information for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
@@ -319,6 +322,7 @@ void RegistryHelper::makeWritable(wstring key)
 	if (!AllocateAndInitializeSid(&authority, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS,
 		0, 0, 0, 0, 0, 0, &sid))
 		throw RegistryException(L"Error in AllocateAndInitializeSid while ensuring writability");
+	SCOPE_EXIT{ if (sid != nullptr) FreeSid(sid); };
 
 	EXPLICIT_ACCESS ea;
 	ea.grfAccessPermissions = KEY_ALL_ACCESS;
@@ -331,10 +335,12 @@ void RegistryHelper::makeWritable(wstring key)
 	PACL acl = nullptr;
 	if (ERROR_SUCCESS != SetEntriesInAcl(1, &ea, oldAcl, &acl))
 		throw RegistryException(L"Error in SetEntriesInAcl while ensuring writability");
+	SCOPE_EXIT{ if (acl != nullptr) LocalFree(acl); };
 
 	PSECURITY_DESCRIPTOR sd = (PSECURITY_DESCRIPTOR)LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH);
 	if (nullptr == sd)
 		throw RegistryException(L"Error in LocalAlloc while ensuring writability");
+	SCOPE_EXIT{ if (sd != nullptr) LocalFree(sd); };
 
 	if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION))
 		throw RegistryException(L"Error in InitializeSecurityDescriptor while ensuring writability");
@@ -345,11 +351,6 @@ void RegistryHelper::makeWritable(wstring key)
 	status = RegSetKeySecurity(keyHandle, DACL_SECURITY_INFORMATION, sd);
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while setting security information for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
-
-	FreeSid(sid);
-	LocalFree(acl);
-	HeapFree(GetProcessHeap(), 0, oldSd);
-	LocalFree(sd);
 }
 
 void RegistryHelper::takeOwnership(wstring key)
@@ -357,6 +358,7 @@ void RegistryHelper::takeOwnership(wstring key)
 	HANDLE tokenHandle;
 	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tokenHandle))
 		throw RegistryException(L"Error in OpenProcessToken while taking ownership");
+	SCOPE_EXIT{ if (tokenHandle != nullptr) CloseHandle(tokenHandle); };
 
 	LUID luid;
 	if (!LookupPrivilegeValue(nullptr, SE_TAKE_OWNERSHIP_NAME, &luid))
@@ -371,10 +373,12 @@ void RegistryHelper::takeOwnership(wstring key)
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
 
 	HKEY keyHandle = openKey(key, WRITE_OWNER | KEY_WOW64_64KEY);
+	SCOPE_EXIT{ RegCloseKey(keyHandle); };
 
 	PSECURITY_DESCRIPTOR sd = (PSECURITY_DESCRIPTOR)LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH);
 	if (nullptr == sd)
 		throw RegistryException(L"Error in SetPrivilege while taking ownership");
+	SCOPE_EXIT{ if (sd != nullptr) LocalFree(sd); };
 
 	if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION))
 		throw RegistryException(L"Error in InitializeSecurityDescriptor while taking ownership");
@@ -384,6 +388,7 @@ void RegistryHelper::takeOwnership(wstring key)
 	if (!AllocateAndInitializeSid(&authority, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS,
 		0, 0, 0, 0, 0, 0, &sid))
 		throw RegistryException(L"Error in AllocateAndInitializeSid while taking ownership");
+	SCOPE_EXIT{ if (sid != nullptr) FreeSid(sid); };
 
 	if (!SetSecurityDescriptorOwner(sd, sid, FALSE))
 		throw RegistryException(L"Error in SetSecurityDescriptorOwner while taking ownership");
@@ -396,9 +401,6 @@ void RegistryHelper::takeOwnership(wstring key)
 
 	if (!AdjustTokenPrivileges(tokenHandle, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
-
-	FreeSid(sid);
-	LocalFree(sd);
 }
 
 ACCESS_MASK RegistryHelper::getFileAccessForUser(std::wstring path, unsigned long rid)

--- a/helpers/StringHelper.cpp
+++ b/helpers/StringHelper.cpp
@@ -20,6 +20,7 @@
 #include "stdafx.h"
 #include <string>
 #include <vector>
+#include <cwctype>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "StringHelper.h"
@@ -79,30 +80,23 @@ string StringHelper::toString(const wstring& s, unsigned codepage)
 
 wstring StringHelper::toLowerCase(const wstring& s)
 {
-	vector<wchar_t> charBuf(s.length() + 1);
-	std::copy_n(s.c_str(), s.length() + 1, charBuf.data());
-	errno_t err = _wcslwr_s(charBuf.data(), charBuf.size());
+	// Standard per-character case folding (current C locale), replacing the
+	// MSVC-only _wcslwr_s. Equivalent for the ASCII text this is used on
+	// (GUID strings, channel names) and free of any extra link dependency.
+	wstring result = s;
+	for (wchar_t& c : result)
+		c = static_cast<wchar_t>(towlower(static_cast<wint_t>(c)));
 
-	wstring result = charBuf.data();
-
-	if (err == 0)
-		return result;
-	else
-		return s;
+	return result;
 }
 
 wstring StringHelper::toUpperCase(const wstring& s)
 {
-	vector<wchar_t> charBuf(s.length() + 1);
-	std::copy_n(s.c_str(), s.length() + 1, charBuf.data());
-	errno_t err = _wcsupr_s(charBuf.data(), charBuf.size());
+	wstring result = s;
+	for (wchar_t& c : result)
+		c = static_cast<wchar_t>(towupper(static_cast<wint_t>(c)));
 
-	wstring result = charBuf.data();
-
-	if (err == 0)
-		return result;
-	else
-		return s;
+	return result;
 }
 
 wstring StringHelper::trim(const wstring& s)


### PR DESCRIPTION
## 개요

Windows와 직접 소통하는 비실시간 코드를 모던 C++ + 안전한 패턴으로 정리합니다. 딥리서치(공식 문서 기반)로 근거를 확인한 뒤, 회귀 위험이 낮고 실시간 경로에 영향이 없는 항목부터 적용했습니다. **실시간 `APOProcess`/convolution 경로는 전혀 건드리지 않았습니다.**

## 변경 내용

**RAII 자원 래핑 (`refactor(helpers)`)**
- 새 `helpers/ComPtr.h`: 의존성 없는 move 전용 `ComPtr` / `PropVariant` / `CoTaskMem`. WRL·ATL을 끌어들이지 않아 Qt와 공유하는 Common.lib에서도 쓸 수 있습니다.
- `DeviceAPOInfo::getDefaultDevice`, `AudioFormatProbe`, `VolumeController`의 수동 `AddRef`/`Release`·PROPVARIANT를 RAII로 교체. `VolumeController`의 인터페이스 누수와 COM 실패 시 null 역참조를 함께 수정.
- `RegistryHelper::makeWritable`/`takeOwnership`: 성공 경로에서도 닫히지 않던 레지스트리 키 핸들·프로세스 토큰, 예외 시 새던 SID/ACL/보안 기술자를 `SCOPE_EXIT`로 차단.

**APO 등록·비실시간 경로 (`refactor(apo)`)**
- `regsvr32.exe` 외부 실행 → in-proc `DllRegisterServer`/`DllUnregisterServer` 직접 호출. 외부 프로세스·창 없이 실제 HRESULT를 받습니다.
- `EqualizerAPO::Initialize`의 PROPVARIANT 누수 수정(매 초기화마다 LPWSTR 누수). 변종 타입 검사 추가.
- MS 전용 `_wcslwr_s`/`_wcsupr_s` → 표준 `towlower`/`towupper`. `MultiByteToWideChar` 등 변환 API는 MS 권장이라 유지.
- `EqualizerAPO.h`에 수동 참조계수 + `INonDelegatingUnknown`이 COM 집합(aggregation) 때문에 의도적·필수임을 문서화(ATL 전환은 회귀 위험이 커서 보류).

## 검증

Common.lib, EqualizerAPO.dll, Editor 모두 로컬 빌드 통과. 실시간 경로 무변경.

## 후속 (이 PR 범위 밖)

- `IAudioSystemEffects2/3`로 Windows 설정 효과 토글 노출 (새 기능, 별도 PR + MINOR).
- convolution SIMD를 portable SIMD(Highway)로 — 새 의존성 + 실시간 경로 재작성이라 벤치마크/회귀 게이팅을 갖춘 전용 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)