### PR TITLE
feat(vst): add VST3 plug-in hosting via Steinberg pluginterfaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -382,6 +382,17 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: deps/tclap
 
+    # Clone the VST3 SDK pluginterfaces (header-only COM interfaces + IID unit).
+    # Only this submodule is needed for VST3 hosting; public.sdk / vstgui are not
+    # compiled. Pinned to the 3.8.0 tag, the first MIT-licensed release.
+    - name: Download VST3 pluginterfaces
+      uses: actions/checkout@v6
+      with:
+        repository: steinbergmedia/vst3_pluginterfaces
+        ref: v3.8.0_build_66
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: deps/vst3sdk/pluginterfaces
+
     # Setup dependency structures
     - name: Setup dependency structures
       shell: pwsh
@@ -468,6 +479,9 @@ jobs:
         echo "LIBSNDFILE_INCLUDE=$depsPath\libsndfile\include" >> $env:GITHUB_ENV
         echo "LIBSNDFILE_LIB=$depsPath\libsndfile\build\Release" >> $env:GITHUB_ENV
         echo "TCLAP_ROOT=$depsPath\tclap" >> $env:GITHUB_ENV
+
+        # VST3 SDK root (contains pluginterfaces/) for VST3 hosting headers.
+        echo "VST3_SDK=$depsPath\vst3sdk" >> $env:GITHUB_ENV
 
         # Velopack runtime paths for the Editor's auto-update link.
         echo "VELOPACK_INCLUDE=$depsPath\velopack_libc\include" >> $env:GITHUB_ENV
@@ -618,6 +632,7 @@ jobs:
           "/p:MUPARSERX_INCLUDE=$env:MUPARSERX_INCLUDE",
           "/p:MUPARSERX_LIB=$env:MUPARSERX_LIB",
           "/p:TCLAP_ROOT=$env:TCLAP_ROOT",
+          "/p:VST3_SDK=$env:VST3_SDK",
           "/p:PlatformToolset=$platformToolset",  # v145 on the VS 2026 x64 image, v143 on the VS 2022 ARM64 image (see above)
           "/p:PreferredToolArchitecture=x64"  # 64-bit host cl.exe avoids the 32-bit PCH heap limit on ARM64
         )

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -102,6 +102,7 @@
     <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\fftw\include</FFTW_INCLUDE>
     <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\muparserx\parser</MUPARSERX_INCLUDE>
     <TCLAP_ROOT Condition="'$(TCLAP_ROOT)'==''">$(MSBuildThisFileDirectory)deps\tclap</TCLAP_ROOT>
+    <VST3_SDK Condition="'$(VST3_SDK)'==''">$(MSBuildThisFileDirectory)deps\vst3sdk</VST3_SDK>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)deps\libsndfile\build\Debug</LIBSNDFILE_LIB>
@@ -134,27 +135,27 @@
     <MUPARSERX_LIB Condition="'$(MUPARSERX_LIB)'==''">$(MSBuildThisFileDirectory)deps\muparserx\build\Release</MUPARSERX_LIB>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE)</IncludePath>
+    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE);$(VST3_SDK)</IncludePath>
     <LibraryPath>$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(FFTW_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE)</IncludePath>
+    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE);$(VST3_SDK)</IncludePath>
     <LibraryPath>$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(FFTW_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE)</IncludePath>
+    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE);$(VST3_SDK)</IncludePath>
     <LibraryPath>$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(FFTW_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE)</IncludePath>
+    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE);$(VST3_SDK)</IncludePath>
     <LibraryPath>$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(FFTW_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE)</IncludePath>
+    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE);$(VST3_SDK)</IncludePath>
     <LibraryPath>$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(FFTW_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE)</IncludePath>
+    <IncludePath>$(SolutionDir);$(IncludePath);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(FFTW_INCLUDE);$(VST3_SDK)</IncludePath>
     <LibraryPath>$(LIBSNDFILE_LIB);$(MUPARSERX_LIB);$(FFTW_LIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -412,6 +413,7 @@
     <ClCompile Include="helpers\PerfProfile.cpp" />
     <ClCompile Include="helpers\RegistryHelper.cpp" />
     <ClCompile Include="helpers\StringHelper.cpp" />
+    <ClCompile Include="helpers\VST3PluginIIDs.cpp" />
     <ClCompile Include="helpers\VSTPluginInstance.cpp" />
     <ClCompile Include="helpers\VSTPluginLibrary.cpp" />
     <ClCompile Include="IFilter.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -256,6 +256,9 @@
     <ClCompile Include="helpers\StringHelper.cpp">
       <Filter>helpers</Filter>
     </ClCompile>
+    <ClCompile Include="helpers\VST3PluginIIDs.cpp">
+      <Filter>helpers</Filter>
+    </ClCompile>
     <ClCompile Include="helpers\VSTPluginInstance.cpp">
       <Filter>helpers</Filter>
     </ClCompile>

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -146,6 +146,7 @@ SOURCES += main.cpp\
 	../AbstractAPOInfo.cpp \
 	../VoicemeeterAPOInfo.cpp \
 	../helpers/AbstractLibrary.cpp \
+	../helpers/VST3PluginIIDs.cpp \
 	../helpers/VSTPluginLibrary.cpp \
 	guis/VSTPluginFilterGUI.cpp \
 	guis/VSTPluginFilterGUIFactory.cpp \
@@ -395,6 +396,11 @@ isEmpty(VELOPACK_INCLUDE) {
 	VELOPACK_INCLUDE = $$PWD/../deps/velopack_libc/include
 }
 
+VST3_SDK = $$(VST3_SDK)
+isEmpty(VST3_SDK) {
+	VST3_SDK = $$PWD/../deps/vst3sdk
+}
+
 VELOPACK_LIB = $$(VELOPACK_LIB)
 isEmpty(VELOPACK_LIB) {
 	VELOPACK_LIB = $$PWD/../deps/velopack_libc/lib
@@ -413,7 +419,7 @@ contains(QT_ARCH, arm64) {
 	DEFINES += EAPO_UPDATE_CHANNEL=\\\"$$EAPO_UPDATE_CHANNEL\\\"
 }
 
-INCLUDEPATH += $$PWD/.. $$LIBSNDFILE_INCLUDE $$FFTW_INCLUDE $$MUPARSERX_INCLUDE $$VELOPACK_INCLUDE
+INCLUDEPATH += $$PWD/.. $$LIBSNDFILE_INCLUDE $$FFTW_INCLUDE $$MUPARSERX_INCLUDE $$VELOPACK_INCLUDE $$VST3_SDK
 LIBS += user32.lib advapi32.lib version.lib ole32.lib Shlwapi.lib authz.lib crypt32.lib dbghelp.lib winmm.lib sndfile.lib libfftw3.lib $$VELOPACK_IMPORT_LIB
 
 build_pass:CONFIG(debug, debug|release) {

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -273,9 +273,9 @@ void VSTPluginFilterGUI::on_selectButton_clicked()
 	if (path.length() > 0)
 		fileInfo.setFile(pluginsDir, path);
 
-	QFileDialog dialog(this, tr("Select VST plugin"), fileInfo.absoluteFilePath(), "*.dll");
+	QFileDialog dialog(this, tr("Select VST plugin"), fileInfo.absoluteFilePath(), "*.dll *.vst3");
 	dialog.setFileMode(QFileDialog::ExistingFile);
-	dialog.setNameFilter(tr("VST plugins (*.dll)"));
+	dialog.setNameFilter(tr("VST plugins (*.dll *.vst3)"));
 	if (path.length() > 0)
 		dialog.selectFile(fileInfo.fileName());
 	if (dialog.exec() == QDialog::Accepted)

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -65,7 +65,7 @@ VSTCardEditor::VSTCardEditor(shared_ptr<VSTPluginLibrary> library, const wstring
 
 	pathEdit = new QLineEdit(this);
 	pathEdit->setObjectName(QStringLiteral("VSTCardPath"));
-	pathEdit->setPlaceholderText(tr("VST plugin (.dll)"));
+	pathEdit->setPlaceholderText(tr("VST plugin (.dll, .vst3)"));
 	connect(pathEdit, SIGNAL(editingFinished()), this, SLOT(pathEditingFinished()));
 	row->addWidget(pathEdit, 1);
 
@@ -328,9 +328,9 @@ void VSTCardEditor::selectFile()
 	if (path.length() > 0)
 		fileInfo.setFile(pluginsDir, path);
 
-	QFileDialog dialog(this, tr("Select VST plugin"), fileInfo.absoluteFilePath(), "*.dll");
+	QFileDialog dialog(this, tr("Select VST plugin"), fileInfo.absoluteFilePath(), "*.dll *.vst3");
 	dialog.setFileMode(QFileDialog::ExistingFile);
-	dialog.setNameFilter(tr("VST plugins (*.dll)"));
+	dialog.setNameFilter(tr("VST plugins (*.dll *.vst3)"));
 	if (path.length() > 0)
 		dialog.selectFile(fileInfo.fileName());
 	if (dialog.exec() == QDialog::Accepted)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ After that, the project will focus on:
 ## Features
 
 - Double-precision internal audio processing for complex filter chains.
-- Convolution, GraphicEQ, parametric EQ, VST, and standard Equalizer APO filter support.
+- Convolution, GraphicEQ, parametric EQ, VST2/VST3, and standard Equalizer APO filter support.
+- Native VST3 hosting through the Steinberg VST3 SDK (MIT-licensed pluginterfaces), with 64-bit (double) processing where the plug-in supports it.
 - x64 SIMD builds for AVX2, AVX-512, and AVX10.1 in CI.
 - ARM64 build support with native dependency builds.
 - AOCL-FFTW, libsndfile, muparserx, TCLAP, and Qt-based GUI tools.

--- a/helpers/AbstractLibrary.cpp
+++ b/helpers/AbstractLibrary.cpp
@@ -42,7 +42,7 @@ int AbstractLibrary::initialize()
 {
 	if (module == nullptr)
 	{
-		wstring libPath = getLibPath();
+		wstring libPath = getLoadPath();
 		if (GetFileAttributesW(libPath.c_str()) == INVALID_FILE_ATTRIBUTES)
 			return FILE_NOT_FOUND;
 		module = LoadLibraryW(libPath.c_str());
@@ -84,6 +84,13 @@ int AbstractLibrary::customInitialize()
 {
 	// overwrite if needed
 	return 0;
+}
+
+wstring AbstractLibrary::getLoadPath()
+{
+	// By default the load path equals the library path. Subclasses such as
+	// VSTPluginLibrary override this to resolve the binary inside a .vst3 bundle.
+	return getLibPath();
 }
 
 unsigned short AbstractLibrary::getFileArchitecture(const wstring& filePath)

--- a/helpers/AbstractLibrary.h
+++ b/helpers/AbstractLibrary.h
@@ -33,6 +33,7 @@ public:
 
 	int initialize();
 	virtual std::wstring getLibPath() = 0;
+	virtual std::wstring getLoadPath();
 
 protected:
 	virtual bool loadFunctions() = 0;

--- a/helpers/VST3PluginIIDs.cpp
+++ b/helpers/VST3PluginIIDs.cpp
@@ -1,0 +1,14 @@
+#include "stdafx.h"
+
+#define INIT_CLASS_IID
+#include "pluginterfaces/base/funknown.h"
+#include "pluginterfaces/base/ipluginbase.h"
+#include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/gui/iplugview.h"
+#include "pluginterfaces/vst/ivstaudioprocessor.h"
+#include "pluginterfaces/vst/ivstcomponent.h"
+#include "pluginterfaces/vst/ivsteditcontroller.h"
+#include "pluginterfaces/vst/ivstevents.h"
+#include "pluginterfaces/vst/ivsthostapplication.h"
+#include "pluginterfaces/vst/ivstmessage.h"
+#include "pluginterfaces/vst/ivstparameterchanges.h"

--- a/helpers/VSTPluginInstance.cpp
+++ b/helpers/VSTPluginInstance.cpp
@@ -19,29 +19,218 @@
 
 #include "stdafx.h"
 #include <wincrypt.h>
-#include <vector>
-#include "LogHelper.h"
+#include <inttypes.h>
 #include "StringHelper.h"
 #include "../Version.h"
 #include "VSTPluginLibrary.h"
 #include "VSTPluginInstance.h"
+#include "pluginterfaces/base/futils.h"
 
-using std::find;
-using std::max;
-using std::string;
-using std::vector;
-using std::wstring;
+using namespace std;
+using namespace Steinberg;
+using namespace Steinberg::Vst;
 
 #define equalizerApoVSTID VST_FOURCC('E', 'A', 'P', 'O');
 
 vst_time_info vstTime{ 0,0,0,0,0,0,0,0,0,0,{0}, 0xFFFF };
 
+class VSTPluginInstance::VST3MemoryStream : public IBStream
+{
+public:
+	VST3MemoryStream() {}
+	VST3MemoryStream(const vector<char>& data) : data(data) {}
+
+	tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override
+	{
+		QUERY_INTERFACE(iid, obj, FUnknown::iid, IBStream)
+		QUERY_INTERFACE(iid, obj, IBStream::iid, IBStream)
+		*obj = NULL;
+		return kNoInterface;
+	}
+
+	uint32 PLUGIN_API addRef() override { return InterlockedIncrement(&refCount); }
+	uint32 PLUGIN_API release() override
+	{
+		uint32 result = InterlockedDecrement(&refCount);
+		if (result == 0)
+			delete this;
+		return result;
+	}
+
+	tresult PLUGIN_API read(void* buffer, int32 numBytes, int32* numBytesRead = nullptr) override
+	{
+		int32 available = (int32)min<size_t>(numBytes, data.size() - min<size_t>(position, data.size()));
+		if (available > 0)
+			memcpy(buffer, data.data() + position, available);
+		position += available;
+		if (numBytesRead != NULL)
+			*numBytesRead = available;
+		return kResultOk;
+	}
+
+	tresult PLUGIN_API write(void* buffer, int32 numBytes, int32* numBytesWritten = nullptr) override
+	{
+		if (numBytes <= 0)
+		{
+			if (numBytesWritten != NULL)
+				*numBytesWritten = 0;
+			return kResultOk;
+		}
+		if (position + numBytes > data.size())
+			data.resize(position + numBytes);
+		memcpy(data.data() + position, buffer, numBytes);
+		position += numBytes;
+		if (numBytesWritten != NULL)
+			*numBytesWritten = numBytes;
+		return kResultOk;
+	}
+
+	tresult PLUGIN_API seek(int64 pos, int32 mode, int64* result = nullptr) override
+	{
+		int64 newPosition = 0;
+		if (mode == kIBSeekSet)
+			newPosition = pos;
+		else if (mode == kIBSeekCur)
+			newPosition = (int64)position + pos;
+		else if (mode == kIBSeekEnd)
+			newPosition = (int64)data.size() + pos;
+		if (newPosition < 0)
+			newPosition = 0;
+		position = (size_t)newPosition;
+		if (position > data.size())
+			data.resize(position);
+		if (result != NULL)
+			*result = (int64)position;
+		return kResultOk;
+	}
+
+	tresult PLUGIN_API tell(int64* pos) override
+	{
+		if (pos == NULL)
+			return kInvalidArgument;
+		*pos = (int64)position;
+		return kResultOk;
+	}
+
+	const vector<char>& getData() const { return data; }
+
+private:
+	volatile LONG refCount = 1;
+	vector<char> data;
+	size_t position = 0;
+};
+
+class EmptyVST3ParameterChanges : public IParameterChanges
+{
+public:
+	tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override
+	{
+		QUERY_INTERFACE(iid, obj, FUnknown::iid, IParameterChanges)
+		QUERY_INTERFACE(iid, obj, IParameterChanges::iid, IParameterChanges)
+		*obj = NULL;
+		return kNoInterface;
+	}
+
+	uint32 PLUGIN_API addRef() override { return 2; }
+	uint32 PLUGIN_API release() override { return 1; }
+	int32 PLUGIN_API getParameterCount() override { return 0; }
+	IParamValueQueue* PLUGIN_API getParameterData(int32) override { return NULL; }
+	IParamValueQueue* PLUGIN_API addParameterData(const ParamID&, int32& index) override
+	{
+		index = -1;
+		return NULL;
+	}
+};
+
+class EmptyVST3EventList : public IEventList
+{
+public:
+	tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override
+	{
+		QUERY_INTERFACE(iid, obj, FUnknown::iid, IEventList)
+		QUERY_INTERFACE(iid, obj, IEventList::iid, IEventList)
+		*obj = NULL;
+		return kNoInterface;
+	}
+
+	uint32 PLUGIN_API addRef() override { return 2; }
+	uint32 PLUGIN_API release() override { return 1; }
+	int32 PLUGIN_API getEventCount() override { return 0; }
+	tresult PLUGIN_API getEvent(int32, Event&) override { return kInvalidArgument; }
+	tresult PLUGIN_API addEvent(Event&) override { return kResultFalse; }
+};
+
+static EmptyVST3ParameterChanges emptyVST3ParameterChanges;
+static EmptyVST3EventList emptyVST3EventList;
+
+class VSTPluginInstance::VST3HostContext : public IHostApplication, public IComponentHandler, public IPlugFrame
+{
+public:
+	VST3HostContext(VSTPluginInstance* instance) : instance(instance) {}
+
+	tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override
+	{
+		QUERY_INTERFACE(iid, obj, FUnknown::iid, IHostApplication)
+		QUERY_INTERFACE(iid, obj, IHostApplication::iid, IHostApplication)
+		QUERY_INTERFACE(iid, obj, IComponentHandler::iid, IComponentHandler)
+		QUERY_INTERFACE(iid, obj, IPlugFrame::iid, IPlugFrame)
+		*obj = NULL;
+		return kNoInterface;
+	}
+
+	uint32 PLUGIN_API addRef() override { return InterlockedIncrement(&refCount); }
+	uint32 PLUGIN_API release() override
+	{
+		uint32 result = InterlockedDecrement(&refCount);
+		if (result == 0)
+			delete this;
+		return result;
+	}
+
+	tresult PLUGIN_API getName(String128 name) override
+	{
+		wcsncpy_s((wchar_t*)name, 128, L"Equalizer APO", _TRUNCATE);
+		return kResultOk;
+	}
+
+	tresult PLUGIN_API createInstance(TUID, TUID, void**) override
+	{
+		return kNoInterface;
+	}
+
+	tresult PLUGIN_API beginEdit(ParamID) override { return kResultOk; }
+	tresult PLUGIN_API performEdit(ParamID, ParamValue) override
+	{
+		if (instance != NULL)
+			instance->onAutomate();
+		return kResultOk;
+	}
+	tresult PLUGIN_API endEdit(ParamID) override { return kResultOk; }
+	tresult PLUGIN_API restartComponent(int32) override { return kResultOk; }
+
+	tresult PLUGIN_API resizeView(IPlugView* view, ViewRect* newSize) override
+	{
+		if (view != NULL && newSize != NULL)
+		{
+			view->onSize(newSize);
+			if (instance != NULL)
+				instance->onSizeWindow(newSize->getWidth(), newSize->getHeight());
+		}
+		return kResultOk;
+	}
+
+private:
+	volatile LONG refCount = 1;
+	VSTPluginInstance* instance;
+};
+
 static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t index, int64_t value, const char* ptr, float opt)
 {
-	VSTPluginInstance* instance = effect != nullptr ? static_cast<VSTPluginInstance*>(effect->host_internal) : nullptr;
+	VSTPluginInstance* instance = effect != NULL ? (VSTPluginInstance*)effect->host_internal : NULL;
 #ifdef _DEBUG
-	TraceFStatic(L"vst: %p opcode: %d index: %d value: %Id ptr: %p opt: %f host_internal: %p",
-		effect, opcode, index, value, ptr, opt, effect != nullptr ? effect->host_internal : nullptr);
+	printf("vst: %p opcode: %d index: %d value: %" PRIdPTR " ptr: %p opt: %f host_internal: %p\n",
+		effect, opcode, index, value, ptr, opt, effect != NULL ? effect->host_internal : NULL);
+	fflush(stdout);
 #endif
 
 	switch (opcode)
@@ -53,43 +242,43 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 		return equalizerApoVSTID;
 
 	case VST_EFFECT_OPCODE_PRODUCT_NAME:
-		strcpy_s(const_cast<char*>(ptr), 64, "Equalizer APO");
+		strcpy_s((char*) ptr, 64, "Equalizer APO");
 		return 1;
 
 	case VST_EFFECT_OPCODE_VENDOR_VERSION:
 		return (intptr_t) (MAJOR << 24 | MINOR << 16 | REVISION << 8 | 0);
 
 	case VST_HOST_OPCODE_PIN_CONNECTED:
-		if (instance != nullptr)
+		if (instance != NULL)
 			return index < instance->getUsedChannelCount() ? 0 : 1;
 		else
 			return 0;
 
 	case VST_HOST_OPCODE_IO_NEED_IDLE:
-		return effect != nullptr ? effect->control(effect, VST_HOST_OPCODE_KEEPALIVE_OR_IDLE, 0, 0, nullptr, 0.0f) : 0;
+		return effect != NULL ? effect->control(effect, VST_HOST_OPCODE_KEEPALIVE_OR_IDLE, 0, 0, NULL, 0.0f) : 0;
 
 	case VST_HOST_OPCODE_EDITOR_UPDATE:
-		return effect != nullptr ? effect->control(effect, VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, nullptr, 0.0f) : 0;
+		return effect != NULL ? effect->control(effect, VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, NULL, 0.0f) : 0;
 
 	case VST_HOST_OPCODE_GET_TIME:
-		if (instance != nullptr) {
+		if (instance != NULL) {
 			vstTime.sampleRate = instance->getSampleRate();
 			return (intptr_t)&vstTime;
 		}
 		return 0;
 
 	case VST_HOST_OPCODE_GET_SAMPLE_RATE:
-		if (instance != nullptr)
+		if (instance != NULL)
 			return (intptr_t)instance->getSampleRate();
 		return 0;
 
 	case VST_HOST_OPCODE_GET_ACTIVE_THREAD:
-		if (instance != nullptr)
+		if (instance != NULL)
 			return instance->getProcessLevel();
 		return 0;
 
 	case VST_HOST_OPCODE_LANGUAGE:
-		if (instance != nullptr)
+		if (instance != NULL)
 			return instance->getLanguage();
 		return 0;
 
@@ -97,18 +286,19 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 		return 1;
 
 	case VST_HOST_OPCODE_EDITOR_RESIZE:
-		if (instance != nullptr)
+		if (instance != NULL)
 		{
-			instance->onSizeWindow(static_cast<int>(index), static_cast<int>(value));
+			instance->onSizeWindow((int)index, (int)value);
 			return 0;
 		}
 		return 1;
 
 	case VST_HOST_OPCODE_SUPPORTS:
 		{
-			const char* s = ptr;
+			char* s = (char*)ptr;
 #ifdef _DEBUG
-			TraceFStatic(L"VST canDo: %S", s);
+			printf("VST canDo: %s\n", s);
+			fflush(stdout);
 #endif
 			if (strcmp(s, "startStopProcess") == 0 ||
 				strcmp(s, "sizeWindow") == 0)
@@ -117,7 +307,7 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 		return 0;
 
 	case VST_HOST_OPCODE_AUTOMATE:
-		if (instance != nullptr)
+		if (instance != NULL)
 			instance->onAutomate();
 		return 0;
 
@@ -131,6 +321,30 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 	return 0;
 }
 
+static BOOL CALLBACK showChildWindow(HWND hWnd, LPARAM)
+{
+	ShowWindow(hWnd, SW_SHOW);
+	return TRUE;
+}
+
+static const wchar_t* vst3EditorHostWindowClass = L"EqualizerAPOVST3EditorHost";
+
+static void registerVST3EditorHostWindowClass()
+{
+	static bool registered = false;
+	if (registered)
+		return;
+
+	WNDCLASSW wc;
+	memset(&wc, 0, sizeof(wc));
+	wc.lpfnWndProc = DefWindowProcW;
+	wc.hInstance = GetModuleHandleW(NULL);
+	wc.lpszClassName = vst3EditorHostWindowClass;
+	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+	RegisterClassW(&wc);
+	registered = true;
+}
+
 VSTPluginInstance::VSTPluginInstance(const std::shared_ptr<VSTPluginLibrary>& library, int processLevel)
 	: library(library), processLevel(processLevel)
 {
@@ -138,14 +352,24 @@ VSTPluginInstance::VSTPluginInstance(const std::shared_ptr<VSTPluginLibrary>& li
 
 VSTPluginInstance::~VSTPluginInstance()
 {
-	if (effect != nullptr)
+	automateFunc = nullptr;
+	sizeWindowFunc = nullptr;
+	releaseVST3();
+	if (effect != NULL)
 	{
-		effect->control(effect, VST_EFFECT_OPCODE_DESTROY, 0, 0, nullptr, 0.0f);
-		effect = nullptr;
+		effect->control(effect, VST_EFFECT_OPCODE_DESTROY, 0, 0, NULL, 0.0f);
+		effect = NULL;
 	}
 }
 
 bool VSTPluginInstance::initialize()
+{
+	if (library->isVST3())
+		return initializeVST3();
+	return initializeVST2();
+}
+
+bool VSTPluginInstance::initializeVST2()
 {
 	bool result = true;
 
@@ -155,13 +379,13 @@ bool VSTPluginInstance::initialize()
 		effect->host_internal = this;
 		if (effect->magic_number == VST_MAGICNUMBER)
 		{
-			effect->control(effect, VST_EFFECT_OPCODE_INITIALIZE, 0, 0, nullptr, 0.0f);
+			effect->control(effect, VST_EFFECT_OPCODE_INITIALIZE, 0, 0, NULL, 0.0f);
 
 			usedChannelCount = max(numInputs(), numOutputs());
 		}
 		else
 		{
-			effect = nullptr;
+			effect = NULL;
 		}
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
@@ -172,9 +396,81 @@ bool VSTPluginInstance::initialize()
 	return result;
 }
 
+bool VSTPluginInstance::initializeVST3()
+{
+	vst3HostContext = new VST3HostContext(this);
+
+	const PClassInfo& classInfo = library->getVST3ClassInfo();
+	FUID componentId(classInfo.cid);
+	TUID componentIid;
+	IComponent::iid.toTUID(componentIid);
+	if (library->getFactory()->createInstance(componentId, componentIid, (void**)&vst3Component) != kResultOk || vst3Component == NULL)
+		return false;
+
+	vst3Component->setIoMode(kSimple);
+	if (vst3Component->initialize(static_cast<IHostApplication*>(vst3HostContext)) != kResultOk)
+		return false;
+
+	TUID processorIid;
+	IAudioProcessor::iid.toTUID(processorIid);
+	if (vst3Component->queryInterface(processorIid, (void**)&vst3Processor) != kResultOk || vst3Processor == NULL)
+		return false;
+
+	TUID controllerClassId;
+	memset(controllerClassId, 0, sizeof(controllerClassId));
+	if (vst3Component->getControllerClassId(controllerClassId) == kResultOk)
+	{
+		TUID controllerIid;
+		IEditController::iid.toTUID(controllerIid);
+		library->getFactory()->createInstance(controllerClassId, controllerIid, (void**)&vst3Controller);
+	}
+	if (vst3Controller == NULL)
+	{
+		TUID controllerIid;
+		IEditController::iid.toTUID(controllerIid);
+		vst3Component->queryInterface(controllerIid, (void**)&vst3Controller);
+	}
+	if (vst3Controller != NULL)
+	{
+		vst3Controller->initialize(static_cast<IHostApplication*>(vst3HostContext));
+		vst3Controller->setComponentHandler(vst3HostContext);
+
+		VST3MemoryStream* stream = new VST3MemoryStream();
+		if (vst3Component->getState(stream) == kResultOk)
+		{
+			stream->seek(0, IBStream::kIBSeekSet);
+			vst3Controller->setComponentState(stream);
+		}
+		stream->release();
+
+		TUID connectionPointIid;
+		Steinberg::Vst::IConnectionPoint::iid.toTUID(connectionPointIid);
+		if (vst3Component->queryInterface(connectionPointIid, (void**)&vst3ComponentConnection) == kResultOk
+			&& vst3Controller->queryInterface(connectionPointIid, (void**)&vst3ControllerConnection) == kResultOk)
+		{
+			vst3ComponentConnection->connect(vst3ControllerConnection);
+			vst3ControllerConnection->connect(vst3ComponentConnection);
+		}
+	}
+
+	vst3InputBusCount = max(0, vst3Component->getBusCount(kAudio, kInput));
+	vst3OutputBusCount = max(0, vst3Component->getBusCount(kAudio, kOutput));
+	configureVST3Buses(2);
+
+	vst3SupportsDouble = vst3Processor->canProcessSampleSize(kSample64) == kResultOk;
+	if (!vst3SupportsDouble && vst3Processor->canProcessSampleSize(kSample32) != kResultOk)
+		return false;
+
+	usedChannelCount = max(numInputs(), numOutputs());
+
+	return true;
+}
+
 int VSTPluginInstance::numInputs() const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+		return vst3InputChannelCount;
+	if (effect == NULL)
 		return 0;
 
 	return effect->num_inputs;
@@ -182,7 +478,9 @@ int VSTPluginInstance::numInputs() const
 
 int VSTPluginInstance::numOutputs() const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+		return vst3OutputChannelCount;
+	if (effect == NULL)
 		return 0;
 
 	return effect->num_outputs;
@@ -190,7 +488,9 @@ int VSTPluginInstance::numOutputs() const
 
 bool VSTPluginInstance::canReplacing() const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+		return true;
+	if (effect == NULL)
 		return true;
 
 	return (effect->flags & VST_EFFECT_FLAG_SUPPORTS_FLOAT) != 0;
@@ -198,7 +498,14 @@ bool VSTPluginInstance::canReplacing() const
 
 int VSTPluginInstance::uniqueID() const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		const PClassInfo& classInfo = library->getVST3ClassInfo();
+		int result = 0;
+		memcpy(&result, classInfo.cid, sizeof(result));
+		return result;
+	}
+	if (effect == NULL)
 		return 0;
 
 	return effect->unique_id;
@@ -206,10 +513,13 @@ int VSTPluginInstance::uniqueID() const
 
 std::wstring VSTPluginInstance::getName() const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+		return StringHelper::toWString(library->getVST3ClassInfo().name, CP_UTF8);
+	if (effect == NULL)
 		return L"";
 
-	char buf[256] = {};
+	char buf[256];
+	memset(buf, 0, sizeof(buf));
 	effect->control(effect, VST_EFFECT_OPCODE_EFFECT_NAME, 0, 0, buf, 0.0f);
 	buf[255] = '\0'; // just to be sure
 
@@ -238,12 +548,16 @@ int VSTPluginInstance::getProcessLevel() const
 
 bool VSTPluginInstance::canDoubleReplacing() const
 {
+	if (library->isVST3())
+		return vst3SupportsDouble;
 	return (effect->flags & VST_EFFECT_FLAG_SUPPORTS_DOUBLE) != 0;
 }
 
 int VSTPluginInstance::getInitialDelay() const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+		return vst3Processor != NULL ? (int)vst3Processor->getLatencySamples() : 0;
+	if (effect == NULL)
 		return 0;
 
 	return effect->delay;
@@ -266,17 +580,71 @@ void VSTPluginInstance::setLanguage(int value)
 
 void VSTPluginInstance::prepareForProcessing(float sampleRate, int blockSize)
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3Processor == NULL || vst3Component == NULL)
+			return;
+
+		this->sampleRate = sampleRate;
+		configureVST3Buses(usedChannelCount > 0 ? usedChannelCount : max(vst3InputChannelCount, vst3OutputChannelCount));
+		ProcessSetup setup;
+		setup.processMode = kRealtime;
+		setup.symbolicSampleSize = vst3SupportsDouble ? kSample64 : kSample32;
+		setup.maxSamplesPerBlock = blockSize;
+		setup.sampleRate = sampleRate;
+		vst3Processor->setupProcessing(setup);
+		vst3SamplePosition = 0;
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
 	this->sampleRate = sampleRate;
-	effect->control(effect, VST_EFFECT_OPCODE_SET_SAMPLE_RATE, 0, 0, nullptr, sampleRate);
-	effect->control(effect, VST_EFFECT_OPCODE_SET_BLOCK_SIZE, 0, blockSize, nullptr, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_SET_SAMPLE_RATE, 0, 0, NULL, sampleRate);
+	effect->control(effect, VST_EFFECT_OPCODE_SET_BLOCK_SIZE, 0, blockSize, NULL, 0.0f);
 }
 
 void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::unordered_map<std::wstring, float>& paramMap)
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (chunkData != L"")
+		{
+			DWORD bufSize = 0;
+			CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, NULL, &bufSize, NULL, NULL);
+			vector<char> data(bufSize);
+			if (bufSize > 0 && CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, (BYTE*)data.data(), &bufSize, NULL, NULL) == TRUE)
+			{
+				VST3MemoryStream* stream = new VST3MemoryStream(data);
+				if (vst3Component != NULL)
+					vst3Component->setState(stream);
+				stream->seek(0, IBStream::kIBSeekSet);
+				if (vst3Controller != NULL)
+					vst3Controller->setState(stream);
+				stream->release();
+			}
+		}
+		else if (vst3Controller != NULL)
+		{
+			for (auto it : paramMap)
+			{
+				for (int32 i = 0; i < vst3Controller->getParameterCount(); i++)
+				{
+					ParameterInfo info;
+					if (vst3Controller->getParameterInfo(i, info) == kResultOk
+						&& it.first == wstring((wchar_t*)info.title))
+					{
+						vst3Controller->setParamNormalized(info.id, it.second);
+						break;
+					}
+				}
+			}
+		}
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
 	if (effect->flags & VST_EFFECT_FLAG_CHUNKS)
@@ -284,10 +652,11 @@ void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::
 		if (chunkData != L"")
 		{
 			DWORD bufSize = 0;
-			CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, nullptr, &bufSize, nullptr, nullptr);
-			vector<BYTE> buf(bufSize);
-			if (CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, buf.data(), &bufSize, nullptr, nullptr) == TRUE)
-				effect->control(effect, VST_EFFECT_OPCODE_SET_CHUNK_DATA, 1, bufSize, buf.data(), 0.0f);
+			CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, NULL, &bufSize, NULL, NULL);
+			BYTE* buf = new BYTE[bufSize];
+			if (CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, buf, &bufSize, NULL, NULL) == TRUE)
+				effect->control(effect, VST_EFFECT_OPCODE_SET_CHUNK_DATA, 1, bufSize, buf, 0.0f);
+			delete[] buf;
 		}
 	}
 	else
@@ -307,7 +676,39 @@ void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::
 
 void VSTPluginInstance::readFromEffect(std::wstring& chunkData, std::unordered_map<std::wstring, float>& paramMap) const
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		chunkData = L"";
+		paramMap.clear();
+
+		if (vst3Component != NULL)
+		{
+			VST3MemoryStream* stream = new VST3MemoryStream();
+			if (vst3Component->getState(stream) == kResultOk && !stream->getData().empty())
+			{
+				DWORD stringLength = 0;
+				CryptBinaryToStringW((BYTE*)stream->getData().data(), (DWORD)stream->getData().size(), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &stringLength);
+				wchar_t* string = new wchar_t[stringLength];
+				if (CryptBinaryToStringW((BYTE*)stream->getData().data(), (DWORD)stream->getData().size(), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, string, &stringLength) == TRUE)
+					chunkData = string;
+				delete[] string;
+			}
+			stream->release();
+		}
+
+		if (chunkData == L"" && vst3Controller != NULL)
+		{
+			for (int32 i = 0; i < vst3Controller->getParameterCount(); i++)
+			{
+				ParameterInfo info;
+				if (vst3Controller->getParameterInfo(i, info) == kResultOk)
+					paramMap[wstring((wchar_t*)info.title)] = (float)vst3Controller->getParamNormalized(info.id);
+			}
+		}
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
 	chunkData = L"";
@@ -315,13 +716,14 @@ void VSTPluginInstance::readFromEffect(std::wstring& chunkData, std::unordered_m
 
 	if (effect->flags & VST_EFFECT_FLAG_CHUNKS)
 	{
-		BYTE* chunk = nullptr;
-		int size = static_cast<int>(effect->control(effect, VST_EFFECT_OPCODE_GET_CHUNK_DATA, 1, 0, &chunk, 0.0f));
+		BYTE* chunk = NULL;
+		int size = (int)effect->control(effect, VST_EFFECT_OPCODE_GET_CHUNK_DATA, 1, 0, &chunk, 0.0f);
 		DWORD stringLength = 0;
-		CryptBinaryToStringW(chunk, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr, &stringLength);
-		vector<wchar_t> string(stringLength);
-		if (CryptBinaryToStringW(chunk, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, string.data(), &stringLength) == TRUE)
-			chunkData = string.data();
+		CryptBinaryToStringW(chunk, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &stringLength);
+		wchar_t* string = new wchar_t[stringLength];
+		if (CryptBinaryToStringW(chunk, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, string, &stringLength) == TRUE)
+			chunkData = string;
+		delete[] string;
 	}
 	else
 	{
@@ -338,16 +740,61 @@ void VSTPluginInstance::readFromEffect(std::wstring& chunkData, std::unordered_m
 
 void VSTPluginInstance::startProcessing()
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3Component != NULL && !vst3Active)
+		{
+			vst3Component->setActive(true);
+			vst3Active = true;
+		}
+		if (vst3Processor != NULL && !vst3Processing)
+		{
+			vst3Processor->setProcessing(true);
+			vst3Processing = true;
+		}
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_SUSPEND, 0, 1, nullptr, 0.0f);
-	effect->control(effect, VST_EFFECT_OPCODE_PROCESS_BEGIN, 0, 0, nullptr, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_SUSPEND, 0, 1, NULL, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_PROCESS_BEGIN, 0, 0, NULL, 0.0f);
 }
 
 void VSTPluginInstance::processReplacing(float** inputArray, float** outputArray, int frameCount)
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3Processor == NULL)
+			return;
+		AudioBusBuffers inputBuffers;
+		inputBuffers.numChannels = numInputs();
+		inputBuffers.channelBuffers32 = inputArray;
+		AudioBusBuffers outputBuffers;
+		outputBuffers.numChannels = numOutputs();
+		outputBuffers.channelBuffers32 = outputArray;
+		ProcessData data;
+		data.processMode = kRealtime;
+		data.symbolicSampleSize = kSample32;
+		data.numSamples = frameCount;
+		data.numInputs = vst3InputBusCount > 0 ? 1 : 0;
+		data.numOutputs = vst3OutputBusCount > 0 ? 1 : 0;
+		data.inputs = data.numInputs > 0 ? &inputBuffers : NULL;
+		data.outputs = data.numOutputs > 0 ? &outputBuffers : NULL;
+		data.inputParameterChanges = &emptyVST3ParameterChanges;
+		data.inputEvents = &emptyVST3EventList;
+		data.processContext = &vst3ProcessContext;
+		vst3ProcessContext.state = ProcessContext::kPlaying | ProcessContext::kContTimeValid;
+		vst3ProcessContext.sampleRate = sampleRate;
+		vst3ProcessContext.projectTimeSamples = vst3SamplePosition;
+		vst3ProcessContext.continousTimeSamples = vst3SamplePosition;
+		if (vst3Processor->process(data) == kResultOk)
+			vst3SamplePosition += frameCount;
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
 	effect->process_float(effect, inputArray, outputArray, frameCount);
@@ -355,7 +802,37 @@ void VSTPluginInstance::processReplacing(float** inputArray, float** outputArray
 
 void VSTPluginInstance::processDoubleReplacing(double** inputArray, double** outputArray, int frameCount)
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3Processor == NULL)
+			return;
+		AudioBusBuffers inputBuffers;
+		inputBuffers.numChannels = numInputs();
+		inputBuffers.channelBuffers64 = inputArray;
+		AudioBusBuffers outputBuffers;
+		outputBuffers.numChannels = numOutputs();
+		outputBuffers.channelBuffers64 = outputArray;
+		ProcessData data;
+		data.processMode = kRealtime;
+		data.symbolicSampleSize = kSample64;
+		data.numSamples = frameCount;
+		data.numInputs = vst3InputBusCount > 0 ? 1 : 0;
+		data.numOutputs = vst3OutputBusCount > 0 ? 1 : 0;
+		data.inputs = data.numInputs > 0 ? &inputBuffers : NULL;
+		data.outputs = data.numOutputs > 0 ? &outputBuffers : NULL;
+		data.inputParameterChanges = &emptyVST3ParameterChanges;
+		data.inputEvents = &emptyVST3EventList;
+		data.processContext = &vst3ProcessContext;
+		vst3ProcessContext.state = ProcessContext::kPlaying | ProcessContext::kContTimeValid;
+		vst3ProcessContext.sampleRate = sampleRate;
+		vst3ProcessContext.projectTimeSamples = vst3SamplePosition;
+		vst3ProcessContext.continousTimeSamples = vst3SamplePosition;
+		if (vst3Processor->process(data) == kResultOk)
+			vst3SamplePosition += frameCount;
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
 	effect->process_double(effect, inputArray, outputArray, frameCount);
@@ -363,7 +840,13 @@ void VSTPluginInstance::processDoubleReplacing(double** inputArray, double** out
 
 void VSTPluginInstance::process(float** inputArray, float** outputArray, int frameCount)
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		processReplacing(inputArray, outputArray, frameCount);
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
 	effect->process(effect, inputArray, outputArray, frameCount);
@@ -371,41 +854,146 @@ void VSTPluginInstance::process(float** inputArray, float** outputArray, int fra
 
 void VSTPluginInstance::stopProcessing()
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3Processor != NULL && vst3Processing)
+		{
+			vst3Processor->setProcessing(false);
+			vst3Processing = false;
+		}
+		if (vst3Component != NULL && vst3Active)
+		{
+			vst3Component->setActive(false);
+			vst3Active = false;
+		}
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_PROCESS_END, 0, 0, nullptr, 0.0f);
-	effect->control(effect, VST_EFFECT_OPCODE_SUSPEND, 0, 0, nullptr, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_PROCESS_END, 0, 0, NULL, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_SUSPEND, 0, 0, NULL, 0.0f);
 }
 
-void VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height)
+bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height)
 {
-	if (effect == nullptr)
-		return;
+	if (width != NULL)
+		*width = 400;
+	if (height != NULL)
+		*height = 300;
+
+	if (library->isVST3())
+	{
+		if (vst3Controller == NULL)
+			return false;
+		stopEditing();
+		vst3View = vst3Controller->createView(ViewType::kEditor);
+		if (vst3View == NULL)
+			return false;
+		vst3View->setFrame(vst3HostContext);
+		ViewRect rect;
+		if (vst3View->getSize(&rect) == kResultOk)
+		{
+			if (width != NULL)
+				*width = (short)max<int32>(1, rect.getWidth());
+			if (height != NULL)
+				*height = (short)max<int32>(1, rect.getHeight());
+		}
+		tresult platformResult = vst3View->isPlatformTypeSupported(kPlatformTypeHWND);
+		if (platformResult != kResultOk && platformResult != kNotImplemented)
+		{
+			stopEditing();
+			return false;
+		}
+		registerVST3EditorHostWindowClass();
+		vst3EditorHostWindow = CreateWindowExW(0, vst3EditorHostWindowClass, L"",
+			WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_VISIBLE,
+			0, 0, *width, *height, hWnd, NULL, GetModuleHandleW(NULL), NULL);
+		if (vst3EditorHostWindow == NULL)
+		{
+			stopEditing();
+			return false;
+		}
+		if (vst3View->attached(vst3EditorHostWindow, kPlatformTypeHWND) != kResultOk)
+		{
+			stopEditing();
+			return false;
+		}
+		if (vst3View->getSize(&rect) == kResultOk)
+		{
+			if (width != NULL)
+				*width = (short)max<int32>(1, rect.getWidth());
+			if (height != NULL)
+				*height = (short)max<int32>(1, rect.getHeight());
+			vst3View->onSize(&rect);
+		}
+		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, *width, *height, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+		EnumChildWindows(vst3EditorHostWindow, showChildWindow, 0);
+		return true;
+	}
+
+	if (effect == NULL)
+		return false;
 
 	vst_rect_t* rect;
 	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_GET_RECT, 0, 0, &rect, 0.0f);
 	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_OPEN, 0, 0, hWnd, 0.0f);
 	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_GET_RECT, 0, 0, &rect, 0.0f);
 
-	*width = rect->right - rect->left;
-	*height = rect->bottom - rect->top;
+	if (width != NULL)
+		*width = rect->right - rect->left;
+	if (height != NULL)
+		*height = rect->bottom - rect->top;
+	return true;
 }
 
 void VSTPluginInstance::doIdle()
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3EditorHostWindow != NULL)
+		{
+			InvalidateRect(vst3EditorHostWindow, NULL, FALSE);
+			UpdateWindow(vst3EditorHostWindow);
+			EnumChildWindows(vst3EditorHostWindow, [](HWND hWnd, LPARAM) -> BOOL {
+				InvalidateRect(hWnd, NULL, FALSE);
+				UpdateWindow(hWnd);
+				return TRUE;
+			}, 0);
+		}
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, nullptr, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, NULL, 0.0f);
 }
 
 void VSTPluginInstance::stopEditing()
 {
-	if (effect == nullptr)
+	if (library->isVST3())
+	{
+		if (vst3View != NULL)
+		{
+			vst3View->removed();
+			vst3View->setFrame(NULL);
+			vst3View->release();
+			vst3View = NULL;
+		}
+		if (vst3EditorHostWindow != NULL)
+		{
+			DestroyWindow(vst3EditorHostWindow);
+			vst3EditorHostWindow = NULL;
+		}
+		return;
+	}
+
+	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_CLOSE, 0, 0, nullptr, 0.0f);
+	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_CLOSE, 0, 0, NULL, 0.0f);
 }
 
 void VSTPluginInstance::setAutomateFunc(std::function<void()> func)
@@ -424,8 +1012,133 @@ void VSTPluginInstance::setSizeWindowFunc(std::function<void(int, int)> func)
 	sizeWindowFunc = func;
 }
 
+bool VSTPluginInstance::getEditorSize(int* width, int* height)
+{
+	(void)width;
+	(void)height;
+	return false;
+}
+
 void VSTPluginInstance::onSizeWindow(int w, int h)
 {
+	if (vst3EditorHostWindow != NULL)
+		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
 	if (sizeWindowFunc)
 		sizeWindowFunc(w, h);
+}
+
+void VSTPluginInstance::releaseVST3()
+{
+	if (!library->isVST3())
+		return;
+
+	automateFunc = nullptr;
+	sizeWindowFunc = nullptr;
+	stopEditing();
+	stopProcessing();
+
+	if (vst3Controller != NULL)
+		vst3Controller->setComponentHandler(NULL);
+
+	if (vst3ComponentConnection != NULL && vst3ControllerConnection != NULL)
+	{
+		vst3ComponentConnection->disconnect(vst3ControllerConnection);
+		vst3ControllerConnection->disconnect(vst3ComponentConnection);
+	}
+	if (vst3ComponentConnection != NULL)
+	{
+		vst3ComponentConnection->release();
+		vst3ComponentConnection = NULL;
+	}
+	if (vst3ControllerConnection != NULL)
+	{
+		vst3ControllerConnection->release();
+		vst3ControllerConnection = NULL;
+	}
+	if (vst3Controller != NULL)
+	{
+		vst3Controller->terminate();
+		vst3Controller->release();
+		vst3Controller = NULL;
+	}
+	if (vst3Processor != NULL)
+	{
+		vst3Processor->release();
+		vst3Processor = NULL;
+	}
+	if (vst3Component != NULL)
+	{
+		vst3Component->terminate();
+		vst3Component->release();
+		vst3Component = NULL;
+	}
+	if (vst3HostContext != NULL)
+	{
+		vst3HostContext->release();
+		vst3HostContext = NULL;
+	}
+}
+
+void VSTPluginInstance::configureVST3Buses(int requestedChannelCount)
+{
+	if (vst3Component == NULL || vst3Processor == NULL)
+		return;
+
+	int channelCount = max(1, requestedChannelCount);
+	SpeakerArrangement inputArrangement = speakerArrangementForChannelCount(channelCount);
+	SpeakerArrangement outputArrangement = speakerArrangementForChannelCount(channelCount);
+
+	if (inputArrangement == SpeakerArr::kEmpty || outputArrangement == SpeakerArr::kEmpty)
+	{
+		BusInfo busInfo;
+		memset(&busInfo, 0, sizeof(busInfo));
+		if (vst3InputBusCount > 0 && vst3Component->getBusInfo(kAudio, kInput, 0, busInfo) == kResultOk && busInfo.channelCount > 0)
+			inputArrangement = speakerArrangementForChannelCount(busInfo.channelCount);
+		if (vst3OutputBusCount > 0 && vst3Component->getBusInfo(kAudio, kOutput, 0, busInfo) == kResultOk && busInfo.channelCount > 0)
+			outputArrangement = speakerArrangementForChannelCount(busInfo.channelCount);
+	}
+
+	for (int i = 0; i < vst3InputBusCount; i++)
+		vst3Component->activateBus(kAudio, kInput, i, i == 0);
+	for (int i = 0; i < vst3OutputBusCount; i++)
+		vst3Component->activateBus(kAudio, kOutput, i, i == 0);
+
+	if (inputArrangement != SpeakerArr::kEmpty || outputArrangement != SpeakerArr::kEmpty)
+	{
+		vst3Processor->setBusArrangements(
+			vst3InputBusCount > 0 && inputArrangement != SpeakerArr::kEmpty ? &inputArrangement : NULL,
+			vst3InputBusCount > 0 && inputArrangement != SpeakerArr::kEmpty ? 1 : 0,
+			vst3OutputBusCount > 0 && outputArrangement != SpeakerArr::kEmpty ? &outputArrangement : NULL,
+			vst3OutputBusCount > 0 && outputArrangement != SpeakerArr::kEmpty ? 1 : 0);
+	}
+
+	BusInfo busInfo;
+	memset(&busInfo, 0, sizeof(busInfo));
+	if (vst3InputBusCount > 0 && vst3Component->getBusInfo(kAudio, kInput, 0, busInfo) == kResultOk)
+		vst3InputChannelCount = max(0, busInfo.channelCount);
+	if (vst3OutputBusCount > 0 && vst3Component->getBusInfo(kAudio, kOutput, 0, busInfo) == kResultOk)
+		vst3OutputChannelCount = max(0, busInfo.channelCount);
+}
+
+SpeakerArrangement VSTPluginInstance::speakerArrangementForChannelCount(int count) const
+{
+	switch (count)
+	{
+	case 1:
+		return SpeakerArr::kMono;
+	case 2:
+		return SpeakerArr::kStereo;
+	case 4:
+		return SpeakerArr::k40Music;
+	case 5:
+		return SpeakerArr::k50;
+	case 6:
+		return SpeakerArr::k51;
+	case 7:
+		return SpeakerArr::k61Cine;
+	case 8:
+		return SpeakerArr::k71Music;
+	default:
+		return SpeakerArr::kEmpty;
+	}
 }

--- a/helpers/VSTPluginInstance.h
+++ b/helpers/VSTPluginInstance.h
@@ -23,6 +23,15 @@
 #include <memory>
 #include <functional>
 #include "aeffectx.h"
+#include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/vst/ivstaudioprocessor.h"
+#include "pluginterfaces/vst/ivsteditcontroller.h"
+#include "pluginterfaces/vst/ivstevents.h"
+#include "pluginterfaces/vst/ivsthostapplication.h"
+#include "pluginterfaces/vst/ivstmessage.h"
+#include "pluginterfaces/vst/ivstparameterchanges.h"
+#include "pluginterfaces/vst/ivstprocesscontext.h"
+#include "pluginterfaces/gui/iplugview.h"
 
 class VSTPluginLibrary;
 
@@ -59,7 +68,7 @@ public:
 	void process(float** inputArray, float** outputArray, int frameCount);
 	void stopProcessing();
 
-	void startEditing(HWND hWnd, short* width, short* height);
+	bool startEditing(HWND hWnd, short* width, short* height);
 	void doIdle();
 	void stopEditing();
 
@@ -68,10 +77,37 @@ public:
 
 	void setSizeWindowFunc(std::function<void(int, int)> func);
 	void onSizeWindow(int w, int h);
+	bool getEditorSize(int* width, int* height);
 
 private:
+	class VST3HostContext;
+	class VST3MemoryStream;
+
+	bool initializeVST2();
+	bool initializeVST3();
+	void releaseVST3();
+	void configureVST3Buses(int requestedChannelCount);
+	Steinberg::Vst::SpeakerArrangement speakerArrangementForChannelCount(int count) const;
+
 	std::shared_ptr<VSTPluginLibrary> library;
-	vst_effect_t* effect = nullptr;
+	vst_effect_t* effect = NULL;
+	Steinberg::Vst::IComponent* vst3Component = NULL;
+	Steinberg::Vst::IAudioProcessor* vst3Processor = NULL;
+	Steinberg::Vst::IEditController* vst3Controller = NULL;
+	Steinberg::Vst::IConnectionPoint* vst3ComponentConnection = NULL;
+	Steinberg::Vst::IConnectionPoint* vst3ControllerConnection = NULL;
+	Steinberg::IPlugView* vst3View = NULL;
+	HWND vst3EditorHostWindow = NULL;
+	VST3HostContext* vst3HostContext = NULL;
+	int vst3InputBusCount = 0;
+	int vst3OutputBusCount = 0;
+	int vst3InputChannelCount = 0;
+	int vst3OutputChannelCount = 0;
+	bool vst3SupportsDouble = false;
+	bool vst3Active = false;
+	bool vst3Processing = false;
+	Steinberg::Vst::ProcessContext vst3ProcessContext = {};
+	Steinberg::Vst::TSamples vst3SamplePosition = 0;
 	std::function<void()> automateFunc;
 	std::function<void(int, int)> sizeWindowFunc;
 	float sampleRate = 0.0f;

--- a/helpers/VSTPluginLibrary.cpp
+++ b/helpers/VSTPluginLibrary.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of Equalizer APO, a system-wide equalizer.
     Copyright (C) 2017  Jonas Thedering
 
@@ -21,23 +21,12 @@
 #include "RegistryHelper.h"
 #include "LogHelper.h"
 #include "VSTPluginLibrary.h"
+#include "pluginterfaces/vst/ivstaudioprocessor.h"
 
-using std::find;
-using std::make_shared;
-using std::shared_ptr;
-using std::weak_ptr;
-using std::wstring;
+using namespace std;
 
 std::unordered_map<std::wstring, std::weak_ptr<VSTPluginLibrary>> VSTPluginLibrary::instanceMap;
 std::wstring VSTPluginLibrary::defaultPluginPath;
-
-struct VSTPluginLibrary::MakeSharedEnabler : VSTPluginLibrary
-{
-	MakeSharedEnabler(const wstring& libPath)
-		: VSTPluginLibrary(libPath)
-	{
-	}
-};
 
 std::shared_ptr<VSTPluginLibrary> VSTPluginLibrary::getInstance(const wstring& libPath)
 {
@@ -50,9 +39,9 @@ std::shared_ptr<VSTPluginLibrary> VSTPluginLibrary::getInstance(const wstring& l
 		ptr = instance.lock();
 	}
 
-	if (ptr == nullptr)
+	if (ptr == NULL)
 	{
-		ptr = make_shared<MakeSharedEnabler>(libPath);
+		ptr = shared_ptr<VSTPluginLibrary>(new VSTPluginLibrary(libPath));
 		instanceMap[libPath] = ptr;
 	}
 
@@ -75,14 +64,102 @@ std::wstring VSTPluginLibrary::getLibPath()
 	return libPath;
 }
 
+std::wstring VSTPluginLibrary::getLoadPath()
+{
+	return loadPath;
+}
+
+bool VSTPluginLibrary::isVST3() const
+{
+	return vst3;
+}
+
+Steinberg::IPluginFactory* VSTPluginLibrary::getFactory() const
+{
+	return factory;
+}
+
+const Steinberg::PClassInfo& VSTPluginLibrary::getVST3ClassInfo() const
+{
+	return vst3ClassInfo;
+}
+
 bool VSTPluginLibrary::loadFunctions()
 {
-	VSTPluginMain = (vstPluginMain)GetProcAddress(module, "VSTPluginMain");
+	if (vst3)
+	{
+		GetPluginFactory = (getPluginFactoryFunc)GetProcAddress(module, "GetPluginFactory");
+		return GetPluginFactory != NULL;
+	}
 
-	return VSTPluginMain != nullptr;
+	VSTPluginMain = (vstPluginMain)GetProcAddress(module, "VSTPluginMain");
+	return VSTPluginMain != NULL;
+}
+
+int VSTPluginLibrary::customInitialize()
+{
+	if (!vst3)
+		return 0;
+
+	factory = GetPluginFactory();
+	if (factory == NULL)
+		return FUNCTIONS_MISSING;
+
+	for (Steinberg::int32 i = 0; i < factory->countClasses(); i++)
+	{
+		Steinberg::PClassInfo info;
+		if (factory->getClassInfo(i, &info) == Steinberg::kResultOk
+			&& strcmp(info.category, kVstAudioEffectClass) == 0)
+		{
+			vst3ClassInfo = info;
+			return 0;
+		}
+	}
+
+	return FUNCTIONS_MISSING;
 }
 
 VSTPluginLibrary::VSTPluginLibrary(const wstring& libPath)
-	: libPath(libPath)
+	: libPath(libPath), loadPath(libPath)
 {
+	wchar_t extension[_MAX_EXT];
+	_wsplitpath_s(libPath.c_str(), NULL, 0, NULL, 0, NULL, 0, extension, _MAX_EXT);
+	vst3 = _wcsicmp(extension, L".vst3") == 0;
+	if (vst3)
+		loadPath = resolveVST3ModulePath(libPath);
+}
+
+wstring VSTPluginLibrary::resolveVST3ModulePath(const wstring& libPath)
+{
+	DWORD attributes = GetFileAttributesW(libPath.c_str());
+	if (attributes == INVALID_FILE_ATTRIBUTES || (attributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
+		return libPath;
+
+#if defined(_M_ARM64)
+	const wchar_t* platformDir = L"arm64-win";
+#elif defined(_WIN64)
+	const wchar_t* platformDir = L"x86_64-win";
+#else
+	const wchar_t* platformDir = L"x86-win";
+#endif
+
+	wchar_t searchPath[MAX_PATH];
+	wcscpy_s(searchPath, libPath.c_str());
+	PathAppendW(searchPath, L"Contents");
+	PathAppendW(searchPath, platformDir);
+	PathAppendW(searchPath, L"*.vst3");
+
+	WIN32_FIND_DATAW findData;
+	HANDLE hFind = FindFirstFileW(searchPath, &findData);
+	if (hFind == INVALID_HANDLE_VALUE)
+		return libPath;
+
+	wchar_t modulePath[MAX_PATH];
+	wcscpy_s(modulePath, libPath.c_str());
+	PathAppendW(modulePath, L"Contents");
+	PathAppendW(modulePath, platformDir);
+	PathAppendW(modulePath, findData.cFileName);
+	FindClose(hFind);
+
+	return modulePath;
 }

--- a/helpers/VSTPluginLibrary.h
+++ b/helpers/VSTPluginLibrary.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include "AbstractLibrary.h"
 #include "aeffectx.h"
+#include "pluginterfaces/base/ipluginbase.h"
 #include <queue>
 #include "VSTPluginInstance.h"
 
@@ -34,17 +35,28 @@ public:
 	static std::wstring getDefaultPluginPath();
 
 	std::wstring getLibPath() override;
+	std::wstring getLoadPath() override;
+	bool isVST3() const;
 
 	typedef vst_effect_t* (* vstPluginMain)(vst_host_callback_t audioMaster);
 	vstPluginMain VSTPluginMain;
+	typedef Steinberg::IPluginFactory* (PLUGIN_API* getPluginFactoryFunc)();
+	getPluginFactoryFunc GetPluginFactory;
+	Steinberg::IPluginFactory* getFactory() const;
+	const Steinberg::PClassInfo& getVST3ClassInfo() const;
 
 protected:
 	bool loadFunctions() override;
+	int customInitialize() override;
 
 private:
-	struct MakeSharedEnabler;
 	VSTPluginLibrary(const std::wstring& libPath);
+	static std::wstring resolveVST3ModulePath(const std::wstring& libPath);
 	static std::unordered_map<std::wstring, std::weak_ptr<VSTPluginLibrary>> instanceMap;
 	static std::wstring defaultPluginPath;
 	std::wstring libPath;
+	std::wstring loadPath;
+	bool vst3 = false;
+	Steinberg::IPluginFactory* factory = NULL;
+	Steinberg::PClassInfo vst3ClassInfo;
 };

--- a/setup-build.ps1
+++ b/setup-build.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
     This script:
     1. Downloads FFTW, muparserx, libsndfile from their GitHub release pages
-    2. Clones the TCLAP header-only library
+    2. Clones the TCLAP header-only library and the VST3 SDK pluginterfaces
     3. Installs Qt 6.10.1 via aqtinstall (Python)
 
     All sources match the project's CI workflow (.github/workflows/build.yml).
@@ -239,6 +239,24 @@ if (Test-Path (Join-Path $tclapDir "include")) {
     Write-Host "  -> $tclapDir"
 }
 
+# --- 2b. Clone VST3 SDK (pluginterfaces only) ---
+# VST3 hosting only needs the Steinberg pluginterfaces headers (COM-style interface
+# definitions + the IID instantiation unit). public.sdk / vstgui / samples are not
+# compiled, so we fetch just the pluginterfaces submodule. Pinned to the 3.8.0 tag,
+# which is the first MIT-licensed release (compatible with our GPLv2-or-later code).
+Write-Host "`n=== Step 2b: Clone VST3 SDK (pluginterfaces) ===" -ForegroundColor Yellow
+$vst3Tag = "v3.8.0_build_66"
+$vst3Dir = Join-Path $depsDir "vst3sdk"
+$vst3InterfacesDir = Join-Path $vst3Dir "pluginterfaces"
+if (Test-Path (Join-Path $vst3InterfacesDir "base\funknown.h")) {
+    Write-Host "  [cached] VST3 pluginterfaces already present"
+} else {
+    New-Item -ItemType Directory -Force -Path $vst3Dir | Out-Null
+    git clone --depth 1 --branch $vst3Tag https://github.com/steinbergmedia/vst3_pluginterfaces $vst3InterfacesDir
+    if ($LASTEXITCODE -ne 0) { throw "Failed to clone VST3 pluginterfaces" }
+    Write-Host "  -> $vst3InterfacesDir"
+}
+
 # --- 3. Install Qt ---
 if ($SkipQt) {
     Write-Host "`n=== Step 3: Qt Installation (SKIPPED) ===" -ForegroundColor Yellow
@@ -283,7 +301,8 @@ $checks = @(
     @{ Name = "muparserx header"; Path = "$depsDir\muparserx\parser\mpParser.h" },
     @{ Name = "libsndfile header"; Path = "$depsDir\libsndfile\include\sndfile.h" },
     @{ Name = "libsndfile lib";  Path = "$depsDir\libsndfile\build\Release\sndfile.lib" },
-    @{ Name = "TCLAP header";    Path = "$depsDir\tclap\include\tclap\CmdLine.h" }
+    @{ Name = "TCLAP header";    Path = "$depsDir\tclap\include\tclap\CmdLine.h" },
+    @{ Name = "VST3 pluginterfaces"; Path = "$depsDir\vst3sdk\pluginterfaces\base\funknown.h" }
 )
 
 # velopack_libc ships per-arch import libs/DLLs in a single zip; check the one we link.


### PR DESCRIPTION
## 요약

기존 VST2 호스트를 확장해 VST3 플러그인을 로드하고 처리합니다. [Mixomo/EqAPO64_with_VST3_support](https://github.com/Mixomo/EqAPO64_with_VST3_support) fork의 VST3 호스팅 구현을 우리 프로젝트(현대화된 빌드/Editor/멀티 SIMD/ARM64/Velopack) 위에 이식했습니다.

## 변경 내용

- **`helpers/VSTPluginLibrary`**: 확장자로 `.vst3`를 판별하고, `.vst3` 번들 디렉터리 내부의 실제 모듈 경로를 아키텍처별 `Contents` 경로(`arm64-win` 포함)에서 해석하며, `GetPluginFactory` 진입점을 로드합니다.
- **`helpers/VSTPluginInstance`**: 기존 VST2 경로는 그대로 두고, `initialize()`에서 분기되는 VST3 경로(IComponent / IAudioProcessor / IEditController 설정, 버스 구성, 32/64비트 처리, 에디터 호스팅)를 추가했습니다. 플러그인이 지원하면 64비트(double)로 처리합니다.
- **`helpers/VST3PluginIIDs.cpp`** (신규): Steinberg 인터페이스 IID를 단일 번역 단위에서 인스턴스화합니다.
- **`helpers/AbstractLibrary`**: 번들 내부 모듈 경로가 사용자에게 보이는 라이브러리 경로와 다를 수 있도록 `getLoadPath()`를 추가했습니다.
- **Editor**: 파일 선택 대화상자가 `*.dll`에 더해 `*.vst3`를 받습니다.
- **`filters/VSTPluginFilter`는 의도적으로 그대로 둡니다.** VST3는 기존 `VSTPluginInstance` API 뒤에서 투명하게 처리되므로, 프로젝트의 기존 delay/reverb 처리를 보존합니다.

## VST3 SDK 조달

헤더만 사용합니다. MIT 라이선스인 `pluginterfaces` 서브트리(VST 3.8.0, 676KB)만 `setup-build.ps1`과 CI에서 `deps/vst3sdk`로 받아옵니다. 다른 의존성과 동일하게 저장소에 커밋하지 않고 빌드 시점에 조달합니다. `public.sdk`/`vstgui` 소스는 컴파일하지 않으므로 BSD 구성요소를 재배포하지 않습니다.

## 라이선스

- VST3 SDK `pluginterfaces`: **MIT**(2025년 10월 VST 3.8.0부터). GPLv2·GPLv3 모두와 호환됩니다.
- 우리 소스 헤더는 기존대로 **GPLv2 or later**를 유지합니다. fork가 GPL3 LICENSE를 단 것은 SDK가 GPLv3-only이던 시절의 관성이며, MIT 전환 이후 GPL3로 올릴 필요가 없습니다.
- VST2 헤더(`helpers/aeffectx.h`)는 Steinberg 원본이 아니라 Xaymar Dirks의 클린룸 재구현본(BSD-2)이라 재배포 제약이 없습니다.

## 검증

Windows/Qt 빌드라 로컬 컴파일 검증은 불가능하며 CI에 의존합니다. 정합성 측면에서 확인한 사항:

- VST2 공통 경로는 우리 코드와 fork가 동일(원본 Jonas Thedering 코드, 리팩토링 없음)함을 함수별로 대조했습니다.
- 소멸자가 `releaseVST3()`로 VST3 COM 객체를 멱등적으로 해제하므로, Editor의 기존 `delete effect` 수명 관리가 VST3에서도 안전하고 누수가 없습니다.
- `PathAppendW`(Shlwapi)는 이미 `VSTPluginFilterFactory`/`IncludeFilterFactory`가 Common.lib에서 사용 중이라 새 링크 의존성이 추가되지 않습니다.
- MSBuild 쪽은 Common.vcxproj만, Qt 쪽은 Editor.pro만 VST3 include 경로가 필요함을 transitive include로 확인했습니다.

버전 bump(새 기능 → MINOR)는 CI 그린 확인 후 별도 커밋으로 처리할 예정입니다.

https://claude.ai/code/session_01XL7VwMnrkTer6gFZGJEvmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7VwMnrkTer6gFZGJEvmM)_