### PR TITLE
fix(editor): build Editor with Highway include; fail CI on missing Qt exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -944,17 +944,19 @@ jobs:
         $deviceSelectorSuccess = Build-QtProject "DeviceSelector" "DeviceSelector\DeviceSelector.pro"
         $updateCheckerSuccess = Build-QtProject "UpdateChecker" "UpdateChecker\UpdateChecker.pro"
 
-        # Check if any builds failed
-        if (-not $editorSuccess) {
-          Write-Error "Editor build failed"
-          exit 1
-        }
-        if (-not $deviceSelectorSuccess) {
-          Write-Error "DeviceSelector build failed"
-          exit 1
-        }
-        if (-not $updateCheckerSuccess) {
-          Write-Error "UpdateChecker build failed"
+        # Verify the executables exist. We check the files directly rather than the
+        # Build-QtProject return values: PowerShell folds the external tools' stdout
+        # into a function's output, so $...Success ended up a non-empty (always
+        # truthy) array and a failed Editor build slipped through as "success",
+        # only surfacing later as a missing Editor.exe in create-release.
+        $requiredExes = @(
+          "build-Editor-${{ matrix.platform }}\release\Editor.exe",
+          "build-DeviceSelector-${{ matrix.platform }}\release\DeviceSelector.exe",
+          "build-UpdateChecker-${{ matrix.platform }}\release\UpdateChecker.exe"
+        )
+        $missingExes = @($requiredExes | Where-Object { -not (Test-Path $_) })
+        if ($missingExes.Count -gt 0) {
+          Write-Error "Qt build did not produce: $($missingExes -join ', ')"
           exit 1
         }
 

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -401,6 +401,14 @@ isEmpty(VST3_SDK) {
 	VST3_SDK = $$PWD/../deps/vst3sdk
 }
 
+# The Editor compiles the Common DSP sources directly (PreampFilter, BiQuadFilter,
+# libHybridConv, FilterEngine.Process), which now include hwy/highway.h. Mirror
+# Common.vcxproj's HIGHWAY_INCLUDE so qmake finds the Highway headers.
+HIGHWAY_INCLUDE = $$(HIGHWAY_INCLUDE)
+isEmpty(HIGHWAY_INCLUDE) {
+	HIGHWAY_INCLUDE = $$PWD/../deps/highway
+}
+
 VELOPACK_LIB = $$(VELOPACK_LIB)
 isEmpty(VELOPACK_LIB) {
 	VELOPACK_LIB = $$PWD/../deps/velopack_libc/lib
@@ -419,7 +427,7 @@ contains(QT_ARCH, arm64) {
 	DEFINES += EAPO_UPDATE_CHANNEL=\\\"$$EAPO_UPDATE_CHANNEL\\\"
 }
 
-INCLUDEPATH += $$PWD/.. $$LIBSNDFILE_INCLUDE $$FFTW_INCLUDE $$MUPARSERX_INCLUDE $$VELOPACK_INCLUDE $$VST3_SDK
+INCLUDEPATH += $$PWD/.. $$LIBSNDFILE_INCLUDE $$FFTW_INCLUDE $$MUPARSERX_INCLUDE $$VELOPACK_INCLUDE $$VST3_SDK $$HIGHWAY_INCLUDE
 LIBS += user32.lib advapi32.lib version.lib ole32.lib Shlwapi.lib authz.lib crypt32.lib dbghelp.lib winmm.lib sndfile.lib libfftw3.lib $$VELOPACK_IMPORT_LIB
 
 build_pass:CONFIG(debug, debug|release) {


### PR DESCRIPTION
Fixes the v1.14.0 release: `create-release` failed with `Editor.exe not found in velopack-input/arm64-neon`.

## Root cause (two issues)
1. **Editor.pro lacked the Highway include.** The Editor compiles the Common DSP sources directly (`PreampFilter`, `BiQuadFilter`, `libHybridConv`, `FilterEngine.Process`). After the Highway port those `#include "hwy/highway.h"`, but `Editor.pro`'s INCLUDEPATH had no Highway entry, so the qmake/nmake Editor build failed and produced no `Editor.exe`. (`Common.vcxproj` got `HIGHWAY_INCLUDE` in #43; `Editor.pro` was missed.)
2. **CI hid it.** `Build-QtProject` returns `$true/$false`, but PowerShell folds the external tools' stdout into the function output, so `$editorSuccess` was a non-empty (always-truthy) array and the `if (-not $editorSuccess) { exit 1 }` guard never fired. The broken Editor build was reported as success and only surfaced in `create-release`.

## Fix
- `Editor.pro`: read `$$(HIGHWAY_INCLUDE)` from the environment (CI exports it) with a `deps/highway` fallback, and add it to INCLUDEPATH. Only Editor.pro compiles the SIMD sources; DeviceSelector/UpdateChecker do not.
- `build.yml`: verify the three produced `.exe` files exist instead of trusting the polluted boolean, so a failed Qt build fails the build job loudly.

## Verification
Pre-flighted on the full 6-variant matrix (SIMD_CI). ARM64 Qt build now logs `Editor built successfully` where it previously logged `Editor build failed`, and every variant is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)