### PR TITLE
refactor(audit): Convolution/Channel command codecs and contract docs

### DIFF
--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -316,8 +316,10 @@
     <ClInclude Include="filters\BiQuadCommand.h" />
     <ClInclude Include="filters\BiQuadFilter.h" />
     <ClInclude Include="filters\BiQuadFilterFactory.h" />
+    <ClInclude Include="filters\ChannelCommand.h" />
     <ClInclude Include="filters\ChannelFilter.h" />
     <ClInclude Include="filters\ChannelFilterFactory.h" />
+    <ClInclude Include="filters\ConvolutionCommand.h" />
     <ClInclude Include="filters\ConvolutionFilter.h" />
     <ClInclude Include="filters\ConvolutionFilePath.h" />
     <ClInclude Include="filters\ConvolutionFilterFactory.h" />
@@ -390,8 +392,10 @@
     <ClCompile Include="filters\BiQuadCommand.cpp" />
     <ClCompile Include="filters\BiQuadFilter.cpp" />
     <ClCompile Include="filters\BiQuadFilterFactory.cpp" />
+    <ClCompile Include="filters\ChannelCommand.cpp" />
     <ClCompile Include="filters\ChannelFilter.cpp" />
     <ClCompile Include="filters\ChannelFilterFactory.cpp" />
+    <ClCompile Include="filters\ConvolutionCommand.cpp" />
     <ClCompile Include="filters\ConvolutionFilter.cpp" />
     <ClCompile Include="filters\ConvolutionFilePath.cpp" />
     <ClCompile Include="filters\ConvolutionFilterFactory.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -14,7 +14,13 @@
     <ClInclude Include="filters\BiQuadFilterFactory.h">
       <Filter>filters</Filter>
     </ClInclude>
+    <ClInclude Include="filters\ChannelCommand.h">
+      <Filter>filters</Filter>
+    </ClInclude>
     <ClInclude Include="filters\ChannelFilter.h">
+      <Filter>filters</Filter>
+    </ClInclude>
+    <ClInclude Include="filters\ConvolutionCommand.h">
       <Filter>filters</Filter>
     </ClInclude>
     <ClInclude Include="filters\ChannelFilterFactory.h">
@@ -188,6 +194,12 @@
       <Filter>filters</Filter>
     </ClCompile>
     <ClCompile Include="filters\BiQuadFilterFactory.cpp">
+      <Filter>filters</Filter>
+    </ClCompile>
+    <ClCompile Include="filters\ChannelCommand.cpp">
+      <Filter>filters</Filter>
+    </ClCompile>
+    <ClCompile Include="filters\ConvolutionCommand.cpp">
       <Filter>filters</Filter>
     </ClCompile>
     <ClCompile Include="filters\ChannelFilter.cpp">

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -131,10 +131,12 @@ SOURCES += main.cpp\
 	../engine/FilterEngine.Runtime.cpp \
 	../filters/FilterFactoryRegistry.cpp \
 	../FilterConfiguration.cpp \
+	../filters/ChannelCommand.cpp \
 	../filters/ChannelFilterFactory.cpp \
 	../filters/ExpressionFilterFactory.cpp \
 	../filters/IfFilterFactory.cpp \
 	../filters/StageFilterFactory.cpp \
+	../filters/ConvolutionCommand.cpp \
 	../filters/ConvolutionFilterFactory.cpp \
 	../filters/IIRFilter.cpp \
 	../filters/IIRFilterFactory.cpp \
@@ -296,7 +298,9 @@ HEADERS  += \
 	../filters/IIRFilter.h \
 	../filters/IIRFilterFactory.h \
 	../filters/IncludeFilterFactory.h \
+	../filters/ChannelCommand.h \
 	../filters/ChannelFilter.h \
+	../filters/ConvolutionCommand.h \
 	../filters/ConvolutionFilter.h \
 	../parser/RegexFunctions.h \
 	../parser/RegistryFunctions.h \

--- a/Editor/guis/ChannelFilterGUI.cpp
+++ b/Editor/guis/ChannelFilterGUI.cpp
@@ -17,6 +17,7 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include "filters/ChannelCommand.h"
 #include "ChannelFilterGUI.h"
 #include "ChannelFilterGUIDialog.h"
 #include "ui_ChannelFilterGUI.h"
@@ -38,10 +39,12 @@ ChannelFilterGUI::ChannelFilterGUI(const QString& parameters, int selectedChanne
 
 	selectedChannels.clear();
 
-	QStringList words = parameters.trimmed().split(' ', Qt::SkipEmptyParts);
-	for (QString word : words)
-		if (word.length() > 0)
-			selectedChannels.append(word.toUpper());
+	// Parse through the shared codec so the GUI accepts exactly what the engine
+	// accepts (the previous split(' ') missed comma-separated selectors).
+	ChannelCommand cmd;
+	ChannelCommand::parse(L"Channel", parameters.toStdWString(), cmd);
+	for (const wstring& channel : cmd.channels)
+		selectedChannels.append(QString::fromStdWString(channel));
 }
 
 ChannelFilterGUI::~ChannelFilterGUI()
@@ -61,7 +64,11 @@ void ChannelFilterGUI::store(QString& command, QString& parameters)
 	command = "Channel";
 
 	selectedChannels = scene->getSelectedChannels();
-	parameters = selectedChannels.join(' ');
+
+	ChannelCommand cmd;
+	for (const QString& channel : selectedChannels)
+		cmd.channels.push_back(channel.toStdWString());
+	parameters = QString::fromStdWString(cmd.serialize());
 }
 
 void ChannelFilterGUI::on_pushButton_clicked()

--- a/Editor/guis/ConvolutionFilterGUI.cpp
+++ b/Editor/guis/ConvolutionFilterGUI.cpp
@@ -23,6 +23,7 @@
 
 #include "Editor/helpers/ConvolutionPathHelper.h"
 #include "Editor/helpers/GUIHelper.h"
+#include "filters/ConvolutionCommand.h"
 #include "helpers/RegistryHelper.h"
 #include "ConvolutionFilterGUI.h"
 #include "ui_ConvolutionFilterGUI.h"
@@ -53,7 +54,10 @@ ConvolutionFilterGUI::~ConvolutionFilterGUI()
 void ConvolutionFilterGUI::store(QString& command, QString& parameters)
 {
 	command = "Convolution";
-	parameters = ui->pathLineEdit->text();
+
+	ConvolutionCommand cmd;
+	cmd.path = ui->pathLineEdit->text().toStdWString();
+	parameters = QString::fromStdWString(cmd.serialize());
 }
 
 void ConvolutionFilterGUI::on_selectFileToolButton_clicked()

--- a/Editor/guis/ConvolutionFilterGUIFactory.cpp
+++ b/Editor/guis/ConvolutionFilterGUIFactory.cpp
@@ -19,6 +19,7 @@
 
 #include "DeviceAPOInfo.h"
 #include "Editor/FilterTable.h"
+#include "filters/ConvolutionCommand.h"
 #include "ConvolutionFilterGUI.h"
 #include "ConvolutionFilterGUIFactory.h"
 
@@ -54,9 +55,10 @@ IFilterGUI* ConvolutionFilterGUIFactory::createFilterGUI(QString& command, QStri
 {
 	ConvolutionFilterGUI* result = nullptr;
 
-	if (command == "Convolution")
+	ConvolutionCommand cmd;
+	if (ConvolutionCommand::parse(command.toStdWString(), parameters.toStdWString(), cmd))
 	{
-		result = new ConvolutionFilterGUI(configPath, deviceSampleRate, parameters.trimmed());
+		result = new ConvolutionFilterGUI(configPath, deviceSampleRate, QString::fromStdWString(cmd.path));
 	}
 
 	return result;

--- a/IFilterFactory.h
+++ b/IFilterFactory.h
@@ -36,7 +36,16 @@ public:
 	virtual void initialize(FilterEngine* engine) {}
 	virtual std::vector<IFilter*> startOfConfiguration() {return std::vector<IFilter*>();}
 	virtual std::vector<IFilter*> startOfFile(const std::wstring& configPath) {return std::vector<IFilter*>();}
-	// command and parameter may be altered by the factory
+	// Contract (see the dispatch loop in engine/FilterEngine.Configuration.cpp):
+	// the engine offers each config line to every factory in priority order.
+	// - Returning one or more filters consumes the line; iteration stops.
+	// - Clearing `command` to L"" also consumes the line without producing a
+	//   filter. Only control-flow factories (Device/If/Else/EndIf/Eval/Include/
+	//   Stage) use this signal; processing factories leave `command` untouched.
+	// - Leaving `command` set and returning no filters passes the line on to
+	//   the next factory.
+	// `parameters` may be normalized in place (e.g. decimal-comma fixes); the
+	// engine does not read it back after the call.
 	virtual std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) = 0;
 	virtual std::vector<IFilter*> endOfFile(const std::wstring& configPath) {return std::vector<IFilter*>();}
 	virtual std::vector<IFilter*> endOfConfiguration() {return std::vector<IFilter*>();}

--- a/Tests/HybridConvTests/ChannelCommandTests.cpp
+++ b/Tests/HybridConvTests/ChannelCommandTests.cpp
@@ -1,0 +1,92 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	Round-trip tests for the shared "Channel:" config-line codec
+	(filters/ChannelCommand.{h,cpp}), which the engine factory and the
+	Editor GUI both consume.
+*/
+
+#include <string>
+#include <vector>
+
+#include "filters/ChannelCommand.h"
+#include "Tests/TestHarness.h"
+
+using std::wstring;
+
+namespace
+{
+test::Harness harness("ChannelCommandTests");
+
+std::vector<wstring> parseChannels(const wstring& parameters)
+{
+	ChannelCommand cmd;
+	if (!ChannelCommand::parse(L"Channel", parameters, cmd))
+		harness.fail("'Channel' command was not recognized");
+	return cmd.channels;
+}
+
+void testTokenization()
+{
+	std::vector<wstring> channels = parseChannels(L" L R ");
+	harness.expectEqual(channels.size(), (size_t)2, "'L R' selector count");
+	harness.expectTrue(channels[0] == L"L", "first selector");
+	harness.expectTrue(channels[1] == L"R", "second selector");
+
+	// Commas are separators too; the Editor GUI historically missed this.
+	channels = parseChannels(L"L,R");
+	harness.expectEqual(channels.size(), (size_t)2, "'L,R' selector count");
+	harness.expectTrue(channels[0] == L"L", "'L,R' first selector");
+	harness.expectTrue(channels[1] == L"R", "'L,R' second selector");
+
+	// Mixed separators and position numbers.
+	channels = parseChannels(L"1, c  SUB");
+	harness.expectEqual(channels.size(), (size_t)3, "mixed separator selector count");
+	harness.expectTrue(channels[0] == L"1", "numeric selector");
+	harness.expectTrue(channels[1] == L"C", "lower-case selector is upper-cased");
+	harness.expectTrue(channels[2] == L"SUB", "name selector");
+
+	// An empty selector list is a valid Channel line.
+	channels = parseChannels(L"   ");
+	harness.expectEqual(channels.size(), (size_t)0, "blank parameters give no selectors");
+}
+
+void testCommandRecognition()
+{
+	ChannelCommand cmd;
+	harness.expectFalse(ChannelCommand::parse(L"Preamp", L"L R", cmd), "'Preamp' must not parse as Channel");
+	harness.expectFalse(ChannelCommand::parse(L"channel", L"L R", cmd), "command match is case-sensitive");
+}
+
+void testRoundTrip()
+{
+	const wstring cases[] = {
+		L"L R",
+		L"L,R",
+		L"  l   r,c ",
+		L"1 2 3",
+		L"",
+	};
+
+	for (const wstring& parameters : cases)
+	{
+		ChannelCommand first;
+		ChannelCommand::parse(L"Channel", parameters, first);
+		wstring serialized = first.serialize();
+
+		ChannelCommand second;
+		ChannelCommand::parse(L"Channel", serialized, second);
+		harness.expectTrue(first.channels == second.channels, "serialize/parse round trip is stable");
+		harness.expectTrue(second.serialize() == serialized, "second serialization is identical");
+	}
+}
+}
+
+void runChannelCommandTests()
+{
+	testTokenization();
+	testCommandRecognition();
+	testRoundTrip();
+
+	harness.report();
+}

--- a/Tests/HybridConvTests/ConvolutionCommandTests.cpp
+++ b/Tests/HybridConvTests/ConvolutionCommandTests.cpp
@@ -1,0 +1,77 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	Round-trip tests for the shared "Convolution:" config-line codec
+	(filters/ConvolutionCommand.{h,cpp}), which the engine factory and the
+	Editor GUI both consume.
+*/
+
+#include <string>
+
+#include "filters/ConvolutionCommand.h"
+#include "Tests/TestHarness.h"
+
+using std::wstring;
+
+namespace
+{
+test::Harness harness("ConvolutionCommandTests");
+
+wstring parsePath(const wstring& parameters)
+{
+	ConvolutionCommand cmd;
+	if (!ConvolutionCommand::parse(L"Convolution", parameters, cmd))
+		harness.fail("'Convolution' command was not recognized");
+	return cmd.path;
+}
+
+void testParse()
+{
+	harness.expectTrue(parsePath(L" ir.wav") == L"ir.wav", "leading whitespace is trimmed");
+	harness.expectTrue(parsePath(L"sub dir\\room ir.wav ") == L"sub dir\\room ir.wav",
+		"inner spaces survive, trailing whitespace is trimmed");
+	harness.expectTrue(parsePath(L"C:\\IRs\\room.wav") == L"C:\\IRs\\room.wav", "absolute path");
+
+	// Quotes and environment variables are preserved for the resolver.
+	harness.expectTrue(parsePath(L"\"quoted path.wav\"") == L"\"quoted path.wav\"", "quotes preserved");
+	harness.expectTrue(parsePath(L"%USERPROFILE%\\ir.wav") == L"%USERPROFILE%\\ir.wav",
+		"environment variables preserved");
+
+	// Empty path is recognized; emptiness policy stays with the caller.
+	harness.expectTrue(parsePath(L"   ") == L"", "blank parameters give an empty path");
+
+	ConvolutionCommand cmd;
+	harness.expectFalse(ConvolutionCommand::parse(L"Channel", L"ir.wav", cmd),
+		"'Channel' must not parse as Convolution");
+}
+
+void testRoundTrip()
+{
+	const wstring cases[] = {
+		L"ir.wav",
+		L" sub\\room ir.wav ",
+		L"\"quoted.wav\"",
+		L"%USERPROFILE%\\ir.wav",
+	};
+
+	for (const wstring& parameters : cases)
+	{
+		ConvolutionCommand first;
+		ConvolutionCommand::parse(L"Convolution", parameters, first);
+		wstring serialized = first.serialize();
+
+		ConvolutionCommand second;
+		ConvolutionCommand::parse(L"Convolution", serialized, second);
+		harness.expectTrue(second.path == first.path, "serialize/parse round trip is stable");
+		harness.expectTrue(second.serialize() == serialized, "second serialization is identical");
+	}
+}
+}
+
+void runConvolutionCommandTests()
+{
+	testParse();
+	testRoundTrip();
+
+	harness.report();
+}

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -27,7 +27,9 @@
 // main() (defined in CommonLogicTests.cpp, CopyCommandTests.cpp,
 // DelayCommandTests.cpp, GraphicEQCommandTests.cpp, VSTPluginCommandTests.cpp,
 // VstHostTests.cpp, ParserTests.cpp and ParserPreampTests.cpp).
+void runChannelCommandTests();
 void runCommonLogicTests();
+void runConvolutionCommandTests();
 void runCopyCommandTests();
 void runDelayCommandTests();
 void runGraphicEQCommandTests();
@@ -228,7 +230,9 @@ int main()
 	// console binary (see CommonLogicTests.cpp, CopyCommandTests.cpp,
 	// DelayCommandTests.cpp, GraphicEQCommandTests.cpp, VSTPluginCommandTests.cpp,
 	// VstHostTests.cpp, ParserTests.cpp and ParserPreampTests.cpp).
+	runChannelCommandTests();
 	runCommonLogicTests();
+	runConvolutionCommandTests();
 	runCopyCommandTests();
 	runDelayCommandTests();
 	runGraphicEQCommandTests();

--- a/Tests/HybridConvTests/HybridConvTests.vcxproj
+++ b/Tests/HybridConvTests/HybridConvTests.vcxproj
@@ -248,7 +248,9 @@ if exist "$(MSBuildThisFileDirectory)..\TestVst2Plugin\$(Platform)\$(Configurati
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="HybridConvTests.cpp" />
+    <ClCompile Include="ChannelCommandTests.cpp" />
     <ClCompile Include="CommonLogicTests.cpp" />
+    <ClCompile Include="ConvolutionCommandTests.cpp" />
     <ClCompile Include="CopyCommandTests.cpp" />
     <ClCompile Include="DelayCommandTests.cpp" />
     <ClCompile Include="GraphicEQCommandTests.cpp" />

--- a/Tests/HybridConvTests/HybridConvTests.vcxproj.filters
+++ b/Tests/HybridConvTests/HybridConvTests.vcxproj.filters
@@ -14,6 +14,12 @@
     <ClCompile Include="HybridConvTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ChannelCommandTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ConvolutionCommandTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="CopyCommandTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/UpdateChecker/UpdateChecker.cpp
+++ b/UpdateChecker/UpdateChecker.cpp
@@ -52,6 +52,10 @@ void UpdateChecker::goToWebsite()
 {
 	QDesktopServices::openUrl(downloadUrl);
 
+	// Intentionally QSettings rather than helpers/RegistryHelper: skipVersion is
+	// a per-user (HKCU) preference owned by this Qt tool, where silent-miss
+	// semantics are wanted; RegistryHelper's exception model is for the engine's
+	// HKLM configuration keys.
 	QSettings settings(QString::fromWCharArray(UPDATE_CHECKER_REGPATH), QSettings::NativeFormat);
 	settings.remove("skipVersion");
 	accept();

--- a/UpdateChecker/UpdateChecker.pro
+++ b/UpdateChecker/UpdateChecker.pro
@@ -14,6 +14,9 @@ TEMPLATE = app
 DEFINES += WIN32
 DEFINES += _UNICODE
 DEFINES += MUP_USE_WIDE_STRING
+# Release channel baked in at build time (mirrors Editor.pro). When unset, a
+# local build falls back to VelopackUpdateInfo::defaultChannel()'s per-arch
+# guess for feed lookups; CI always passes the channel explicitly.
 !isEmpty(EAPO_UPDATE_CHANNEL) {
 	DEFINES += EAPO_UPDATE_CHANNEL=\\\"$$EAPO_UPDATE_CHANNEL\\\"
 }

--- a/filters/ChannelCommand.cpp
+++ b/filters/ChannelCommand.cpp
@@ -1,0 +1,68 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2014  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+
+#include "ChannelCommand.h"
+
+#include <cwctype>
+
+std::wstring ChannelCommand::serialize() const
+{
+	std::wstring result;
+	for (const std::wstring& channel : channels)
+	{
+		if (!result.empty())
+			result += L" ";
+		result += channel;
+	}
+	return result;
+}
+
+bool ChannelCommand::parse(const std::wstring& command, const std::wstring& parameters, ChannelCommand& out)
+{
+	if (command != L"Channel")
+		return false;
+
+	out.channels.clear();
+
+	// Tokenizer preserved from the engine factory: split on whitespace and
+	// commas, upper-case every selector.
+	std::wstring value = parameters + L" ";
+	std::wstring currentWord;
+	for (unsigned i = 0; i < value.length(); i++)
+	{
+		wchar_t c = towupper(value[i]);
+
+		if (iswspace(c) || c == L',')
+		{
+			if (currentWord.length() > 0)
+			{
+				out.channels.push_back(currentWord);
+				currentWord.clear();
+			}
+		}
+		else
+		{
+			currentWord += c;
+		}
+	}
+
+	return true;
+}

--- a/filters/ChannelCommand.h
+++ b/filters/ChannelCommand.h
@@ -1,0 +1,40 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2014  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Single owner of the "Channel:" config-line grammar, shared by the engine
+// factory and the Editor GUI. Channel selectors are upper-cased names or
+// position numbers separated by whitespace and/or commas.
+struct ChannelCommand
+{
+	// Upper-cased selector tokens in the order they were written. May be empty:
+	// "Channel:" with no selectors is a valid line that selects no channel.
+	std::vector<std::wstring> channels;
+
+	// Canonical space-separated parameter string.
+	std::wstring serialize() const;
+
+	// Returns true when command names a Channel line; channels is then filled
+	// from parameters. Emptiness policy stays with the caller.
+	static bool parse(const std::wstring& command, const std::wstring& parameters, ChannelCommand& out);
+};

--- a/filters/ChannelFilterFactory.cpp
+++ b/filters/ChannelFilterFactory.cpp
@@ -21,6 +21,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "helpers/MemoryHelper.h"
 #include "helpers/StringHelper.h"
 #include "helpers/LogHelper.h"
+#include "ChannelCommand.h"
 #include "ChannelFilter.h"
 #include "filters/FilterFactoryRegistry.h"
 #include "ChannelFilterFactory.h"
@@ -32,37 +33,10 @@ using std::wstring;
 
 vector<IFilter*> ChannelFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	ChannelFilter* filter = nullptr;
-
-	if (command == L"Channel")
-	{
-		wstring value = parameters + L" ";
-
-		vector<wstring> words;
-		wstring currentWord;
-		for (unsigned i = 0; i < value.length(); i++)
-		{
-			wchar_t c = towupper(value[i]);
-
-			if (iswspace(c) || c == L',')
-			{
-				if (currentWord.length() > 0)
-				{
-					words.push_back(currentWord);
-
-					currentWord.clear();
-				}
-			}
-			else
-			{
-				currentWord += c;
-			}
-		}
-
-		filter = MemoryHelper::construct<ChannelFilter>(words);
-	}
-
-	if (filter == nullptr)
+	ChannelCommand cmd;
+	if (!ChannelCommand::parse(command, parameters, cmd))
 		return vector<IFilter*>(0);
+
+	ChannelFilter* filter = MemoryHelper::construct<ChannelFilter>(cmd.channels);
 	return vector<IFilter*>(1, filter);
 }

--- a/filters/ConvolutionCommand.cpp
+++ b/filters/ConvolutionCommand.cpp
@@ -1,0 +1,38 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2014  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+
+#include "ConvolutionCommand.h"
+
+#include "helpers/StringHelper.h"
+
+std::wstring ConvolutionCommand::serialize() const
+{
+	return path;
+}
+
+bool ConvolutionCommand::parse(const std::wstring& command, const std::wstring& parameters, ConvolutionCommand& out)
+{
+	if (command != L"Convolution")
+		return false;
+
+	out.path = StringHelper::trim(parameters);
+	return true;
+}

--- a/filters/ConvolutionCommand.h
+++ b/filters/ConvolutionCommand.h
@@ -1,0 +1,42 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2014  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+
+// Single owner of the "Convolution:" config-line grammar, shared by the engine
+// factory and the Editor GUI.
+struct ConvolutionCommand
+{
+	// Impulse response path as the author wrote it (whitespace-trimmed only).
+	// Quotes and environment variables are preserved so serialize() round-trips
+	// the config text; ConvolutionFilePath::resolve applies unquoting, variable
+	// expansion, and config-relative resolution when the engine loads the file.
+	std::wstring path;
+
+	// Canonical parameter string: the path itself.
+	std::wstring serialize() const;
+
+	// Returns true when command names a Convolution line; path is then the
+	// trimmed parameter text and may be empty. Emptiness policy stays with the
+	// caller (the engine builds no filter for an empty path; the Editor still
+	// opens the GUI so the user can pick a file).
+	static bool parse(const std::wstring& command, const std::wstring& parameters, ConvolutionCommand& out);
+};

--- a/filters/ConvolutionFilterFactory.cpp
+++ b/filters/ConvolutionFilterFactory.cpp
@@ -21,6 +21,7 @@
 
 #include "helpers/MemoryHelper.h"
 #include "helpers/LogHelper.h"
+#include "ConvolutionCommand.h"
 #include "ConvolutionFilePath.h"
 #include "ConvolutionFilter.h"
 #include "filters/FilterFactoryRegistry.h"
@@ -33,18 +34,14 @@ using std::wstring;
 
 vector<IFilter*> ConvolutionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	ConvolutionFilter* filter = nullptr;
-
-	if (command == L"Convolution")
-	{
-		wstring absolutePath = ConvolutionFilePath::resolve(configPath, parameters);
-		if (absolutePath.empty())
-			return vector<IFilter*>(0);
-
-		filter = MemoryHelper::construct<ConvolutionFilter>(absolutePath);
-	}
-
-	if (filter == nullptr)
+	ConvolutionCommand cmd;
+	if (!ConvolutionCommand::parse(command, parameters, cmd))
 		return vector<IFilter*>(0);
+
+	wstring absolutePath = ConvolutionFilePath::resolve(configPath, cmd.path);
+	if (absolutePath.empty())
+		return vector<IFilter*>(0);
+
+	ConvolutionFilter* filter = MemoryHelper::construct<ConvolutionFilter>(absolutePath);
 	return vector<IFilter*>(1, filter);
 }

--- a/helpers/VelopackBootstrap.h
+++ b/helpers/VelopackBootstrap.h
@@ -21,6 +21,14 @@
 
 #include <string>
 
+// The Editor's half of the update story: Velopack hooks plus in-app background
+// download/apply through the Velopack SDK (which does its own feed parsing and
+// package verification). The OTHER half is UpdateChecker.exe, a standalone
+// notify-only tool that parses the GitHub/Velopack feeds itself in
+// UpdateChecker/VelopackUpdateInfo.{h,cpp} (covered by EditorLogicTests). The
+// two deliberately do not share feed code: UpdateChecker never downloads or
+// applies, and this class never decides "is there a newer version" outside the
+// SDK. Both read the channel baked in at build time via EAPO_UPDATE_CHANNEL.
 class VelopackBootstrap
 {
 public:


### PR DESCRIPTION
Part 3 of the issue #53 (biweekly audit) resolution campaign: continuing the shared command-codec migration and recording the contract decisions the audit asked about.

## What changed

| Finding | Change |
| --- | --- |
| F006/F017 | New `filters/ChannelCommand` and `filters/ConvolutionCommand` are the single owners of the `Channel:` / `Convolution:` config-line grammars. The engine factories and the Editor GUIs both consume them (the audit's recommended "Convolution and Channel first"), with round-trip tests in HybridConvTests (`ChannelCommandTests` 23 checks, `ConvolutionCommandTests` 15 checks). One real drift this immediately fixes: the Channel GUI split selectors on spaces only, so a `Channel: L,R` line the engine accepts displayed as a single bogus selector in the Editor; the GUI now parses exactly what the engine parses. |
| F008 | Disposition: documented, not rewritten. Reconnaissance showed the "string side channel" is a deliberate consumption signal used only by control-flow factories (Device/If/Else/EndIf/Eval/Include/Stage) and already explained at the engine dispatch loop; the contract is now also documented on `IFilterFactory::createFilter` itself. The mechanical 14-factory result-struct rewrite is deferred to the codec campaign's completion, where it lands naturally. |
| F011 | Disposition: intentional separation, now documented on `VelopackBootstrap`. UpdateChecker is a standalone notify-only tool with its own tested feed parsing and never downloads/applies; the Editor uses the Velopack SDK for download/apply and never re-implements feed decisions. Forcing one module across both would destabilize a tested update path for no behavioral gain. |
| F012 | The channel is already authored once (CI injects `EAPO_UPDATE_CHANNEL` into every qmake build; x64 builds fail loudly without it). The macro blocks in both `.pro` files now cross-reference each other and the local-build fallback. |
| F013 | UpdateChecker's `QSettings` use is documented as intentional: per-user HKCU preference with silent-miss semantics, vs `RegistryHelper`'s exception model for the engine's HKLM keys. |
| F007/F016 | No code change needed: decimal-comma normalization already lives at each codec's parse boundary (the shared `StringHelper::replaceCharacters` call), and filter ownership already follows the `FilterDeleter` contract; the audit itself advised against a standalone sweep. |

The remaining 7 filters without codecs (IIR, Device, Stage, Include, If/Expression, LoudnessCorrection, GraphicEQ-adjacent forms) stay a follow-up campaign, one filter at a time, per the audit's own recommendation.

## Verification

- Local x64 build of Common + HybridConvTests + EditorLogicTests + EngineOrchestrationTests + AudioRegressionTests passes; all suites green, including the two new codec suites.
- AudioRegressionTests passes 9/9 bit-identically — `channel_left_only` and `convolution_short` exercise the two refactored factories end to end with `maxAbsError=0`.
- The Editor builds via qmake/nmake with the GUI changes and the new codec sources in `Editor.pro`.

Issue #53 stays open until the audit-CI migration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)