### PR TITLE
[codex] update audit workflow actions for Node 24

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -140,7 +140,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -359,7 +359,7 @@ jobs:
           fi
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "audit-report-${{ github.run_id }}"
           path: |


### PR DESCRIPTION
## Summary
- Update the audit workflow from actions/setup-node@v4 to @v6.
- Update the audit artifact upload step from actions/upload-artifact@v4 to @v7.
- This addresses the GitHub Actions Node 20 deprecation warning without rerunning the audit manually.

## Validation
- git diff --check
- verified official latest releases: setup-node v6.4.0 and upload-artifact v7.0.1
- confirmed only .github/workflows/biweekly-audit.yml changed