### PR TITLE
feat(update): apply Velopack updates on Editor exit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,14 @@ jobs:
             Repo = "TheFireKahuna/muparserx"
             Asset = "${{ matrix.muparserx_asset }}"
             Destination = "${{ github.workspace }}\deps\muparserx"
+          },
+          @{
+            # Velopack C/C++ runtime (Velopack.h + import libs + DLLs). Always fetched;
+            # the Editor links it for auto-update. Keep the version in sync with setup-build.ps1.
+            Repo = "velopack/velopack"
+            Asset = "velopack_libc_1.1.1.zip"
+            Url = "https://github.com/velopack/velopack/releases/download/1.1.1/velopack_libc_1.1.1.zip"
+            Destination = "${{ github.workspace }}\deps\velopack_libc"
           }
         )
 
@@ -216,7 +224,7 @@ jobs:
         }
 
         foreach ($download in $downloads) {
-          $url = "https://github.com/$($download.Repo)/releases/latest/download/$($download.Asset)"
+          $url = if ($download.Url) { $download.Url } else { "https://github.com/$($download.Repo)/releases/latest/download/$($download.Asset)" }
           $zipPath = Join-Path $downloadRoot $download.Asset
 
           Write-Host "Downloading $($download.Repo) release asset $($download.Asset)"
@@ -452,6 +460,10 @@ jobs:
         echo "LIBSNDFILE_INCLUDE=$depsPath\libsndfile\include" >> $env:GITHUB_ENV
         echo "LIBSNDFILE_LIB=$depsPath\libsndfile\build\Release" >> $env:GITHUB_ENV
         echo "TCLAP_ROOT=$depsPath\tclap" >> $env:GITHUB_ENV
+
+        # Velopack runtime paths for the Editor's auto-update link.
+        echo "VELOPACK_INCLUDE=$depsPath\velopack_libc\include" >> $env:GITHUB_ENV
+        echo "VELOPACK_LIB=$depsPath\velopack_libc\lib" >> $env:GITHUB_ENV
 
         Write-Host "`nAll dependency paths configured successfully"
 
@@ -938,6 +950,10 @@ jobs:
         Copy-Item ${{ github.workspace }}\deps\fftw\Release\*.dll -Destination $artifactPath -Force
         Copy-Item ${{ github.workspace }}\deps\libsndfile\build\Release\*.dll -Destination $artifactPath -Force
 
+        # Velopack runtime DLL the Editor links against (per-arch).
+        $velopackArch = if ($platform -eq "ARM64") { "arm64" } else { "x64" }
+        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_${velopackArch}_msvc.dll" -Destination $artifactPath -Force
+
         # Copy Qt applications built with qmake (Editor, DeviceSelector, UpdateChecker)
         # Include all deployed Qt dependencies (DLLs, plugins, etc.)
         $qtApps = @("Editor", "DeviceSelector", "UpdateChecker")
@@ -1092,6 +1108,8 @@ jobs:
     - name: Resolve release version
       id: version
       shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         function Get-VersionPart {
           param([string]$Name)
@@ -1107,18 +1125,33 @@ jobs:
         $minor = Get-VersionPart "MINOR"
         $revision = Get-VersionPart "REVISION"
         $baseVersion = "$major.$minor.$revision"
-        $packVersion = "$baseVersion-main.${{ github.run_number }}"
+        # Clean SemVer release version (no -main.<run> prerelease suffix). version-bump
+        # already advances version.h per main push, so the base version is unique enough,
+        # and GitHub publishes a tag without a prerelease identifier as a full release.
+        $packVersion = $baseVersion
         $tag = "v$packVersion"
+
+        # If this exact version was already published (version.h did not bump on this
+        # push), skip re-releasing so we don't overwrite an existing release/tag.
+        $alreadyReleased = "false"
+        gh release view $tag --repo "${{ github.repository }}" *> $null
+        if ($LASTEXITCODE -eq 0) {
+          $alreadyReleased = "true"
+          Write-Host "Release $tag already exists; release steps will be skipped."
+        }
+        $global:LASTEXITCODE = 0
 
         "base_version=$baseVersion" >> $env:GITHUB_OUTPUT
         "pack_version=$packVersion" >> $env:GITHUB_OUTPUT
         "tag=$tag" >> $env:GITHUB_OUTPUT
+        "already_released=$alreadyReleased" >> $env:GITHUB_OUTPUT
 
         Write-Host "Base version: $baseVersion"
         Write-Host "Release version: $packVersion"
         Write-Host "Release tag: $tag"
 
     - name: Create source archive
+      if: steps.version.outputs.already_released != 'true'
       shell: pwsh
       run: |
         $sourceZip = "${{ github.workspace }}\EqualizerAPO-XT-source-${{ steps.version.outputs.pack_version }}.zip"
@@ -1133,6 +1166,7 @@ jobs:
         Write-Host "Created source archive: $sourceZip"
 
     - name: Create Velopack release
+      if: steps.version.outputs.already_released != 'true'
       shell: pwsh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1272,6 +1306,7 @@ jobs:
         }
 
     - name: Write release notes
+      if: steps.version.outputs.already_released != 'true'
       shell: pwsh
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1288,9 +1323,13 @@ jobs:
           exit $LASTEXITCODE
         }
 
+        # --prerelease=false: the clean X.Y.Z tag is a full release; make sure vpk's
+        # upload (which may default to prerelease) does not leave it marked as one.
         gh release edit "${{ steps.version.outputs.tag }}" `
           --repo "${{ github.repository }}" `
-          --notes-file $notesPath
+          --notes-file $notesPath `
+          --prerelease=false `
+          --latest
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
         }

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -390,8 +390,31 @@ isEmpty(MUPARSERX_LIB) {
 	MUPARSERX_LIB = $$PWD/../deps/muparserx/build/Release
 }
 
-INCLUDEPATH += $$PWD/.. $$LIBSNDFILE_INCLUDE $$FFTW_INCLUDE $$MUPARSERX_INCLUDE
-LIBS += user32.lib advapi32.lib version.lib ole32.lib Shlwapi.lib authz.lib crypt32.lib dbghelp.lib winmm.lib sndfile.lib libfftw3.lib
+VELOPACK_INCLUDE = $$(VELOPACK_INCLUDE)
+isEmpty(VELOPACK_INCLUDE) {
+	VELOPACK_INCLUDE = $$PWD/../deps/velopack_libc/include
+}
+
+VELOPACK_LIB = $$(VELOPACK_LIB)
+isEmpty(VELOPACK_LIB) {
+	VELOPACK_LIB = $$PWD/../deps/velopack_libc/lib
+}
+
+# velopack_libc ships per-arch import libs in one folder; pick the matching one.
+contains(QT_ARCH, arm64) {
+	VELOPACK_IMPORT_LIB = velopack_libc_win_arm64_msvc.dll.lib
+} else {
+	VELOPACK_IMPORT_LIB = velopack_libc_win_x64_msvc.dll.lib
+}
+
+# The Editor's auto-update needs to know which release channel it was built for so
+# UpdateManager fetches the matching feed (mirrors UpdateChecker.pro).
+!isEmpty(EAPO_UPDATE_CHANNEL) {
+	DEFINES += EAPO_UPDATE_CHANNEL=\\\"$$EAPO_UPDATE_CHANNEL\\\"
+}
+
+INCLUDEPATH += $$PWD/.. $$LIBSNDFILE_INCLUDE $$FFTW_INCLUDE $$MUPARSERX_INCLUDE $$VELOPACK_INCLUDE
+LIBS += user32.lib advapi32.lib version.lib ole32.lib Shlwapi.lib authz.lib crypt32.lib dbghelp.lib winmm.lib sndfile.lib libfftw3.lib $$VELOPACK_IMPORT_LIB
 
 build_pass:CONFIG(debug, debug|release) {
 	LIBS += muparserxd.lib
@@ -400,18 +423,18 @@ build_pass:CONFIG(debug, debug|release) {
 }
 
 contains(QT_ARCH, arm64) {
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB
+	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 } else:!isEmpty(EAPO_SIMD_FLAGS) {
 	QMAKE_CXXFLAGS += $$EAPO_SIMD_FLAGS
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB
+	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 } else:equals(EAPO_SIMD_BASELINE, 1) {
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB
+	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 } else:contains(QT_ARCH, x86_64) {
 	QMAKE_CXXFLAGS += /arch:AVX2
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB
+	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 } else {
 	QMAKE_CXXFLAGS += /arch:AVX2
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB
+	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 }
 
 # Include Common.lib

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -37,6 +37,9 @@
 #include <windows.h>
 #include <shellapi.h>
 
+// After windows.h so the Velopack C ABI header sees the platform headers in order.
+#include <Velopack.hpp>
+
 #include <fftw3.h>
 
 #include "CustomStyle.h"
@@ -328,6 +331,11 @@ int main(int argc, char* argv[])
 	if (hookResult >= 0)
 		return hookResult;
 
+	// Normal launch (not a Velopack hook; handleVelopackHook already handled and exited
+	// for those). Initialise the Velopack runtime so UpdateManager resolves the correct
+	// install context. Auto-apply-on-startup is off because we apply on exit instead.
+	Velopack::VelopackApp::Build().SetAutoApplyOnStartup(false).Run();
+
 	int result = -1;
 #ifdef _DEBUG
 	// _CrtSetDbgFlag ( _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF );
@@ -461,12 +469,17 @@ int main(int argc, char* argv[])
 
 		if (VelopackBootstrap::isVelopackInstall() && !firstRun)
 		{
-			// Defer the background update so it does not race with audio service
+			// Defer the background download so it does not race with audio service
 			// work or a Device Selector launch right after the Editor opens.
 			// 60s is long enough that the initial GUI paint, config load, and
-			// device enumeration are all comfortably finished.
+			// device enumeration are all comfortably finished. The download runs on
+			// its own worker thread and just stages the update for apply-on-exit.
 			QTimer::singleShot(60000, qApp, []() {
-				VelopackBootstrap::triggerBackgroundUpdate(QStringLiteral("115dkk/EqualizerAPO-XT").toStdWString());
+				std::string channel;
+#ifdef EAPO_UPDATE_CHANNEL
+				channel = EAPO_UPDATE_CHANNEL;
+#endif
+				VelopackBootstrap::startBackgroundDownload("https://github.com/115dkk/EqualizerAPO-XT", channel);
 			});
 		}
 
@@ -475,6 +488,12 @@ int main(int argc, char* argv[])
 		restart = w.shouldRestart();
 	}
 	while (restart);
+
+	// If the background worker staged an update, apply it now. exec() has returned and
+	// the QApplication is destroyed, so no other thread is writing to the install dir.
+	// The apply is silent and does not restart; the new version comes up next launch.
+	if (VelopackBootstrap::isVelopackInstall() && VelopackBootstrap::hasPendingUpdate())
+		VelopackBootstrap::applyPendingUpdateAndExit();
 
 	return result;
 }

--- a/docs/VelopackUpdates.md
+++ b/docs/VelopackUpdates.md
@@ -23,7 +23,19 @@ The channel is injected by CI with `EAPO_UPDATE_CHANNEL` during qmake builds. Cu
 
 Local builds without an injected channel default to `x64-avx2` on x64 and `arm64` on ARM64.
 
-The actual APO installation and device registration are still handled by the NSIS installer inside the Velopack package. Until the project embeds a native Velopack client, UpdateChecker uses Velopack feeds for discovery and sends users to the correct channel setup executable.
+APO installation and device registration run through the Velopack hooks the Editor handles (`--veloapp-install`, `--veloapp-updated`, etc.), which call `ApoRegistration`. The NSIS installer has been removed.
+
+## Editor in-app auto-update
+
+The Editor embeds the native Velopack client (`velopack_libc`) and updates itself without sending the user anywhere:
+
+1. On a normal launch the Editor calls `Velopack::VelopackApp::Build().SetAutoApplyOnStartup(false).Run()`. Auto-apply on startup is off because updates are applied on exit instead.
+2. About 60 seconds after start (only for Velopack installs), a background worker checks the GitHub release feed for the build's channel with `UpdateManager::CheckForUpdates()` and, if a newer build exists, downloads it with `DownloadUpdates()` into the Velopack staging area. The download runs off the GUI thread and never blocks shutdown.
+3. When the Editor exits, if an update was staged it calls `WaitExitThenApplyUpdates(info, silent: true, restart: false)` and quits. The updater waits for the process to close, swaps the files silently, and does not relaunch. The new version comes up on the next launch.
+
+This logic lives in `helpers/VelopackBootstrap.cpp` (`startBackgroundDownload`, `hasPendingUpdate`, `applyPendingUpdateAndExit`) and is wired into `Editor/main.cpp`. The channel is injected at build time with `EAPO_UPDATE_CHANNEL`, the same macro UpdateChecker uses.
+
+`UpdateChecker.exe` stays as a separate discovery/notification tool. It still runs at logon via the scheduled task, checks the GitHub release feed, and tells the user when a newer version is available; the Editor performs the actual download and apply.
 
 Tests for feed selection, channel matching, setup URL selection, and version comparison live in `Tests/EditorLogicTests`.
 

--- a/helpers/VelopackBootstrap.cpp
+++ b/helpers/VelopackBootstrap.cpp
@@ -21,10 +21,18 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <vector>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
+// Velopack.hpp pulls in the C ABI header; include it after windows.h so the
+// platform headers resolve in the expected order.
+#include <Velopack.hpp>
 
 namespace
 {
@@ -55,6 +63,15 @@ std::wstring envVar(const wchar_t* name)
 		return std::wstring();
 	return std::wstring(buffer, length);
 }
+
+// State for the staged update produced by the background worker. The UpdateManager
+// must outlive the worker thread so applyPendingUpdateAndExit() can drive the apply,
+// hence it is kept here rather than on the worker's stack.
+std::mutex g_updateMutex;
+std::unique_ptr<Velopack::UpdateManager> g_manager;
+std::unique_ptr<Velopack::UpdateInfo> g_pendingUpdate;
+std::atomic<bool> g_downloadStarted{ false };
+std::atomic<bool> g_updateReady{ false };
 }
 
 bool VelopackBootstrap::isFirstRun()
@@ -102,40 +119,77 @@ bool VelopackBootstrap::isVelopackInstall()
 	return !updateExePath().empty();
 }
 
-bool VelopackBootstrap::triggerBackgroundUpdate(const std::wstring& githubRepo)
+void VelopackBootstrap::startBackgroundDownload(const std::string& repoUrl, const std::string& channel)
 {
-	std::wstring updateExe = updateExePath();
-	if (updateExe.empty())
-		return false;
-	if (githubRepo.empty())
-		return false;
+	if (!isVelopackInstall())
+		return;
+	if (repoUrl.empty())
+		return;
 
-	std::wstring repo = githubRepo;
-	if (repo.find(L"://") == std::wstring::npos)
-		repo = L"https://github.com/" + repo;
+	// Run the check + download at most once per session.
+	bool expected = false;
+	if (!g_downloadStarted.compare_exchange_strong(expected, true))
+		return;
 
-	std::wstring commandLine = L"\"" + updateExe + L"\" --silent --update " + repo;
-	std::vector<wchar_t> mutableCommand(commandLine.begin(), commandLine.end());
-	mutableCommand.push_back(L'\0');
-
-	STARTUPINFOW startupInfo;
-	ZeroMemory(&startupInfo, sizeof(startupInfo));
-	startupInfo.cb = sizeof(startupInfo);
-	startupInfo.dwFlags = STARTF_USESHOWWINDOW;
-	startupInfo.wShowWindow = SW_HIDE;
-
-	PROCESS_INFORMATION processInfo;
-	ZeroMemory(&processInfo, sizeof(processInfo));
-
-	if (!CreateProcessW(updateExe.c_str(), mutableCommand.data(), nullptr, nullptr, FALSE,
-			CREATE_NO_WINDOW | DETACHED_PROCESS, nullptr, nullptr, &startupInfo, &processInfo))
+	std::thread([repoUrl, channel]()
 	{
-		fwprintf(stderr, L"[VelopackBootstrap] CreateProcess for %s failed: %lu\n",
-			updateExe.c_str(), GetLastError());
-		return false;
+		try
+		{
+			Velopack::UpdateOptions options{};
+			options.AllowVersionDowngrade = false;
+			options.MaximumDeltasBeforeFallback = 10;
+			if (!channel.empty())
+				options.ExplicitChannel = channel;
+
+			auto manager = std::make_unique<Velopack::UpdateManager>(
+				std::make_unique<Velopack::GithubSource>(repoUrl, "", false),
+				&options);
+
+			std::optional<Velopack::UpdateInfo> info = manager->CheckForUpdates();
+			if (!info.has_value())
+				return; // already up to date
+
+			manager->DownloadUpdates(*info);
+
+			std::lock_guard<std::mutex> lock(g_updateMutex);
+			g_pendingUpdate = std::make_unique<Velopack::UpdateInfo>(*info);
+			g_manager = std::move(manager);
+			g_updateReady.store(true);
+		}
+		catch (const std::exception& e)
+		{
+			fprintf(stderr, "[VelopackBootstrap] background update failed: %s\n", e.what());
+		}
+		catch (...)
+		{
+			fprintf(stderr, "[VelopackBootstrap] background update failed: unknown error\n");
+		}
+	}).detach();
+}
+
+bool VelopackBootstrap::hasPendingUpdate()
+{
+	return g_updateReady.load();
+}
+
+void VelopackBootstrap::applyPendingUpdateAndExit()
+{
+	std::lock_guard<std::mutex> lock(g_updateMutex);
+	if (!g_updateReady.load() || !g_manager || !g_pendingUpdate)
+		return;
+
+	try
+	{
+		// Apply silently and do not restart: the user closed the app, so we just swap
+		// files in the background and let the new version come up on the next launch.
+		g_manager->WaitExitThenApplyUpdates(*g_pendingUpdate, /*silent*/ true, /*restart*/ false);
+	}
+	catch (const std::exception& e)
+	{
+		fprintf(stderr, "[VelopackBootstrap] apply update failed: %s\n", e.what());
+		return;
 	}
 
-	CloseHandle(processInfo.hProcess);
-	CloseHandle(processInfo.hThread);
-	return true;
+	// The updater is now waiting for this process to exit before swapping files.
+	std::exit(0);
 }

--- a/helpers/VelopackBootstrap.h
+++ b/helpers/VelopackBootstrap.h
@@ -32,5 +32,19 @@ public:
 	static std::wstring installRoot();
 	static std::wstring currentBinDir();
 
-	static bool triggerBackgroundUpdate(const std::wstring& githubRepo);
+	// Check the GitHub release feed and, if a newer build exists, download it into the
+	// Velopack staging area so it is ready to apply on exit. Runs the network work on a
+	// detached worker thread and returns immediately; repeat calls in the same session
+	// are ignored. `repoUrl` is the full repository URL ("https://github.com/user/repo").
+	// `channel` overrides the build channel; leave empty to use the installed channel.
+	static void startBackgroundDownload(const std::string& repoUrl, const std::string& channel = std::string());
+
+	// True once a downloaded update is staged and waiting to be applied.
+	static bool hasPendingUpdate();
+
+	// Apply the staged update silently without restarting, then exit the process. The
+	// updater waits for this process to close before swapping files, so the new version
+	// appears on the next launch. Does nothing (and returns) if no update is staged;
+	// otherwise it does not return.
+	static void applyPendingUpdateAndExit();
 };

--- a/setup-build.ps1
+++ b/setup-build.ps1
@@ -37,6 +37,10 @@ param(
 $ErrorActionPreference = "Stop"
 $workspace = $PSScriptRoot
 
+# velopack_libc ships as a single cross-platform zip attached to the velopack/velopack
+# release. Pin the version so the asset name and download URL stay in sync with CI.
+$velopackLibcVersion = "1.1.1"
+
 Write-Host "=== EqualizerAPO-XT Build Setup ===" -ForegroundColor Cyan
 Write-Host "Workspace: $workspace"
 Write-Host "Platform:  $Platform"
@@ -93,6 +97,14 @@ $downloads = @(
         Repo        = "TheFireKahuna/muparserx"
         Asset       = $assets.muparserx
         Destination = Join-Path $depsDir "muparserx"
+    },
+    @{
+        # Velopack C/C++ runtime (Velopack.h + import libs + DLLs for every platform).
+        # Always fetched regardless of SIMD variant; the Editor links it for auto-update.
+        Repo        = "velopack/velopack"
+        Asset       = "velopack_libc_$velopackLibcVersion.zip"
+        Url         = "https://github.com/velopack/velopack/releases/download/$velopackLibcVersion/velopack_libc_$velopackLibcVersion.zip"
+        Destination = Join-Path $depsDir "velopack_libc"
     }
 )
 
@@ -114,7 +126,7 @@ if (-not $usesVcpkg) {
 }
 
 foreach ($dl in $downloads) {
-    $url = "https://github.com/$($dl.Repo)/releases/latest/download/$($dl.Asset)"
+    $url = if ($dl.Url) { $dl.Url } else { "https://github.com/$($dl.Repo)/releases/latest/download/$($dl.Asset)" }
     $zipPath = Join-Path $downloadDir $dl.Asset
 
     if (Test-Path $zipPath) {
@@ -274,6 +286,14 @@ $checks = @(
     @{ Name = "TCLAP header";    Path = "$depsDir\tclap\include\tclap\CmdLine.h" }
 )
 
+# velopack_libc ships per-arch import libs/DLLs in a single zip; check the one we link.
+$velopackArch = if ($Platform -eq "ARM64") { "arm64" } else { "x64" }
+$checks += @(
+    @{ Name = "Velopack header"; Path = "$depsDir\velopack_libc\include\Velopack.hpp" },
+    @{ Name = "Velopack import lib"; Path = "$depsDir\velopack_libc\lib\velopack_libc_win_${velopackArch}_msvc.dll.lib" },
+    @{ Name = "Velopack DLL";    Path = "$depsDir\velopack_libc\lib\velopack_libc_win_${velopackArch}_msvc.dll" }
+)
+
 $allOk = $true
 foreach ($check in $checks) {
     if (Test-Path $check.Path) {
@@ -314,6 +334,8 @@ To build the project, open a VS Developer Command Prompt and run:
   `$env:MUPARSERX_LIB    = "$depsDir\muparserx\build\Release"
   `$env:LIBSNDFILE_INCLUDE = "$depsDir\libsndfile\include"
   `$env:LIBSNDFILE_LIB   = "$depsDir\libsndfile\build\Release"
+  `$env:VELOPACK_INCLUDE = "$depsDir\velopack_libc\include"
+  `$env:VELOPACK_LIB     = "$depsDir\velopack_libc\lib"
   `$env:TCLAP_ROOT       = "$depsDir\tclap"
   `$env:QT_ROOT          = "$qtRoot"
 


### PR DESCRIPTION
## 배경

설치는 되어 있었지만 자동 업데이트는 실제로 동작하지 않았습니다. 기존 `Update.exe --silent --update` 호출은 Velopack에 없는 Squirrel 레거시 verb라 무동작이었고, Velopack의 `Update.exe`에는 다운로드 verb 자체가 없습니다(다운로드는 `velopack_libc`의 `UpdateManager`가 담당). 이 PR은 네이티브 Velopack 클라이언트를 Editor에 링크해 자동 업데이트 경로를 처음으로 동작시키고, CI 릴리스 버전을 정리합니다.

## 자동 업데이트 흐름

- 실행 60초 뒤 워커 스레드가 채널별 GitHub 피드를 확인하고 새 버전을 백그라운드로 다운로드(GUI/종료를 막지 않음).
- 종료 시(메인 exec 루프 뒤) 받아 둔 업데이트가 있으면 `WaitExitThenApplyUpdates(silent=true, restart=false)` 후 종료. 재시작 없이 조용히 교체되며 다음 실행 때 새 버전이 뜸.
- `SetAutoApplyOnStartup(false)`: 기본이 ON이라 끄지 않으면 시작 시 적용되어 '종료 시 적용' 설계와 충돌.
- `VelopackApp.Run()`은 정상 경로에서만 호출(기존 수동 `--veloapp-*` 훅 핸들러와 충돌 회피).
- `velopack_libc` 1.1.1 동적 링크(import lib + per-arch DLL 번들). FFTW/libsndfile과 동일하게 `deps/`에 두고 `setup-build.ps1`·CI에서 다운로드.
- UpdateChecker.exe는 손대지 않고 발견/알림 도구로 공존.

## CI 버전 정리

- 릴리스 버전의 `-main.<run_number>` 프리릴리스 접미사 제거 → 깨끗한 정식 `X.Y.Z`.
- 버전 미증가 push가 같은 태그를 재생성하는 문제를 `already_released` 가드로 릴리스 단계 skip.
- `gh release edit --prerelease=false --latest`로 정식 릴리스 확정.

## 검증

- `VelopackBootstrap.cpp`를 velopack_libc 헤더와 단독 컴파일(`cl /c` 정상 종료)로 API 정합 확인.
- `setup-build.ps1` PowerShell 파서 / `build.yml` YAML 파서 통과, `git diff --check` 클린.
- Editor 전체 빌드와 업데이트 E2E는 로컬에 Qt/deps가 없어 CI에 위임.

`version.h`는 의도적으로 건드리지 않았습니다. `feat:` 커밋이라 CI version-bump가 MINOR를 자동으로 올립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)