### PR TITLE
feat: CPU auto-detect front-door installer (+ ARM64 update-channel fix)

### DIFF
--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -26,7 +26,7 @@ $ErrorActionPreference = "Stop"
 # Order matters: Get-ChannelFromAssetName matches Pattern values top to bottom,
 # so more specific patterns (e.g. avx10/avx512/avx2) must precede broader ones (avx).
 $ChannelTable = [ordered]@{
-  "arm64"       = @{ Pattern = "arm64";                      SortOrder = 40;  Guidance = "Windows on ARM64 devices." }
+  "arm64-neon"  = @{ Pattern = "arm64";                      SortOrder = 40;  Guidance = "Windows on ARM64 devices." }
   "x64-sse2"    = @{ Pattern = "sse2|baseline";              SortOrder = 5;   Guidance = "Baseline 64-bit Intel/AMD systems. Pick this for older x64 CPUs that do not support AVX." }
   "x64-avx10-1" = @{ Pattern = "avx10-1|avx10_1";            SortOrder = 30;  Guidance = "64-bit Intel/AMD systems with AVX10.1 support." }
   "x64-avx512"  = @{ Pattern = "avx512";                     SortOrder = 20;  Guidance = "64-bit Intel/AMD systems where you specifically want the AVX-512 build." }

--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -49,6 +49,13 @@ if (Test-Path $manifestPath) {
 $UnknownChannelSortOrder = 100
 $UnknownChannelGuidance = "Special-purpose asset. Use one of the setup executables for normal installation."
 
+# The architecture-agnostic front-door installer (docs/AutoDetectInstaller.md).
+# It is not a channel: it detects the CPU at install time and pulls the matching
+# per-channel build. Featured first in the download table.
+$UniversalInstallerName = "EqualizerAPO-XT-Setup.exe"
+$UniversalInstallerSortOrder = -1
+$UniversalInstallerGuidance = "Recommended. Detects your CPU (architecture and AVX level) and installs the matching build automatically. Use this unless you have a reason to pick a specific build below."
+
 function Invoke-GhJson {
   param(
     [Parameter(Mandatory = $true)]
@@ -124,6 +131,10 @@ function Get-AssetPurpose {
     [string]$AssetName
   )
 
+  if ($AssetName -ieq $UniversalInstallerName) {
+    return "Recommended installer. Detects your CPU and installs the matching build automatically."
+  }
+
   $channel = Get-ChannelFromAssetName $AssetName
 
   if ($AssetName -match "-Setup\.exe$") {
@@ -195,7 +206,13 @@ $assets = @($release.assets | Sort-Object name)
 $installerAssets = @(
   $assets |
     Where-Object { $_.name -match "-Setup\.exe$" } |
-    Sort-Object @{ Expression = { Get-ChannelSortOrder (Get-ChannelFromAssetName $_.name) } }, name
+    Sort-Object @{ Expression = {
+        if ($_.name -ieq $UniversalInstallerName) {
+          $UniversalInstallerSortOrder
+        } else {
+          Get-ChannelSortOrder (Get-ChannelFromAssetName $_.name)
+        }
+      } }, name
 )
 $sourceAssets = @($assets | Where-Object { $_.name -match "^EqualizerAPO-XT-source-.*\.zip$" })
 
@@ -242,14 +259,17 @@ $lines = [System.Collections.Generic.List[string]]::new()
 [void]$lines.Add("| --- | --- |")
 
 foreach ($asset in $installerAssets) {
-  $channel = Get-ChannelFromAssetName $asset.name
-  $guidance = Get-DownloadGuidance $channel
+  if ($asset.name -ieq $UniversalInstallerName) {
+    $guidance = $UniversalInstallerGuidance
+  } else {
+    $guidance = Get-DownloadGuidance (Get-ChannelFromAssetName $asset.name)
+  }
   $name = Escape-MarkdownCell $asset.name
   [void]$lines.Add("| [$name]($($asset.browser_download_url)) | $(Escape-MarkdownCell $guidance) |")
 }
 
 [void]$lines.Add("")
-[void]$lines.Add('The setup executables are the normal installer downloads. The `.nupkg` and `releases.*.json` files are for the Velopack/update pipeline.')
+[void]$lines.Add('The recommended download auto-detects your CPU and installs the matching build. The per-channel setup executables are for picking a specific build by hand. The `.nupkg` and `releases.*.json` files are for the Velopack/update pipeline.')
 [void]$lines.Add("")
 [void]$lines.Add("## All files")
 [void]$lines.Add("")

--- a/.github/simd-variants.psd1
+++ b/.github/simd-variants.psd1
@@ -112,7 +112,7 @@
             Simd      = 'neon'
             ArchFlag  = $null                                   # ARM64 passes no /arch override
             QtArchFlag = $null
-            Channel   = 'arm64'
+            Channel   = 'arm64-neon'                            # matches the published Velopack channel
             Fftw      = 'fftw-windows-release-arm64.zip'
             Muparserx = 'muparserx-msvc-release-ARM64.zip'
             Sndfile   = 'libsndfile-arm64.zip'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -866,7 +866,11 @@ jobs:
 
         $BuildPlatform = "${{ matrix.platform }}"
         $updateChannel = if ($BuildPlatform -eq "ARM64") {
-          "arm64"
+          # Must match the channel the create-release job publishes for ARM64
+          # (derived from the artifact name EqualizerAPO-ARM64-neon -> arm64-neon).
+          # The old "arm64" looked for releases.arm64.json, which is never
+          # published, so ARM64 builds never found updates.
+          "arm64-neon"
         } elseif ($BuildPlatform -eq "x64") {
           "x64-" + ("${{ matrix.simd_variant }}" -replace "_", "-")
         } else {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1174,6 +1174,12 @@ jobs:
         pattern: EqualizerAPO-*
         path: ${{ github.workspace }}\release-input
 
+    # MSBuild for the x86 auto-detect installer built in this job (the matrix
+    # builds the per-variant binaries; this front-door installer is a single
+    # architecture-agnostic binary built once here).
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v3
+
     - name: Resolve release version
       id: version
       shell: pwsh
@@ -1370,6 +1376,37 @@ jobs:
 
         $sourceZip = "${{ github.workspace }}\EqualizerAPO-XT-source-${{ steps.version.outputs.pack_version }}.zip"
         gh release upload $tag $sourceZip --clobber --repo "${{ github.repository }}"
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+    - name: Build and publish auto-detect installer
+      if: steps.version.outputs.already_released != 'true'
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # EqualizerAPO-XT-Setup.exe is the x86 front-door installer: it detects the
+        # CPU (architecture + AVX level) and downloads/runs the matching per-channel
+        # Setup. It has no external dependencies, so it builds standalone here.
+        # See docs/AutoDetectInstaller.md.
+        $tag = "${{ steps.version.outputs.tag }}"
+
+        msbuild Installer\Installer.vcxproj `
+          /p:Configuration=Release `
+          /p:Platform=Win32 `
+          /m /v:minimal /nologo
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        $setupExe = "${{ github.workspace }}\Installer\Release\EqualizerAPO-XT-Setup.exe"
+        if (-not (Test-Path $setupExe)) {
+          Write-Error "Auto-detect installer was not produced at $setupExe"
+          exit 1
+        }
+
+        gh release upload $tag $setupExe --clobber --repo "${{ github.repository }}"
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
         }

--- a/EqualizerAPO.sln
+++ b/EqualizerAPO.sln
@@ -41,6 +41,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UpdateChecker", "UpdateChec
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestVst2Plugin", "Tests\TestVst2Plugin\TestVst2Plugin.vcxproj", "{7E2B1C44-9A3D-4E58-B6F1-2C9D8A7F4E10}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Installer", "Installer\Installer.vcxproj", "{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -171,6 +173,14 @@ Global
 		{7E2B1C44-9A3D-4E58-B6F1-2C9D8A7F4E10}.Release|Win32.Build.0 = Release|Win32
 		{7E2B1C44-9A3D-4E58-B6F1-2C9D8A7F4E10}.Release|x64.ActiveCfg = Release|x64
 		{7E2B1C44-9A3D-4E58-B6F1-2C9D8A7F4E10}.Release|x64.Build.0 = Release|x64
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Debug|Win32.ActiveCfg = Debug|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Debug|Win32.Build.0 = Debug|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Debug|x64.ActiveCfg = Debug|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Release|ARM64.ActiveCfg = Release|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Release|Win32.ActiveCfg = Release|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Release|Win32.Build.0 = Release|Win32
+		{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}.Release|x64.ActiveCfg = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Installer/AutoInstaller.cpp
+++ b/Installer/AutoInstaller.cpp
@@ -1,0 +1,485 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    EqualizerAPO-XT-Setup.exe - the auto-detect front-door installer.
+
+    It detects the machine's native CPU architecture and best supported x86
+    instruction set, then downloads and runs the matching per-variant Velopack
+    Setup.exe from the latest GitHub release. The user chooses nothing.
+
+    Design and rationale: docs/AutoDetectInstaller.md. The short version:
+      - Built as a 32-bit (x86) Win32 GUI app so one binary runs on x64 natively
+        and on ARM64 under emulation. CPUID/XGETBV report true CPU/OS state
+        regardless of process bitness, and IsWow64Process2 reports the native
+        machine even under emulation, so detection is accurate from x86.
+      - It does NOT touch the six per-channel Velopack packages or their
+        per-channel auto-update path; it only picks which one to install.
+
+    The six channel strings below MUST stay in sync with
+    .github/simd-variants.psd1, .github/workflows/build.yml and
+    .github/scripts/New-ReleaseNotes.ps1 (this file is compiled C++ and cannot
+    read the manifest).
+*/
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <winhttp.h>
+#include <shlobj.h>      // IProgressDialog
+#include <shellapi.h>    // CommandLineToArgvW
+#include <intrin.h>      // __cpuid, __cpuidex, _xgetbv
+#include <string>
+
+#pragma comment(lib, "winhttp.lib")
+#pragma comment(lib, "ole32.lib")
+#pragma comment(lib, "shell32.lib")
+
+namespace
+{
+// GitHub repository that hosts the releases. Matches the GithubSource URL used by
+// the in-app updater (Editor/main.cpp).
+const wchar_t* kRepoOwner = L"115dkk";
+const wchar_t* kRepoName = L"EqualizerAPO-XT";
+const wchar_t* kReleasesPage = L"https://github.com/115dkk/EqualizerAPO-XT/releases/latest";
+const wchar_t* kUserAgent = L"EqualizerAPO-XT-Setup";
+
+// Channel index used as the process exit code for --detect-only, so a script can
+// read the detected variant without parsing stdout.
+enum ChannelIndex
+{
+    kSse2 = 0,
+    kAvx = 1,
+    kAvx2 = 2,
+    kAvx512 = 3,
+    kAvx10_1 = 4,
+    kArm64 = 5
+};
+
+// IsWow64Process2 reports the native machine even when this x86 process runs
+// under x64/ARM64 emulation. Fall back to GetNativeSystemInfo on the (very old)
+// systems that lack it.
+bool isArm64Native()
+{
+    typedef BOOL(WINAPI * PFN_IsWow64Process2)(HANDLE, USHORT*, USHORT*);
+    HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
+    if (kernel32 != nullptr)
+    {
+        PFN_IsWow64Process2 fn =
+            reinterpret_cast<PFN_IsWow64Process2>(GetProcAddress(kernel32, "IsWow64Process2"));
+        if (fn != nullptr)
+        {
+            USHORT processMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+            USHORT nativeMachine = IMAGE_FILE_MACHINE_UNKNOWN;
+            if (fn(GetCurrentProcess(), &processMachine, &nativeMachine))
+                return nativeMachine == IMAGE_FILE_MACHINE_ARM64;
+        }
+    }
+
+    SYSTEM_INFO si = {};
+    GetNativeSystemInfo(&si);
+    return si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64;
+}
+
+// Resolve the best build channel for this machine. The CPUID feature bits are
+// gated on the OS having actually enabled the wider register state (XGETBV/XCR0),
+// so we never pick a build the OS cannot context-switch.
+std::wstring detectChannel(int* outIndex)
+{
+    if (isArm64Native())
+    {
+        if (outIndex != nullptr)
+            *outIndex = kArm64;
+        return L"arm64-neon";
+    }
+
+    int info[4] = { 0, 0, 0, 0 };
+    __cpuid(info, 0);
+    const int maxLeaf = info[0];
+
+    __cpuid(info, 1);
+    const bool osxsave = (info[2] & (1 << 27)) != 0;   // ECX[27]
+    const bool cpuAvx = (info[2] & (1 << 28)) != 0;    // ECX[28]
+
+    bool osYmm = false;   // XMM + YMM state enabled by the OS
+    bool osZmm = false;   // + opmask + ZMM_Hi256 + Hi16_ZMM
+    if (osxsave)
+    {
+        const unsigned long long xcr0 = _xgetbv(0); // _XCR_XFEATURE_ENABLED_MASK
+        osYmm = (xcr0 & 0x6) == 0x6;                 // bits 1,2
+        osZmm = osYmm && ((xcr0 & 0xE0) == 0xE0);    // bits 5,6,7
+    }
+    const bool haveAvx = cpuAvx && osYmm;
+
+    bool haveAvx2 = false;
+    bool haveAvx512f = false;
+    bool haveAvx10_1 = false;
+    if (maxLeaf >= 7)
+    {
+        __cpuidex(info, 7, 0);
+        haveAvx2 = ((info[1] & (1 << 5)) != 0) && haveAvx;       // EBX[5], needs YMM
+        haveAvx512f = ((info[1] & (1 << 16)) != 0) && osZmm;     // EBX[16], needs ZMM
+
+        __cpuidex(info, 7, 1);
+        const bool avx10Enumerated = (info[3] & (1 << 19)) != 0; // EDX[19]
+        if (avx10Enumerated && maxLeaf >= 0x24)
+        {
+            __cpuidex(info, 0x24, 0);
+            const int avx10Version = info[1] & 0xFF;             // EBX[7:0]
+            const bool avx10Has512 = (info[1] & (1 << 18)) != 0; // EBX[18] AVX10/512
+            haveAvx10_1 = (avx10Version >= 1) && avx10Has512 && osZmm;
+        }
+    }
+
+    // Most specific / newest first.
+    if (haveAvx10_1)
+    {
+        if (outIndex != nullptr)
+            *outIndex = kAvx10_1;
+        return L"x64-avx10-1";
+    }
+    if (haveAvx512f)
+    {
+        if (outIndex != nullptr)
+            *outIndex = kAvx512;
+        return L"x64-avx512";
+    }
+    if (haveAvx2)
+    {
+        if (outIndex != nullptr)
+            *outIndex = kAvx2;
+        return L"x64-avx2";
+    }
+    if (haveAvx)
+    {
+        if (outIndex != nullptr)
+            *outIndex = kAvx;
+        return L"x64-avx";
+    }
+    if (outIndex != nullptr)
+        *outIndex = kSse2;
+    return L"x64-sse2";
+}
+
+// Per-variant installer asset name. The channel appears twice because each
+// variant's packId already embeds the channel (EqualizerAPO-XT-<channel>), and
+// Velopack appends "-<channel>-Setup.exe".
+std::wstring assetName(const std::wstring& channel)
+{
+    return L"EqualizerAPO-XT-" + channel + L"-" + channel + L"-Setup.exe";
+}
+
+// Always-latest download path. GitHub redirects /releases/latest/download/<asset>
+// to the newest release's asset, so this binary never needs rebuilding per release.
+std::wstring assetPath(const std::wstring& channel)
+{
+    return std::wstring(L"/") + kRepoOwner + L"/" + kRepoName +
+        L"/releases/latest/download/" + assetName(channel);
+}
+
+std::wstring downloadUrl(const std::wstring& channel)
+{
+    return std::wstring(L"https://github.com") + assetPath(channel);
+}
+
+std::wstring tempFilePath(const std::wstring& fileName)
+{
+    wchar_t dir[MAX_PATH] = {};
+    DWORD len = GetTempPathW(MAX_PATH, dir);
+    if (len == 0 || len > MAX_PATH)
+        return fileName;
+    return std::wstring(dir) + fileName;
+}
+
+// Download github.com<path> to outFile over HTTPS. WinHTTP follows GitHub's
+// redirect to the objects CDN automatically (https->https, allowed by the
+// default redirect policy). Returns true on HTTP 200 + complete write.
+bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::wstring& error)
+{
+    bool ok = false;
+    HINTERNET session = nullptr;
+    HINTERNET connect = nullptr;
+    HINTERNET request = nullptr;
+    HANDLE file = INVALID_HANDLE_VALUE;
+
+    session = WinHttpOpen(kUserAgent, WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+        WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (session == nullptr)
+    {
+        error = L"Could not initialise WinHTTP.";
+        goto cleanup;
+    }
+
+    connect = WinHttpConnect(session, L"github.com", INTERNET_DEFAULT_HTTPS_PORT, 0);
+    if (connect == nullptr)
+    {
+        error = L"Could not connect to github.com.";
+        goto cleanup;
+    }
+
+    request = WinHttpOpenRequest(connect, L"GET", path.c_str(), nullptr,
+        WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+    if (request == nullptr)
+    {
+        error = L"Could not create the download request.";
+        goto cleanup;
+    }
+
+    if (!WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+            WINHTTP_NO_REQUEST_DATA, 0, 0, 0) ||
+        !WinHttpReceiveResponse(request, nullptr))
+    {
+        error = L"No response from the download server. Check your internet connection.";
+        goto cleanup;
+    }
+
+    {
+        DWORD statusCode = 0;
+        DWORD size = sizeof(statusCode);
+        WinHttpQueryHeaders(request,
+            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            WINHTTP_HEADER_NAME_BY_INDEX, &statusCode, &size, WINHTTP_NO_HEADER_INDEX);
+        if (statusCode != 200)
+        {
+            error = L"The matching installer was not found on the release page (HTTP " +
+                std::to_wstring(statusCode) + L").";
+            goto cleanup;
+        }
+    }
+
+    file = CreateFileW(outFile.c_str(), GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE)
+    {
+        error = L"Could not create a temporary file for the download.";
+        goto cleanup;
+    }
+
+    for (;;)
+    {
+        DWORD available = 0;
+        if (!WinHttpQueryDataAvailable(request, &available))
+        {
+            error = L"The download was interrupted.";
+            goto cleanup;
+        }
+        if (available == 0)
+            break;
+
+        std::string buffer;
+        buffer.resize(available);
+        DWORD read = 0;
+        if (!WinHttpReadData(request, &buffer[0], available, &read) || read == 0)
+        {
+            error = L"The download was interrupted.";
+            goto cleanup;
+        }
+
+        DWORD written = 0;
+        if (!WriteFile(file, buffer.data(), read, &written, nullptr) || written != read)
+        {
+            error = L"Could not write the downloaded installer to disk.";
+            goto cleanup;
+        }
+    }
+
+    ok = true;
+
+cleanup:
+    if (file != INVALID_HANDLE_VALUE)
+        CloseHandle(file);
+    if (request != nullptr)
+        WinHttpCloseHandle(request);
+    if (connect != nullptr)
+        WinHttpCloseHandle(connect);
+    if (session != nullptr)
+        WinHttpCloseHandle(session);
+    if (!ok && file != INVALID_HANDLE_VALUE)
+        DeleteFileW(outFile.c_str());
+    return ok;
+}
+
+// Launch the downloaded per-variant Setup.exe. When silent, forward Velopack's
+// -s/--silent and wait so a caller knows when the install finished; otherwise
+// hand off to Velopack's own install UI and return immediately.
+bool launchSetup(const std::wstring& setupPath, bool silent, DWORD& exitCode)
+{
+    std::wstring commandLine = L"\"" + setupPath + L"\"";
+    if (silent)
+        commandLine += L" --silent";
+
+    STARTUPINFOW startup = {};
+    startup.cb = sizeof(startup);
+    PROCESS_INFORMATION proc = {};
+
+    // CreateProcessW may modify the command-line buffer, so pass a writable copy.
+    std::wstring mutableCommand = commandLine;
+    if (!CreateProcessW(setupPath.c_str(), &mutableCommand[0], nullptr, nullptr, FALSE,
+            0, nullptr, nullptr, &startup, &proc))
+    {
+        return false;
+    }
+
+    if (silent)
+    {
+        WaitForSingleObject(proc.hProcess, INFINITE);
+        GetExitCodeProcess(proc.hProcess, &exitCode);
+    }
+    else
+    {
+        exitCode = 0;
+    }
+
+    CloseHandle(proc.hThread);
+    CloseHandle(proc.hProcess);
+    return true;
+}
+
+bool hasFlag(int argc, wchar_t** argv, const wchar_t* flag)
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        if (_wcsicmp(argv[i], flag) == 0)
+            return true;
+    }
+    return false;
+}
+
+const wchar_t* flagValue(int argc, wchar_t** argv, const wchar_t* flag)
+{
+    for (int i = 1; i + 1 < argc; ++i)
+    {
+        if (_wcsicmp(argv[i], flag) == 0)
+            return argv[i + 1];
+    }
+    return nullptr;
+}
+
+void writeTextFile(const wchar_t* path, const std::wstring& text)
+{
+    HANDLE file = CreateFileW(path, GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE)
+        return;
+    std::string utf8;
+    int needed = WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (needed > 1)
+    {
+        utf8.resize(needed - 1);
+        WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1, &utf8[0], needed - 1, nullptr, nullptr);
+        DWORD written = 0;
+        WriteFile(file, utf8.data(), static_cast<DWORD>(utf8.size()), &written, nullptr);
+    }
+    CloseHandle(file);
+}
+
+// Print the detection result for --detect-only. Try the parent console first
+// (so it works from a shell), then fall back to a message box and an optional
+// --out file. Returns the channel index for use as the process exit code.
+int reportDetection(const std::wstring& channel, const std::wstring& url,
+    const wchar_t* outPath, int index)
+{
+    const std::wstring text = channel + L"\n" + url + L"\n";
+
+    if (AttachConsole(ATTACH_PARENT_PROCESS))
+    {
+        HANDLE conout = CreateFileW(L"CONOUT$", GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+        if (conout != INVALID_HANDLE_VALUE)
+        {
+            DWORD written = 0;
+            WriteConsoleW(conout, text.c_str(), static_cast<DWORD>(text.size()), &written, nullptr);
+            CloseHandle(conout);
+        }
+        FreeConsole();
+    }
+    else
+    {
+        MessageBoxW(nullptr, (channel + L"\n" + url).c_str(),
+            L"EqualizerAPO-XT - detected variant", MB_OK | MB_ICONINFORMATION);
+    }
+
+    if (outPath != nullptr)
+        writeTextFile(outPath, channel + L"\n" + url + L"\n");
+
+    return index;
+}
+} // namespace
+
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
+{
+    int argc = 0;
+    wchar_t** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    const bool detectOnly = argv != nullptr && hasFlag(argc, argv, L"--detect-only");
+    const bool silent = argv != nullptr && hasFlag(argc, argv, L"--silent");
+    const wchar_t* outPath = argv != nullptr ? flagValue(argc, argv, L"--out") : nullptr;
+
+    int index = kAvx2;
+    const std::wstring channel = detectChannel(&index);
+    const std::wstring url = downloadUrl(channel);
+
+    if (detectOnly)
+    {
+        const int code = reportDetection(channel, url, outPath, index);
+        if (argv != nullptr)
+            LocalFree(argv);
+        return code;
+    }
+
+    if (argv != nullptr)
+        LocalFree(argv);
+
+    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
+    // A marquee shell progress dialog covers the detect+download gap so the user
+    // is not left staring at nothing before Velopack's installer appears.
+    IProgressDialog* progress = nullptr;
+    if (SUCCEEDED(CoCreateInstance(CLSID_ProgressDialog, nullptr, CLSCTX_INPROC_SERVER,
+            IID_PPV_ARGS(&progress))) && progress != nullptr)
+    {
+        progress->SetTitle(L"EqualizerAPO-XT");
+        progress->SetLine(1, L"Selecting the best build for your CPU...", FALSE, nullptr);
+        progress->SetLine(2, channel.c_str(), FALSE, nullptr);
+        progress->StartProgressDialog(nullptr, nullptr,
+            PROGDLG_MARQUEEPROGRESS | PROGDLG_NOMINIMIZE | PROGDLG_NOCANCEL, nullptr);
+    }
+
+    const std::wstring outFile = tempFilePath(assetName(channel));
+    std::wstring error;
+    const bool downloaded = downloadToFile(assetPath(channel), outFile, error);
+
+    if (progress != nullptr)
+    {
+        progress->StopProgressDialog();
+        progress->Release();
+        progress = nullptr;
+    }
+
+    int result = 0;
+    if (!downloaded)
+    {
+        const std::wstring message = error + L"\n\nYou can download a build manually from:\n" +
+            kReleasesPage;
+        MessageBoxW(nullptr, message.c_str(),
+            L"EqualizerAPO-XT - install failed", MB_OK | MB_ICONERROR);
+        result = 2;
+    }
+    else
+    {
+        DWORD setupExit = 0;
+        if (!launchSetup(outFile, silent, setupExit))
+        {
+            MessageBoxW(nullptr,
+                L"The downloaded installer could not be started.",
+                L"EqualizerAPO-XT - install failed", MB_OK | MB_ICONERROR);
+            result = 3;
+        }
+        else if (silent)
+        {
+            result = static_cast<int>(setupExit);
+        }
+    }
+
+    CoUninitialize();
+    return result;
+}

--- a/Installer/AutoInstaller.exe.manifest
+++ b/Installer/AutoInstaller.exe.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="EqualizerAPO-XT.Setup" version="1.0.0.0" processorArchitecture="*" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!-- The per-variant Velopack Setup installs per-user to %LocalAppData%, so
+             no elevation here. APO registration elevates later, inside the Editor. -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/Installer/AutoInstaller.rc
+++ b/Installer/AutoInstaller.rc
@@ -1,0 +1,39 @@
+#include <windows.h>
+#include "../version.h"
+
+// Stringize the numeric version parts from version.h for the string fields.
+#define EAPO_STR2(x) #x
+#define EAPO_STR(x) EAPO_STR2(x)
+#define EAPO_VERSION_STR EAPO_STR(MAJOR) "." EAPO_STR(MINOR) "." EAPO_STR(REVISION) ".0"
+
+// Application icon (reuses the Editor's icon).
+1 ICON "..\\Editor\\icons\\applications-graphics-rotated.ico"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION MAJOR,MINOR,REVISION,0
+ PRODUCTVERSION MAJOR,MINOR,REVISION,0
+ FILEFLAGSMASK 0x3fL
+ FILEFLAGS 0x0L
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_APP
+ FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "EqualizerAPO-XT contributors"
+            VALUE "FileDescription", "EqualizerAPO-XT auto-detect installer"
+            VALUE "FileVersion", EAPO_VERSION_STR
+            VALUE "InternalName", "EqualizerAPO-XT-Setup"
+            VALUE "LegalCopyright", "GNU General Public License v2 or later"
+            VALUE "OriginalFilename", "EqualizerAPO-XT-Setup.exe"
+            VALUE "ProductName", "EqualizerAPO-XT"
+            VALUE "ProductVersion", EAPO_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/Installer/Installer.vcxproj
+++ b/Installer/Installer.vcxproj
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    EqualizerAPO-XT-Setup.exe — the auto-detect front-door installer.
+    Built for Win32 (x86) only: one x86 binary runs on x64 natively and on ARM64
+    under emulation, covering every target the app ships for. See
+    docs/AutoDetectInstaller.md. It has no external dependencies and statically
+    links the CRT (/MT) because it runs before any vcredist is installed.
+  -->
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3F1A9C2E-7B45-4D8A-9E61-2C7D4B8F0A13}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Installer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v145</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <TargetName>EqualizerAPO-XT-Setup</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(MSBuildThisFileDirectory)AutoInstaller.exe.manifest</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(MSBuildThisFileDirectory)AutoInstaller.exe.manifest</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="AutoInstaller.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="AutoInstaller.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="AutoInstaller.exe.manifest" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ After that, the project will focus on:
 
 Use the [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases) when XT builds are published. A push to `main` builds all supported variants and creates a GitHub Release with Velopack-packaged installers and a source code zip.
 
+The recommended download is **EqualizerAPO-XT-Setup.exe**, an auto-detect installer. It detects your CPU (architecture and AVX level) and downloads the matching build automatically, so you do not have to pick a SIMD variant by hand. The per-channel `…-Setup.exe` files stay available for installing a specific build. See [docs/AutoDetectInstaller.md](docs/AutoDetectInstaller.md).
+
 The installed update checker reads the matching Velopack channel feed and opens the correct channel setup asset when a newer release is available. The flow is documented in [docs/VelopackUpdates.md](docs/VelopackUpdates.md).
 
 Until then, build locally or use upstream Equalizer APO for normal production use.

--- a/UpdateChecker/VelopackUpdateInfo.cpp
+++ b/UpdateChecker/VelopackUpdateInfo.cpp
@@ -176,7 +176,7 @@ QString VelopackUpdateInfo::defaultChannel()
 #ifdef EAPO_UPDATE_CHANNEL
 	return QStringLiteral(EAPO_UPDATE_CHANNEL);
 #elif defined(_M_ARM64) || defined(__aarch64__)
-	return QStringLiteral("arm64");
+	return QStringLiteral("arm64-neon");
 #else
 	return QStringLiteral("x64-avx2");
 #endif

--- a/docs/AutoDetectInstaller.md
+++ b/docs/AutoDetectInstaller.md
@@ -1,0 +1,139 @@
+# Auto-detect installer
+
+`EqualizerAPO-XT-Setup.exe` is a small front-door installer. It detects the
+machine's CPU architecture and the best supported x86 instruction set, then
+downloads and runs the matching per-variant Velopack `Setup.exe`. The user picks
+nothing; the right build installs itself.
+
+This document records why the feature is shaped the way it is and what it does
+*not* touch, so the working release pipeline stays understandable.
+
+## The problem
+
+EqualizerAPO-XT ships six build variants, one per instruction set, each as its
+own Velopack channel:
+
+| Channel       | For |
+| ------------- | --- |
+| `x64-sse2`    | baseline x64 (no AVX) |
+| `x64-avx`     | x64 with AVX, no AVX2 |
+| `x64-avx2`    | most modern x64 |
+| `x64-avx512`  | x64 with AVX-512 |
+| `x64-avx10-1` | x64 with AVX10.1 |
+| `arm64-neon`  | Windows on ARM64 |
+
+Before this feature the release page offered six `…-Setup.exe` files and the
+user had to know their own CPU's AVX level to choose. Most people cannot, so
+they either guessed (and lost performance, or installed a build their CPU can't
+run) or picked the AVX2 default regardless.
+
+## Why this approach
+
+Two alternatives were considered and rejected:
+
+- **Runtime dispatch (one fat binary).** A single build that picks SIMD kernels
+  at runtime. This means abandoning the per-variant builds and rebuilding the
+  FFTW bundle, the CI matrix, the Velopack channels and the release scripts —
+  a large change for the same end result the user sees.
+- **Velopack-native detection.** Velopack has no built-in "detect the CPU and
+  install the matching build" step. The exact feature request,
+  [velopack/velopack#7](https://github.com/velopack/velopack/issues/7), is
+  closed as *not planned*. Velopack channel switching (`ExplicitChannel` +
+  `AllowVersionDowngrade`) only works **within one `packId`**, but each variant
+  here is published under its own `packId` (`EqualizerAPO-XT-<channel>`), so a
+  channel switch cannot move between them without re-identifying the app and
+  breaking update continuity for existing installs.
+
+The front-door detector delivers exactly what the user wanted — one download,
+the correct variant, silently — while changing **nothing** about how the six
+variants are packaged or how each one updates itself.
+
+## What it does
+
+1. **Detect the native architecture.** `IsWow64Process2` reports the *native*
+   machine even when the detector runs under emulation, so a single x86 binary
+   correctly sees ARM64. ARM64 → `arm64-neon`.
+2. **Detect the best x86 instruction set** (x64 machines only) with `CPUID` plus
+   an `XGETBV`/`XCR0` check that the OS actually enabled the wider register
+   state. Highest match wins:
+
+   | Detected | Channel |
+   | --- | --- |
+   | AVX10.1 (leaf `0x24` version ≥ 1, 512-bit, OS ZMM state) | `x64-avx10-1` |
+   | AVX-512F (leaf 7.0 EBX[16], OS ZMM state) | `x64-avx512` |
+   | AVX2 (leaf 7.0 EBX[5], OS YMM state) | `x64-avx2` |
+   | AVX (leaf 1 ECX[28], OS YMM state) | `x64-avx` |
+   | none of the above | `x64-sse2` |
+
+3. **Download the matching installer** from the latest release using GitHub's
+   `…/releases/latest/download/<asset>` redirect, so the detector never needs to
+   be rebuilt per release and always installs the newest build. The per-variant
+   asset name is `EqualizerAPO-XT-<channel>-<channel>-Setup.exe` (the channel
+   appears twice because each variant's `packId` already contains the channel).
+4. **Run the downloaded `Setup.exe`.** By default Velopack shows its normal
+   install UI for the auto-selected variant. Passing `--silent` to the detector
+   forwards `-s/--silent` to that `Setup.exe` for fully unattended installs.
+
+The detector is built as a 32-bit (x86) Win32 GUI app. x86 runs natively on x64
+and under emulation on ARM64 (both Windows 10 and 11 ARM), so one binary covers
+every target the app supports. `CPUID`/`XGETBV` report true CPU and OS state
+regardless of process bitness, so detection from x86 is accurate.
+
+### What it deliberately does not change
+
+- The six per-channel Velopack packages (`vpk pack --packId … --channel …`) are
+  untouched.
+- Each installed variant keeps updating itself within its own channel via the
+  build-time `EAPO_UPDATE_CHANNEL` define and the background updater in
+  `helpers/VelopackBootstrap`.
+- The per-variant `…-Setup.exe` files remain on the release page for users who
+  want to pick a specific build by hand.
+
+## ARM64 update-channel convergence
+
+While building this, an existing mismatch surfaced: ARM64 builds baked
+`EAPO_UPDATE_CHANNEL=arm64` (build.yml) and `simd-variants.psd1` declared the
+channel as `arm64`, but releases are published under `arm64-neon`. The ARM64
+auto-updater therefore looked for `releases.arm64.json`, which does not exist,
+so ARM64 never self-updated.
+
+Everything now converges on the already-published `arm64-neon`: the baked
+channel (build.yml), the manifest `Channel`, and the release-notes channel
+table. No migration is needed — older ARM64 installs were already unable to
+update, and new ones now resolve the correct feed.
+
+## Channel list is duplicated — keep it in sync
+
+The detector hard-codes the six channel strings (it is compiled C++ and cannot
+read `simd-variants.psd1`). If a variant is added, renamed or removed, update
+`Installer/AutoInstaller.cpp` alongside `.github/simd-variants.psd1`,
+`.github/workflows/build.yml` and `.github/scripts/New-ReleaseNotes.ps1`. The
+release-notes script already fails the build if the manifest channels drift from
+its own table, which is the loudest of these guards.
+
+## Build and CI
+
+- `Installer/Installer.vcxproj` builds the detector for `Win32` only. It has no
+  external dependencies (just `winhttp`, `comctl32`, `shell32`), so it builds
+  without FFTW/Qt/etc.
+- The `create-release` job builds it (`/p:Platform=Win32 /p:Configuration=Release`)
+  and uploads it to the release tag as `EqualizerAPO-XT-Setup.exe`, before the
+  release notes step so the notes can feature it as the recommended download.
+
+## Local verification
+
+```
+Installer\Win32\Release\EqualizerAPO-XT-Setup.exe --detect-only
+```
+
+`--detect-only` prints the resolved channel and the download URL and exits
+without downloading or installing anything. Its process exit code is the channel
+index (`0`=sse2, `1`=avx, `2`=avx2, `3`=avx512, `4`=avx10-1, `5`=arm64-neon), so
+the detection can be checked from a script.
+
+## Limitations
+
+- The detector and the downloaded `Setup.exe` are unsigned, like the existing
+  per-channel installers, so SmartScreen will warn on first run.
+- It requires network access at install time. On failure it shows the releases
+  page URL so the user can pick a build manually.

--- a/docs/VelopackUpdates.md
+++ b/docs/VelopackUpdates.md
@@ -19,9 +19,9 @@ The channel is injected by CI with `EAPO_UPDATE_CHANNEL` during qmake builds. Cu
 - `x64-avx2`
 - `x64-avx512`
 - `x64-avx10-1`
-- `arm64`
+- `arm64-neon`
 
-Local builds without an injected channel default to `x64-avx2` on x64 and `arm64` on ARM64.
+Local builds without an injected channel default to `x64-avx2` on x64 and `arm64-neon` on ARM64.
 
 APO installation and device registration run through the Velopack hooks the Editor handles (`--veloapp-install`, `--veloapp-updated`, etc.), which call `ApoRegistration`. The NSIS installer has been removed.
 


### PR DESCRIPTION
## What

Adds **`EqualizerAPO-XT-Setup.exe`**, an auto-detect front-door installer: a small x86 Win32 app that detects the machine's CPU (architecture + AVX level) and downloads + runs the matching per-variant Velopack `Setup.exe`. One download installs the right build with no manual SIMD choice.

It also fixes a pre-existing ARM64 auto-update bug found along the way.

## Why this approach

- **Not runtime dispatch:** keeps the six optimally-compiled per-variant builds; no fat binary, no FFTW/CI/Velopack rework.
- **Not Velopack-native:** Velopack has no "detect the CPU and install the matching build" step ([velopack/velopack#7](https://github.com/velopack/velopack/issues/7) is closed as not-planned), and channel switching needs a shared `packId`, which the per-channel `packId` scheme precludes.

A front-door detector delivers the UX with **zero change** to how the six variants are packaged or how each one updates itself. Full rationale: `docs/AutoDetectInstaller.md`.

## How it works

1. `IsWow64Process2` resolves the native architecture (works under emulation, so one x86 binary covers x64 + ARM64). ARM64 -> `arm64-neon`.
2. `CPUID` + `XGETBV`/`XCR0` (OS-state-gated) pick the best x86 ISA: AVX10.1 > AVX-512 > AVX2 > AVX > SSE2.
3. Downloads `EqualizerAPO-XT-<channel>-<channel>-Setup.exe` via GitHub's `/releases/latest/download/` redirect (always newest, no per-release rebuild).
4. Runs it (Velopack's normal install UI; `--silent` forwards `-s` for unattended installs).

It statically links the CRT (it runs before any vcredist is installed). Win32-only and wired into the solution so the x64/ARM64 platforms skip it (no `Build.0`), leaving the matrix build untouched. The `create-release` job builds it and attaches it to the release; the release notes feature it as the recommended download.

## ARM64 update-channel fix (separate commit)

ARM64 builds baked `EAPO_UPDATE_CHANNEL=arm64` and the manifest declared `arm64`, but releases publish under `arm64-neon`, so ARM64 looked for a `releases.arm64.json` that is never published and never self-updated. Converged build.yml, `simd-variants.psd1`, the release-notes table, `VelopackUpdateInfo::defaultChannel()` and `docs/VelopackUpdates.md` on `arm64-neon`. No migration needed (older ARM64 installs already could not update).

## Verification (local)

- Builds clean (Win32/Release) standalone and through the solution.
- `--detect-only` on an i5-12600KF (Alder Lake) -> `x64-avx2` (correct: AVX2, no AVX-512). Process exit code is the channel index.
- `.../releases/latest/download/EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe` -> HTTP 200 (~60 MB), confirming the redirect/download path.
- `New-ReleaseNotes.ps1` runs clean (manifest drift check passes) with the renamed ARM64 channel.
- `build.yml` is valid YAML; `git diff --check` is clean.

CI is the gate for the 6-variant matrix and the create-release packaging.

## Commits

- `feat(installer)` - the detector, project, solution wiring, design doc
- `ci(release)` - build + publish in create-release, feature it in the release notes
- `fix(release)` - ARM64 channel convergence
- `docs` - README mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
