### PR TITLE
fix(editor): modern filter card icons and non-overlapping Copy gain labels

### DIFF
--- a/Editor/Editor.qrc
+++ b/Editor/Editor.qrc
@@ -32,6 +32,11 @@
         <file>icons/reset_response.svg</file>
         <file>icons/dark-mode/toolbar-ext-h.svg</file>
         <file>icons/dark-mode/toolbar-ext-v.svg</file>
+        <file>icons/modern/folder-open.svg</file>
+        <file>icons/modern/pencil.svg</file>
+        <file>icons/modern/import.svg</file>
+        <file>icons/modern/file-include.svg</file>
+        <file>icons/modern/plugin.svg</file>
         <file>translations/Editor_zh_CN.qm</file>
         <file>translations/qtbase_zh_CN.qm</file>
         <file>translations/Editor_fr.qm</file>

--- a/Editor/guis/ConvolutionFilterGUI.cpp
+++ b/Editor/guis/ConvolutionFilterGUI.cpp
@@ -22,6 +22,7 @@
 #include <sndfile.h>
 
 #include "Editor/helpers/ConvolutionPathHelper.h"
+#include "Editor/helpers/GUIHelper.h"
 #include "helpers/RegistryHelper.h"
 #include "ConvolutionFilterGUI.h"
 #include "ui_ConvolutionFilterGUI.h"
@@ -35,6 +36,11 @@ ConvolutionFilterGUI::ConvolutionFilterGUI(const QString& configPath, unsigned d
 	ui->pathLineEdit->setText(path);
 	ui->labelError->setWordWrap(true);
 	ui->selectFileToolButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+	// Replace the dated Tango "drawer" icon baked into the .ui with the modern
+	// browse glyph, recoloured to the active text colour so it reads on whichever
+	// skin or palette hosts the card.
+	ui->selectFileToolButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/folder-open.svg"),
+		palette().color(QPalette::WindowText), 18));
 
 	updateFileInfo();
 }

--- a/Editor/guis/CopyFilterGUIConnectionItem.cpp
+++ b/Editor/guis/CopyFilterGUIConnectionItem.cpp
@@ -47,6 +47,19 @@ CopyFilterGUIConnectionItem::CopyFilterGUIConnectionItem(CopyFilterGUIChannelIte
 	setAcceptHoverEvents(true);
 }
 
+void CopyFilterGUIConnectionItem::setLabelPosition(double t)
+{
+	labelT = t;
+	prepareGeometryChange();
+	update();
+}
+
+QPointF CopyFilterGUIConnectionItem::labelCenter() const
+{
+	QLineF l = line();
+	return l.p1() + (l.p2() - l.p1()) * labelT;
+}
+
 QRectF CopyFilterGUIConnectionItem::boundingRect() const
 {
 	QRectF rect = QGraphicsLineItem::boundingRect();
@@ -94,18 +107,18 @@ QPainterPath CopyFilterGUIConnectionItem::shape() const
 		{
 			QFont font;
 			font.setPixelSize(GUIHelper::scale(10));
-			QPointF center = (l.p1() + l.p2()) / 2;
+			QPointF center = labelCenter();
 			QString text = QString("%1").arg(factor);
 			if (isDecibel)
 				text += " dB";
 
 			QFontMetrics fontMetrics(font);
 			QSizeF size = fontMetrics.size(0, text);
-			size += QSizeF(2, 0);
+			size += QSizeF(GUIHelper::scale(8), GUIHelper::scale(4));
 			QRectF rect;
 			rect.setSize(size);
 			rect.moveCenter(center);
-			path.addRoundedRect(rect.adjusted(-0.5, 0.5, 0.5, 0.5), 3, 3);
+			path.addRoundedRect(rect, 4, 4);
 		}
 	}
 
@@ -152,21 +165,25 @@ void CopyFilterGUIConnectionItem::paint(QPainter* painter, const QStyleOptionGra
 			QFont font = painter->font();
 			font.setPixelSize(GUIHelper::scale(10));
 			painter->setFont(font);
-			QPointF center = (l.p1() + l.p2()) / 2;
+			QPointF center = labelCenter();
 			QString text = QString("%1").arg(factor);
 			if (isDecibel)
 				text += " dB";
 
 			QSizeF size = painter->fontMetrics().size(0, text);
-			size += QSizeF(2, 0);
+			size += QSizeF(GUIHelper::scale(8), GUIHelper::scale(4));
 			QRectF rect;
 			rect.setSize(size);
 			rect.moveCenter(center);
+			painter->setPen(Qt::NoPen);
 			painter->setBrush(Qt::white);
-			painter->drawRoundedRect(rect.adjusted(-0.5, 0.5, 0.5, 0.5), 3, 3);
-			// make sure that text is visible in dark mode
-			if(painter->pen().color() == Qt::white)
-				painter->setPen(Qt::black);
+			painter->drawRoundedRect(rect, 4, 4);
+			// The label box is always white, so the coefficient text must always be
+			// dark. The previous code only swapped to black when the line pen was
+			// exactly white; in the dark skins the pen is a light grey (not pure
+			// white), so the test missed and the text rendered light-on-white and
+			// nearly unreadable.
+			painter->setPen(QColor(0x20, 0x20, 0x28));
 			painter->drawText(rect, Qt::AlignCenter, text);
 		}
 	}
@@ -182,8 +199,7 @@ void CopyFilterGUIConnectionItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent
 	connect(lineEdit, SIGNAL(editingFinished()), this, SLOT(lineEditEditingFinished()));
 	connect(lineEdit, SIGNAL(editingCanceled()), this, SLOT(lineEditEditingCanceled()));
 	QGraphicsProxyWidget* proxyItem = scene()->addWidget(lineEdit);
-	QLineF l = line();
-	QPointF center = (l.p1() + l.p2()) / 2;
+	QPointF center = labelCenter();
 	QRectF rect;
 	rect.setSize(lineEdit->size());
 	rect.moveCenter(center);

--- a/Editor/guis/CopyFilterGUIConnectionItem.h
+++ b/Editor/guis/CopyFilterGUIConnectionItem.h
@@ -47,6 +47,12 @@ public:
 	double getFactor() const;
 	bool getIsDecibel() const;
 
+	// Position of the gain label along the connection line, 0 = source end,
+	// 1 = target end. The scene staggers this per target so the coefficient
+	// labels of arrows that converge on the same output channel no longer
+	// stack on top of each other at the shared midpoint.
+	void setLabelPosition(double t);
+
 protected:
 	void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
 	void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
@@ -58,8 +64,11 @@ private slots:
 	void lineEditEditingCanceled();
 
 private:
+	QPointF labelCenter() const;
+
 	CopyFilterGUIChannelItem* source = nullptr;
 	CopyFilterGUIChannelItem* target = nullptr;
 	double factor = 1.0;
 	bool isDecibel = false;
+	double labelT = 0.5;
 };

--- a/Editor/guis/CopyFilterGUIScene.cpp
+++ b/Editor/guis/CopyFilterGUIScene.cpp
@@ -87,6 +87,7 @@ void CopyFilterGUIScene::load(const vector<wstring>& channelNames, vector<Assign
 			outputChannelMap.insert(oc, outputItem);
 			lastOutputItem = outputItem;
 		}
+		std::vector<CopyFilterGUIConnectionItem*> targetConnections;
 		for (Assignment::Summand summand : assignment.sourceSum)
 		{
 			QString ic = QString::fromStdWString(summand.channel);
@@ -105,6 +106,18 @@ void CopyFilterGUIScene::load(const vector<wstring>& channelNames, vector<Assign
 
 			CopyFilterGUIConnectionItem* connItem = new CopyFilterGUIConnectionItem(inputItem, outputItem, summand.factor, summand.isDecibel);
 			addItem(connItem);
+			targetConnections.push_back(connItem);
+		}
+
+		// Spread the coefficient labels of every arrow feeding this output along
+		// their own lines. A single source keeps the midpoint; multiple sources
+		// (a mix such as VC = 0.7071*L + 0.7071*R) fan the labels between 28% and
+		// 72% of each line so the boxes no longer overlap at the shared midpoint.
+		const int connectionCount = static_cast<int>(targetConnections.size());
+		for (int k = 0; k < connectionCount; k++)
+		{
+			double t = (connectionCount <= 1) ? 0.5 : 0.28 + 0.44 * k / (connectionCount - 1);
+			targetConnections[k]->setLabelPosition(t);
 		}
 	}
 

--- a/Editor/helpers/GUIHelper.cpp
+++ b/Editor/helpers/GUIHelper.cpp
@@ -22,6 +22,8 @@
 #include <QApplication>
 #include <QFont>
 #include <QFontMetrics>
+#include <QPainter>
+#include <QPixmap>
 #include <QScreen>
 #include <QStyleHints>
 
@@ -73,4 +75,23 @@ double GUIHelper::invScaleZoom(double zoom)
 bool GUIHelper::isDarkMode()
 {
 	return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+}
+
+QIcon GUIHelper::tintedIcon(const QString& resource, const QColor& color, int size)
+{
+	QIcon base(resource);
+	QPixmap pixmap = base.pixmap(scale(QSize(size, size)));
+	if (pixmap.isNull())
+		return base;
+
+	// Keep the rendered glyph's alpha mask, replace its colour. CompositionMode_SourceIn
+	// paints the fill only where the source already has coverage, so the result is the
+	// same shape in the requested colour. The fill rect is in device-independent units;
+	// any overshoot on a high-DPI pixmap is harmless because untouched pixels stay clear.
+	QPainter painter(&pixmap);
+	painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+	painter.fillRect(QRect(QPoint(0, 0), pixmap.deviceIndependentSize().toSize()), color);
+	painter.end();
+
+	return QIcon(pixmap);
 }

--- a/Editor/helpers/GUIHelper.h
+++ b/Editor/helpers/GUIHelper.h
@@ -18,6 +18,9 @@
 */
 
 #include <QSize>
+#include <QString>
+#include <QColor>
+#include <QIcon>
 
 #pragma once
 
@@ -30,4 +33,9 @@ public:
 	static double invScale(int pixel);
 	static double invScaleZoom(double zoom);
     static bool isDarkMode();
+	// Render a monochrome resource icon (SVG silhouette) recoloured to the given
+	// skin colour. The artwork's own colour is ignored: only its alpha mask is
+	// kept, so the same icon adapts to any dark/light skin without per-theme
+	// duplicate files. size is in logical pixels and is DPI-scaled internally.
+	static QIcon tintedIcon(const QString& resource, const QColor& color, int size = 20);
 };

--- a/Editor/icons/modern/file-include.svg
+++ b/Editor/icons/modern/file-include.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.5 3.5H7A1.5 1.5 0 0 0 5.5 5v14A1.5 1.5 0 0 0 7 20.5h10A1.5 1.5 0 0 0 18.5 19V8.5z"/>
+  <path d="M13.5 3.5V8.5H18.5"/>
+  <path d="M8.8 12.5h6.4"/>
+  <path d="M8.8 15.5h6.4"/>
+</svg>

--- a/Editor/icons/modern/folder-open.svg
+++ b/Editor/icons/modern/folder-open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 8.5V6.5A1.5 1.5 0 0 1 5.5 5H9l2 2h5.5A1.5 1.5 0 0 1 18 8.5v1.5"/>
+  <path d="M3.2 10h16.4a1 1 0 0 1 .96 1.27l-1.6 5.7A1.6 1.6 0 0 1 17.4 18.2H5.1a1.6 1.6 0 0 1-1.54-1.18l-1.3-5.7A1 1 0 0 1 3.2 10z"/>
+</svg>

--- a/Editor/icons/modern/import.svg
+++ b/Editor/icons/modern/import.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3.5v9.5"/>
+  <path d="M8 9.5l4 4 4-4"/>
+  <path d="M4.5 15.5v2.5A1.6 1.6 0 0 0 6.1 19.6h11.8a1.6 1.6 0 0 0 1.6-1.6v-2.5"/>
+</svg>

--- a/Editor/icons/modern/pencil.svg
+++ b/Editor/icons/modern/pencil.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14.2 5.3l4.5 4.5"/>
+  <path d="M4 20l1.1-4.2L16 4.9a1.4 1.4 0 0 1 2 0l1.1 1.1a1.4 1.4 0 0 1 0 2L8.2 18.9 4 20z"/>
+</svg>

--- a/Editor/icons/modern/plugin.svg
+++ b/Editor/icons/modern/plugin.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6.5" y="6.5" width="11" height="11" rx="2"/>
+  <path d="M9.5 3.5v3M14.5 3.5v3M9.5 17.5v3M14.5 17.5v3"/>
+  <path d="M3.5 9.5h3M3.5 14.5h3M17.5 9.5h3M17.5 14.5h3"/>
+</svg>

--- a/Editor/widgets/cards/IncludeCardEditor.cpp
+++ b/Editor/widgets/cards/IncludeCardEditor.cpp
@@ -16,6 +16,8 @@
 #include <windows.h>
 
 #include "Editor/FilterTable.h"
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
 #include "Editor/import/ConfigDependencyScanner.h"
 #include "Editor/import/ImportDialog.h"
 #include "Editor/import/ImportExecutor.h"
@@ -31,9 +33,13 @@ IncludeCardEditor::IncludeCardEditor(FilterTable* filterTable, const QString& pa
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(10);
 
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const QColor glyphColor(tokens.mutedText);
+	const QColor actionColor(tokens.text);
+
 	QLabel* fileGlyph = new QLabel(this);
 	fileGlyph->setObjectName(QStringLiteral("IncludeCardGlyph"));
-	fileGlyph->setPixmap(style()->standardIcon(QStyle::SP_FileIcon).pixmap(20, 20));
+	fileGlyph->setPixmap(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/file-include.svg"), glyphColor, 20).pixmap(GUIHelper::scale(QSize(20, 20))));
 	layout->addWidget(fileGlyph, 0, Qt::AlignVCenter);
 
 	QWidget* pathBlock = new QWidget(this);
@@ -57,21 +63,21 @@ IncludeCardEditor::IncludeCardEditor(FilterTable* filterTable, const QString& pa
 
 	chooseButton = new QToolButton(this);
 	chooseButton->setObjectName(QStringLiteral("FilterCardIconButton"));
-	chooseButton->setIcon(QIcon(QStringLiteral(":/icons/document-open.ico")));
+	chooseButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/folder-open.svg"), actionColor, 18));
 	chooseButton->setToolTip(tr("Choose include file"));
 	connect(chooseButton, SIGNAL(clicked()), this, SLOT(chooseFile()));
 	layout->addWidget(chooseButton, 0, Qt::AlignTop);
 
 	openButton = new QToolButton(this);
 	openButton->setObjectName(QStringLiteral("FilterCardIconButton"));
-	openButton->setIcon(QIcon(QStringLiteral(":/icons/accessories-text-editor.ico")));
+	openButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/pencil.svg"), actionColor, 18));
 	openButton->setToolTip(tr("Open include file"));
 	connect(openButton, SIGNAL(clicked()), this, SLOT(openFile()));
 	layout->addWidget(openButton, 0, Qt::AlignTop);
 
 	importButton = new QToolButton(this);
 	importButton->setObjectName(QStringLiteral("FilterCardIconButton"));
-	importButton->setIcon(QIcon(QStringLiteral(":/icons/document-save.ico")));
+	importButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/import.svg"), actionColor, 18));
 	importButton->setToolTip(tr("Copy this file and its dependencies into the config directory"));
 	importButton->setVisible(false);
 	connect(importButton, SIGNAL(clicked()), this, SLOT(importToConfig()));

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -33,6 +33,7 @@
 #include "helpers/StringHelper.h"
 #include "helpers/RegistryHelper.h"
 #include "Editor/helpers/GUIHelper.h"
+#include "Editor/SkinManager.h"
 #include "Editor/MainWindow.h"
 #include "Editor/guis/VSTPluginFilterGUIDialog.h"
 
@@ -55,9 +56,11 @@ VSTCardEditor::VSTCardEditor(shared_ptr<VSTPluginLibrary> library, const wstring
 	row->setContentsMargins(0, 0, 0, 0);
 	row->setSpacing(8);
 
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+
 	QLabel* glyph = new QLabel(this);
 	glyph->setObjectName(QStringLiteral("VSTCardGlyph"));
-	glyph->setPixmap(style()->standardIcon(QStyle::SP_ComputerIcon).pixmap(20, 20));
+	glyph->setPixmap(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/plugin.svg"), QColor(tokens.mutedText), 20).pixmap(GUIHelper::scale(QSize(20, 20))));
 	row->addWidget(glyph, 0, Qt::AlignVCenter);
 
 	pathEdit = new QLineEdit(this);
@@ -68,7 +71,7 @@ VSTCardEditor::VSTCardEditor(shared_ptr<VSTPluginLibrary> library, const wstring
 
 	selectButton = new QToolButton(this);
 	selectButton->setObjectName(QStringLiteral("FilterCardIconButton"));
-	selectButton->setIcon(QIcon(QStringLiteral(":/icons/document-open.ico")));
+	selectButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/folder-open.svg"), QColor(tokens.text), 18));
 	selectButton->setToolTip(tr("Select VST plugin"));
 	connect(selectButton, SIGNAL(clicked()), this, SLOT(selectFile()));
 	row->addWidget(selectButton);


### PR DESCRIPTION
## 무엇을

모던 필터 카드의 두 가지 GUI 문제를 고칩니다.

### 1. 시대에 뒤떨어진 아이콘 교체
- **Include 카드 글리프**: Windows 셸 파일 아이콘 → 새 문서 아이콘
- **VST 카드 글리프**: Windows 셸 컴퓨터(모니터) 아이콘 → 칩/플러그인 아이콘
- **Include 찾기/열기/가져오기 버튼, VST 찾기 버튼, Convolution `Select file` 버튼**: 낡은 Tango `.ico`(드로어 모양 등) → 새 라인 SVG(folder-open / pencil / import)

새 아이콘은 직접 그린 24×24 라인 SVG 5종(`file-include`, `plugin`, `folder-open`, `pencil`, `import`)이며, `GUIHelper::tintedIcon`으로 런타임에 활성 스킨 색으로 틴팅합니다. 테마별 중복 파일 없이 하나의 아트워크가 모든 dark/light 스킨에 맞춰집니다.

### 2. Copy 게인 라벨 숫자 겹침 (Studio Glass)
곡선 노드 Copy 라우팅이 모든 연결 계수를 선 중점에 그려, 한 출력으로 모이는 화살표들(예: `VC=0.7071*L+0.7071*R`)의 라벨이 한 자리에 포개져 읽을 수 없었습니다.

- 타깃별로 라벨을 각 선의 28%~72% 지점에 분산시켜 겹치지 않게 했습니다.
- 라벨 텍스트를 흰 박스 위에서 항상 어두운 색으로 강제합니다(기존의 `== Qt::white` 정확 비교가 다크 스킨의 밝은 회색 펜을 놓쳐 텍스트가 거의 안 보였습니다).

카드→카드 화살표 형식은 그대로 유지합니다.

## 검증
- `Common` + `Editor` 로컬 빌드 통과(VS2022 v143 / Qt 6.10.1 msvc2022_64).
- Editor 실행 후 studio dark에서 PrintWindow 캡처로 확인:
  - Include 문서 글리프, Convolution `Select file` 폴더 아이콘(드로어 제거), VST 칩 글리프(모니터 제거) 렌더 확인.
  - `C=0.7071*L+0.7071*R` 카드에서 두 `0.7071` 라벨이 대각선으로 분리, 어두운 텍스트로 선명하게 표시됨을 확인.

## 버전
사용자 가시 동작 변경이지만 기존 UI 결함 수정 범위라 `fix:`로 커밋했습니다. `version.h`는 건드리지 않았고 CI가 conventional commit으로 patch 범프합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)