### PR TITLE
ci: bump GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -703,7 +703,7 @@ jobs:
 
     - name: Upload audio regression outputs
       if: (matrix.platform != 'x64' || matrix.simd_variant == 'sse2' || matrix.simd_variant == 'avx' || matrix.simd_variant == 'avx2')
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: audio-regression-output-${{ matrix.simd_variant }}
         path: Tests/AudioRegressionTests/output
@@ -712,7 +712,7 @@ jobs:
 
     - name: Upload audio regression references (primary variant)
       if: matrix.simd_variant == 'avx2'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: audio-regression-references
         path: Tests/AudioRegressionTests/references
@@ -1022,7 +1022,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install cppcheck
       run: sudo apt-get update && sudo apt-get install -y cppcheck
@@ -1056,7 +1056,7 @@ jobs:
 
     - name: Upload cppcheck report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cppcheck-report
         path: cppcheck-report.txt
@@ -1070,10 +1070,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download per-variant audio outputs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: audio-regression-output-*
         path: artifacts


### PR DESCRIPTION
## 배경

GitHub Actions 러너가 2026-06-16부터 Node.js 20 액션을 Node.js 24로 강제 실행하고, 2026-09-16에는 Node.js 20을 러너에서 제거합니다. 현재 빌드의 모든 build job에서 다음 deprecation 경고가 출력됩니다.

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 ...: `actions/upload-artifact@v4` ...

## 변경

`.github/workflows/build.yml`에 남아 있던 node20(v4) 액션 인스턴스를, **같은 워크플로우에서 이미 통과 중인** node24 메이저로 통일했습니다.

| 액션 | 전 | 후 |
|---|---|---|
| `actions/upload-artifact` | `@v4` (3곳) | `@v7` |
| `actions/download-artifact` | `@v4` (1곳) | `@v7` |
| `actions/checkout` | `@v4` (2곳) | `@v6` |

`upload-artifact@v7`·`download-artifact@v7`·`checkout@v6`는 이 파일의 다른 step에서 이미 쓰여 직전 main 릴리스 run에서 통과한 버전이라, 새로 도입하는 위험이 없습니다.

## 호환성

v4와 v7에서 쓰는 입력 키(`name`/`path`/`retention-days`/`if-no-files-found`/`pattern`)가 동일해 업로드·다운로드 동작은 그대로입니다. `audio-regression-output-*` 아티팩트는 업로드(build job)와 다운로드(cross-variant-compare job)를 함께 v7로 올려 같은 백엔드에서 짝이 맞습니다.

`microsoft/setup-msbuild@v3`와 `actions/setup-python@v6`는 deprecation 경고에 잡히지 않았으므로(이미 node24) 그대로 둡니다.

## 검증

CI를 감시해 Node.js 20 deprecation annotation이 0건이 되고 빌드/릴리스가 그대로 통과하는지 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)