### PR TITLE
[codex] add biweekly audit workflow

### DIFF
--- a/.claude/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.claude/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.claude/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.claude/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms ([LANGUAGE.md](LANGUAGE.md)) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from [LANGUAGE.md](LANGUAGE.md). Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in [LANGUAGE.md](LANGUAGE.md), reach for one that is before inventing a new one.

--- a/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.claude/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, the same template as before, but rendered as a card:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.claude/skills/tech-debt-audit/README.md
+++ b/.claude/skills/tech-debt-audit/README.md
@@ -1,0 +1,168 @@
+# tech-debt-audit
+
+A Claude Code skill that produces a thorough, citable tech debt audit of your entire codebase — not a generic best-practices checklist.
+
+```
+/tech-debt-audit
+```
+
+That's the whole interface. Run it in any repo, get back `TECH_DEBT_AUDIT.md` with file-cited findings, severity, effort estimates, and a ranked list of what to actually fix.
+
+## Why this exists
+
+LLM-generated code reviews fail in a predictable way: they pattern-match against generic heuristics, surface obvious findings without grounding them in the actual code, and produce comprehensive-feeling output that nobody acts on. The result is a tab nobody opens twice.
+
+This skill is opinionated about avoiding that failure mode. Three design choices do most of the work:
+
+**Forced orientation before judgment.** The protocol requires the model to read the manifest, map the directory structure, analyze git churn, and write a mental model of the architecture *before* it forms any opinions. Phase 1 isn't optional. Findings without context are vibes.
+
+**File:line citations on every finding.** A finding without a citation is unfalsifiable, and unfalsifiable findings don't get fixed. The skill rejects vague claims like "the code generally..." and requires `path/to/file.ext:LINE` on every concrete finding.
+
+**A required "looks bad but is actually fine" section.** This is the single biggest separator between a real audit and a checklist regurgitation. Forcing the model to surface calls it considered making and chose not to is what catches shallow analysis. If that section comes back empty, the audit didn't look hard enough.
+
+The skill also explicitly forbids recommending rewrites, forbids padding categories with filler, and produces a persistent artifact (`TECH_DEBT_AUDIT.md`) you can commit and track over time.
+
+## Why not the built-in Claude Code skills?
+
+Claude Code ships several skills that touch this space. None of them do what a debt audit needs to do.
+
+| Built-in | What it does | Why it's not a debt audit |
+|----------|--------------|----------------------------|
+| `/review` | PR-style code review of changes | Diff-scoped. Useful before merging a branch, not useful when you've inherited 80k LOC and want to know what's rotten. |
+| `/simplify` | Reduces over-engineered code in a specific area | Tactical, not architectural. Doesn't survey, doesn't cite, doesn't produce an artifact. |
+| `/debug` | Targets a specific failure or unexpected behavior | Reactive. You point it at a known problem; an audit's job is to *find* the problems. |
+| `/loop`, `/batch` | Workflow primitives for repeated or grouped tasks | Orchestration, not analysis. |
+
+What this skill adds:
+
+- **Whole-repo scope** across the nine dimensions that actually matter for debt: architectural decay, consistency rot, type & contract debt, test debt, dep & config debt, performance & resource hygiene, error handling & observability, security hygiene, and documentation drift.
+- **Multi-tool grounding.** Detects the stack and runs the right tools — `npm audit`, `knip`, `madge`, `depcheck` for TS/JS; `pip-audit`, `ruff`, `vulture`, `pydeps` for Python; `cargo audit`, `cargo udeps`, `cargo machete` for Rust; `govulncheck`, `staticcheck`, `golangci-lint` for Go — and folds the findings into the report.
+- **Subagent dispatch for large repos.** For codebases over ~50k LOC, the protocol parallelizes across modules so the main agent doesn't run out of context window before Phase 3.
+- **Persistent, citable artifact.** `TECH_DEBT_AUDIT.md` lives in your repo. You can commit it, review it in PRs, link to specific findings.
+- **Repeat-run mode.** On subsequent runs, resolved findings are marked `RESOLVED`, stale ones are updated, and new ones are tagged `NEW`. The audit becomes a living document.
+
+## Installation
+
+Personal install (available across all your projects):
+
+```bash
+mkdir -p ~/.claude/skills/tech-debt-audit
+```
+
+```bash
+curl -o ~/.claude/skills/tech-debt-audit/SKILL.md https://raw.githubusercontent.com/ksimback/tech-debt-skill/main/SKILL.md
+```
+
+Project-only install (just this repo):
+
+```bash
+mkdir -p .claude/skills/tech-debt-audit && curl -o .claude/skills/tech-debt-audit/SKILL.md https://raw.githubusercontent.com/ksimback/tech-debt-skill/main/SKILL.md
+```
+
+Verify it's available:
+
+```bash
+claude --print "/skills" | grep tech-debt-audit
+```
+
+## Usage
+
+In Claude Code, in the repo you want audited:
+
+```
+/tech-debt-audit
+```
+
+That's it. Output goes to `TECH_DEBT_AUDIT.md` in the repo root. First run takes 5–20 minutes depending on repo size. Subsequent runs in repeat-run mode are faster because the existing audit is used as a baseline.
+
+To audit only a specific subtree (useful for very large monorepos):
+
+```
+/tech-debt-audit src/payments
+```
+
+To get a mid-audit course correction (recommended on first run for any new codebase), interrupt after Phase 1 with:
+
+> Before Phase 2, tell me what surprised you in Phase 1 and what you want to investigate that isn't in the dimensions list.
+
+The best findings often come from things the prompt didn't anticipate.
+
+## How it works
+
+Three phases:
+
+1. **Orient** — read the manifest, map the structure, analyze `git log` for churn, identify the largest and most-modified files (their intersection is where debt usually hides), write a mental model.
+2. **Audit** — sweep across nine dimensions using `rg`, `ast-grep`, and language-native tooling. Cite `file:line` on every finding.
+3. **Deliverable** — write `TECH_DEBT_AUDIT.md` with executive summary, mental model, findings table, top-5 priorities, quick wins, the "looks bad but is fine" section, and open questions.
+
+The full protocol is in [`SKILL.md`](./SKILL.md).
+
+## What the output looks like
+
+`TECH_DEBT_AUDIT.md` has this shape:
+
+```
+## Executive summary
+- 3 Critical findings, 12 High, 31 Medium, 18 Low
+- Largest debt concentration: src/payments/* (3 of 3 Critical findings)
+- ...
+
+## Findings
+| ID   | Category            | File:Line                       | Severity | Effort | Description | Recommendation |
+| F001 | Architectural decay | src/payments/processor.ts:1240  | Critical | L      | 1,400-line god class handling routing, validation, retry, and reconciliation | Extract retry and reconciliation into separate services |
+| ...
+
+## Top 5
+1. F001 — Decompose payments/processor.ts: ...
+
+## Quick wins
+- [ ] F042: Remove unused dep `lodash.merge` (replaced by native ...)
+- [ ] ...
+
+## Things that look bad but are actually fine
+- The deeply nested callback pattern in src/legacy/webhooks.ts looks like a refactor target, but it preserves ordering guarantees the queue-based replacement would break. Leave it.
+- ...
+
+## Open questions for the maintainer
+- Is src/experiments/ intentionally untested, or did it fall through?
+- ...
+```
+
+## Customization
+
+The skill is designed to be forked and adapted. Common modifications:
+
+- **Add domain-specific dimensions.** The nine in Phase 2 are a starting point. Frontend repos can add accessibility; ML repos can add eval drift; LLM apps can add prompt versioning and tool-call cost; infra can add IaC drift.
+- **Tune severity thresholds.** If your codebase has a higher baseline (e.g., god files defined as >800 LOC instead of >500), edit the dimension definitions directly.
+- **Override per project.** A `.claude/skills/tech-debt-audit/SKILL.md` in a specific repo overrides the global one. Useful when one project needs custom dimensions the others don't.
+- **Split into supporting files.** As `SKILL.md` grows, extract sections into sibling files (`severity-rubric.md`, `stack-tooling.md`) and reference them. Claude Code lazy-loads supporting files, keeping the main protocol tight.
+
+## Limitations
+
+This is a static audit, not a security audit. It catches obvious security hygiene issues (hardcoded secrets, SQL injection patterns, weak crypto) but won't replace a real pen test or threat model.
+
+It won't catch business-logic bugs. Those require domain knowledge the model doesn't have.
+
+It can't perfectly distinguish intentional simplicity from accidental simplicity. The "open questions" section exists for exactly this reason — when the skill is unsure, it asks rather than asserting.
+
+For very large repos (>200k LOC), even subagent dispatch can produce shallow results. Scope to a module or run section-by-section.
+
+## Contributing
+
+PRs welcome. Before submitting:
+
+1. Test against at least two real codebases of different stacks.
+2. If you're adding a dimension, include a justification for why it isn't covered by the existing nine.
+3. If you're tightening a rule, show a before/after audit excerpt demonstrating the improvement.
+
+The single design constraint: this skill must produce findings that engineers act on. Anything that pushes toward "feels comprehensive but nothing changes" is a regression and will be rejected.
+
+## License
+
+MIT. Use it, fork it, ship it. Attribution appreciated but not required.
+
+## Credits
+
+Built on the [Claude Code Agent Skills](https://code.claude.com/docs/en/skills) standard.
+
+Inspired by the experience of working with Claude Code on codebases that got really messy over time.

--- a/.claude/skills/tech-debt-audit/SKILL.md
+++ b/.claude/skills/tech-debt-audit/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: tech-debt-audit
+description: Thorough tech debt and architecture audit of the current codebase. Produces TECH_DEBT_AUDIT.md with file-cited findings, severity, effort estimates, and a required "looks bad but is actually fine" section. Use when the user asks for a debt audit, codebase health check, architecture review, or code quality assessment of an entire repo.
+---
+
+# Tech Debt Audit
+
+A Claude Code skill that conducts a deliberate, opinionated audit of an entire codebase and produces `TECH_DEBT_AUDIT.md` with cited findings.
+
+When invoked via `/tech-debt-audit`, follow the protocol below. Everything from here through the `---` divider is the protocol Claude executes. The section after the divider is documentation for humans installing or maintaining this skill.
+
+---
+
+## Operating principles
+
+Find what's actually wrong. Not diplomatic. Not surface-only. Don't pattern-match to generic best practices without grounding in this specific repo. No sycophancy. No "overall the codebase is well-structured" filler.
+
+Cite `file:line` for every concrete finding. Vague claims like "the code generally..." don't count. Read code before judging it — a pattern that looks wrong in isolation may be load-bearing.
+
+## Phase 1: Orient
+
+Do not skip this. Forming opinions before understanding the system produces bad audits.
+
+1. Read the README, package manifest (`package.json` / `pyproject.toml` / `Cargo.toml` / `go.mod`), and any architecture docs in `/docs` or `/adr`.
+2. Map the directory structure and identify the major modules / layers.
+3. Run `git log --oneline -200` and `git log --stat --since="6 months ago"` to see what's actually changing and where churn concentrates.
+4. Identify entry points, hot paths, and cold corners.
+5. List the top 20 largest files by line count, and the 20 files most frequently modified in the last 6 months. The intersection is where debt usually hides.
+6. Use `TodoWrite` to publish a plan so the user can see progress through the phases.
+
+Write a 1–2 paragraph mental model of the architecture before proceeding. If your model contradicts the README, flag it — that itself is a finding.
+
+## Phase 2: Audit across these dimensions
+
+Use `rg`, `ast-grep`, and language-native tooling to find concrete examples. Cite `path/to/file.ext:LINE` for every finding.
+
+1. **Architectural decay** — circular deps, layering violations, god files (>500 LOC) and god functions, duplicated logic across 3+ sites where an abstraction should exist, abstractions that exist but nobody uses, dead code (unused exports, unreachable branches, stale commented-out blocks).
+
+2. **Consistency rot** — multiple ways of doing the same thing (HTTP clients, error handling, logging, config loading, validation, date handling). Naming drift. Folder structure that no longer reflects what the code actually does.
+
+3. **Type & contract debt** — `any` / `unknown` / `as any` / `# type: ignore` / loose dicts. Untyped API boundaries. Missing schema validation at trust boundaries.
+
+4. **Test debt** — run coverage if available; identify gaps on critical paths. Tests that assert implementation rather than behavior. Skipped or flaky tests. High-churn files with no tests.
+
+5. **Dependency & config debt** — `npm audit` / `pip-audit` / `cargo audit` for CVEs. Unused deps. Duplicate deps doing the same job. Env var sprawl (referenced but not documented; defaults inconsistent across envs).
+
+6. **Performance & resource hygiene** — N+1 queries, sync work in async paths, blocking I/O on hot paths, uncleaned listeners or handles, unnecessary serialization.
+
+7. **Error handling & observability** — swallowed exceptions, blanket catches, errors logged but not handled, inconsistent error shapes across modules, missing structured logs on critical paths.
+
+8. **Security hygiene** — hardcoded secrets, string-concat SQL, missing input validation at trust boundaries, permissive auth or CORS, weak crypto.
+
+9. **Documentation drift** — README claims that don't match reality, comments that contradict adjacent code, public APIs without docstrings.
+
+## Phase 3: Deliverable
+
+Write to `TECH_DEBT_AUDIT.md` in the repo root with this structure:
+
+- **Executive summary** — max 10 bullets, ranked by impact.
+- **Architectural mental model** — your understanding of the system as it actually is.
+- **Findings table** — columns: `ID | Category | File:Line | Severity (Critical/High/Medium/Low) | Effort (S/M/L) | Description | Recommendation`. Aim for 30–80 findings; padding past that is noise.
+- **Top 5 "if you fix nothing else, fix these"** — with concrete diff sketches or refactor outlines, not vague advice.
+- **Quick wins** — Low effort × Medium+ severity, as a checklist.
+- **Things that look bad but are actually fine** — calls you considered flagging and chose not to, with reasoning. **This section is required.** If it's empty, you didn't look hard enough.
+- **Open questions for the maintainer** — things you couldn't tell were debt vs. intentional.
+
+## Rules
+
+- Cite `file:line` for every concrete finding.
+- If unsure whether something is debt or intentional, ask in the open questions section — don't assert.
+- Don't recommend rewrites. Recommend specific, scoped changes.
+- Don't pad. If a category has nothing material, write "Nothing material" and move on.
+- No sycophancy. Tell the user what's broken.
+
+## Stack-specific tooling
+
+Detect the stack from the manifest and run the relevant tools. Run them in parallel when possible.
+
+- **TypeScript / JavaScript** — `npm audit`, `npx knip` (dead exports), `npx madge --circular` (circular deps), `npx depcheck` (unused deps), `tsc --noEmit` for type drift.
+- **Python** — `pip-audit`, `ruff check`, `vulture` (dead code), `pydeps --show-cycles`, `mypy --strict` for type drift.
+- **Rust** — `cargo audit`, `cargo udeps`, `cargo machete`, `cargo clippy -- -W clippy::pedantic`.
+- **Go** — `govulncheck`, `go vet`, `staticcheck`, `golangci-lint run`.
+
+If a tool isn't installed, note it in the audit and move on rather than blocking. Do not install dev tools globally without permission.
+
+## Large repos: spawn subagents
+
+If the repo is >50k LOC or has >5 top-level modules, dispatch subagents (Task tool) in parallel — one per module — and synthesize their reports. Serial reading on a large repo eats the context window before findings can be written.
+
+Each subagent gets: scope (one module), the dimensions list above, the citation requirement, and a 200-finding cap. The main agent merges, dedupes, and ranks.
+
+## Repeat-run mode
+
+If `TECH_DEBT_AUDIT.md` already exists in the repo, read it first. Mark resolved findings as `RESOLVED`, update stale ones, and tag new findings with `NEW`. This turns the audit into a living document tracked over time.
+
+---
+
+# Project documentation
+
+Everything below is for humans installing, using, or contributing to this skill. It is not part of the audit protocol.
+
+## Installation
+
+Personal install (available across all your projects):
+
+```bash
+mkdir -p ~/.claude/skills/tech-debt-audit
+```
+
+```bash
+curl -o ~/.claude/skills/tech-debt-audit/SKILL.md https://raw.githubusercontent.com/ksimback/tech-debt-skill/main/SKILL.md
+```
+
+Or for a project-only install (just this repo):
+
+```bash
+mkdir -p .claude/skills/tech-debt-audit && cp /path/to/SKILL.md .claude/skills/tech-debt-audit/SKILL.md
+```
+
+Verify it loaded:
+
+```bash
+echo "/skills" | claude
+```
+
+## Usage
+
+In Claude Code, in the repo you want audited:
+
+```
+/tech-debt-audit
+```
+
+That's it. Output goes to `TECH_DEBT_AUDIT.md` in the repo root. First run takes 5–20 minutes depending on repo size; subsequent runs in repeat-run mode are faster.
+
+## Philosophy
+
+Most "code review" prompts produce a bulleted list of generic best-practice violations dressed up as findings. This skill is built to avoid that failure mode. Three design choices do most of the work:
+
+**Forced orientation before judgment.** Phase 1 isn't optional decoration. Without a real mental model of the architecture, every Phase 2 finding is just pattern-matching against generic heuristics. Reading `git log` for churn data is what surfaces the files that *actually* have debt versus the files that just look messy.
+
+**File:line citations on every finding.** This is the single biggest quality lever. A finding without a citation is a vibe. Vibes don't get fixed.
+
+**The "looks bad but is actually fine" section is required.** This is the one most people remove when adapting the prompt. Don't. Forcing the model to surface the calls it considered making and chose not to is what separates a real audit from a checklist regurgitation. If that section is empty, the audit is shallow.
+
+The skill also explicitly forbids recommending rewrites and forbids padding categories. Both are common LLM failure modes — rewriting is easier than diagnosing, and padding makes outputs feel thorough when they aren't.
+
+## What you get
+
+`TECH_DEBT_AUDIT.md` looks like this in shape:
+
+```
+# Tech Debt Audit — <repo name>
+Generated: 2026-04-25
+
+## Executive summary
+- 3 Critical findings, 12 High, 31 Medium, 18 Low
+- Largest debt concentration: src/payments/* (god module, 4 of 3 Critical findings)
+- ...
+
+## Architectural mental model
+The system is a [...]
+
+## Findings
+| ID | Category | File:Line | Severity | Effort | Description | Recommendation |
+|----|----------|-----------|----------|--------|-------------|----------------|
+| F001 | Architectural decay | src/payments/processor.ts:1240 | Critical | L | 1,400-line god class handling routing, validation, retry, and reconciliation | Extract retry and reconciliation into separate services |
+| ... |
+
+## Top 5
+1. **F001 — Decompose payments/processor.ts** ...
+
+## Quick wins
+- [ ] F042: Remove unused dep `lodash.merge` (replaced by native ...)
+- [ ] ...
+
+## Things that look bad but are actually fine
+- The deeply nested callback pattern in `src/legacy/webhooks.ts` looks like a refactor target, but it preserves ordering guarantees that the queue-based replacement would break. Leave it.
+- ...
+
+## Open questions
+- Is `src/experiments/` intentionally untested, or did it fall through?
+- ...
+```
+
+## Adaptation notes
+
+**Project-level overrides.** A `.claude/skills/tech-debt-audit/SKILL.md` in a specific repo overrides the global one. Useful when a project needs custom dimensions — e.g., an agent codebase might add "prompt injection surface area" or "tool-call cost per turn" as audit categories.
+
+**Mid-audit course correction.** After Phase 1 completes, you can interrupt with: *"Before Phase 2, tell me what surprised you in Phase 1 and what you want to investigate that isn't in the dimensions list."* The best findings often come from things the prompt didn't anticipate. Worth doing on first run for any new codebase.
+
+**Tuning severity calibration.** If the model is over- or under-flagging, edit the Phase 2 dimensions list to add explicit thresholds. Example: change "god files (>500 LOC)" to ">800 LOC" if your codebase has a higher baseline.
+
+**Adding categories.** The 9 dimensions in Phase 2 are a starting point. Add domain-specific ones for your stack — accessibility for frontend, IaC drift for infra, model evals for ML, prompt versioning for LLM apps.
+
+**Splitting into supporting files.** As this SKILL.md grows, you can extract sections into sibling files (`severity-rubric.md`, `stack-tooling.md`) and reference them from the protocol. Claude Code lazy-loads them only when needed.
+
+## Limitations
+
+This is a static audit, not a security audit. It catches obvious security hygiene issues (hardcoded secrets, SQL injection patterns) but won't replace a real pen test or threat model.
+
+It won't catch business-logic bugs. Those require domain knowledge the model doesn't have.
+
+It can't tell intentional simplicity from accidental simplicity. The "open questions" section exists for exactly this reason — when in doubt, the skill asks rather than assuming.
+
+For very large repos (>200k LOC), even subagent dispatch can produce shallow results. Consider scoping to a module: `/tech-debt-audit src/payments`.
+
+## Contributing
+
+PRs welcome. Before submitting:
+
+1. Test against at least two real codebases of different stacks.
+2. If you're adding a dimension, include a justification for why it isn't covered by the existing 9.
+3. If you're tightening a rule, show a before/after audit excerpt demonstrating the improvement.
+
+The single design constraint: this skill must produce findings that engineers act on. Anything that pushes toward "feels comprehensive but nothing changes" is a regression.
+
+## License
+
+MIT. Use it, fork it, ship it. Attribution appreciated but not required.
+
+## Credits
+
+Built on the Claude Code Agent Skills standard. Inspired by the experience of working with Claude Code on codebases that got really messy over time.

--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -1,0 +1,357 @@
+# Biweekly Architecture & Tech Debt Audit
+#
+# Runs /improve-codebase-architecture and /tech-debt-audit in a single
+# Claude Code session. Skips scheduled runs when no relevant code/build files
+# changed since the last audit tag.
+#
+# Requirements:
+#   1. Add CLAUDE_CODE_OAUTH_TOKEN under repository Actions secrets.
+#   2. Set Actions workflow permissions to "Read and write permissions".
+#   3. Keep the two audit skills vendored under .claude/skills.
+
+name: Biweekly Audit
+
+on:
+  schedule:
+    - cron: '0 9 1,15 * *'
+  workflow_dispatch:
+    inputs:
+      force_run:
+        description: 'Run even if no relevant code changed'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_audit: ${{ steps.detect.outputs.should_audit }}
+      last_audit_ref: ${{ steps.detect.outputs.last_audit_ref }}
+      changed_files_count: ${{ steps.detect.outputs.changed_files_count }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect code changes since last audit
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          code_pathspecs=(
+            "."
+            ":!*.md"
+            ":!*.txt"
+            ":!*.rst"
+            ":!*.adoc"
+            ":!*.ipynb"
+            ":!*.png"
+            ":!*.jpg"
+            ":!*.jpeg"
+            ":!*.gif"
+            ":!*.bmp"
+            ":!*.webp"
+            ":!*.ico"
+            ":!*.svg"
+            ":!*.xcf"
+            ":!*.odg"
+            ":!*.odf"
+            ":!*.ttf"
+            ":!*.otf"
+            ":!*.qm"
+            ":!*.raw"
+            ":!*.flac"
+            ":!*.wav"
+            ":!*.url"
+            ":!*.licenseheader"
+            ":!docs/**"
+            ":!doc/**"
+            ":!Wiki/**"
+            ":!wiki/**"
+            ":!.github/ISSUE_TEMPLATE/**"
+            ":!.vscode/**"
+            ":!**/translations/*.ts"
+            ":!**/translations/*.qm"
+            ":!Tests/AudioRegressionTests/references/**"
+            ":!Tests/AudioRegressionTests/output/**"
+            ":!LICENSE*"
+            ":!License.txt"
+            ":!CHANGELOG*"
+            ":!CHANGES*"
+            ":!SECURITY.md"
+            ":!AGENTS.md"
+            ":!Agent.md"
+            ":!CLAUDE.md"
+            ":!CONTEXT.md"
+            ":!*.mermaid"
+            ":!.gitignore"
+            ":!.gitattributes"
+          )
+
+          if [ "${{ inputs.force_run }}" = "true" ]; then
+            echo "Force run requested."
+            echo "should_audit=true" >> "$GITHUB_OUTPUT"
+            echo "last_audit_ref=HEAD~50" >> "$GITHUB_OUTPUT"
+            echo "changed_files_count=forced" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t audit_tags < <(git tag -l 'audit/*' --sort=-creatordate)
+          LAST_AUDIT="${audit_tags[0]:-}"
+
+          if [ -z "$LAST_AUDIT" ]; then
+            echo "Initial audit."
+            echo "should_audit=true" >> "$GITHUB_OUTPUT"
+            echo "last_audit_ref=" >> "$GITHUB_OUTPUT"
+            echo "changed_files_count=initial" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Last audit: $LAST_AUDIT"
+          echo "last_audit_ref=$LAST_AUDIT" >> "$GITHUB_OUTPUT"
+
+          CODE_CHANGES=$(git diff --name-only "$LAST_AUDIT"..HEAD -- "${code_pathspecs[@]}" | wc -l | tr -d ' ')
+
+          echo "Code files changed: $CODE_CHANGES"
+          echo "changed_files_count=$CODE_CHANGES" >> "$GITHUB_OUTPUT"
+
+          if [ "$CODE_CHANGES" -eq 0 ]; then
+            echo "No relevant code changes. Skipping audit."
+            echo "should_audit=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_audit=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  audit:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_audit == 'true'
+    runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Install audit skills
+        run: |
+          install -d "$HOME/.claude/skills"
+          cp -R .claude/skills/improve-codebase-architecture "$HOME/.claude/skills/"
+          cp -R .claude/skills/tech-debt-audit "$HOME/.claude/skills/"
+
+          test -f "$HOME/.claude/skills/improve-codebase-architecture/SKILL.md"
+          test -f "$HOME/.claude/skills/tech-debt-audit/SKILL.md"
+
+          echo "Installed Claude audit skills:"
+          find "$HOME/.claude/skills" -maxdepth 2 -name SKILL.md -print
+
+      - name: Verify Claude subscription credentials
+        run: |
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured."
+            echo "Generate a subscription OAuth token with 'claude setup-token'."
+            echo "Add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+          if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+            echo "::warning::Ignoring ANTHROPIC_* credentials so Claude Code uses CLAUDE_CODE_OAUTH_TOKEN."
+          fi
+
+      - name: Generate change summary
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          code_pathspecs=(
+            "."
+            ":!*.md"
+            ":!*.txt"
+            ":!*.rst"
+            ":!*.adoc"
+            ":!*.ipynb"
+            ":!*.png"
+            ":!*.jpg"
+            ":!*.jpeg"
+            ":!*.gif"
+            ":!*.bmp"
+            ":!*.webp"
+            ":!*.ico"
+            ":!*.svg"
+            ":!*.xcf"
+            ":!*.odg"
+            ":!*.odf"
+            ":!*.ttf"
+            ":!*.otf"
+            ":!*.qm"
+            ":!*.raw"
+            ":!*.flac"
+            ":!*.wav"
+            ":!*.url"
+            ":!*.licenseheader"
+            ":!docs/**"
+            ":!doc/**"
+            ":!Wiki/**"
+            ":!wiki/**"
+            ":!.github/ISSUE_TEMPLATE/**"
+            ":!.vscode/**"
+            ":!**/translations/*.ts"
+            ":!**/translations/*.qm"
+            ":!Tests/AudioRegressionTests/references/**"
+            ":!Tests/AudioRegressionTests/output/**"
+            ":!LICENSE*"
+            ":!License.txt"
+            ":!CHANGELOG*"
+            ":!CHANGES*"
+            ":!SECURITY.md"
+            ":!AGENTS.md"
+            ":!Agent.md"
+            ":!CLAUDE.md"
+            ":!CONTEXT.md"
+            ":!*.mermaid"
+            ":!.gitignore"
+            ":!.gitattributes"
+          )
+
+          LAST_REF="${{ needs.check-changes.outputs.last_audit_ref }}"
+          if [ -n "$LAST_REF" ]; then
+            echo "## Changed files" > change-summary.txt
+            echo "" >> change-summary.txt
+            git diff --stat "$LAST_REF"..HEAD -- "${code_pathspecs[@]}" >> change-summary.txt 2>/dev/null || true
+          else
+            echo "Initial audit run." > change-summary.txt
+          fi
+
+      - name: Run combined audit
+        run: |
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+
+          set +e
+          claude \
+            --model claude-opus-4-8 \
+            --effort xhigh \
+            --permission-mode auto \
+            --max-turns 50 \
+            -p "
+          You will perform two analyses in sequence within this
+          single session. Output everything to stdout.
+
+          GLOBAL RULES:
+          - Completely ignore all .ipynb files.
+          - Treat docs/, Wiki/, image assets, fonts, compiled translations,
+            and audio reference blobs as out of scope unless they expose a
+            code or build-system issue.
+          - Focus on the C++ audio engine, Qt GUI, tests, build scripts,
+            release automation, and project configuration.
+          - Cite file paths for every finding.
+          - Do not suggest full rewrites.
+          - Do not pad categories with filler findings.
+
+          PART 1: Architecture Analysis
+          Run /improve-codebase-architecture.
+          Identify specific consolidation and deepening opportunities.
+          When done, print a Markdown horizontal rule (---) as a
+          separator, then proceed immediately to Part 2.
+
+          PART 2: Tech Debt Audit
+          Run /tech-debt-audit.
+          Produce the full TECH_DEBT_AUDIT.md content with severity,
+          effort estimates, and the required 'looks bad but is
+          actually fine' section.
+          " > combined-audit-report.md 2>&1
+          CLAUDE_EXIT=$?
+          set -e
+
+          if [ -f TECH_DEBT_AUDIT.md ]; then
+            {
+              echo ""
+              echo "---"
+              echo ""
+              cat TECH_DEBT_AUDIT.md
+            } >> combined-audit-report.md
+          fi
+
+          if [ ! -s combined-audit-report.md ]; then
+            echo "Audit produced no output." > combined-audit-report.md
+            cat combined-audit-report.md
+            exit 1
+          fi
+
+          if [ "$CLAUDE_EXIT" -ne 0 ]; then
+            echo "Claude audit failed with exit code $CLAUDE_EXIT."
+            cat combined-audit-report.md
+            exit "$CLAUDE_EXIT"
+          fi
+
+      - name: Create GitHub Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          COUNT="${{ needs.check-changes.outputs.changed_files_count }}"
+
+          {
+            echo "# Biweekly Audit: ${DATE}"
+            echo ""
+            echo "Changed relevant files: **${COUNT}**"
+            echo "Model: Opus 4.8 - Effort: xhigh - 1M context"
+            echo ""
+            cat change-summary.txt
+            echo ""
+            echo "---"
+            echo ""
+            head -c 60000 combined-audit-report.md
+          } > issue-body.md
+
+          gh label create audit \
+            --repo "${GITHUB_REPOSITORY}" \
+            --color "5319e7" \
+            --description "Architecture and tech debt audit" \
+            >/dev/null 2>&1 || true
+
+          gh label create maintenance \
+            --repo "${GITHUB_REPOSITORY}" \
+            --color "fbca04" \
+            --description "Maintenance work" \
+            >/dev/null 2>&1 || true
+
+          ISSUE_URL=$(gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Biweekly Audit: ${DATE}" \
+            --body-file issue-body.md \
+            --label audit \
+            --label maintenance)
+
+          echo "Created issue: ${ISSUE_URL}"
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "audit-report-${{ github.run_id }}"
+          path: |
+            combined-audit-report.md
+            change-summary.txt
+            TECH_DEBT_AUDIT.md
+          retention-days: 90
+
+      - name: Tag audit checkpoint
+        run: |
+          AUDIT_TAG="audit/$(date +%Y%m%d-%H%M%S)"
+          git tag "$AUDIT_TAG"
+          git push origin "$AUDIT_TAG"
+          echo "Tagged: $AUDIT_TAG"


### PR DESCRIPTION
## Summary
- Add a biweekly Claude Code architecture and tech-debt audit workflow.
- Vendor the two audit skills under .claude/skills so CI can install them.
- Exclude docs, Wiki pages, images, fonts, translations, and audio reference blobs from scheduled change detection while keeping C++/Qt/build/CI files in scope.

## Validation
- git diff --cached --check
- verified the staged audit pathspec only counts .github/workflows/biweekly-audit.yml for this PR

Notes: pre-existing untracked local reference/ and .claude/worktrees files were left untouched.