### PR TITLE
fix(editor): seed Copy routing editors with the device channel list

### DIFF
--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -72,6 +72,10 @@ public:
 	// (delete + rebuild every row in the file).
 	void updateSingleRowGui(Item* item);
 	void propagateChannels();
+	// Channel names for the currently selected device/mask (e.g. L, R, C, ...).
+	// Empty when no device is selected. Used both to configure the legacy filter
+	// GUIs and to seed the modern card routing editors with the real channel set.
+	std::vector<std::wstring> getChannelNames() const;
 	QList<QString> getLines();
 	void setLines(const QString& configPath, const QList<QString>& lines);
 	Item* addLine(const QString& line, Item* before = nullptr);

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -58,11 +58,18 @@ using std::vector;
 using std::wstring;
 
 
-void FilterTable::propagateChannels()
+vector<wstring> FilterTable::getChannelNames() const
 {
 	vector<wstring> channelNames;
 	if (selectedDevice != nullptr)
 		channelNames = ChannelHelper::getChannelNames(selectedDevice->getChannelCount(), selectedChannelMask);
+
+	return channelNames;
+}
+
+void FilterTable::propagateChannels()
+{
+	vector<wstring> channelNames = getChannelNames();
 
 	for (Item* item : items)
 	{

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -166,7 +166,13 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 		QString parameters;
 		FilterCardModel::commandForLine(item->text, &parameters);
 		std::vector<Assignment> routingAssignments = CopyRoutingAdapter::parse(parameters);
-		std::vector<std::wstring> channelNames;
+		// Seed the routing editor with the real device channel set (L, R, C, ...),
+		// the same list the legacy CopyFilterGUI receives via configureChannels.
+		// Without it the graph only shows channels already named in the line, so
+		// the user cannot route to/from a channel that has no assignment yet
+		// (e.g. copying L onto R when R is not referenced). That was the studio
+		// (glass) Copy card's "cannot edit" bug.
+		std::vector<std::wstring> channelNames = table->getChannelNames();
 		routingView = routingRenderer->create(routingAssignments, channelNames, editorContainer);
 
 		QScrollArea* routingScroll = new QScrollArea(editorContainer);


### PR DESCRIPTION
## 버그

Studio Glass(및 다른 스킨)의 Copy 카드에서 라우팅 편집이 막혔습니다. 예를 들어 'L의 반응을 R로 복사'(R = L)가 불가능했습니다.

## 원인

`FilterCardRow`가 스킨 라우팅 렌더러에 **빈 채널 목록**을 넘겼습니다(`std::vector<std::wstring> channelNames;`). 그래서 노드 그래프/크로스포인트 매트릭스 등은 줄에 이미 적힌 채널만 노드로 표시했고, 새로 추가한 Copy나 아직 대상에 없는 채널(R 등)로는 드래그할 노드가 없어 편집이 불가능했습니다. 레거시 `CopyFilterGUI`는 `configureChannels`로 실제 채널 목록을 받아 이 문제가 없었습니다.

## 수정

`FilterTable::getChannelNames()`(선택된 디바이스의 실제 채널: L, R, C, …)를 추가하고, 카드의 라우팅 렌더러를 이 목록으로 시드합니다. 레거시 경로와 동일한 채널 소스입니다. `getChannelNames()`는 `propagateChannels()`에서 분리해 한 곳에서 관리합니다. 디바이스/마스크 변경은 이미 `updateGuis()`로 모든 행을 재생성하므로 카드는 항상 최신 채널을 받습니다.

## 검증

Common.lib·EqualizerAPO.dll·Editor 빌드 통과. Editor 정상 기동 6/6(크래시 없음). 채널은 선택된 디바이스에서 채워지므로 전체 효과는 GUI에서 디바이스를 고른 상태에서 보입니다. (디바이스 없는 스크린샷 하니스로는 채널 차이가 드러나지 않습니다.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)