### PR TITLE
feat(apo): expose effect via IAudioSystemEffects2::GetEffectsList

### DIFF
--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -677,6 +677,30 @@ void EqualizerAPO::APOProcess(UINT32 u32NumInputConnections,
 }
 #pragma AVRT_CODE_END
 
+HRESULT EqualizerAPO::GetEffectsList(LPGUID* effects, UINT* numEffects, HANDLE /*event*/)
+{
+	if (effects == nullptr || numEffects == nullptr)
+		return E_POINTER;
+
+	// EqualizerAPO always represents a single, user-configurable processing
+	// effect. Report it so the audio engine (and the Windows Settings audio
+	// enhancements surface) can see that an effect is present on the endpoint.
+	// The reported set never changes at runtime, so the change-notification
+	// event is intentionally not retained or signalled.
+	LPGUID list = static_cast<LPGUID>(CoTaskMemAlloc(sizeof(GUID)));
+	if (list == nullptr)
+	{
+		*effects = nullptr;
+		*numEffects = 0;
+		return E_OUTOFMEMORY;
+	}
+
+	list[0] = EQUALIZERAPO_EFFECT_GUID;
+	*effects = list;
+	*numEffects = 1;
+	return S_OK;
+}
+
 HRESULT EqualizerAPO::NonDelegatingQueryInterface(const IID& iid, void** ppv)
 {
 	if (iid == __uuidof(IUnknown))
@@ -689,6 +713,8 @@ HRESULT EqualizerAPO::NonDelegatingQueryInterface(const IID& iid, void** ppv)
 		*ppv = static_cast<IAudioProcessingObjectConfiguration*>(this);
 	else if (iid == __uuidof(IAudioSystemEffects))
 		*ppv = static_cast<IAudioSystemEffects*>(this);
+	else if (iid == __uuidof(IAudioSystemEffects2))
+		*ppv = static_cast<IAudioSystemEffects2*>(this);
 	else
 	{
 		*ppv = nullptr;

--- a/EqualizerAPO/EqualizerAPO.h
+++ b/EqualizerAPO/EqualizerAPO.h
@@ -25,6 +25,13 @@
 #include <BaseAudioProcessingObject.h>
 #include "../FilterEngine.h"
 
+// Identifies the single, user-configurable processing effect that
+// EqualizerAPO represents. Reported through IAudioSystemEffects2::GetEffectsList
+// so the audio engine and the Windows Settings "audio enhancements" surface can
+// see that an effect is present on the endpoint. It is a stable private
+// identifier for this APO, not one of the well-known AUDIO_EFFECT_TYPE GUIDs.
+const GUID EQUALIZERAPO_EFFECT_GUID = {0x9d2e7b14, 0x6c3a, 0x4f8d, {0xa1, 0x5e, 0x2b, 0x7c, 0x9f, 0x4d, 0x8e, 0x60}};
+
 // The hand-written reference counting (InterlockedIncrement/Decrement +
 // "delete this") and this INonDelegatingUnknown interface implement COM
 // aggregation: the audio engine can aggregate this APO, in which case the
@@ -41,7 +48,7 @@ class INonDelegatingUnknown
 	virtual ULONG __stdcall NonDelegatingRelease() = 0;
 };
 
-class EqualizerAPO : public CBaseAudioProcessingObject, public IAudioSystemEffects, public INonDelegatingUnknown
+class EqualizerAPO : public CBaseAudioProcessingObject, public IAudioSystemEffects2, public INonDelegatingUnknown
 {
 public:
 	EqualizerAPO(IUnknown* pUnkOuter);
@@ -68,6 +75,9 @@ public:
 	virtual void __stdcall APOProcess(UINT32 u32NumInputConnections,
 		APO_CONNECTION_PROPERTY** ppInputConnections, UINT32 u32NumOutputConnections,
 		APO_CONNECTION_PROPERTY** ppOutputConnections);
+
+	// IAudioSystemEffects2 (inherits the marker IAudioSystemEffects)
+	virtual HRESULT __stdcall GetEffectsList(LPGUID* effects, UINT* numEffects, HANDLE event);
 
 	// INonDelegatingUnknown
 	virtual HRESULT __stdcall NonDelegatingQueryInterface(const IID& iid, void** ppv);

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define MAJOR 1
-#define MINOR 8
+#define MINOR 9
 #define REVISION 0


### PR DESCRIPTION
## 개요

APO를 마커 인터페이스 `IAudioSystemEffects`에서 `IAudioSystemEffects2`로 올리고 `GetEffectsList`를 구현해, Windows 오디오 엔진과 설정 앱의 '오디오 향상' 화면이 이 엔드포인트에 효과가 있음을 인식하도록 합니다. 현행 Microsoft APO 샘플과 같은 방향입니다.

> 이 PR은 #23(Windows-interop 모던화) 위에 스택되어 있습니다. #23이 main에 머지되면 자동으로 base가 main으로 재지정됩니다. diff에는 item 5 변경만 포함됩니다.

## 변경 내용

- `EqualizerAPO`가 `IAudioSystemEffects2`를 구현하고 `NonDelegatingQueryInterface`로 노출(상속 관계라 기존 `IAudioSystemEffects` IID도 그대로 해석).
- `GetEffectsList`가 단일 처리 효과(`EQUALIZERAPO_EFFECT_GUID`)를 보고. 보고 집합이 고정이므로 변경 알림 이벤트는 사용하지 않음.
- 새 기능이라 `version.h` MINOR 8 → 9 (별도 커밋).

## 범위 메모

`IAudioSystemEffects3`(Windows 11의 설정 on/off 토글 = `SetAudioSystemEffectState`)는 의도적으로 후속으로 남깁니다. 토글을 실제 enable/disable에 배선하는 건 동작 변경이고 라이브 Windows 11 엔드포인트에서 검증해야 하는데, 이 빌드 환경에서는 불가능합니다.

## 검증

`EqualizerAPO.dll` 로컬 빌드 통과(컴파일 검증). 설정 앱 통합은 실기 Windows에서 확인 필요. 실시간 경로 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)