### PR TITLE
ci: move Windows builds to windows-2025-vs2026 runner image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,6 +592,12 @@ jobs:
         echo "QT_ROOT=$qtRoot" >> $env:GITHUB_ENV
         Write-Host "QT_ROOT=$qtRoot"
 
+        # x64 variants run on windows-2025-vs2026 (VS 2026 / v145); ARM64 runs on
+        # windows-11-arm, which still ships VS 2022 (v143). Pick the toolset present
+        # on each image so MSBuild does not fail with MSB8020 (toolset not found).
+        $platformToolset = if ("${{ matrix.platform }}" -eq "ARM64") { "v143" } else { "v145" }
+        Write-Host "PlatformToolset=$platformToolset (platform ${{ matrix.platform }})"
+
         $buildParams = @(
           "/m",
           "/p:Configuration=${{ env.BUILD_CONFIGURATION }}",
@@ -604,7 +610,7 @@ jobs:
           "/p:MUPARSERX_INCLUDE=$env:MUPARSERX_INCLUDE",
           "/p:MUPARSERX_LIB=$env:MUPARSERX_LIB",
           "/p:TCLAP_ROOT=$env:TCLAP_ROOT",
-          "/p:PlatformToolset=v145",  # windows-2025-vs2026 ships VS 2026 (v145); matches the .vcxproj and the qmake VsDevCmd toolset on this image
+          "/p:PlatformToolset=$platformToolset",  # v145 on the VS 2026 x64 image, v143 on the VS 2022 ARM64 image (see above)
           "/p:PreferredToolArchitecture=x64"  # 64-bit host cl.exe avoids the 32-bit PCH heap limit on ARM64
         )
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       && github.ref == 'refs/heads/main'
       && !contains(github.event.head_commit.message, '[skip ci]')
       && !startsWith(github.event.head_commit.message, 'chore(version):')
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     permissions:
       contents: write
     outputs:
@@ -112,14 +112,14 @@ jobs:
         name: ${{ fromJson(github.event_name == 'pull_request' && '["windows-x64-avx2"]' || '["windows-x64-sse2","windows-x64-avx","windows-x64-avx2","windows-x64-avx512","windows-x64-avx10_1","windows-arm64"]') }}
         include:
           - name: windows-x64-sse2
-            os: windows-2025
+            os: windows-2025-vs2026
             platform: x64
             simd_variant: sse2
             arch_flag: NotSet
             muparserx_asset: muparserx-msvc-release-x64-avx2.zip
             msvcdevplatform: x64
           - name: windows-x64-avx
-            os: windows-2025
+            os: windows-2025-vs2026
             platform: x64
             simd_variant: avx
             arch_flag: AdvancedVectorExtensions
@@ -127,7 +127,7 @@ jobs:
             muparserx_asset: muparserx-msvc-release-x64-avx2.zip
             msvcdevplatform: x64
           - name: windows-x64-avx2
-            os: windows-2025
+            os: windows-2025-vs2026
             platform: x64
             simd_variant: avx2
             arch_flag: AdvancedVectorExtensions2
@@ -137,7 +137,7 @@ jobs:
             libsndfile_asset: libsndfile-x64-avx2.zip
             msvcdevplatform: x64
           - name: windows-x64-avx512
-            os: windows-2025
+            os: windows-2025-vs2026
             platform: x64
             simd_variant: avx512
             arch_flag: AdvancedVectorExtensions512
@@ -147,7 +147,7 @@ jobs:
             libsndfile_asset: libsndfile-x64-avx512.zip
             msvcdevplatform: x64
           - name: windows-x64-avx10_1
-            os: windows-2025
+            os: windows-2025-vs2026
             platform: x64
             simd_variant: avx10_1
             arch_flag: AdvancedVectorExtensions101
@@ -604,7 +604,7 @@ jobs:
           "/p:MUPARSERX_INCLUDE=$env:MUPARSERX_INCLUDE",
           "/p:MUPARSERX_LIB=$env:MUPARSERX_LIB",
           "/p:TCLAP_ROOT=$env:TCLAP_ROOT",
-          "/p:PlatformToolset=v143",  # Override to VS 2022 toolset for CI (project uses v145/VS 2026)
+          "/p:PlatformToolset=v145",  # windows-2025-vs2026 ships VS 2026 (v145); matches the .vcxproj and the qmake VsDevCmd toolset on this image
           "/p:PreferredToolArchitecture=x64"  # 64-bit host cl.exe avoids the 32-bit PCH heap limit on ARM64
         )
 
@@ -1086,7 +1086,7 @@ jobs:
 
   create-release:
     needs: [build, version-bump]
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build.result == 'success'
     permissions:
       actions: read


### PR DESCRIPTION
## 배경

이번 CI 검증 중 새 notice를 발견했습니다.

> NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by June 15, 2026

6월 15일부터 `windows-2025` 라벨이 VS 2026 이미지(`windows-2025-vs2026`)로 자동 리다이렉트됩니다. 자동 전환이라 가만 둬도 일어나지만, 새 이미지에서 빌드가 그대로 통과하는지는 별개 문제라 컷오버 전에 선제 검증합니다.

## 변경

- `runs-on`/matrix `os`의 `windows-2025`를 모두 `windows-2025-vs2026`으로 명시(version-bump, x64 build 5종, create-release). `windows-11-arm`(ARM64)은 영향 없음.
- MSBuild `/p:PlatformToolset`을 `v143` → `v145`로 정렬.

## 왜 toolset도 바꾸나

기존 `v143` 오버라이드는 주석 그대로 **구 windows-2025 이미지에 VS 2022만 있어서** 둔 임시방편이었습니다. 새 이미지는 VS 2026(v145)을 담고, 모든 `.vcxproj`가 v145이며, Qt(qmake) 빌드도 그 이미지의 `vswhere -latest`(=VS 2026) VsDevCmd로 컴파일합니다. 새 이미지에선 v143이 없을 수 있고, 그대로 두면 C++(MSBuild)와 Qt 빌드가 서로 다른 toolset로 갈라집니다. v145로 맞추면 둘 다 VS 2026에서 일관됩니다.

## 검증

PR은 AVX2 변형만 빌드하므로, 새 이미지에서 C++ MSBuild(v145) + Qt 빌드가 통과하는지 확인합니다. create-release(컴파일 없음, main push 전용)는 머지 후 main 파이프라인에서 검증됩니다. CI를 감시해 빌드 success와 새 toolset 관련 오류 부재를 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)