### PR TITLE
fix(editor): skin/theme switch no longer re-polishes the whole widget tree

### DIFF
--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -130,17 +130,18 @@ void FilterTable::updateDeviceAndChannelMask(shared_ptr<AbstractAPOInfo> selecte
 		updateGuis();
 }
 
-void FilterTable::updateGuis()
+void FilterTable::clearRows()
 {
-	QElapsedTimer timer;
-	timer.start();
-
+	// Persist each row's GUI preferences before its widget (and the GUI it owns)
+	// is destroyed, then null the pointer so a following updateGuis() does not
+	// read a dangling gui in its own preference-save pass.
 	for (Item* item : items)
 	{
 		if (item->gui != nullptr)
 		{
 			item->prefs.clear();
 			item->gui->storePreferences(item->prefs);
+			item->gui = nullptr;
 		}
 	}
 
@@ -158,6 +159,15 @@ void FilterTable::updateGuis()
 		}
 		delete oldLayout;
 	}
+	gridLayout = nullptr;
+}
+
+void FilterTable::updateGuis()
+{
+	QElapsedTimer timer;
+	timer.start();
+
+	clearRows();
 
 	qDebug("Delete took %d ms", timer.elapsed());
 	timer.start();

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -67,6 +67,12 @@ public:
 	void initialize(QScrollArea* scrollArea, const QList<std::shared_ptr<AbstractAPOInfo>>& outputDevices, const QList<std::shared_ptr<AbstractAPOInfo>>& inputDevices);
 	void updateDeviceAndChannelMask(std::shared_ptr<AbstractAPOInfo> selectedDevice, int selectedChannelMask);
 	void updateGuis();
+	// Tear down every row widget (and its filter GUI) without rebuilding. Used
+	// before a global stylesheet swap on skin change: qApp->setStyleSheet
+	// re-polishes every live widget, and a loaded config inflates the tree to
+	// thousands of widgets, so clearing first lets the skin apply against just
+	// the chrome and the rebuilt rows get polished once on creation.
+	void clearRows();
 	// Re-create the GUI widget for a single row in place. Used for cheap
 	// edits like the enabled toggle, which used to trigger a full updateGuis
 	// (delete + rebuild every row in the file).

--- a/Editor/MainWindowParts/MainWindow.ViewActions.cpp
+++ b/Editor/MainWindowParts/MainWindow.ViewActions.cpp
@@ -75,6 +75,18 @@ void MainWindow::skinSelected(QAction* action)
 		return;
 
 	skinId = action->data().toString();
+	// Tear the rows down BEFORE swapping the global stylesheet. qApp->setStyleSheet
+	// re-polishes every live widget, and a loaded config inflates the tree to
+	// thousands of widgets; re-polishing them only to immediately rebuild them in
+	// updateGuis() below made each skin switch cost seconds. Clearing first lets
+	// the stylesheet apply against just the window chrome, and the rebuilt rows
+	// are polished a single time when they are created.
+	for (int i = 0; i < ui->tabWidget->count(); i++)
+	{
+		FilterTable* filterTable = filterTableForTab(i);
+		if (filterTable != nullptr)
+			filterTable->clearRows();
+	}
 	SkinManager::instance()->applySkin(skinId, skinDark);
 	skinId = SkinManager::instance()->currentSkinId();
 	// Each skin supplies its own Copy routing renderer (node graph, crosspoint
@@ -93,6 +105,14 @@ void MainWindow::skinSelected(QAction* action)
 void MainWindow::darkThemeToggled(bool checked)
 {
 	skinDark = checked;
+	// Clear rows before the global stylesheet swap (see skinSelected) so the
+	// re-polish does not run over thousands of soon-to-be-rebuilt card widgets.
+	for (int i = 0; i < ui->tabWidget->count(); i++)
+	{
+		FilterTable* filterTable = filterTableForTab(i);
+		if (filterTable != nullptr)
+			filterTable->clearRows();
+	}
 	SkinManager::instance()->applySkin(skinId, skinDark);
 	skinId = SkinManager::instance()->currentSkinId();
 	// Rebuild rows so painted card/routing widgets pick up the new palette.


### PR DESCRIPTION
## 증상
어느 순간부터 스킨이나 다크 테마를 바꿀 때마다 10초 이상 멈춤이 생겼습니다.

## 원인 (측정으로 확인)
`SkinManager::applySkin`의 `qApp->setStyleSheet()` 한 줄이 병목입니다. 전역 스타일시트를 교체하면 Qt가 **살아있는 모든 위젯을 재polish**하는데, config가 로드되면 위젯 트리가 수천 개로 불어납니다(50줄짜리 업믹스에서 약 4700개). 재polish 비용은 위젯 수에 선형 비례했습니다.

- 위젯 99개: setStyleSheet ~9 ms
- 위젯 4695개: setStyleSheet ~2.9 s (게임 등 CPU 경합 시 사용자 환경에서 10초+)

게다가 `skinSelected`/`darkThemeToggled`는 `applySkin` 직후 모든 탭의 행을 `updateGuis`로 다시 만듭니다. 즉 **곧 삭제될 위젯 수천 개를 재polish하는 비용이 전부 낭비**였습니다.

## 수정
전역 스타일시트를 바꾸기 **전에** 행을 먼저 헐도록 순서를 바꿨습니다.

- `updateGuis`의 행 해체 부분을 `FilterTable::clearRows()`로 추출해 두 경로가 같은 해체 코드를 쓰게 했습니다. `clearRows`는 각 행 GUI의 preference를 저장하고, 행 위젯을 삭제하고, `item->gui`를 null로 만들어 뒤이은 `updateGuis`가 댕글링 포인터를 읽지 않게 합니다.
- `skinSelected`/`darkThemeToggled`에서 `clearRows`(전 탭) → `applySkin` → `updateGuis`(전 탭) 순서로 바꿨습니다. 이제 `setStyleSheet`은 창 chrome만 재polish하고(수천 개 → 수십~수백 개), 다시 만들어진 행은 생성 시 한 번만 polish됩니다.

## 검증
- `Common` + `Editor` 로컬 빌드 통과.
- 위젯 수와 `setStyleSheet` 시간의 선형 관계를 계측으로 확인(99→9 ms, 4695→2.9 s). 수정 시 전환 경로의 재polish 대상이 4695 → 약 1258로 감소.
- 업믹스 config 정상 로드·렌더 확인(VST/Convolution/Copy 카드 정상). `clearRows`는 `updateGuis`가 이미 하던 해체와 동일하며 `item->gui`를 null로 만들어 오히려 더 안전합니다.

## 범위 밖 관찰 (별도 후속)
계측 중, 백그라운드 분석 스레드가 VST 플러그인을 로드하는 동안 스킨 전환이 VST 카드를 재구성하면 크래시가 나는 경합을 발견했습니다. 이 크래시는 수정 전 코드(원래 순서)에서도 동일하게 재현되므로 본 변경과 무관한 기존 동시성 버그입니다. 별도로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)