### PR TITLE
fix(editor): rotary filter knob that tracks the cursor + CI concurrency guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,14 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Serialize runs per ref. On main this queues release pipelines so two quick
+# merges can't both try to create the same release (which raced to a 403 on the
+# GitHub releases API). On pull requests a new push cancels the stale run for
+# faster feedback.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   actions: write

--- a/Editor/widgets/AudioKnob.cpp
+++ b/Editor/widgets/AudioKnob.cpp
@@ -12,7 +12,7 @@ AudioKnob::AudioKnob(QWidget* parent)
 	setRange(0, 100);
 	setNotchesVisible(false);
 	setWrapping(false);
-	setCursor(Qt::SizeVerCursor);
+	setCursor(Qt::OpenHandCursor);
 	connect(SkinManager::instance(), &SkinManager::skinChanged, this, [this](const SkinTokens&) {
 		update();
 	});
@@ -34,7 +34,11 @@ QPointF AudioKnob::pointOnArc(const QRectF& rect, double degrees) const
 	double radians = qDegreesToRadians(degrees);
 	QPointF center = rect.center();
 	double radius = qMin(rect.width(), rect.height()) / 2.0;
-	return QPointF(center.x() + qCos(radians) * radius, center.y() + qSin(radians) * radius);
+	// Qt measures arc angles counter-clockwise from 3 o'clock, so the matching
+	// screen point subtracts sin for Y (screen Y grows downward). The previous
+	// +sin mirrored the indicator dot vertically, so it never tracked the value
+	// arc and looked like it floated on its own.
+	return QPointF(center.x() + qCos(radians) * radius, center.y() - qSin(radians) * radius);
 }
 
 void AudioKnob::paintEvent(QPaintEvent*)
@@ -86,22 +90,64 @@ void AudioKnob::paintEvent(QPaintEvent*)
 	}
 }
 
+void AudioKnob::setValueFromAngle(const QPointF& widgetPos)
+{
+	// Map the cursor's angle around the knob centre onto the 270-degree value arc
+	// so the indicator turns to follow the mouse like a physical knob. The geometry
+	// matches paintEvent: the arc runs from 135 degrees (minimum, bottom-left)
+	// clockwise to 405 degrees (maximum, bottom-right), with a dead zone across the
+	// bottom. Screen Y grows downward, so a plain atan2 already gives this sweep.
+	const QPointF center = rect().center();
+	const double raw = qRadiansToDegrees(qAtan2(widgetPos.y() - center.y(), widgetPos.x() - center.x()));
+	double angle = (raw < 135.0) ? raw + 360.0 : raw;   // unwrap into 135..495
+	if (angle > 405.0)                                   // inside the bottom dead zone
+		angle = (angle < 450.0) ? 405.0 : 135.0;        // snap to whichever end is nearer
+	const double ratio = (angle - 135.0) / 270.0;
+	setValue(qBound(minimum(), minimum() + static_cast<int>(qRound(ratio * (maximum() - minimum()))), maximum()));
+}
+
 void AudioKnob::mousePressEvent(QMouseEvent* event)
 {
-	dragStartY = event->globalPos().y();
-	dragStartValue = value();
+	if (event->button() == Qt::LeftButton)
+	{
+		// Rotary tracking: the knob turns to follow the cursor. We deliberately do
+		// not call QDial's handlers; QDial maps the cursor with a different angle
+		// convention than our paintEvent, which made the indicator drift and lurched
+		// the value when the button was released.
+		setSliderDown(true);
+		setCursor(Qt::ClosedHandCursor);
+		setValueFromAngle(event->position());
+		event->accept();
+		return;
+	}
+
 	QDial::mousePressEvent(event);
 }
 
 void AudioKnob::mouseMoveEvent(QMouseEvent* event)
 {
-	if (!(event->buttons() & Qt::LeftButton))
+	if (event->buttons() & Qt::LeftButton)
 	{
-		QDial::mouseMoveEvent(event);
+		setValueFromAngle(event->position());
+		event->accept();
 		return;
 	}
 
-	double sensitivity = event->modifiers() & Qt::ShiftModifier ? 0.15 : 1.0;
-	int delta = static_cast<int>((dragStartY - event->globalPos().y()) * sensitivity);
-	setValue(qBound(minimum(), dragStartValue + delta, maximum()));
+	QDial::mouseMoveEvent(event);
+}
+
+void AudioKnob::mouseReleaseEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton)
+	{
+		// End the gesture without deferring to QDial. QDial::mouseReleaseEvent would
+		// re-run setValue() for the release position using its own angle mapping,
+		// which is the sudden value surge seen when letting go of the knob.
+		setSliderDown(false);
+		setCursor(Qt::OpenHandCursor);
+		event->accept();
+		return;
+	}
+
+	QDial::mouseReleaseEvent(event);
 }

--- a/Editor/widgets/AudioKnob.h
+++ b/Editor/widgets/AudioKnob.h
@@ -16,11 +16,11 @@ protected:
 	void paintEvent(QPaintEvent*) override;
 	void mousePressEvent(QMouseEvent* event) override;
 	void mouseMoveEvent(QMouseEvent* event) override;
+	void mouseReleaseEvent(QMouseEvent* event) override;
 
 private:
 	QPointF pointOnArc(const QRectF& rect, double degrees) const;
+	void setValueFromAngle(const QPointF& widgetPos);
 
 	QString text;
-	int dragStartY = 0;
-	int dragStartValue = 0;
 };


### PR DESCRIPTION
두 가지를 담았습니다.

## 1. 노브를 회전 컨트롤로 (fix)

기존 AudioKnob은 세로 드래그 모델이라 마우스를 제한적으로만 따라갔고, 버튼을 떼는 순간 값이 튀었습니다(급발진). 급발진의 원인은 `mouseReleaseEvent`를 오버라이드하지 않아 `QDial::mouseReleaseEvent`가 자기 각도 규약으로 **놓는 지점 좌표에 맞춰 값을 한 번 더 setValue** 한 것입니다.

- 커서가 노브 중심에 대해 이루는 각도를 270° 값 호(최소 7시 30분, 최대 4시 30분, 하단은 데드존)에 직접 매핑해, 노브가 마우스를 따라 회전합니다.
- `mouseReleaseEvent`를 오버라이드해 제스처만 끝내고 그 재적용을 막아 급발진을 제거했습니다.
- 표시 점이 값 호에서 수직으로 뒤집혀 있던 버그도 고쳤습니다(`pointOnArc`가 Qt 호 각도 규약과 달리 Y에 +sin을 써서 미러됨 → -sin).
- 커서를 쥐고 돌리는 손모양(Open/Closed hand)으로 바꿨습니다.

## 2. 릴리스 파이프라인 동시성 가드 (ci)

PR을 연달아 머지하면 main 파이프라인 두 개가 동시에 같은 릴리스를 만들려다 GitHub releases API에서 403으로 충돌합니다(직전에 v1.12.1이 이 경합으로 실패하고 v1.12.2로 대체됨). 워크플로우에 `concurrency` 그룹을 넣어 main은 직렬화(한 번에 하나)하고 PR은 새 푸시가 낡은 실행을 취소하게 했습니다.

## 검증 메모

표시 점이 값 호에 붙는 것(Bug 1)은 실행해 확대로 확인했습니다. 회전 동작·급발진 제거(Bug 2)는 각도 매핑 수학과 release 재적용 제거로 코드 차원에서 맞췄으나, 드래그 '느낌'은 주관적이고 테스트 환경의 시작 플래키 크래시로 헤드리스 재현이 불안정해, 실제 환경에서의 확인을 권합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)