### PR TITLE
docs(wiki): add MediaWiki documentation in English and Korean

### DIFF
--- a/Wiki/wiki/en/Configuration_reference.mediawiki
+++ b/Wiki/wiki/en/Configuration_reference.mediawiki
@@ -1,0 +1,400 @@
+= Configuration reference =
+
+This page describes the configuration file format and the commands EqualizerAPO-XT understands. It is meant for advanced users. For an introduction or troubleshooting, see the [[Documentation|user documentation]]. XT keeps the original Equalizer APO syntax, so configurations written for upstream Equalizer APO work unchanged.
+
+__TOC__
+
+== Configuration file format ==
+
+Configuration files are read line by line. Each meaningful line has the form:
+
+<pre>Command: Parameters</pre>
+
+Any line that does not fit this shape is ignored silently, which is how comments work — a line starting with <code>#</code> is simply not a recognised command. Lines naming a command that does not exist are ignored as well.
+
+Example:
+
+<syntaxhighlight lang="ini">
+Device: High Definition Audio Device Speakers; Benchmark
+#All lines below will only be applied to the specified device and the benchmark application
+Preamp: -6 db
+Include: example.txt
+Filter  1: ON  PK       Fc     50 Hz   Gain  -3.0 dB  Q 10.00
+Filter  2: ON  PEQ      Fc     100 Hz  Gain   1.0 dB  BW Oct 0.167
+
+Channel: L
+#Additional preamp for left channel
+Preamp: -5 dB
+#Filters only for left channel
+Include: demo.txt
+Filter  1: ON  LS       Fc     300 Hz  Gain   5.0 dB
+
+Channel: 2 C
+#Filters for second(right) and center channel
+Filter  1: ON  HP       Fc     30 Hz
+Filter  2: ON  LPQ      Fc     10000 Hz  Q  0.400
+
+Device: Microphone
+#From here, the lines only apply to microphone devices
+Filter: ON  NO       Fc     50 Hz
+</syntaxhighlight>
+
+== Filtering commands ==
+
+These commands change the audio on the currently selected channels directly.
+
+=== Preamp ===
+
+'''Syntax:''' <code>Preamp: <Negative number> dB</code>
+
+Sets a preamplification value in decibels. Use it when filters add positive gain, to keep the signal from clipping. When several preamps apply to the same channel, the effective preamp is their sum in dB.
+
+<syntaxhighlight lang="ini">
+Preamp: -6.5 dB
+</syntaxhighlight>
+
+=== Filter ===
+
+'''Syntax:'''
+<pre>
+Filter <n>: ON <Type> Fc <Frequency> Hz Gain <Gain value> dB Q <Q value>
+Filter <n>: ON <Type> Fc <Frequency> Hz Gain <Gain value> dB BW Oct <Bandwidth value>
+</pre>
+
+Adds a filter of the given type, frequency, gain and Q / bandwidth. The first form (with Q) matches Room EQ Wizard's "Generic" equalizer type; the second (with bandwidth) matches "FBQ2496". The filter number <code><n></code> is not interpreted and may be omitted.
+
+The table below lists the supported filter types. In the parameter columns, '''X''' marks a required parameter and '''O''' an optional one. These cover every filter of the "Generic" and "FBQ2496" types; other equalizer types may also work if their text format matches. Note one difference: the band-pass filter here is a true band-pass with no gain (like the low/high-pass filters), unlike the DCX2496's "BP", which is really a peaking filter.
+
+{| class="wikitable"
+! Type !! Description !! Fc !! Gain !! Q/BW !! Example
+|-
+| PK<br>Modal<br>PEQ || Peaking filter (parametric EQ) || X || X || X || <code>ON PK Fc 50.0 Hz Gain -10.0 dB Q 2.50</code><br><code>ON Modal Fc 100 Hz Gain 3.0 dB Q 5.41 T60 target 100 ms</code><br><code>ON PEQ Fc 100 Hz Gain 1.0 dB BW Oct 0.167</code>
+|-
+| LP<br>LPQ || Low-pass filter || X || || O || <code>ON LP Fc 8000 Hz</code><br><code>ON LPQ Fc 10000 Hz Q 0.400</code>
+|-
+| HP<br>HPQ || High-pass filter || X || || O || <code>ON HP Fc 30.0 Hz</code><br><code>ON HPQ Fc 20.0 Hz Q 0.500</code>
+|-
+| BP || Band-pass filter (not from DCX2496) || X || || O || <code>ON BP Fc 1000 Hz Q 0.100</code>
+|-
+| LS<br>LSC ''x'' dB || Low-shelf filter (with centre freq.; ''x'' dB per octave for LSC) || X || X || O (1.2.1) || <code>ON LS Fc 300 Hz Gain 5.0 dB</code><br><code>ON LSC 10.8 dB Fc 300 Hz Gain 5.0 dB</code><br><code>ON LSC Fc 300 Hz Gain 5.0 dB Q 0.6473</code>
+|-
+| HS<br>HSC ''x'' dB || High-shelf filter (with centre freq.; ''x'' dB per octave for HSC) || X || X || O (1.2.1) || <code>ON HS Fc 1000 Hz Gain -3.0 dB</code><br><code>ON HSC 6 dB Fc 100 Hz Gain -6.0 dB</code><br><code>ON HSC Fc 100 Hz Gain -6.0 dB Q 0.4272</code>
+|-
+| LS 6dB<br>LS 12dB || Low-shelf filter (6 / 12 dB per octave, corner freq.) || X || X || || <code>ON LS 6dB Fc 50.0 Hz Gain 7.2 dB</code><br><code>ON LS 12dB Fc 2000 Hz Gain -5.0 dB</code>
+|-
+| HS 6dB<br>HS 12dB || High-shelf filter (6 / 12 dB per octave, corner freq.) || X || X || || <code>ON HS 6dB Fc 12000 Hz Gain 10.0 dB</code><br><code>ON HS 12dB Fc 500 Hz Gain 5.0 dB</code>
+|-
+| NO || Notch filter || X || || O || <code>ON NO Fc 800 Hz</code>
+|-
+| AP || All-pass filter || X || || X || <code>ON AP Fc 900 Hz Q 0.707</code>
+|}
+
+=== Filter with custom coefficients ===
+
+'''Syntax:''' <code>Filter <n>: ON IIR Order <m> Coefficients <b0> <b1> ... <bm> <a0> <a1> ... <am></code>
+
+Adds a generic IIR filter of the given order and coefficients. The number of coefficients must be <code>2·(order+1)</code>. The transfer function is shown below.
+
+[[File:Transfer function.png|none|frameless|IIR transfer function]]
+
+Because the coefficients usually depend on the sample rate, combine this with the [[#If / ElseIf / Else / EndIf|If]] command or [[#Eval and inline expressions|inline expressions]] to supply the right values for the current rate. You ''can'' reproduce the BiQuad filters of the other types this way, but it runs slower, so it is not advisable.
+
+<syntaxhighlight lang="ini">
+# A lowpass biquad filter with Fc 3000 Hz for the sample rate 48 kHz
+Filter: ON IIR Order 2 Coefficients 0.0380602 0.0761205 0.0380602 1.2706 -1.84776 0.729402
+</syntaxhighlight>
+
+=== Delay ===
+
+'''Syntax:'''
+<pre>
+Delay: <t> ms
+Delay: <n> samples
+</pre>
+
+Delays the selected channels by <code>t</code> milliseconds or <code>n</code> samples. Prefer milliseconds — they give the same delay regardless of sample rate.
+
+<syntaxhighlight lang="ini">
+# Delays the audio by 50.5 ms independent of sample rate
+Delay: 50.5 ms
+# Delays the audio by 480 samples (10 ms at 48 kHz)
+Delay: 480 samples
+</syntaxhighlight>
+
+=== Copy ===
+
+'''Syntax:'''
+<pre>
+Copy: <Target channel>=<Factor>*<Source channel>+...
+Copy: <Target channel>=<Source channel>+...
+Copy: <Target channel>=<Constant value>+...
+</pre>
+
+Replaces the target channel with the sum of the listed source channels, each with an optional factor. To add to the target instead of replacing it, include the target as one of the sources. A factor may be given in dB by appending <code>dB</code>. Several assignments can share one line if separated by spaces, so a single assignment must not contain spaces. A constant value can be used in place of a channel/factor; to keep it distinct from a numeric channel index, the constant must contain a decimal point. See the [[#Channel|Channel]] command for channel identifiers.
+
+<syntaxhighlight lang="ini">
+# Adds the audio on channel R multiplied by 0.5 to channel L
+Copy: L=L+0.5*R
+# Replaces L by R plus C attenuated by 6 dB
+Copy: L=R+-6dB*C
+# Replaces channel 1 by the audio previously on R, and sets R to the constant 0.5
+Copy: 1=R R=0.5
+# Attention: sets L to the audio on channel 2 (not the constant 2 — no decimal point)
+Copy: L=2
+# Replaces the LFE channel with the left channel while muting the rest of a 5.1 system
+Copy: LFE=L L=0.0 R=0.0 C=0.0 RL=0.0 RR=0.0
+</syntaxhighlight>
+
+=== GraphicEQ ===
+
+'''Syntax:''' <code>GraphicEQ: <Frequency> <Gain (dB)>; <Frequency> <Gain (dB)>; ...</code>
+
+Adds a graphic equalizer with the given bands and gains. Gains are interpolated linearly across the logarithmic frequency axis (so the curve looks straight in a log view), and the response is flat outside the specified bands.
+
+<syntaxhighlight lang="ini">
+# A 15-band graphic equalizer with ISO bands
+GraphicEQ: 25 6; 40 4.5; 63 3; 100 1.5; 160 0; 250 0; 400 0; 630 0; 1000 0; 1600 0; 2500 0; 4000 0; 6300 1.5; 10000 3; 16000 3
+</syntaxhighlight>
+
+=== Convolution ===
+
+'''Syntax:''' <code>Convolution: <File name></code>
+
+Adds a convolver that processes the signal with the impulse response in the named file. The file must be one of the formats supported by [https://libsndfile.github.io/libsndfile/ libsndfile] (WAV, FLAC, OGG and others). If it has several channels, they are mapped round-robin onto the selected channels (a stereo file across four channels maps L→1, R→2, L→3, R→4). '''The file's sample rate must match the device's sample rate''' or the convolver cannot be created. Latency and CPU cost depend on the length and phase of the impulse response (linear-phase costs half the file length in latency; minimum-phase is lower but inconsistent). The file name is relative to the configuration file, may be quoted, and may contain environment variables such as <code>%USERPROFILE%</code>. Impulse responses kept inside the config folder (or a subfolder) trigger an automatic reload when changed, so edits apply immediately. EqualizerAPO-XT removes the original length cap on impulse responses.
+
+<syntaxhighlight lang="ini">
+# Convolve with a recorded impulse response for a reverberation effect
+Convolution: church.wav
+</syntaxhighlight>
+
+== Control commands ==
+
+These do not change the audio directly; they control which commands run and how they apply.
+
+=== Include ===
+
+'''Syntax:''' <code>Include: <File name></code>
+
+Loads the named file as a configuration file. Splitting the actual filter definitions into a separate file (rather than editing <code>config.txt</code> directly) lets you, for example, set a preamp before pulling them in.
+
+<syntaxhighlight lang="ini">
+Include: example.txt
+</syntaxhighlight>
+
+=== Device ===
+
+'''Syntax:''' <code>Device: <Device pattern 1>; <Device pattern 2>; ...</code>
+
+Matches the pattern against the connection name, device name and GUID of the current output device. If it does not match, every following command except another <code>Device</code> is ignored. A pattern is a set of space-separated words that must all appear in the string "''Device_name Connection_name GUID''". Separate alternative patterns with <code>;</code>, of which one must match. The special pattern <code>all</code> always matches. The benchmark application reports device name "Benchmark" and connection "File output". The easiest way to produce a correct <code>Device</code> line is the button in the Device Selector.
+
+<syntaxhighlight lang="ini">
+# Matches "High Definition Audio Device" with connection "Speakers",
+# and also "Benchmark" used by the benchmark application
+Device: High Definition Audio Device Speakers; Benchmark
+</syntaxhighlight>
+
+=== Channel ===
+
+'''Syntax:''' <code>Channel: <Channel position 1> <Channel position 2> ...</code>
+
+Selects the channels that following <code>Filter</code> and <code>Preamp</code> commands apply to. Positions may be given by identifier (a 1–3 letter acronym) or by number (counted from 1). The supported configurations are listed below; for an unsupported configuration, channels can only be selected by number. Separate several channels with spaces. The special position <code>all</code> selects every channel.
+
+{| class="wikitable"
+! Configuration !! L !! R !! C !! LFE !! RL !! RR !! RC !! SL !! SR
+|-
+| Mono || || || 1 || || || || || ||
+|-
+| Stereo || 1 || 2 || || || || || || ||
+|-
+| Quadraphonic || 1 || 2 || || || 3 || 4 || || ||
+|-
+| Surround || 1 || 2 || 3 || || || || 4 || ||
+|-
+| 5.1 Surround || 1 || 2 || 3 || 4 || || || || 5 || 6
+|-
+| 5.1 Surround (alt.) || 1 || 2 || 3 || 4 || 5 || 6 || || ||
+|-
+| 7.1 Surround || 1 || 2 || 3 || 4 || 5 || 6 || || 7 || 8
+|}
+
+'''Attention:''' it is tempting to send low-frequency filters only to the LFE channel, but this often does not work as expected. Many systems apply bass redirection ''after'' Equalizer APO, so LFE-only filters miss the redirected sound; and because crossover filters fade in gradually, low frequencies may play across several speakers, not just the subwoofer. '''Apply low-frequency filters to all channels''' to avoid this.
+
+<syntaxhighlight lang="ini">
+# Selects the left channel and the rear left channel
+Channel: L RL
+# Selects the first, second and center channel
+Channel: 1 2 C
+</syntaxhighlight>
+
+=== Stage ===
+
+'''Syntax:''' <code>Stage: <stage 1> <stage 2></code>
+
+Chooses which stage(s) the following filtering commands run on. Output devices have two stages, '''pre-mix''' and '''post-mix'''; input devices have only '''capture'''.
+
+[[File:Stages.png|none|frameless|500px|Pre-mix and post-mix stages of an output device]]
+
+The selected stages start as post-mix and capture, so filtering runs exactly once for output and input devices. Post-mix is preferred over pre-mix because pre-mix filtering happens per-application and costs more CPU. Pre-mix is needed for specific tasks such as upmixing, where filtering must depend on the number of input channels.
+
+<syntaxhighlight lang="ini">
+Stage: pre-mix
+# do upmixing
+If: inputChannelCount == 2
+# note that there may be audio on SL, SR from another APO
+Copy: SL=SL+L SR=SR+R
+EndIf:
+# ...
+Stage: post-mix
+# do room correction
+# ...
+</syntaxhighlight>
+
+== Expression commands ==
+
+These commands use expressions to vary the processing at runtime. Expressions are a tiny embedded language whose syntax is closer to scripting languages, built from constants, variables, operators and functions.
+
+'''Constants:'''
+
+{| class="wikitable"
+! Name !! Description
+|-
+| e, pi || Mathematical constants
+|-
+| inputChannelCount || Number of channels input to the current APO stage
+|-
+| outputChannelCount || Number of channels output from the current APO stage
+|-
+| sampleRate || Sample rate (Hz) of the audio being processed
+|-
+| deviceName || Name of the audio device
+|-
+| connectionName || Name of the connection on the audio device
+|-
+| deviceGuid || GUID of the audio device endpoint
+|-
+| stage || Current APO stage (pre-mix, post-mix or capture)
+|}
+
+'''Variables:''' user-defined variables, valid while the configuration loads, are created with the assignment operator (<code>=</code>). They are not kept between reloads; they only carry temporary values for use later in the same file.
+
+'''Operators:'''
+
+{| class="wikitable"
+! Name !! Description
+|-
+| <code>+ - * / ^</code> || Arithmetic operators
+|-
+| <code>= += -= *= /=</code> || Assignment operators
+|-
+| <code>and or xor</code> || Logical operators
+|-
+| <code>== != < > <= >=</code> || Comparison operators
+|-
+| <code>& | << >></code> || Bit-wise / bit-shift operators
+|-
+| <code>+</code> || String concatenation (at least one operand must be a string)
+|-
+| <code>(float) (int)</code> || Type conversion (from a numeric type)
+|-
+| <code>condition ? then : else</code> || Conditional (ternary) operator
+|-
+| <code>{1,2}</code> || Array creation
+|-
+| <code>array[0]</code> || Array access
+|}
+
+'''Functions:'''
+
+{| class="wikitable"
+! Name !! Description
+|-
+| abs || Absolute value
+|-
+| sin, cos, tan,<br>sinh, cosh, tanh || Trigonometric functions
+|-
+| ln, log, log10, exp || Logarithmic / exponential functions
+|-
+| sqrt || Square root
+|-
+| min, max, sum || Minimum / maximum / sum of arguments
+|-
+| str2dbl || String to float
+|-
+| strlen || Length of a string
+|-
+| tolower, toupper || Lower / upper case conversion
+|-
+| sizeof || Length of an array
+|-
+| regexSearch || First match of a regular expression (first argument) in a string (second). Empty if no match; otherwise an array whose first value is the whole match and whose further values are capturing groups.
+|-
+| regexReplace || Replaces every match of a regular expression (first argument) in a string (second) with a string (third). Returns the result string.
+|-
+| readRegString || Reads a string value (second argument) from a registry key (first). Monitors the key and reloads on change.
+|-
+| readRegDWORD || Reads an integer value (second argument) from a registry key (first). Monitors the key and reloads on change.
+|}
+
+The expression types are string, boolean, int, float and matrix/array (abbreviated ''s'', ''b'', ''i'', ''f'', ''m'' in error messages). String constants use double quotes; backslashes and quotes inside them are escaped with a backslash. Booleans are <code>true</code> / <code>false</code>. Numbers use no thousands separator and a point for the decimal. Arrays use the <code>{}</code> operator. Combine several expressions with semicolons; the result is the value of the last one.
+
+<syntaxhighlight lang="ini">
+# User-defined variables
+Eval: a=0; b=pi
+# Comparison
+Eval: a > b ? "a is larger" : "b is larger"
+# Trigonometric functions and the exponentiation operator
+Eval: sin(a)^2 + cos(a)^2 == 1
+# Matching the device name with a regular expression
+Eval: a=regexSearch("High Definition .*", deviceName); sizeof(a) > 0 ? "found" : "not found"
+# Reading the configuration path from the registry
+Eval: readRegString("HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO", "ConfigPath")
+</syntaxhighlight>
+
+=== If / ElseIf / Else / EndIf ===
+
+'''Syntax:'''
+<pre>
+If: <expression>
+ElseIf: <expression>
+Else:
+EndIf:
+</pre>
+
+Runs the commands between <code>If</code> and <code>EndIf</code> conditionally, like an if/else statement. <code>If</code> evaluates its expression as a boolean and runs the following commands when it is true. <code>ElseIf</code> after a branch that was already true is skipped; otherwise its expression is evaluated and its block runs when true. <code>Else</code> behaves like an <code>ElseIf</code> that is always true. <code>EndIf</code> ends the block. Conditionals can be nested, and <code>ElseIf</code>/<code>Else</code> always bind to the nearest open <code>If</code>. Lines may be indented for readability. For technical reasons, <code>If</code> cannot be used to run <code>Device</code> commands conditionally, because <code>Device</code> has higher priority.
+
+<syntaxhighlight lang="ini">
+If: sampleRate == 44100
+	...
+ElseIf: sampleRate == 48000
+	...
+	If: inputChannelCount == 1
+		...
+	ElseIf: inputChannelCount == 2
+		...
+	EndIf:
+Else:
+	...
+EndIf:
+</syntaxhighlight>
+
+=== Eval and inline expressions ===
+
+'''Syntax:'''
+<pre>
+Eval: <expression>
+<Command>: ... `<expression>` ...
+</pre>
+
+<code>Eval</code> evaluates an expression and discards the result; it is mainly for defining variables or testing. An '''inline expression''' embeds a result into a command's parameter string: everything from the first backtick to the second (inclusive) is replaced by the expression's value converted to a string. Inline expressions cannot be used in <code>Device</code> or <code>If</code>/<code>ElseIf</code> commands, but they can be used inside <code>Eval</code>.
+
+<syntaxhighlight lang="ini">
+# Specify gain linearly
+Eval: linGain = 0.5
+Filter: ON PK Fc 1000 Hz Gain `20*log10(linGain)` dB Q 10.0
+</syntaxhighlight>
+
+== See also ==
+
+* [[Documentation]] — installation, first configuration and troubleshooting.
+* [[Developer documentation]] — building XT and writing your own APO.
+* [[ko:Configuration reference|이 문서의 한국어판 (Korean)]]

--- a/Wiki/wiki/en/Developer_documentation.mediawiki
+++ b/Wiki/wiki/en/Developer_documentation.mediawiki
@@ -1,0 +1,56 @@
+= Developer documentation =
+
+This is the developer documentation for '''EqualizerAPO-XT'''. It is for people who want to review, build or experiment with the source, or write their own APO. If you only want to use the software, see the [[Documentation|user documentation]].
+
+''Disclaimer: this documentation is written to the best of our knowledge. It is neither complete nor guaranteed to be free of errors.''
+
+__TOC__
+
+== Building EqualizerAPO-XT ==
+
+XT is a Windows project. The C++ projects target the Visual Studio 2022 / 2026 toolset with the Windows 10 SDK; the GUI tools are built with Qt. The original Equalizer APO build expected libraries installed under <code>C:\Program Files</code>; XT instead keeps every dependency under a local <code>deps/</code> folder and provides a setup script that fetches them.
+
+=== Prerequisites ===
+
+* '''Visual Studio 2022 Build Tools''' (or 2026), including the components <code>Microsoft.VisualStudio.Component.VC.Tools.x86.x64</code> and <code>Microsoft.VisualStudio.Component.VC.ATL</code>. ATL is required — without it the <code>EqualizerAPO.dll</code> link step cannot find <code>atls.lib</code>. The XT projects build with the VS 2026 toolset <code>v145</code>; on a VS 2022 machine pass <code>/p:PlatformToolset=v143</code>.
+* '''Python 3''' — used to install Qt through <code>aqtinstall</code>.
+* '''Qt 6.10.1 (MSVC 2022 x64)''' — installed under <code>Qt/6.10.1/msvc2022_64/</code>. Needed by the Configuration Editor, the Device Selector and the Update Checker.
+* '''External libraries''' — '''not''' committed to the repository: [https://www.fftw.org/ FFTW], [https://libsndfile.github.io/libsndfile/ libsndfile], [https://github.com/beltoforion/muparserx muParserX], [http://tclap.sourceforge.net/ TCLAP], and the MIT-licensed Steinberg VST3 ''pluginterfaces''. They are placed under <code>deps/</code> at build time.
+* '''Velopack''' (<code>vpk</code> CLI, <code>dotnet tool install -g vpk</code>) — used only by CI to package the binaries into the <code>Setup.exe</code> / <code>.nupkg</code> artifacts. Local development does not need it.
+
+The script '''<code>setup-build.ps1</code>''' downloads the binary dependencies (per SIMD variant), clones the header-only libraries (TCLAP and the VST3 pluginterfaces), and installs Qt. See [https://github.com/115dkk/EqualizerAPO-XT/blob/main/setup-build.ps1 setup-build.ps1] and the in-repo <code>docs/LocalDependencySetup.md</code> for the exact layout and the MSBuild / qmake commands.
+
+=== Source code organization ===
+
+The solution <code>EqualizerAPO.sln</code> groups these projects:
+
+* '''Common''' — a static library with the filter engine (<code>FilterEngine</code>, <code>FilterConfiguration</code>, <code>IFilter</code>), the individual filter implementations under <code>filters/</code>, the muParserX extensions under <code>parser/</code>, and shared helpers under <code>helpers/</code>. The convolution code lives in <code>libHybridConv-0.1.1/</code>. The other projects link against it.
+* '''EqualizerAPO''' — the Audio Processing Object DLL (<code>EqualizerAPO.dll</code>). It contains the COM boilerplate, implements the APO interfaces, and calls into the Common filter engine. Being ATL-based, it needs <code>atls.lib</code>.
+* '''Editor''' — the Qt-based Configuration Editor. <code>Editor.exe</code> is the Velopack package's main executable and handles every Velopack install/update/uninstall hook through <code>helpers/ApoRegistration</code> and <code>helpers/VelopackBootstrap</code>.
+* '''DeviceSelector''' — the Qt utility shown after the first install so the user can pick the audio devices to register the APO for. It replaces the original Configurator.
+* '''UpdateChecker''' — the Qt tool that runs at logon and notifies the user when a newer release for the build channel is available.
+* '''Benchmark''' — a console program for testing the audio processing without installing it on a device. Handy for experimenting with filter types and measuring performance.
+* '''VoicemeeterClient''' — a helper for Voicemeeter integration.
+* '''Tests''' — the unit and regression test projects: <code>HybridConvTests</code>, <code>EditorLogicTests</code> and <code>AudioRegressionTests</code>.
+* '''Setup''' — the sample configuration files (<code>config/</code>) and the documentation <code>.url</code> shortcuts that the CI packaging step bundles into the Velopack output.
+
+CI lives in <code>.github/workflows/build.yml</code>: it builds the x64 <code>sse2</code>, <code>avx</code>, <code>avx2</code>, <code>avx512</code> and <code>avx10_1</code> variants plus ARM64 <code>neon</code>, then calls <code>vpk pack</code> to produce the per-channel installers (see [[Documentation#Installation|the installation section]] and the in-repo <code>docs/SimdBuildMatrix.md</code>). Pull requests build AVX2 only; a push to <code>main</code> builds every variant and creates a GitHub Release. The original NSIS installer has been removed.
+
+== APO development ==
+
+An APO (Audio Processing Object) is a user-space module loaded by the Windows Audio Service to process sample data before it reaches the device driver. APOs are normally shipped with the audio driver and signed so they cannot bypass audio DRM. There are two kinds: '''GFX''' (global effect, applied after the streams are mixed) and '''LFX''' (local effect, applied before mixing). An output device can have one GFX and one LFX APO; an input device can have one LFX APO. An APO is a COM object identified by a GUID under which it is registered. Microsoft's documents [https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/windows-vista-custom-audio-effects Custom Audio Effects] and [https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/reusing-windows-vista-system-effects Reusing System Effects] describe the model and provide samples.
+
+Adding a custom APO means clearing two obstacles: the audio engine must be allowed to load unsigned APOs, and the device's existing APO must be chained to the custom one so it keeps working. The registry changes that make the Windows Audio Service load the DLL are:
+
+# Under <code>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Audio</code>, set the DWORD '''<code>DisableProtectedAudioDG</code>''' to <code>1</code>. This turns off the APO signature check so unsigned APOs load. Applications that need a protected audio path may then change behaviour or refuse to output audio.
+# Register the APO COM class under <code>HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\<GUID></code>. Set a class name as the key's default value, create the <code>InprocServer32</code> subkey with the DLL path as its default value, and set <code>ThreadingModel</code> appropriately.
+# Create <code>HKEY_LOCAL_MACHINE\SOFTWARE\Classes\AudioEngine\AudioProcessingObjects\<GUID></code>. This is normally done by the DDK function <code>RegisterAPO</code> (declared in <code>audioenginebaseapo.h</code>); <code>UnregisterAPO</code> removes it.
+# Register the APO for a device under <code>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render\<endpoint GUID>\FxProperties</code> (the <code>Render</code> path is output devices; <code>Capture</code> is input devices). In <code>FxProperties</code>, the value <code>{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},1</code> holds an LFX APO's GUID and <code>...,2</code> a GFX APO's. These usually already point at the driver's APOs, so registering the custom APO means replacing one value and saving the original elsewhere (Equalizer APO stores it under <code>HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO\Child APOs</code>) — both to restore it on uninstall and to load and call the original APO so it keeps working. Since Windows 8.1 the values ending in <code>,5</code> (LFX) and <code>,6</code> (GFX) are also used, and when an APO is registered through them, one registered through the old <code>,1</code>/<code>,2</code> values is ignored. Also since 8.1 the values <code>{d3993a3f-99c2-4402-b5ec-a92a0367664b},5</code> and <code>,6</code> specify processing modes (type MULTI_SZ); both normally need to be <code>{C18E2F7E-933D-4965-B7D1-1EEF228D2AF3}</code>, the default processing mode.
+
+In XT this registration and the matching cleanup are performed by <code>helpers/ApoRegistration</code>, driven from the Velopack hooks the Editor handles.
+
+== See also ==
+
+* [[Documentation]] — using EqualizerAPO-XT.
+* [[Configuration reference]] — the configuration command set.
+* [[ko:Developer documentation|이 문서의 한국어판 (Korean)]]

--- a/Wiki/wiki/en/Documentation.mediawiki
+++ b/Wiki/wiki/en/Documentation.mediawiki
@@ -1,0 +1,95 @@
+= Documentation =
+
+This is the user documentation for '''EqualizerAPO-XT'''. If you write your own APO or want to build the project from source, see the [[Developer documentation]] instead. Once you have it installed, the detailed command list lives in the [[Configuration reference]].
+
+__TOC__
+
+== Installation ==
+
+Unlike the original Equalizer APO, the XT fork does not ship a single universal installer. It builds one installer per CPU instruction set, and there is '''no 32-bit build''' — only 64-bit x64 and ARM64.
+
+# Open the [https://github.com/115dkk/EqualizerAPO-XT/releases Releases page] and download the <code>EqualizerAPO_Setup-<variant>.exe</code> that matches your CPU. The available variants are <code>x64-sse2</code>, <code>x64-avx</code>, <code>x64-avx2</code>, <code>x64-avx512</code>, <code>x64-avx10_1</code> and <code>arm64</code>.
+# If you are not sure which one to take, '''<code>x64-avx2</code> is the recommended default''' and runs on virtually every desktop CPU released since about 2013. Use <code>x64-sse2</code> as the maximum-compatibility fallback for very old x64 processors, <code>x64-avx</code> if your CPU has AVX but not AVX2, <code>x64-avx512</code> or <code>x64-avx10_1</code> only if your CPU actually supports those extensions, and <code>arm64</code> on Windows-on-ARM devices. You can check your CPU's type under '''Start → Settings → System → About'''.
+# Run the downloaded setup. The Velopack installer unpacks the application and registers EqualizerAPO-XT. You do not need to remember an install path; the location is recorded in the registry (see [[#Where things live|Where things live]]).
+# After the first install the '''Device Selector''' opens. Tick the playback and/or capture devices that Equalizer APO should attach to. If you are unsure, pick your default output device — you can see which one that is under '''Start → Settings → System → Sound'''. You can run the Device Selector again at any time from the installation folder if you want to add or remove devices later.
+# Allow Windows to restart the audio service (or reboot). A freshly registered APO is not picked up until the audio engine restarts.
+# Once the service has restarted the APO is active. With the bundled example configuration this is only noticeable as a small drop in volume and a mild low-frequency boost. To make it do something useful, continue with the [[#First configuration|First configuration]] section.
+
+=== Where things live ===
+
+EqualizerAPO-XT records its paths in the registry key '''<code>HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO</code>''':
+
+* <code>InstallPath</code> — the directory the application was installed to.
+* <code>ConfigPath</code> — the <code>config</code> folder that holds your configuration files.
+
+The easiest way to reach the configuration folder is to open the '''Configuration Editor''', which points at it directly. The folder ships with <code>config.txt</code> (the main file, loaded automatically) plus several ready-made examples: <code>example.txt</code>, <code>demo.txt</code>, <code>convolution.txt</code>, <code>iir_lowpass.txt</code>, <code>multichannel.txt</code> and <code>selective_delay.txt</code>.
+
+=== Automatic updates ===
+
+XT installs through [https://velopack.io/ Velopack], so updates are delivered per build channel rather than by reinstalling from scratch:
+
+* '''UpdateChecker''' runs at logon (via a scheduled task) and tells you when a newer release for your channel is available. It checks the GitHub release feed for your variant and respects a 24-hour throttle and any version you chose to skip.
+* The '''Configuration Editor''' also updates itself: about a minute after launch it quietly downloads a newer build for your channel in the background, then applies it silently when you close the editor. The new version comes up the next time you start it.
+
+== First configuration ==
+
+# Open the configuration folder (see [[#Where things live|above]]). The main file is <code>config.txt</code>; Equalizer APO loads it automatically and reloads it whenever you save.
+# Open <code>config.txt</code> in the Configuration Editor or any text editor. It defines a preamplification value and then includes <code>example.txt</code>. To confirm the APO is running, start any audio playback and change the <code>Preamp</code> value while sound is playing — the volume should change the moment you save the file.
+# To build your own correction, the classic approach is to measure your system with [https://www.roomeqwizard.com/ Room EQ Wizard] (REW) and export the result as filter text. EqualizerAPO-XT also includes a graphical '''Configuration Editor''' where you can add and tune filters directly, which many users find easier for small adjustments.
+
+[[File:RoomEQWizard.png|thumb|none|600px|Room EQ Wizard (the markers A–F are referenced in the steps below)]]
+
+A full Room EQ Wizard tutorial is outside the scope of this page, but the basic measurement-to-filters flow is:
+
+# Click '''Measure''' (mark '''A''') to open the measurement dialog. Run '''Check Levels''' first, set a sensible output volume, then '''Start Measuring'''. A frequency-response graph appears when it finishes.
+# Click '''EQ''' (mark '''B''') and choose an equalizer type (mark '''C'''). Use '''Generic''', or '''FBQ2496''' if you prefer bandwidth over Q. Other equalizer types are not guaranteed to be compatible.
+# Click '''EQ Filters''' (mark '''D'''). Add filters by setting ''Control'' to ''Manual'', ''Type'' to ''PK/PEQ'', then adjusting ''Frequency'', ''Gain'' and ''Q''/''Bw Oct''. The graph updates live. Peaking filters are usually the right choice for room correction, though the other [[Configuration reference#Filter|filter types]] are available too.
+# Save the REW filter set with '''Save this filter set''' (mark '''E''') so you can reload it later.
+# Export in the format Equalizer APO reads: from the main window open '''File''' (mark '''F''') → '''Export''' → '''Filter Settings as text''', and save it into the configuration folder under a new name.
+# Edit <code>config.txt</code> so its <code>Include</code> line points at your new file. The change takes effect immediately.
+
+That is your first working configuration. For the complete syntax — filters, channel routing, delay, convolution, graphic EQ and the expression language — see the [[Configuration reference]]. The REW [https://www.roomeqwizard.com/help/ help] explains the measurement side in much more depth.
+
+== Convolution ==
+
+One of the reasons to use the XT fork is its convolution support. The [[Configuration reference#Convolution|Convolution]] command loads an impulse response from a sound file (WAV, FLAC, OGG and the other formats handled by [https://libsndfile.github.io/libsndfile/ libsndfile]) and convolves the selected channels with it. XT removes the impulse-response length cap of the original and simplifies the setup; the bundled <code>convolution.txt</code> is a starting point. The impulse response's sample rate must match the audio device's sample rate, and configurations reload automatically when an impulse-response file inside the config folder changes.
+
+== Troubleshooting ==
+
+This section collects the usual reasons Equalizer APO might not behave as expected.
+
+=== Original APOs and the Device Selector ===
+
+By default Equalizer APO tries to keep the effects that shipped with your sound-card driver (the "original APOs") working alongside it. On some systems this chaining causes glitches. If playback or recording becomes unstable, open the '''Device Selector''', select the affected device, enable the troubleshooting options, and clear both '''Use original APO''' checkboxes.
+
+[[File:UseOriginalAPO.png|thumb|none|500px|Disabling the original APOs in the Device Selector]]
+
+Doing this loses any effects the driver provided through its own APOs, so you can also try clearing only one box to keep part of that functionality. Some drivers disable their own options when they detect another APO; installing Equalizer APO into only the pre-mix or only the post-mix stage (via the '''Install APO''' checkboxes) can recover some of those driver features for the other stage.
+
+=== Audio enhancements are disabled in Control Panel ===
+
+If nothing you change in the configuration file has any audible effect, APOs may be switched off for the device in the Windows sound settings. Open '''Start → Settings → System → Sound''', open the device's properties, and:
+
+* if there is an '''Enhancements''' tab, make sure '''Disable all enhancements''' is unchecked — even if you use none of the listed enhancements;
+* if there is no Enhancements tab, open the '''Advanced''' tab and make sure '''Enable audio enhancements''' is checked.
+
+[[File:EnhancementsTab.png|thumb|none|350px|"Enhancements" tab — leave "Disable all enhancements" unchecked]]
+[[File:NoEnhancementsTab.png|thumb|none|350px|"Advanced" tab — keep "Enable audio enhancements" checked]]
+
+=== Log files ===
+
+When Equalizer APO hits a critical problem it appends a line to:
+
+<pre>C:\Windows\ServiceProfiles\LocalService\AppData\Local\Temp\EqualizerAPO.log</pre>
+
+Under normal operation the file does not even exist — it is only created on an error. For more detail you can enable trace output: open <code>regedit.exe</code>, go to <code>HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO</code>, and set the value '''<code>EnableTrace</code>''' to <code>true</code>. Lines marked <code>(TRACE)</code> are then written during normal playback or recording, which is useful for checking how your configuration files are interpreted. Set <code>EnableTrace</code> back to <code>false</code> when you are done so the log does not grow without need.
+
+=== Hardware-accelerated OpenAL ===
+
+Applications that use OpenAL usually pose no problem because they fall back to DirectSound, which supports APOs. Some vendors, however, ship hardware-accelerated OpenAL libraries that talk to the hardware directly and bypass APOs entirely. There is no way to add APO support to hardware-accelerated OpenAL, so the options are to switch the application to another output backend, or to force OpenAL into software mode — for example by replacing <code>OpenAL32.dll</code> with the [https://openal-soft.org/ OpenAL Soft] build, or by renaming the vendor's hardware OpenAL library (often named like <code>*_oal.dll</code>) in <code>C:\Windows\System32</code> or <code>C:\Windows\SysWOW64</code>. The latter changes the sound driver and is not officially supported.
+
+== See also ==
+
+* [[Configuration reference]] — every command and its syntax.
+* [[Developer documentation]] — building XT and writing your own APO.
+* [[ko:Documentation|이 문서의 한국어판 (Korean)]]

--- a/Wiki/wiki/en/Main_Page.mediawiki
+++ b/Wiki/wiki/en/Main_Page.mediawiki
@@ -1,0 +1,19 @@
+= EqualizerAPO-XT Wiki =
+
+EqualizerAPO-XT is a Windows system-wide equalizer based on [https://sourceforge.net/projects/equalizerapo/ Equalizer APO] by Jonas Thedering. The XT fork keeps the familiar configuration workflow while adding 64-bit (double) internal processing, an uncapped convolver impulse-response length, VST2/VST3 hosting, multiple SIMD build variants, ARM64 support, and a Velopack-based installer with automatic updates.
+
+This wiki mirrors the structure of the original Equalizer APO documentation and adapts the install and packaging sections to the XT builds.
+
+== Pages ==
+
+* '''[[Documentation]]''' — user guide: installation, first configuration, and troubleshooting. Start here.
+* '''[[Configuration reference]]''' — the configuration file format and every supported command. For advanced users.
+* '''[[Developer documentation]]''' — building from source, project layout, and how an APO is registered with Windows.
+
+== Other languages ==
+
+* [[ko:Main Page|한국어 (Korean)]]
+
+== License and credits ==
+
+EqualizerAPO-XT is distributed under the [https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License, version 2 or later], the same terms as the original Equalizer APO. The VST3 hosting layer uses the MIT-licensed Steinberg VST3 ''pluginterfaces''; the VST2 interface header is an independent BSD-2 clean-room reimplementation. See the project [https://github.com/115dkk/EqualizerAPO-XT repository] for full details.

--- a/Wiki/wiki/index.mediawiki
+++ b/Wiki/wiki/index.mediawiki
@@ -1,0 +1,39 @@
+= EqualizerAPO-XT wiki sources =
+
+This folder holds the EqualizerAPO-XT documentation as MediaWiki markup, ready to import into a MediaWiki instance. It mirrors the original Equalizer APO SourceForge wiki, with the installation and packaging sections rewritten for the XT builds.
+
+== Layout ==
+
+* <code>en/</code> — English pages
+** <code>en/Main_Page.mediawiki</code>
+** <code>en/Documentation.mediawiki</code>
+** <code>en/Configuration_reference.mediawiki</code>
+** <code>en/Developer_documentation.mediawiki</code>
+* <code>ko/</code> — Korean pages (same four page names)
+
+Internal links use MediaWiki page links such as <code><nowiki>[[Configuration reference]]</nowiki></code> and section anchors such as <code><nowiki>[[Configuration reference#Filter]]</nowiki></code>. Cross-language links use the <code><nowiki>[[en:...]]</nowiki></code> / <code><nowiki>[[ko:...]]</nowiki></code> prefix and assume interwiki/language-link setup; adjust them to your wiki's convention if needed.
+
+== Images ==
+
+The pages reference these images with <code><nowiki>[[File:...]]</nowiki></code>. The source files live one level up, in the <code>Wiki/</code> folder, and must be uploaded to the wiki under the same names:
+
+* <code>RoomEQWizard.png</code>
+* <code>UseOriginalAPO.png</code>
+* <code>EnhancementsTab.png</code>
+* <code>NoEnhancementsTab.png</code>
+* <code>Stages.png</code> (vector source: <code>Stages.svg</code>)
+* <code>Transfer function.png</code>
+
+== Page map ==
+
+{| class="wikitable"
+! Page !! English !! Korean
+|-
+| Landing || <code>en/Main_Page.mediawiki</code> || <code>ko/Main_Page.mediawiki</code>
+|-
+| User guide || <code>en/Documentation.mediawiki</code> || <code>ko/Documentation.mediawiki</code>
+|-
+| Command reference || <code>en/Configuration_reference.mediawiki</code> || <code>ko/Configuration_reference.mediawiki</code>
+|-
+| Developer guide || <code>en/Developer_documentation.mediawiki</code> || <code>ko/Developer_documentation.mediawiki</code>
+|}

--- a/Wiki/wiki/ko/Configuration_reference.mediawiki
+++ b/Wiki/wiki/ko/Configuration_reference.mediawiki
@@ -1,0 +1,400 @@
+= 설정 레퍼런스 =
+
+이 문서는 EqualizerAPO-XT가 이해하는 설정 파일 형식과 명령을 설명합니다. 고급 사용자를 위한 내용입니다. 입문이나 문제 해결은 [[Documentation|사용자 문서]]를 보세요. XT는 원본 Equalizer APO 문법을 그대로 유지하므로, 원본용으로 작성한 설정도 그대로 동작합니다.
+
+__TOC__
+
+== 설정 파일 형식 ==
+
+설정 파일은 한 줄씩 읽습니다. 의미 있는 줄은 모두 다음 형태입니다.
+
+<pre>Command: Parameters</pre>
+
+이 형태에 맞지 않는 줄은 조용히 무시됩니다. 주석이 이렇게 동작합니다. <code>#</code>로 시작하는 줄은 그냥 인식되는 명령이 아닐 뿐입니다. 존재하지 않는 명령을 적은 줄도 무시됩니다.
+
+예시:
+
+<syntaxhighlight lang="ini">
+Device: High Definition Audio Device Speakers; Benchmark
+#아래 줄들은 지정한 장치와 benchmark 애플리케이션에만 적용됩니다
+Preamp: -6 db
+Include: example.txt
+Filter  1: ON  PK       Fc     50 Hz   Gain  -3.0 dB  Q 10.00
+Filter  2: ON  PEQ      Fc     100 Hz  Gain   1.0 dB  BW Oct 0.167
+
+Channel: L
+#왼쪽 채널에만 추가 프리앰프
+Preamp: -5 dB
+#왼쪽 채널에만 적용할 필터
+Include: demo.txt
+Filter  1: ON  LS       Fc     300 Hz  Gain   5.0 dB
+
+Channel: 2 C
+#두 번째(오른쪽)와 센터 채널용 필터
+Filter  1: ON  HP       Fc     30 Hz
+Filter  2: ON  LPQ      Fc     10000 Hz  Q  0.400
+
+Device: Microphone
+#여기부터는 마이크 장치에만 적용됩니다
+Filter: ON  NO       Fc     50 Hz
+</syntaxhighlight>
+
+== 필터링 명령 ==
+
+선택한 채널의 오디오를 직접 바꾸는 명령입니다.
+
+=== Preamp ===
+
+'''문법:''' <code>Preamp: <음수> dB</code>
+
+프리앰프 값을 데시벨로 정합니다. 양의 게인을 더하는 필터를 쓸 때 클리핑을 막기 위해 씁니다. 같은 채널에 프리앰프가 여러 개 걸리면 dB 단위로 더한 값이 적용됩니다.
+
+<syntaxhighlight lang="ini">
+Preamp: -6.5 dB
+</syntaxhighlight>
+
+=== Filter ===
+
+'''문법:'''
+<pre>
+Filter <n>: ON <Type> Fc <주파수> Hz Gain <게인> dB Q <Q 값>
+Filter <n>: ON <Type> Fc <주파수> Hz Gain <게인> dB BW Oct <대역폭>
+</pre>
+
+지정한 종류, 주파수, 게인, Q/대역폭의 필터를 추가합니다. 첫 번째 형태(Q)는 Room EQ Wizard의 "Generic" 이퀄라이저 유형과, 두 번째 형태(대역폭)는 "FBQ2496"과 맞습니다. 필터 번호 <code><n></code>은 해석되지 않으며 생략해도 됩니다.
+
+아래 표는 지원하는 필터 종류입니다. 매개변수 열에서 '''X'''는 필수, '''O'''는 선택입니다. "Generic"과 "FBQ2496" 유형의 모든 필터를 포함하며, 텍스트 형식이 맞으면 다른 유형도 동작할 수 있습니다. 한 가지 차이가 있습니다. 여기의 밴드패스 필터는 게인이 없는 진짜 밴드패스 필터(로/하이패스처럼)로, 실제로는 피킹 필터인 DCX2496의 "BP"와는 다릅니다.
+
+{| class="wikitable"
+! 종류 !! 설명 !! Fc !! Gain !! Q/BW !! 예시
+|-
+| PK<br>Modal<br>PEQ || 피킹 필터 (파라메트릭 EQ) || X || X || X || <code>ON PK Fc 50.0 Hz Gain -10.0 dB Q 2.50</code><br><code>ON Modal Fc 100 Hz Gain 3.0 dB Q 5.41 T60 target 100 ms</code><br><code>ON PEQ Fc 100 Hz Gain 1.0 dB BW Oct 0.167</code>
+|-
+| LP<br>LPQ || 로패스 필터 || X || || O || <code>ON LP Fc 8000 Hz</code><br><code>ON LPQ Fc 10000 Hz Q 0.400</code>
+|-
+| HP<br>HPQ || 하이패스 필터 || X || || O || <code>ON HP Fc 30.0 Hz</code><br><code>ON HPQ Fc 20.0 Hz Q 0.500</code>
+|-
+| BP || 밴드패스 필터 (DCX2496 아님) || X || || O || <code>ON BP Fc 1000 Hz Q 0.100</code>
+|-
+| LS<br>LSC ''x'' dB || 로셸프 필터 (센터 주파수; LSC는 옥타브당 ''x'' dB) || X || X || O (1.2.1) || <code>ON LS Fc 300 Hz Gain 5.0 dB</code><br><code>ON LSC 10.8 dB Fc 300 Hz Gain 5.0 dB</code><br><code>ON LSC Fc 300 Hz Gain 5.0 dB Q 0.6473</code>
+|-
+| HS<br>HSC ''x'' dB || 하이셸프 필터 (센터 주파수; HSC는 옥타브당 ''x'' dB) || X || X || O (1.2.1) || <code>ON HS Fc 1000 Hz Gain -3.0 dB</code><br><code>ON HSC 6 dB Fc 100 Hz Gain -6.0 dB</code><br><code>ON HSC Fc 100 Hz Gain -6.0 dB Q 0.4272</code>
+|-
+| LS 6dB<br>LS 12dB || 로셸프 필터 (옥타브당 6/12 dB, 코너 주파수) || X || X || || <code>ON LS 6dB Fc 50.0 Hz Gain 7.2 dB</code><br><code>ON LS 12dB Fc 2000 Hz Gain -5.0 dB</code>
+|-
+| HS 6dB<br>HS 12dB || 하이셸프 필터 (옥타브당 6/12 dB, 코너 주파수) || X || X || || <code>ON HS 6dB Fc 12000 Hz Gain 10.0 dB</code><br><code>ON HS 12dB Fc 500 Hz Gain 5.0 dB</code>
+|-
+| NO || 노치 필터 || X || || O || <code>ON NO Fc 800 Hz</code>
+|-
+| AP || 올패스 필터 || X || || X || <code>ON AP Fc 900 Hz Q 0.707</code>
+|}
+
+=== 사용자 계수 필터 ===
+
+'''문법:''' <code>Filter <n>: ON IIR Order <m> Coefficients <b0> <b1> ... <bm> <a0> <a1> ... <am></code>
+
+지정한 차수와 계수로 일반 IIR 필터를 추가합니다. 계수 개수는 <code>2·(차수+1)</code>이어야 합니다. 전달 함수는 아래와 같습니다.
+
+[[File:Transfer function.png|none|frameless|IIR 전달 함수]]
+
+계수는 보통 샘플레이트에 따라 달라지므로, [[#If / ElseIf / Else / EndIf|If]] 명령이나 [[#Eval과 인라인 표현식|인라인 표현식]]과 함께 써서 현재 샘플레이트에 맞는 값을 넣습니다. 이 필터로 다른 종류의 BiQuad 필터를 똑같이 구현할 수도 있지만, 실행이 더 느리므로 권하지 않습니다.
+
+<syntaxhighlight lang="ini">
+# 샘플레이트 48 kHz에서 Fc 3000 Hz인 로패스 biquad 필터
+Filter: ON IIR Order 2 Coefficients 0.0380602 0.0761205 0.0380602 1.2706 -1.84776 0.729402
+</syntaxhighlight>
+
+=== Delay ===
+
+'''문법:'''
+<pre>
+Delay: <t> ms
+Delay: <n> samples
+</pre>
+
+선택한 채널을 <code>t</code> 밀리초나 <code>n</code> 샘플만큼 지연합니다. 샘플레이트와 무관하게 같은 지연을 주는 밀리초 쪽을 권합니다.
+
+<syntaxhighlight lang="ini">
+# 샘플레이트와 무관하게 50.5 ms 지연
+Delay: 50.5 ms
+# 480 샘플 지연 (48 kHz에서 10 ms)
+Delay: 480 samples
+</syntaxhighlight>
+
+=== Copy ===
+
+'''문법:'''
+<pre>
+Copy: <대상 채널>=<계수>*<원본 채널>+...
+Copy: <대상 채널>=<원본 채널>+...
+Copy: <대상 채널>=<상수>+...
+</pre>
+
+대상 채널을, 나열한 원본 채널들의 합(각각 선택적 계수 포함)으로 바꿉니다. 대상을 바꾸지 않고 더하려면 대상 자신을 원본에 넣으면 됩니다. 계수는 <code>dB</code>를 붙여 데시벨로 줄 수 있습니다. 한 줄에 여러 할당을 공백으로 구분해 넣을 수 있으므로, 할당 하나에는 공백이 없어야 합니다. 채널/계수 자리에 상수를 쓸 수 있는데, 숫자 채널 번호와 구분하기 위해 상수에는 소수점이 있어야 합니다. 채널 식별자는 [[#Channel|Channel]] 명령을 보세요.
+
+<syntaxhighlight lang="ini">
+# R 채널을 0.5배해서 L 채널에 더합니다
+Copy: L=L+0.5*R
+# L을 R과, 6 dB 감쇠한 C의 합으로 바꿉니다
+Copy: L=R+-6dB*C
+# 채널 1을 이전 R의 오디오로 바꾸고, R을 상수 0.5로 설정합니다
+Copy: 1=R R=0.5
+# 주의: L을 채널 2의 오디오로 설정합니다 (소수점이 없으므로 상수 2가 아님)
+Copy: L=2
+# 5.1 시스템에서 나머지를 음소거하고 LFE를 왼쪽 채널로 바꿉니다
+Copy: LFE=L L=0.0 R=0.0 C=0.0 RL=0.0 RR=0.0
+</syntaxhighlight>
+
+=== GraphicEQ ===
+
+'''문법:''' <code>GraphicEQ: <주파수> <게인(dB)>; <주파수> <게인(dB)>; ...</code>
+
+지정한 대역과 게인으로 그래픽 이퀄라이저를 추가합니다. 게인은 로그 주파수 축에서 선형으로 보간되며(로그 보기에서 직선으로 보이도록), 지정한 대역 바깥은 평탄합니다.
+
+<syntaxhighlight lang="ini">
+# ISO 대역의 15밴드 그래픽 이퀄라이저
+GraphicEQ: 25 6; 40 4.5; 63 3; 100 1.5; 160 0; 250 0; 400 0; 630 0; 1000 0; 1600 0; 2500 0; 4000 0; 6300 1.5; 10000 3; 16000 3
+</syntaxhighlight>
+
+=== Convolution ===
+
+'''문법:''' <code>Convolution: <파일 이름></code>
+
+지정한 파일의 임펄스 응답으로 신호를 처리하는 컨볼버를 추가합니다. 파일은 [https://libsndfile.github.io/libsndfile/ libsndfile]이 지원하는 형식(WAV, FLAC, OGG 등)이어야 합니다. 채널이 여러 개면 선택한 채널에 라운드로빈으로 배정됩니다(스테레오 파일을 4채널에 걸면 L→1, R→2, L→3, R→4). '''파일의 샘플레이트는 장치의 샘플레이트와 같아야''' 하며, 다르면 컨볼버를 만들 수 없습니다. 지연과 CPU 사용량은 임펄스 응답의 길이와 위상에 따라 달라집니다(선형 위상은 파일 길이의 절반만큼 지연, 최소 위상은 더 낮지만 일정하지 않음). 파일 이름은 설정 파일 기준 상대 경로이고, 큰따옴표로 감쌀 수 있으며, <code>%USERPROFILE%</code> 같은 환경 변수를 넣을 수 있습니다. 설정 폴더(또는 하위 폴더) 안의 임펄스 응답 파일은 바뀌면 자동으로 다시 로드되어 즉시 적용됩니다. EqualizerAPO-XT는 원본의 임펄스 응답 길이 제한을 없앴습니다.
+
+<syntaxhighlight lang="ini">
+# 잔향 효과를 위해 녹음한 임펄스 응답과 합성곱
+Convolution: church.wav
+</syntaxhighlight>
+
+== 제어 명령 ==
+
+오디오를 직접 바꾸지 않고, 어떤 명령이 실행될지와 어떻게 적용될지를 제어합니다.
+
+=== Include ===
+
+'''문법:''' <code>Include: <파일 이름></code>
+
+지정한 파일을 설정 파일로 불러옵니다. <code>config.txt</code>를 직접 고치는 대신 실제 필터 정의를 별도 파일에 두면, 예를 들어 불러오기 전에 프리앰프를 먼저 정할 수 있습니다.
+
+<syntaxhighlight lang="ini">
+Include: example.txt
+</syntaxhighlight>
+
+=== Device ===
+
+'''문법:''' <code>Device: <장치 패턴 1>; <장치 패턴 2>; ...</code>
+
+현재 출력 장치의 연결 이름, 장치 이름, GUID에 패턴을 맞춥니다. 맞지 않으면 다른 <code>Device</code>를 제외한 이후 모든 명령이 무시됩니다. 패턴은 공백으로 구분한 단어들이며, 이 단어가 모두 "''장치이름 연결이름 GUID''" 문자열에 있어야 합니다. <code>;</code>로 여러 패턴을 구분하면 그중 하나만 맞으면 됩니다. 특수 패턴 <code>all</code>은 항상 맞습니다. benchmark 애플리케이션은 장치 이름 "Benchmark", 연결 "File output"을 씁니다. <code>Device</code> 줄은 장치 선택기의 버튼으로 만드는 것이 가장 쉽습니다.
+
+<syntaxhighlight lang="ini">
+# "High Definition Audio Device"의 "Speakers" 연결과
+# benchmark 애플리케이션의 "Benchmark"에 맞습니다
+Device: High Definition Audio Device Speakers; Benchmark
+</syntaxhighlight>
+
+=== Channel ===
+
+'''문법:''' <code>Channel: <채널 위치 1> <채널 위치 2> ...</code>
+
+이후의 <code>Filter</code>와 <code>Preamp</code> 명령이 적용될 채널을 선택합니다. 위치는 식별자(1~3글자 약어)나 번호(1부터)로 줄 수 있습니다. 지원 구성은 아래와 같으며, 지원하지 않는 구성에서는 번호로만 선택할 수 있습니다. 여러 채널은 공백으로 구분합니다. 특수 위치 <code>all</code>은 모든 채널을 선택합니다.
+
+{| class="wikitable"
+! 구성 !! L !! R !! C !! LFE !! RL !! RR !! RC !! SL !! SR
+|-
+| Mono || || || 1 || || || || || ||
+|-
+| Stereo || 1 || 2 || || || || || || ||
+|-
+| Quadraphonic || 1 || 2 || || || 3 || 4 || || ||
+|-
+| Surround || 1 || 2 || 3 || || || || 4 || ||
+|-
+| 5.1 Surround || 1 || 2 || 3 || 4 || || || || 5 || 6
+|-
+| 5.1 Surround (대체) || 1 || 2 || 3 || 4 || 5 || 6 || || ||
+|-
+| 7.1 Surround || 1 || 2 || 3 || 4 || 5 || 6 || || 7 || 8
+|}
+
+'''주의:''' 저역 필터를 LFE 채널에만 거는 것이 솔깃하지만, 기대대로 되지 않을 때가 많습니다. 많은 시스템이 Equalizer APO 처리 ''뒤에'' 베이스 리다이렉션을 적용하므로 LFE에만 건 필터는 리다이렉트된 소리를 놓칩니다. 또 크로스오버 필터가 서서히 페이드인되는 탓에 저역이 서브우퍼만이 아니라 여러 스피커로 나갈 수 있습니다. 이를 피하려면 '''저역 필터는 모든 채널에 적용'''하세요.
+
+<syntaxhighlight lang="ini">
+# 왼쪽 채널과 후방 왼쪽 채널 선택
+Channel: L RL
+# 첫째, 둘째, 센터 채널 선택
+Channel: 1 2 C
+</syntaxhighlight>
+
+=== Stage ===
+
+'''문법:''' <code>Stage: <단계 1> <단계 2></code>
+
+이후 필터링 명령이 실행될 단계를 정합니다. 출력 장치에는 '''pre-mix'''와 '''post-mix''' 두 단계가, 입력 장치에는 '''capture''' 단계만 있습니다.
+
+[[File:Stages.png|none|frameless|500px|출력 장치의 pre-mix와 post-mix 단계]]
+
+처음 선택된 단계는 post-mix와 capture라, 출력과 입력 장치에서 필터링이 정확히 한 번 실행됩니다. post-mix를 pre-mix보다 선호하는 이유는, pre-mix 필터링이 애플리케이션마다 일어나 CPU를 더 쓰기 때문입니다. 다만 업믹싱처럼 입력 채널 수에 따라 필터링해야 하는 경우에는 pre-mix를 써야 합니다.
+
+<syntaxhighlight lang="ini">
+Stage: pre-mix
+# 업믹싱
+If: inputChannelCount == 2
+# 다른 APO가 SL, SR에 이미 오디오를 넣었을 수 있음에 유의
+Copy: SL=SL+L SR=SR+R
+EndIf:
+# ...
+Stage: post-mix
+# 룸 보정
+# ...
+</syntaxhighlight>
+
+== 표현식 명령 ==
+
+런타임 값에 따라 처리를 바꾸는 명령입니다. 표현식은 설정 파일 언어 안에 들어 있는 작은 언어로, 문법이 스크립트 언어에 가깝습니다. 상수, 변수, 연산자, 함수로 이루어집니다.
+
+'''상수:'''
+
+{| class="wikitable"
+! 이름 !! 설명
+|-
+| e, pi || 수학 상수
+|-
+| inputChannelCount || 현재 APO 단계의 입력 채널 수
+|-
+| outputChannelCount || 현재 APO 단계의 출력 채널 수
+|-
+| sampleRate || 처리 중인 오디오의 샘플레이트(Hz)
+|-
+| deviceName || 오디오 장치 이름
+|-
+| connectionName || 오디오 장치의 연결 이름
+|-
+| deviceGuid || 오디오 장치 엔드포인트의 GUID
+|-
+| stage || 현재 APO 단계 (pre-mix, post-mix, capture)
+|}
+
+'''변수:''' 설정을 불러오는 동안 유효한 사용자 정의 변수는 할당 연산자(<code>=</code>)로 만듭니다. 다시 로드할 때 유지되지 않으며, 같은 파일 안에서 나중에 쓸 임시 값을 담는 용도입니다.
+
+'''연산자:'''
+
+{| class="wikitable"
+! 이름 !! 설명
+|-
+| <code>+ - * / ^</code> || 산술 연산자
+|-
+| <code>= += -= *= /=</code> || 할당 연산자
+|-
+| <code>and or xor</code> || 논리 연산자
+|-
+| <code>== != < > <= >=</code> || 비교 연산자
+|-
+| <code>& | << >></code> || 비트/비트 시프트 연산자
+|-
+| <code>+</code> || 문자열 연결 (피연산자 중 하나 이상이 문자열)
+|-
+| <code>(float) (int)</code> || 형 변환 (숫자형에서)
+|-
+| <code>condition ? then : else</code> || 조건(삼항) 연산자
+|-
+| <code>{1,2}</code> || 배열 생성
+|-
+| <code>array[0]</code> || 배열 접근
+|}
+
+'''함수:'''
+
+{| class="wikitable"
+! 이름 !! 설명
+|-
+| abs || 절댓값
+|-
+| sin, cos, tan,<br>sinh, cosh, tanh || 삼각 함수
+|-
+| ln, log, log10, exp || 로그 / 지수 함수
+|-
+| sqrt || 제곱근
+|-
+| min, max, sum || 인수의 최소 / 최대 / 합
+|-
+| str2dbl || 문자열을 float로
+|-
+| strlen || 문자열 길이
+|-
+| tolower, toupper || 소문자 / 대문자 변환
+|-
+| sizeof || 배열 길이
+|-
+| regexSearch || 문자열(둘째 인수)에서 정규식(첫째 인수)의 첫 일치를 찾습니다. 없으면 비어 있고, 있으면 전체 일치를 첫 값으로, 캡처 그룹을 이어지는 값으로 담은 배열입니다.
+|-
+| regexReplace || 문자열(둘째 인수)에서 정규식(첫째 인수)에 맞는 모든 부분을 문자열(셋째 인수)로 바꿉니다. 결과 문자열을 돌려줍니다.
+|-
+| readRegString || 레지스트리 키(첫째 인수)에서 문자열 값(둘째 인수)을 읽습니다. 키를 감시하다 바뀌면 다시 로드합니다.
+|-
+| readRegDWORD || 레지스트리 키(첫째 인수)에서 정수 값(둘째 인수)을 읽습니다. 키를 감시하다 바뀌면 다시 로드합니다.
+|}
+
+표현식의 자료형은 문자열, 불리언, int, float, 행렬/배열입니다(오류 메시지에서는 ''s'', ''b'', ''i'', ''f'', ''m''으로 줄여 씁니다). 문자열 상수는 큰따옴표로 적고, 그 안의 백슬래시와 큰따옴표는 백슬래시로 이스케이프합니다. 불리언은 <code>true</code> / <code>false</code>입니다. 숫자는 천 단위 구분 없이 적고 소수점은 점을 씁니다. 배열은 <code>{}</code> 연산자로 만듭니다. 여러 표현식을 세미콜론으로 잇면 마지막 값이 결과가 됩니다.
+
+<syntaxhighlight lang="ini">
+# 사용자 정의 변수
+Eval: a=0; b=pi
+# 비교
+Eval: a > b ? "a is larger" : "b is larger"
+# 삼각 함수와 거듭제곱 연산자
+Eval: sin(a)^2 + cos(a)^2 == 1
+# 정규식으로 장치 이름 맞추기
+Eval: a=regexSearch("High Definition .*", deviceName); sizeof(a) > 0 ? "found" : "not found"
+# 레지스트리에서 설정 경로 읽기
+Eval: readRegString("HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO", "ConfigPath")
+</syntaxhighlight>
+
+=== If / ElseIf / Else / EndIf ===
+
+'''문법:'''
+<pre>
+If: <표현식>
+ElseIf: <표현식>
+Else:
+EndIf:
+</pre>
+
+<code>If</code>와 <code>EndIf</code> 사이의 명령을 조건에 따라 실행합니다. 대부분의 프로그래밍 언어의 if/else와 같습니다. <code>If</code>는 표현식을 불리언으로 평가해 참이면 이후 명령을 실행합니다. 이미 참인 분기 뒤의 <code>ElseIf</code>는 건너뛰고, 그렇지 않으면 표현식을 평가해 참일 때 그 블록을 실행합니다. <code>Else</code>는 항상 참인 <code>ElseIf</code>처럼 동작합니다. <code>EndIf</code>는 블록을 끝냅니다. 중첩할 수 있으며, <code>ElseIf</code>/<code>Else</code>는 항상 가장 가까운 열린 <code>If</code>에 묶입니다. 가독성을 위해 줄을 들여쓸 수 있습니다. 기술적인 이유로 <code>If</code>로 <code>Device</code>를 조건부 실행할 수는 없습니다. <code>Device</code>의 우선순위가 더 높기 때문입니다.
+
+<syntaxhighlight lang="ini">
+If: sampleRate == 44100
+	...
+ElseIf: sampleRate == 48000
+	...
+	If: inputChannelCount == 1
+		...
+	ElseIf: inputChannelCount == 2
+		...
+	EndIf:
+Else:
+	...
+EndIf:
+</syntaxhighlight>
+
+=== Eval과 인라인 표현식 ===
+
+'''문법:'''
+<pre>
+Eval: <표현식>
+<Command>: ... `<표현식>` ...
+</pre>
+
+<code>Eval</code>은 표현식을 평가하고 결과를 버립니다. 주로 변수를 정의하거나 시험할 때 씁니다. '''인라인 표현식'''은 명령의 매개변수 문자열에 결과를 끼워 넣습니다. 첫 백틱부터 둘째 백틱까지(포함)가 표현식 값을 문자열로 바꾼 것으로 치환됩니다. 인라인 표현식은 <code>Device</code>나 <code>If</code>/<code>ElseIf</code>에는 못 쓰지만 <code>Eval</code> 안에서는 쓸 수 있습니다.
+
+<syntaxhighlight lang="ini">
+# 게인을 선형으로 지정
+Eval: linGain = 0.5
+Filter: ON PK Fc 1000 Hz Gain `20*log10(linGain)` dB Q 10.0
+</syntaxhighlight>
+
+== 함께 보기 ==
+
+* [[Documentation|사용자 문서]] — 설치, 첫 설정, 문제 해결.
+* [[Developer documentation|개발자 문서]] — XT 빌드와 직접 APO 만들기.
+* [[en:Configuration reference|English version of this page]]

--- a/Wiki/wiki/ko/Developer_documentation.mediawiki
+++ b/Wiki/wiki/ko/Developer_documentation.mediawiki
@@ -1,0 +1,56 @@
+= 개발자 문서 =
+
+'''EqualizerAPO-XT'''의 개발자 문서입니다. 소스를 살펴보거나 빌드하거나 시험하려는 사람, 또는 직접 APO를 만들려는 사람을 위한 내용입니다. 소프트웨어를 쓰기만 할 거라면 [[Documentation|사용자 문서]]를 보세요.
+
+''면책: 이 문서는 아는 한 정확하게 작성했습니다. 완전하지도, 오류가 없다고 보장하지도 못합니다.''
+
+__TOC__
+
+== EqualizerAPO-XT 빌드 ==
+
+XT는 Windows 프로젝트입니다. C++ 프로젝트는 Visual Studio 2022 / 2026 도구와 Windows 10 SDK를 기준으로 하고, GUI 도구는 Qt로 빌드합니다. 원본 Equalizer APO 빌드는 라이브러리를 <code>C:\Program Files</code> 아래에 설치해야 했지만, XT는 모든 의존성을 로컬 <code>deps/</code> 폴더에 두고 이를 받아오는 설정 스크립트를 제공합니다.
+
+=== 사전 준비물 ===
+
+* '''Visual Studio 2022 빌드 도구'''(또는 2026). <code>Microsoft.VisualStudio.Component.VC.Tools.x86.x64</code>와 <code>Microsoft.VisualStudio.Component.VC.ATL</code>을 반드시 포함합니다. ATL이 필요합니다. 없으면 <code>EqualizerAPO.dll</code> 링크 단계에서 <code>atls.lib</code>를 찾지 못합니다. XT 프로젝트는 VS 2026 도구 집합 <code>v145</code>로 빌드하며, VS 2022 환경에서는 <code>/p:PlatformToolset=v143</code>을 넘깁니다.
+* '''Python 3''' — <code>aqtinstall</code>로 Qt를 설치할 때 씁니다.
+* '''Qt 6.10.1 (MSVC 2022 x64)''' — <code>Qt/6.10.1/msvc2022_64/</code>에 설치합니다. 설정 편집기, 장치 선택기, 업데이트 확인기에 필요합니다.
+* '''외부 라이브러리''' — 저장소에 '''커밋하지 않습니다''': [https://www.fftw.org/ FFTW], [https://libsndfile.github.io/libsndfile/ libsndfile], [https://github.com/beltoforion/muparserx muParserX], [http://tclap.sourceforge.net/ TCLAP], 그리고 MIT 라이선스인 Steinberg VST3 ''pluginterfaces''입니다. 빌드 시점에 <code>deps/</code> 아래에 배치합니다.
+* '''Velopack''' (<code>vpk</code> CLI, <code>dotnet tool install -g vpk</code>) — CI가 바이너리를 <code>Setup.exe</code> / <code>.nupkg</code> 산출물로 패키징할 때만 씁니다. 로컬 개발에는 필요 없습니다.
+
+'''<code>setup-build.ps1</code>''' 스크립트가 (SIMD 변형별) 바이너리 의존성을 받고, 헤더 전용 라이브러리(TCLAP과 VST3 pluginterfaces)를 클론하며, Qt를 설치합니다. 정확한 배치와 MSBuild / qmake 명령은 [https://github.com/115dkk/EqualizerAPO-XT/blob/main/setup-build.ps1 setup-build.ps1]과 저장소의 <code>docs/LocalDependencySetup.md</code>를 보세요.
+
+=== 소스 코드 구성 ===
+
+솔루션 <code>EqualizerAPO.sln</code>은 다음 프로젝트를 묶습니다.
+
+* '''Common''' — 필터 엔진(<code>FilterEngine</code>, <code>FilterConfiguration</code>, <code>IFilter</code>), <code>filters/</code>의 필터 구현, <code>parser/</code>의 muParserX 확장, <code>helpers/</code>의 공용 도우미가 들어 있는 정적 라이브러리입니다. 컨볼루션 코드는 <code>libHybridConv-0.1.1/</code>에 있습니다. 다른 프로젝트가 여기에 링크합니다.
+* '''EqualizerAPO''' — Audio Processing Object DLL(<code>EqualizerAPO.dll</code>)입니다. COM 보일러플레이트를 담고 APO 인터페이스를 구현하며 Common 필터 엔진을 호출합니다. ATL 기반이라 <code>atls.lib</code>가 필요합니다.
+* '''Editor''' — Qt 기반 설정 편집기입니다. <code>Editor.exe</code>가 Velopack 패키지의 메인 실행 파일이며, <code>helpers/ApoRegistration</code>과 <code>helpers/VelopackBootstrap</code>을 통해 모든 Velopack 설치/업데이트/제거 훅을 처리합니다.
+* '''DeviceSelector''' — 처음 설치한 뒤 사용자가 APO를 등록할 오디오 장치를 고르도록 보여 주는 Qt 도구입니다. 원본의 Configurator를 대체합니다.
+* '''UpdateChecker''' — 로그온할 때 실행되어 빌드 채널에 새 릴리스가 있으면 알려 주는 Qt 도구입니다.
+* '''Benchmark''' — 장치에 설치하지 않고 오디오 처리를 시험하는 콘솔 프로그램입니다. 필터 종류를 실험하거나 성능을 잴 때 편합니다.
+* '''VoicemeeterClient''' — Voicemeeter 연동용 보조 프로그램입니다.
+* '''Tests''' — 단위/회귀 테스트 프로젝트입니다. <code>HybridConvTests</code>, <code>EditorLogicTests</code>, <code>AudioRegressionTests</code>입니다.
+* '''Setup''' — CI 패키징 단계가 Velopack 출력에 넣는 예제 설정 파일(<code>config/</code>)과 문서 <code>.url</code> 바로 가기입니다.
+
+CI는 <code>.github/workflows/build.yml</code>에 있습니다. x64 <code>sse2</code>, <code>avx</code>, <code>avx2</code>, <code>avx512</code>, <code>avx10_1</code> 변형과 ARM64 <code>neon</code>을 빌드한 뒤 <code>vpk pack</code>으로 채널별 설치 파일을 만듭니다([[Documentation#설치|설치]] 절과 저장소의 <code>docs/SimdBuildMatrix.md</code> 참고). 풀 리퀘스트는 AVX2만, <code>main</code> push는 모든 변형을 빌드하고 GitHub 릴리스를 만듭니다. 원본의 NSIS 설치는 제거되었습니다.
+
+== APO 개발 ==
+
+APO(Audio Processing Object)는 샘플 데이터가 장치 드라이버에 가기 전에 처리하도록 Windows 오디오 서비스가 불러오는 사용자 공간 모듈입니다. APO는 보통 오디오 드라이버와 함께 배포되며, 오디오 DRM을 우회하지 못하도록 서명되어 있습니다. 두 종류가 있습니다. '''GFX'''(전역 효과, 스트림을 믹싱한 뒤 적용)와 '''LFX'''(로컬 효과, 믹싱 전에 적용)입니다. 출력 장치에는 GFX 하나와 LFX 하나를, 입력 장치에는 LFX 하나를 등록할 수 있습니다. APO는 GUID로 식별되는 COM 객체로 등록됩니다. Microsoft의 [https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/windows-vista-custom-audio-effects Custom Audio Effects]와 [https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/reusing-windows-vista-system-effects Reusing System Effects] 문서가 이 모델과 예제를 설명합니다.
+
+사용자 APO를 추가하려면 두 가지를 넘어야 합니다. 오디오 엔진이 서명되지 않은 APO를 불러오도록 허용해야 하고, 장치의 기존 APO를 사용자 APO에 연결해 계속 동작하게 해야 합니다. Windows 오디오 서비스가 DLL을 불러오게 만드는 레지스트리 변경은 이렇습니다.
+
+# <code>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Audio</code>에서 DWORD '''<code>DisableProtectedAudioDG</code>'''를 <code>1</code>로 설정합니다. APO 서명 검사를 꺼서 서명되지 않은 APO가 로드되게 합니다. 보호된 오디오 경로가 필요한 애플리케이션은 동작이 바뀌거나 출력을 거부할 수 있습니다.
+# APO COM 클래스를 <code>HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\<GUID></code>에 등록합니다. 키 기본값으로 클래스 이름을 두고, <code>InprocServer32</code> 하위 키를 만들어 기본값을 DLL 경로로 설정하며, <code>ThreadingModel</code>을 적절히 설정합니다.
+# <code>HKEY_LOCAL_MACHINE\SOFTWARE\Classes\AudioEngine\AudioProcessingObjects\<GUID></code>를 만듭니다. 보통 DDK 함수 <code>RegisterAPO</code>(<code>audioenginebaseapo.h</code>에 선언)가 처리하며, <code>UnregisterAPO</code>가 제거합니다.
+# <code>HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render\<엔드포인트 GUID>\FxProperties</code>에서 장치별로 APO를 등록합니다(<code>Render</code> 경로는 출력 장치, <code>Capture</code>는 입력 장치). <code>FxProperties</code>에서 <code>{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},1</code> 값은 LFX APO의 GUID를, <code>...,2</code>는 GFX APO의 GUID를 담습니다. 보통 이미 드라이버 APO를 가리키므로, 사용자 APO를 등록하려면 값 하나를 교체하고 원래 값을 다른 곳에 저장합니다(Equalizer APO는 <code>HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO\Child APOs</code>에 저장). 제거할 때 원래 값을 복원하기 위해서이기도 하고, 사용자 APO가 기존 APO를 불러 호출해 그 기능을 계속 수행하게 하기 위해서이기도 합니다. Windows 8.1부터는 <code>,5</code>(LFX)와 <code>,6</code>(GFX)으로 끝나는 값도 쓰이며, 이 값으로 등록하면 옛 <code>,1</code>/<code>,2</code> 값으로 등록한 APO는 무시됩니다. 또 8.1부터 <code>{d3993a3f-99c2-4402-b5ec-a92a0367664b},5</code>와 <code>,6</code> 값이 처리 모드를 지정하며(MULTI_SZ 형식), 보통 둘 다 기본 처리 모드인 <code>{C18E2F7E-933D-4965-B7D1-1EEF228D2AF3}</code>으로 설정해야 합니다.
+
+XT에서는 이 등록과 정리를 <code>helpers/ApoRegistration</code>이 수행하며, Editor가 처리하는 Velopack 훅에서 구동됩니다.
+
+== 함께 보기 ==
+
+* [[Documentation|사용자 문서]] — EqualizerAPO-XT 사용하기.
+* [[Configuration reference|설정 레퍼런스]] — 설정 명령 집합.
+* [[en:Developer documentation|English version of this page]]

--- a/Wiki/wiki/ko/Documentation.mediawiki
+++ b/Wiki/wiki/ko/Documentation.mediawiki
@@ -1,0 +1,95 @@
+= 사용자 문서 =
+
+'''EqualizerAPO-XT'''의 사용자 문서입니다. 직접 APO를 만들거나 소스에서 빌드하려면 [[Developer documentation|개발자 문서]]를 보세요. 설치를 마친 뒤 명령을 자세히 알고 싶으면 [[Configuration reference|설정 레퍼런스]]에 전부 정리해 두었습니다.
+
+__TOC__
+
+== 설치 ==
+
+원본 Equalizer APO와 달리 XT 포크는 설치 파일이 하나가 아닙니다. CPU 명령어 집합마다 설치 파일을 따로 빌드하며, '''32비트 빌드는 없습니다.''' 64비트 x64와 ARM64만 있습니다.
+
+# [https://github.com/115dkk/EqualizerAPO-XT/releases 릴리스 페이지]에서 CPU에 맞는 <code>EqualizerAPO_Setup-<변형>.exe</code>를 받습니다. 변형은 <code>x64-sse2</code>, <code>x64-avx</code>, <code>x64-avx2</code>, <code>x64-avx512</code>, <code>x64-avx10_1</code>, <code>arm64</code>가 있습니다.
+# 무엇을 받을지 모르겠으면 '''<code>x64-avx2</code>를 받으면 됩니다.''' 대략 2013년 이후 데스크톱 CPU는 거의 다 돌아갑니다. 아주 오래된 x64 CPU라면 호환성이 가장 넓은 <code>x64-sse2</code>를, AVX는 되지만 AVX2가 안 되는 CPU라면 <code>x64-avx</code>를 받습니다. <code>x64-avx512</code>와 <code>x64-avx10_1</code>은 CPU가 실제로 그 확장을 지원할 때만, <code>arm64</code>는 ARM 기반 Windows 기기에서 받습니다. CPU 종류는 '''시작 → 설정 → 시스템 → 정보'''에서 확인할 수 있습니다.
+# 받은 설치 파일을 실행합니다. Velopack 설치 프로그램이 애플리케이션을 풀고 EqualizerAPO-XT를 등록합니다. 설치 경로를 외울 필요는 없습니다. 위치는 레지스트리에 기록됩니다([[#설치 위치|아래]] 참고).
+# 처음 설치하면 '''장치 선택기(Device Selector)'''가 열립니다. Equalizer APO를 적용할 재생 장치나 녹음 장치를 선택합니다. 잘 모르겠으면 기본 출력 장치를 고르면 됩니다. 어느 것이 기본 장치인지는 '''시작 → 설정 → 시스템 → 소리'''에서 볼 수 있습니다. 나중에 장치를 추가하거나 빼고 싶으면 설치 폴더에서 장치 선택기를 다시 실행하면 됩니다.
+# Windows가 오디오 서비스를 다시 시작하도록 두거나 재부팅합니다. 새로 등록한 APO는 오디오 엔진이 재시작해야 적용됩니다.
+# 서비스가 다시 시작되면 APO가 활성화됩니다. 기본 예제 설정에서는 음량이 조금 줄고 저역이 약간 올라가는 정도라 변화가 크지 않습니다. 쓸모 있게 바꾸려면 [[#첫 설정|첫 설정]]으로 넘어가세요.
+
+=== 설치 위치 ===
+
+EqualizerAPO-XT는 경로를 레지스트리 키 '''<code>HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO</code>'''에 기록합니다.
+
+* <code>InstallPath</code> — 애플리케이션이 설치된 디렉터리입니다.
+* <code>ConfigPath</code> — 설정 파일이 들어 있는 <code>config</code> 폴더입니다.
+
+설정 폴더로 가는 가장 쉬운 방법은 '''설정 편집기(Configuration Editor)'''를 여는 것입니다. 편집기가 이 폴더를 바로 가리킵니다. 폴더에는 자동으로 불러오는 기본 파일 <code>config.txt</code>와 함께 바로 쓸 수 있는 예제들이 들어 있습니다. <code>example.txt</code>, <code>demo.txt</code>, <code>convolution.txt</code>, <code>iir_lowpass.txt</code>, <code>multichannel.txt</code>, <code>selective_delay.txt</code>입니다.
+
+=== 자동 업데이트 ===
+
+XT는 [https://velopack.io/ Velopack]으로 설치되므로, 처음부터 다시 설치하지 않고 빌드 채널별로 업데이트가 전달됩니다.
+
+* '''UpdateChecker'''가 로그온할 때 예약 작업으로 실행되어, 해당 채널에 새 릴리스가 있으면 알려줍니다. GitHub 릴리스 피드에서 변형에 맞는 항목을 확인하고, 24시간 간격 제한과 사용자가 건너뛴 버전을 지킵니다.
+* '''설정 편집기'''도 스스로 업데이트합니다. 실행하고 약 1분 뒤 해당 채널의 새 빌드를 백그라운드에서 조용히 내려받고, 편집기를 닫을 때 조용히 적용합니다. 새 버전은 다음에 실행할 때 올라옵니다.
+
+== 첫 설정 ==
+
+# 설정 폴더를 엽니다([[#설치 위치|위]] 참고). 기본 파일은 <code>config.txt</code>이고, Equalizer APO가 자동으로 불러오며 저장할 때마다 다시 읽습니다.
+# <code>config.txt</code>를 설정 편집기나 텍스트 편집기로 엽니다. 프리앰프 값을 정한 뒤 <code>example.txt</code>를 포함하도록 되어 있습니다. APO가 도는지 확인하려면 아무 음원이나 재생하면서 소리가 나는 동안 <code>Preamp</code> 값을 바꿔 보세요. 파일을 저장하는 순간 음량이 바뀌어야 합니다.
+# 직접 보정을 만들려면 전통적으로 [https://www.roomeqwizard.com/ Room EQ Wizard](REW)로 시스템을 측정한 뒤 필터 텍스트로 내보냅니다. EqualizerAPO-XT에는 필터를 바로 추가하고 조정하는 그래픽 '''설정 편집기'''도 들어 있어, 소소한 조정에는 이쪽이 더 편하다는 사람이 많습니다.
+
+[[File:RoomEQWizard.png|thumb|none|600px|Room EQ Wizard (A–F 표시는 아래 절차에서 언급합니다)]]
+
+REW 사용법을 전부 다루는 것은 이 문서의 범위를 벗어나지만, 측정에서 필터까지의 기본 흐름은 이렇습니다.
+
+# '''Measure'''(표시 '''A''')를 눌러 측정 대화상자를 엽니다. 먼저 '''Check Levels'''로 출력 음량을 적당히 맞춘 뒤 '''Start Measuring'''을 실행합니다. 끝나면 주파수 응답 그래프가 나타납니다.
+# '''EQ'''(표시 '''B''')를 누르고 이퀄라이저 종류(표시 '''C''')를 고릅니다. '''Generic'''을 쓰거나, Q 대신 대역폭을 선호하면 '''FBQ2496'''을 씁니다. 다른 종류는 호환을 보장하지 않습니다.
+# '''EQ Filters'''(표시 '''D''')를 누릅니다. ''Control''을 ''Manual''로, ''Type''을 ''PK/PEQ''로 놓고 ''Frequency'', ''Gain'', ''Q''/''Bw Oct''를 조정해 필터를 추가합니다. 그래프가 실시간으로 갱신됩니다. 룸 보정에는 보통 피킹 필터가 알맞지만, 다른 [[Configuration reference#Filter|필터 종류]]도 쓸 수 있습니다.
+# '''Save this filter set'''(표시 '''E''')으로 REW 필터 세트를 저장해 두면 나중에 다시 불러올 수 있습니다.
+# Equalizer APO가 읽는 형식으로 내보냅니다. 메인 창에서 '''File'''(표시 '''F''') → '''Export''' → '''Filter Settings as text'''를 골라 설정 폴더에 새 이름으로 저장합니다.
+# <code>config.txt</code>의 <code>Include</code> 줄이 방금 만든 파일을 가리키도록 고칩니다. 변경은 즉시 적용됩니다.
+
+이렇게 하면 첫 설정이 완성됩니다. 필터, 채널 라우팅, 딜레이, 컨볼루션, 그래픽 EQ, 표현식 언어 같은 전체 문법은 [[Configuration reference|설정 레퍼런스]]에 있습니다. 측정 쪽을 더 깊이 알고 싶으면 REW [https://www.roomeqwizard.com/help/ 도움말]을 보세요.
+
+== 컨볼루션 ==
+
+XT 포크를 쓰는 이유 중 하나가 컨볼루션 지원입니다. [[Configuration reference#Convolution|Convolution]] 명령은 사운드 파일(WAV, FLAC, OGG 등 [https://libsndfile.github.io/libsndfile/ libsndfile]이 다루는 형식)에서 임펄스 응답을 불러와 선택한 채널과 합성곱합니다. XT는 원본의 임펄스 응답 길이 제한을 없애고 설정을 단순하게 만들었습니다. 함께 들어 있는 <code>convolution.txt</code>가 출발점입니다. 임펄스 응답의 샘플레이트는 오디오 장치의 샘플레이트와 같아야 하며, 설정 폴더 안의 임펄스 응답 파일이 바뀌면 설정이 자동으로 다시 로드됩니다.
+
+== 문제 해결 ==
+
+Equalizer APO가 기대대로 동작하지 않을 때 흔한 원인들을 모았습니다.
+
+=== 원본 APO와 장치 선택기 ===
+
+Equalizer APO는 기본적으로 사운드 카드 드라이버에 딸려 온 효과(원본 APO)를 자기 옆에서 계속 동작하게 두려고 합니다. 일부 시스템에서는 이 연결이 잡음을 일으킵니다. 재생이나 녹음이 불안정하면 '''장치 선택기'''를 열어 해당 장치를 고르고, 문제 해결 옵션을 켠 뒤 '''Use original APO''' 체크박스 두 개를 모두 해제하세요.
+
+[[File:UseOriginalAPO.png|thumb|none|500px|장치 선택기에서 원본 APO 끄기]]
+
+이렇게 하면 드라이버가 자기 APO로 제공하던 효과는 사라집니다. 그래서 한쪽만 해제해 일부 기능을 남겨 두는 방법도 있습니다. 어떤 드라이버는 다른 APO가 감지되면 자기 옵션을 막아 버리는데, '''Install APO''' 체크박스로 Equalizer APO를 pre-mix 단계나 post-mix 단계 중 한쪽에만 설치하면 나머지 단계에서 드라이버 기능 일부를 되살릴 수 있습니다.
+
+=== 제어판에서 오디오 향상이 꺼져 있음 ===
+
+설정 파일을 아무리 바꿔도 소리에 변화가 없다면, Windows 소리 설정에서 해당 장치의 APO가 꺼져 있을 수 있습니다. '''시작 → 설정 → 시스템 → 소리'''에서 장치 속성을 열고 다음을 확인합니다.
+
+* '''향상 기능'''(Enhancements) 탭이 있으면, 목록에 있는 향상 기능을 하나도 안 쓰더라도 '''모든 향상 기능 사용 안 함'''이 해제되어 있는지 확인합니다.
+* 향상 기능 탭이 없으면 '''고급'''(Advanced) 탭을 열어 '''오디오 향상 기능 사용'''이 켜져 있는지 확인합니다.
+
+[[File:EnhancementsTab.png|thumb|none|350px|"향상 기능" 탭 — "모든 향상 기능 사용 안 함"을 해제한 상태로 둡니다]]
+[[File:NoEnhancementsTab.png|thumb|none|350px|"고급" 탭 — "오디오 향상 기능 사용"을 켠 상태로 둡니다]]
+
+=== 로그 파일 ===
+
+Equalizer APO는 치명적인 문제를 만나면 다음 파일에 한 줄을 기록합니다.
+
+<pre>C:\Windows\ServiceProfiles\LocalService\AppData\Local\Temp\EqualizerAPO.log</pre>
+
+정상일 때는 이 파일이 아예 없습니다. 오류가 날 때만 만들어집니다. 더 자세한 정보가 필요하면 추적 출력을 켤 수 있습니다. <code>regedit.exe</code>를 열고 <code>HKEY_LOCAL_MACHINE\SOFTWARE\EqualizerAPO</code>로 가서 '''<code>EnableTrace</code>''' 값을 <code>true</code>로 바꿉니다. 그러면 평소 재생이나 녹음 중에도 <code>(TRACE)</code> 표시가 붙은 줄이 기록되어, 설정 파일이 어떻게 해석되는지 확인할 때 유용합니다. 끝나면 로그가 불필요하게 커지지 않도록 <code>EnableTrace</code>를 다시 <code>false</code>로 되돌리세요.
+
+=== 하드웨어 가속 OpenAL ===
+
+OpenAL을 쓰는 애플리케이션은 대개 APO를 지원하는 DirectSound로 폴백하므로 문제가 없습니다. 다만 일부 제조사는 하드웨어에 직접 접근해 APO를 우회하는 하드웨어 가속 OpenAL 라이브러리를 제공합니다. 하드웨어 가속 OpenAL에 APO 지원을 추가할 방법은 없으므로, 애플리케이션을 다른 출력 백엔드로 바꾸거나 OpenAL을 소프트웨어 모드로 돌리는 수밖에 없습니다. 예를 들어 <code>OpenAL32.dll</code>을 [https://openal-soft.org/ OpenAL Soft] 빌드로 교체하거나, <code>C:\Windows\System32</code> 또는 <code>C:\Windows\SysWOW64</code>에 있는 제조사 하드웨어 OpenAL 라이브러리(흔히 <code>*_oal.dll</code> 형태)의 이름을 바꾸는 방법이 있습니다. 뒤쪽 방법은 사운드 드라이버를 건드리는 것이라 공식적으로 지원되지 않습니다.
+
+== 함께 보기 ==
+
+* [[Configuration reference|설정 레퍼런스]] — 모든 명령과 문법.
+* [[Developer documentation|개발자 문서]] — XT 빌드와 직접 APO 만들기.
+* [[en:Documentation|English version of this page]]

--- a/Wiki/wiki/ko/Main_Page.mediawiki
+++ b/Wiki/wiki/ko/Main_Page.mediawiki
@@ -1,0 +1,19 @@
+= EqualizerAPO-XT 위키 =
+
+EqualizerAPO-XT는 Jonas Thedering의 [https://sourceforge.net/projects/equalizerapo/ Equalizer APO]를 바탕으로 한 Windows 시스템 전체 이퀄라이저입니다. XT 포크는 기존 설정 방식을 그대로 유지하면서 64비트(double) 내부 처리, 길이 제한이 없는 컨볼버 임펄스 응답, VST2/VST3 호스팅, 여러 SIMD 빌드 변형, ARM64 지원, 자동 업데이트가 되는 Velopack 설치 파일을 더했습니다.
+
+이 위키는 원본 Equalizer APO 문서의 구성을 따르되, 설치와 패키징 부분을 XT 빌드에 맞게 고쳐 썼습니다.
+
+== 문서 ==
+
+* '''[[Documentation|사용자 문서]]''' — 설치, 첫 설정, 문제 해결을 다룹니다. 여기서 시작하세요.
+* '''[[Configuration reference|설정 레퍼런스]]''' — 설정 파일 형식과 지원하는 모든 명령입니다. 고급 사용자용입니다.
+* '''[[Developer documentation|개발자 문서]]''' — 소스 빌드, 프로젝트 구조, Windows에 APO를 등록하는 방법입니다.
+
+== 다른 언어 ==
+
+* [[en:Main Page|English (영어)]]
+
+== 라이선스와 출처 ==
+
+EqualizerAPO-XT는 원본 Equalizer APO와 같은 [https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html GNU General Public License 버전 2 이상]으로 배포됩니다. VST3 호스팅에는 MIT 라이선스인 Steinberg VST3 ''pluginterfaces''를 쓰고, VST2 인터페이스 헤더는 독립적으로 다시 작성한 BSD-2 클린룸 구현본입니다. 자세한 내용은 [https://github.com/115dkk/EqualizerAPO-XT 저장소]를 보세요.


### PR DESCRIPTION
## 요약

원본 Equalizer APO의 SourceForge 위키를 **MediaWiki 문법**으로 복제하고, 설치·패키징 부분을 XT 빌드에 맞게 교정했습니다. **영어/한국어 둘 다** 작성했습니다. 저장소에 이미 vendored되어 있는 `Wiki/*.txt` 원문을 기반으로, 설명 산문은 새로 쓰고 설정 명령 레퍼런스(필터·채널·연산자·함수 표)는 기능적 사실이라 충실히 옮겼습니다.

## 구성

`Wiki/wiki/` 아래에 언어별 4페이지 + 유지보수용 인덱스를 추가했습니다.

| 페이지 | 영어 | 한국어 |
| --- | --- | --- |
| 랜딩 | `en/Main_Page.mediawiki` | `ko/Main_Page.mediawiki` |
| 사용자 문서 | `en/Documentation.mediawiki` | `ko/Documentation.mediawiki` |
| 설정 레퍼런스 | `en/Configuration_reference.mediawiki` | `ko/Configuration_reference.mediawiki` |
| 개발자 문서 | `en/Developer_documentation.mediawiki` | `ko/Developer_documentation.mediawiki` |

## 설치 가이드 교정 (XT 버전)

원본의 32/64비트 setup + Configurator.exe + 리부트 흐름을 XT 방식으로 바꿨습니다.

- SIMD 변형별 Velopack `EqualizerAPO_Setup-<채널>.exe` (x64 `sse2`/`avx`/`avx2`/`avx512`/`avx10_1` + `arm64`, **32비트 없음**)
- 어떤 변형을 받을지에 대한 안내(기본 권장: `x64-avx2`)
- DeviceSelector가 장치 선택(Configurator 대체), 레지스트리 경로 `HKLM\SOFTWARE\EqualizerAPO`의 `ConfigPath`
- UpdateChecker + Editor 자동 업데이트, 컨볼루션 길이 제한 제거

## 링크 연결

원문의 링크를 모두 검토해 위키에 연결했습니다.

- 세 문서 사이: `[[Configuration reference]]`, `[[Documentation#Channel]]` 등 위키 내부 링크 + 섹션 앵커
- 언어 간: `[[en:...]]` / `[[ko:...]]`
- 외부 링크: Room EQ Wizard, libsndfile, MSDN→learn.microsoft.com, OpenAL Soft 등 최신 주소로 갱신
- 이미지 6종(`RoomEQWizard.png`, `UseOriginalAPO.png`, `EnhancementsTab.png`, `NoEnhancementsTab.png`, `Stages.png`, `Transfer function.png`)은 `[[File:]]`로 참조, `Wiki/`에 실재하며 인덱스에 업로드 안내 포함
- 원문의 SourceForge 포럼 스레드 링크 하나는 업스트림 한정 휘발성 토론이라 의도적으로 제외

## 라이선스

문서이므로 코드 빌드에는 영향이 없습니다. 내용은 GPLv2-or-later인 우리 저장소의 vendored 위키 원문을 바탕으로 새로 쓰고 적응한 것입니다.

https://claude.ai/code/session_01XL7VwMnrkTer6gFZGJEvmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XL7VwMnrkTer6gFZGJEvmM)_