### PR TITLE
ci(audit): run biweekly audit on Claude Fable 5

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -243,7 +243,7 @@ jobs:
 
           set +e
           claude \
-            --model claude-opus-4-8 \
+            --model claude-fable-5 \
             --effort xhigh \
             --permission-mode auto \
             --max-turns 50 \
@@ -309,7 +309,7 @@ jobs:
             echo "# Biweekly Audit: ${DATE}"
             echo ""
             echo "Changed relevant files: **${COUNT}**"
-            echo "Model: Opus 4.8 - Effort: xhigh - 1M context"
+            echo "Model: Fable 5 - Effort: xhigh - 1M context"
             echo ""
             echo "This issue body corresponds to the generated \`issue-body.md\` artifact."
             echo "The remaining audit outputs are posted in full as file-specific comments below."


### PR DESCRIPTION
Switches the biweekly architecture + tech-debt audit model from `claude-opus-4-8` to `claude-fable-5` (Anthropic's GA Mythos-class model, released 2026-06-09; API/Claude Code model id `claude-fable-5`). Effort stays at `xhigh`: the CLI offers `low/medium/high/xhigh/max` and there is no "ultracode" level, so the existing value is kept rather than raised. The issue-body model banner is updated to match.

Validated end-to-end before merge: manually dispatched on this branch (run 27240338144) with `force_run=true`. It succeeded in ~18 min and produced issue #53 with real Fable 5 audit findings, confirming `claude-fable-5` is accepted by the subscription `CLAUDE_CODE_OAUTH_TOKEN`.

Only `.github/workflows/biweekly-audit.yml` changes; the build pipeline has nothing to compile or release for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)