### PR TITLE
fix(release): ship velopack_libc as velopack_libc.dll so the app starts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -950,9 +950,13 @@ jobs:
         Copy-Item ${{ github.workspace }}\deps\fftw\Release\*.dll -Destination $artifactPath -Force
         Copy-Item ${{ github.workspace }}\deps\libsndfile\build\Release\*.dll -Destination $artifactPath -Force
 
-        # Velopack runtime DLL the Editor links against (per-arch).
+        # Velopack runtime DLL the Editor and UpdateChecker link against (per-arch).
+        # The distributed file carries an arch suffix, but the import lib embeds the
+        # SONAME "velopack_libc.dll", so the loader looks for that exact name at run
+        # time. Deploy it as velopack_libc.dll next to the executables, otherwise the
+        # app fails to start with "velopack_libc.dll is missing".
         $velopackArch = if ($platform -eq "ARM64") { "arm64" } else { "x64" }
-        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_${velopackArch}_msvc.dll" -Destination $artifactPath -Force
+        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_${velopackArch}_msvc.dll" -Destination (Join-Path $artifactPath "velopack_libc.dll") -Force
 
         # Copy Qt applications built with qmake (Editor, DeviceSelector, UpdateChecker)
         # Include all deployed Qt dependencies (DLLs, plugins, etc.)


### PR DESCRIPTION
## 증상

설치한 Editor가 `velopack_libc.dll이(가) 없어 코드 실행을 진행할 수 없습니다`로 실행되지 않습니다. Velopack 설치도 `설치가 부분적으로 성공했습니다`로 끝나는데, 설치 훅이 Editor.exe를 거치므로 Editor가 못 뜨면 훅도 실패합니다. 두 증상은 원인이 같습니다.

## 원인

velopack_libc는 DLL을 아키텍처 접미사가 붙은 이름(`velopack_libc_win_x64_msvc.dll`)으로 배포하지만, 같이 들어있는 import lib은 SONAME으로 `velopack_libc.dll`을 박아 둡니다. 업스트림 zip을 받아 `dumpbin /headers velopack_libc_win_x64_msvc.dll.lib`로 확인한 결과:

```
DLL name : velopack_libc.dll
```

Editor와 UpdateChecker는 이 import lib을 링크하므로 런타임에 `velopack_libc.dll`을 찾는데, CI는 접미사 붙은 파일만 산출물에 넣어, 로더가 의존성을 못 찾습니다.

## 수정

CI 산출물 조립에서 per-arch DLL을 **정확히 `velopack_libc.dll` 이름**으로 실행 파일 옆에 복사합니다. Editor.exe/UpdateChecker.exe는 산출물 루트에 평평하게 들어가므로, 한 번 복사로 두 실행 파일 모두 해결됩니다. create-release의 vpk pack은 산출물 전체를 패키지에 담으므로 설치본에도 포함됩니다.

GPL-2.0 기준 velopack_libc 동적 링크는 문제가 없습니다.

## 검증

CI 빌드 success 확인 후, 머지하면 patch 릴리스가 나갑니다. 새 설치본에서 `velopack_libc.dll`이 실행 파일과 같은 폴더에 들어가고 Editor가 정상 기동하는지 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)