### PR TITLE
docs: refresh README to current state and add a fork changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,265 @@
+# Changelog
+
+All notable changes to EqualizerAPO-XT since it was forked from TheFireKahuna's
+equalizerAPO64 tree (last upstream commit `7156020`, 2025-12-16). Work on this
+fork started on 2026-05-22.
+
+Versions are bumped automatically by CI from Conventional Commits message
+types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, and 1.16
+were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1.11.0 on,
+tags are clean `vX.Y.Z` names. Installers for every version are on the
+[Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
+
+## Unreleased
+
+- The `Channel:` and `Convolution:` config grammars moved into shared command
+  codecs used by both the engine and the Editor, with round-trip tests. This
+  fixed the Channel GUI ignoring comma-separated selectors. The
+  `IFilterFactory` consumption contract and the intentional Editor/UpdateChecker
+  update-path separation are now documented in the code. ([#57])
+- The biweekly audit now runs on a Windows runner with Git Bash and a
+  pre-provisioned buildable tree, so audits can compile and execute the test
+  suites instead of reading the code blind. ([#58])
+- README refreshed to the current project state, and this changelog added.
+
+## v1.17.1 — 2026-06-11
+
+First round of fixes from biweekly audit issue #53.
+
+- The auto-detect installer now verifies downloaded setups against a
+  `SHA256SUMS.txt` release asset before launching them; CI publishes the
+  checksum file with every release. ([#56])
+- libHybridConv buffer ownership moved from unguarded process-global maps into
+  the convolution structs themselves, removing a latent data race between APO
+  instances. Audio output is bit-identical. ([#56])
+- New `EngineOrchestrationTests` suite covers channel-name routing, `Copy`
+  semantics, and config-swap crossfading through the public engine API. ([#56])
+- The CI build matrix is generated from the `.github/simd-variants.psd1`
+  manifest, binary dependency downloads are tag-pinned and SHA-256-verified,
+  and a lint step fails CI when installer channel names drift from the
+  manifest. Pull requests now genuinely build only the primary avx2 variant
+  (the old PR filter silently built all six). ([#55])
+- The biweekly audit runs on Claude Fable 5. ([#54])
+
+## v1.17.0 — 2026-06-10
+
+- **Auto-detect installer**: a new front-door `EqualizerAPO-XT-Setup.exe`
+  detects the CPU (architecture and AVX level) and downloads the matching
+  build, so users no longer pick a SIMD variant by hand. The ARM64 update
+  channel was aligned with the published `arm64-neon` name. ([#52])
+- Second round of fixes from audit issue #48: a shared test harness with new
+  regression/helper/parser coverage, a runtime VST2 host test built around a
+  self-built test plug-in, the `VSTPluginInstance` god-file split into cohesive
+  units, one owning parse routine for BiQuad config lines, a config-file codec
+  extracted from MainWindow, shared parse/serialize codecs for the Preamp,
+  Delay, GraphicEQ, Copy, and VSTPlugin GUIs, the SIMD variant set defined once
+  in `simd-variants.psd1`, and qmake failing loudly when no SIMD flag is
+  passed. ([#51])
+
+## v1.15.3 — 2026-06-09
+
+First round of fixes from audit issue #48. ([#50])
+
+- The convolution IR cache is size-bounded and `ConvolutionFilter` resource
+  handling was hardened.
+- Filter factories register through a central registry, allocations go through
+  a typed checked allocator, and the engine warns when a recognized command
+  produces no filter. VST plug-in initialization failures are logged with
+  reasons.
+- The Editor's known-command list is derived from the factory registry instead
+  of a hand-maintained copy, and the legacy filter-list UI path is frozen and
+  documented. Release-notes SIMD channel tables are driven from one table.
+
+## v1.15.2 — 2026-06-09
+
+- Audit workflow actions updated for Node 24. ([#49])
+
+## v1.15.1 — 2026-06-08
+
+- Added a biweekly automated code-audit workflow that runs Claude against the
+  codebase and files its findings as a GitHub issue. ([#46], [#47])
+- The B-plan epic for runtime SIMD dispatch is recorded in
+  `docs/RuntimeDispatchEpic.md`. ([#45])
+
+## v1.15.0 — 2026-06-08
+
+- **Portable SIMD with Google Highway**: the four hand-written SIMD sites
+  (convolution kernels, BiQuadFilter, PreampFilter, float↔double conversion)
+  were ported from per-ISA intrinsics to single Highway kernels compiled per
+  variant. ARM64 moves from scalar fallbacks to real NEON. A new
+  `convolution_short` regression case with a committed reference gates the
+  port; output stays within the regression tolerance on all variants.
+  ([#43], [#44])
+- CI fails the build when a Qt application executable is missing instead of
+  packaging an incomplete release. ([#44])
+
+## v1.13.1 — 2026-06-08
+
+- VST plug-in library load/unload is thread-safe. ([#42])
+- User documentation was rewritten in English and Korean and is published to
+  the GitHub Wiki by CI. ([#36], [#37], [#38], [#39])
+- Audio regression reference data is committed, and cross-variant comparison
+  fails on missing outputs instead of passing silently. ([#40], [#41])
+
+## v1.13.0 — 2026-06-07
+
+- **Native VST3 hosting** through the Steinberg VST3 SDK pluginterfaces, with
+  double-precision processing where the plug-in supports it. ([#35])
+
+## v1.12.x — 2026-06-03 ~ 2026-06-06
+
+- Skin and theme switching no longer re-polishes the whole widget tree, making
+  it near-instant. (v1.12.5, [#34])
+- Modern filter card icons render correctly and Copy gain labels no longer
+  overlap. (v1.12.4, [#33])
+- The filter knob is a true rotary control that tracks the cursor, and release
+  pipelines are serialized with a CI concurrency group. (v1.12.3, [#32])
+- CI moved to the `windows-2025-vs2026` runner image with per-runner platform
+  toolsets, GitHub Actions moved off deprecated Node.js 20, and
+  `velopack_libc.dll` ships under the name the app actually loads — fixing
+  startup of packaged builds. (v1.12.2, [#29], [#30], [#31])
+- Legacy filter cards use the modern AudioKnob, channel selection badges are
+  colour-coded, and Qt high-DPI scaling is enabled so the UI is not tiny on 4K
+  displays. (v1.12.0, [#28])
+
+## v1.11.0 — 2026-06-03
+
+- **Automatic updates**: the Editor downloads new releases in the background
+  through the Velopack SDK and applies them when the Editor exits. ([#27])
+- Font weights render correctly and the Copy routing renderer swaps when the
+  skin changes. ([#27])
+
+## v1.10.x — 2026-06-02
+
+- The APO reports its effect through `IAudioSystemEffects2::GetEffectsList`,
+  so Windows can show what processing is active. (v1.10.0, [#25])
+- Copy routing editors are seeded with the device channel list instead of an
+  empty canvas. (v1.10.1, [#26])
+
+## v1.8.0 — 2026-05-31 ~ 2026-06-02
+
+- **Per-skin Copy routing renderers**: each of the five Editor skins renders
+  channel routing with its own visual language, driven by a new `ISkin`
+  delegation engine. DM Sans, DM Mono, and Pretendard fonts are embedded and
+  QSS fonts are tokenized. ([#22])
+- A flaky Editor startup crash was fixed by serializing FFTW planner access.
+  ([#22])
+- Non-realtime COM/Win32 resources are wrapped in RAII, and the APO registers
+  itself in-process instead of shelling out to regsvr32. ([#23])
+
+## v1.6.0 — 2026-05-26 ~ 2026-05-27
+
+- The APO passes audio through unchanged when the sample format is not
+  IEEE_FLOAT 32/64 instead of corrupting it, and the Editor surfaces the
+  passthrough status so users can see when EQ is inactive. ([#21])
+- Three Modern Card rendering bugs found by variant diagnostics were fixed,
+  and the Modern Card right header toolbar is visible again. ([#19], [#20])
+
+## v1.5.x — 2026-05-24 ~ 2026-05-25
+
+- **Five distinct Editor skins** (studio, minimal, soft, rack, matrix) with
+  per-skin token QSS, plus automated version bumping from Conventional
+  Commits. (v1.5.0, [#11], [#12])
+- All filter factories link from Common.lib (some filters silently did
+  nothing before) and FFTW wisdom is cached. (v1.5.1, [#13])
+- Performance passes over the DSP hot path, Editor analysis panel, and
+  convolution: decoded impulse responses are cached per filter type, only the
+  toggled row refreshes on enable/disable, and the Velopack update check is
+  deferred 60 s from startup. (v1.5.1, [#14], [#15], [#16], [#17])
+- Commented-out rows no longer grey the whole card and BiQuad cards show a
+  richer summary. (v1.5.2, [#18])
+
+## v1.4.3 — 2026-05-22 ~ 2026-05-24
+
+- **Velopack migration (phases 1–5)**: headless APO registration, Velopack
+  install/update/uninstall hooks in the Editor, raw binaries packed directly
+  into Velopack, a runtime helper that triggers background updates, and the
+  NSIS installer with its scheduled-task update path removed. ([#4])
+- **AudioRegressionTests**: a regression suite that renders DSP scenarios and
+  compares output against committed references, run in CI with cross-variant
+  comparison and cppcheck; PR and push builds were split. ([#6])
+- SSE2 and AVX release channels were added (threaded FFTW in lower SIMD
+  builds), Velopack feed assets for AVX are recognized, legacy card editors
+  were replaced, and default Qt styling was swept out of the Editor UI
+  ([#3]).
+- A stage-level profiler measures the audio pipeline in Benchmark. ([#5])
+- An import-to-config flow scans a referenced config's dependencies and copies
+  them into the config directory from the Include card. ([#7])
+- The install directory grants LOCAL SERVICE access so audiodg can load the
+  APO, with diagnostics and recovery scripts under `tools/`. ([#9], [#10])
+- `setup-build.ps1` provisions a local build environment. ([#8])
+
+## v1.4.2 — 2026-05-22
+
+Fork bootstrap on top of TheFireKahuna's tree.
+
+- **Convolution tail fix**: reverb tails no longer cut out around the 1000 ms
+  mark after frame size changes, guarded by new hybrid-convolution regression
+  tests. ([#2])
+- Broad modernization refactor: RAII for filter configuration storage and COM
+  objects, `nullptr`/typed casts/typed buffer copies, large implementation
+  files split by responsibility, filter factories registered outside
+  FilterEngine, and FilterEngine synchronization modernized. ([#1], [#2])
+- Convolution file path handling was tightened and path parsing expanded.
+  ([#2])
+- A Velopack release workflow and update feed integration were added ([#1],
+  [#2]). GitHub Actions builds were stabilized: dependencies download from
+  release assets, Qt installs directly in CI, actions run on Node 24, and
+  ARM64 builds use a native MSVC environment.
+- First version of the modern card-based Editor UI.
+
+[#1]: https://github.com/115dkk/EqualizerAPO-XT/pull/1
+[#2]: https://github.com/115dkk/EqualizerAPO-XT/pull/2
+[#3]: https://github.com/115dkk/EqualizerAPO-XT/pull/3
+[#4]: https://github.com/115dkk/EqualizerAPO-XT/pull/4
+[#5]: https://github.com/115dkk/EqualizerAPO-XT/pull/5
+[#6]: https://github.com/115dkk/EqualizerAPO-XT/pull/6
+[#7]: https://github.com/115dkk/EqualizerAPO-XT/pull/7
+[#8]: https://github.com/115dkk/EqualizerAPO-XT/pull/8
+[#9]: https://github.com/115dkk/EqualizerAPO-XT/pull/9
+[#10]: https://github.com/115dkk/EqualizerAPO-XT/pull/10
+[#11]: https://github.com/115dkk/EqualizerAPO-XT/pull/11
+[#12]: https://github.com/115dkk/EqualizerAPO-XT/pull/12
+[#13]: https://github.com/115dkk/EqualizerAPO-XT/pull/13
+[#14]: https://github.com/115dkk/EqualizerAPO-XT/pull/14
+[#15]: https://github.com/115dkk/EqualizerAPO-XT/pull/15
+[#16]: https://github.com/115dkk/EqualizerAPO-XT/pull/16
+[#17]: https://github.com/115dkk/EqualizerAPO-XT/pull/17
+[#18]: https://github.com/115dkk/EqualizerAPO-XT/pull/18
+[#19]: https://github.com/115dkk/EqualizerAPO-XT/pull/19
+[#20]: https://github.com/115dkk/EqualizerAPO-XT/pull/20
+[#21]: https://github.com/115dkk/EqualizerAPO-XT/pull/21
+[#22]: https://github.com/115dkk/EqualizerAPO-XT/pull/22
+[#23]: https://github.com/115dkk/EqualizerAPO-XT/pull/23
+[#25]: https://github.com/115dkk/EqualizerAPO-XT/pull/25
+[#26]: https://github.com/115dkk/EqualizerAPO-XT/pull/26
+[#27]: https://github.com/115dkk/EqualizerAPO-XT/pull/27
+[#28]: https://github.com/115dkk/EqualizerAPO-XT/pull/28
+[#29]: https://github.com/115dkk/EqualizerAPO-XT/pull/29
+[#30]: https://github.com/115dkk/EqualizerAPO-XT/pull/30
+[#31]: https://github.com/115dkk/EqualizerAPO-XT/pull/31
+[#32]: https://github.com/115dkk/EqualizerAPO-XT/pull/32
+[#33]: https://github.com/115dkk/EqualizerAPO-XT/pull/33
+[#34]: https://github.com/115dkk/EqualizerAPO-XT/pull/34
+[#35]: https://github.com/115dkk/EqualizerAPO-XT/pull/35
+[#36]: https://github.com/115dkk/EqualizerAPO-XT/pull/36
+[#37]: https://github.com/115dkk/EqualizerAPO-XT/pull/37
+[#38]: https://github.com/115dkk/EqualizerAPO-XT/pull/38
+[#39]: https://github.com/115dkk/EqualizerAPO-XT/pull/39
+[#40]: https://github.com/115dkk/EqualizerAPO-XT/pull/40
+[#41]: https://github.com/115dkk/EqualizerAPO-XT/pull/41
+[#42]: https://github.com/115dkk/EqualizerAPO-XT/pull/42
+[#43]: https://github.com/115dkk/EqualizerAPO-XT/pull/43
+[#44]: https://github.com/115dkk/EqualizerAPO-XT/pull/44
+[#45]: https://github.com/115dkk/EqualizerAPO-XT/pull/45
+[#46]: https://github.com/115dkk/EqualizerAPO-XT/pull/46
+[#47]: https://github.com/115dkk/EqualizerAPO-XT/pull/47
+[#49]: https://github.com/115dkk/EqualizerAPO-XT/pull/49
+[#50]: https://github.com/115dkk/EqualizerAPO-XT/pull/50
+[#51]: https://github.com/115dkk/EqualizerAPO-XT/pull/51
+[#52]: https://github.com/115dkk/EqualizerAPO-XT/pull/52
+[#54]: https://github.com/115dkk/EqualizerAPO-XT/pull/54
+[#55]: https://github.com/115dkk/EqualizerAPO-XT/pull/55
+[#56]: https://github.com/115dkk/EqualizerAPO-XT/pull/56
+[#57]: https://github.com/115dkk/EqualizerAPO-XT/pull/57
+[#58]: https://github.com/115dkk/EqualizerAPO-XT/pull/58

--- a/README.md
+++ b/README.md
@@ -4,39 +4,44 @@ EqualizerAPO-XT is an active fork of [Equalizer APO 1.4.2](https://sourceforge.n
 
 This fork builds on earlier double-precision work from [equalizer-apo-64](https://github.com/chebum/equalizer-apo-64) and later SIMD/build work from TheFireKahuna's Equalizer APO forks.
 
-## Current Focus
+## Project Status
 
-The first goal is to fix a reverb playback bug where the tail can disappear around the 1000 ms mark.
+The original fork goals are complete: the convolution tail bug is fixed, the engine code was refactored and put under regression tests, the Editor UI was rebuilt, SIMD support was consolidated, and releases ship as Velopack packages with automatic updates. The full history since the fork is in [CHANGELOG.md](CHANGELOG.md).
 
-After that, the project will focus on:
+Current work areas:
 
-1. Updating the Editor and helper tools so the UI is easier to use.
-2. Expanding convolution support and exposing the new options in the UI.
-3. Consolidating x64 SIMD support around AVX10 where it makes sense.
-4. Keeping supported paths for machines that do not support AVX.
+1. Migrating the remaining filter config parsers to shared command codecs used by both the engine and the Editor.
+2. Runtime SIMD dispatch in a single binary, replacing the per-variant release channels ([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
+3. Acting on findings from the biweekly automated code audit.
 
 ## Features
 
 - Double-precision internal audio processing for complex filter chains.
 - Convolution, GraphicEQ, parametric EQ, VST2/VST3, and standard Equalizer APO filter support.
 - Native VST3 hosting through the Steinberg VST3 SDK (MIT-licensed pluginterfaces), with 64-bit (double) processing where the plug-in supports it.
-- x64 builds for the SSE2 and AVX baselines plus AVX2, AVX-512, and AVX10.1 in CI.
-- ARM64 build support with native dependency builds.
+- Portable SIMD kernels written once with [Google Highway](https://github.com/google/highway) and compiled per variant: SSE2, AVX, AVX2, AVX-512, and AVX10.1 on x64, NEON on ARM64.
+- Modernized Qt Editor: card-based filter UI, five visual skins with per-skin Copy routing renderers, embedded fonts, and high-DPI scaling.
+- Automatic updates: the Editor downloads new releases in the background and applies them on exit. A standalone UpdateChecker tool provides notify-only checks.
+- Auto-detect installer that picks the matching SIMD build for the local CPU and verifies the download against the release checksums before running it.
 - AOCL-FFTW, libsndfile, muparserx, TCLAP, and Qt-based GUI tools.
 - Shared VC++ runtime DLLs for better Windows compatibility.
-- GitHub Actions build pipeline for dependencies, binaries, and installers.
+- GitHub Actions pipeline for builds, tests, installers, and releases, plus a biweekly automated code audit that builds the tree and runs the test suites.
 
 ## Installation
 
 Install from the [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases). A push to `main` builds all supported variants and creates a GitHub Release with Velopack-packaged installers and a source code zip.
 
-The recommended download is **EqualizerAPO-XT-Setup.exe**, an auto-detect installer. It detects your CPU (architecture and AVX level) and downloads the matching build automatically, so you do not have to pick a SIMD variant by hand. The per-channel `…-Setup.exe` files stay available for installing a specific build. See [docs/AutoDetectInstaller.md](docs/AutoDetectInstaller.md).
+The recommended download is **EqualizerAPO-XT-Setup.exe**, an auto-detect installer. It detects your CPU (architecture and AVX level), downloads the matching build, and verifies it against the release's `SHA256SUMS.txt` before launching it. The per-channel `…-Setup.exe` files stay available for installing a specific build. See [docs/AutoDetectInstaller.md](docs/AutoDetectInstaller.md).
 
-The installed update checker reads the matching Velopack channel feed and opens the correct channel setup asset when a newer release is available. The flow is documented in [docs/VelopackUpdates.md](docs/VelopackUpdates.md).
+After installation the Editor keeps itself current: it downloads newer releases in the background and applies them when the Editor closes. The flow is documented in [docs/VelopackUpdates.md](docs/VelopackUpdates.md).
+
+## Documentation
+
+User documentation lives in the [GitHub Wiki](https://github.com/115dkk/EqualizerAPO-XT/wiki) in English and Korean, synced from `Wiki/github-wiki/` in this repository. Developer notes live under [docs/](docs/).
 
 ## Building
 
-The project uses Visual Studio, Qt, Velopack, and a small set of external libraries.
+The project uses Visual Studio, Qt, Velopack, and a small set of external libraries. Running [setup-build.ps1](setup-build.ps1) provisions all of them for a local build (binary dependencies, header-only checkouts, and Qt 6.10.1). The manual layout is documented in [docs/LocalDependencySetup.md](docs/LocalDependencySetup.md).
 
 The forked dependency repositories are:
 
@@ -45,7 +50,7 @@ The forked dependency repositories are:
 - [libsndfile 1.2.2](https://github.com/thefirekahuna/libsndfile)
 - [tclap 1.2.5](https://github.com/thefirekahuna/tclap)
 
-Local dependency setup is documented in [docs/LocalDependencySetup.md](docs/LocalDependencySetup.md).
+Two header-only dependencies are checked out rather than vendored: [Google Highway](https://github.com/google/highway) under `deps/highway` and the Steinberg [VST3 pluginterfaces](https://github.com/steinbergmedia/vst3_pluginterfaces) under `deps/vst3sdk/pluginterfaces`.
 
 By default, project files look for dependencies under the repo-local `deps/` directory:
 
@@ -53,6 +58,8 @@ By default, project files look for dependencies under the repo-local `deps/` dir
 - `deps/libsndfile`
 - `deps/muparserx`
 - `deps/tclap`
+- `deps/highway`
+- `deps/vst3sdk`
 
 The same environment variables can override those defaults:
 
@@ -60,8 +67,10 @@ The same environment variables can override those defaults:
 - `LIBSNDFILE_INCLUDE`, `LIBSNDFILE_LIB`
 - `MUPARSERX_INCLUDE`, `MUPARSERX_LIB`
 - `TCLAP_ROOT`
+- `HIGHWAY_INCLUDE`
+- `VST3_SDK`
 
-CI currently builds these variants:
+The SIMD variant set is defined once in `.github/simd-variants.psd1`. That manifest drives the CI matrix, the pinned dependency downloads, the installer channel names, and the release notes. CI currently builds these variants:
 
 - `windows-x64-sse2`
 - `windows-x64-avx`
@@ -70,9 +79,10 @@ CI currently builds these variants:
 - `windows-x64-avx10_1`
 - `windows-arm64`
 
-The SIMD matrix, dependency artifact names, installer artifact names, and test
-policy are tracked in [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md).
-
-The broad preparation/refactoring pass is summarized in [docs/RefactoringBaseline.md](docs/RefactoringBaseline.md).
+Pull requests build only the primary `avx2` variant; pushes to `main` and manual `workflow_dispatch` runs build all six. The SIMD matrix, dependency artifact names, installer artifact names, and test policy are tracked in [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md).
 
 Qt tools are built through qmake in CI and in the documented local setup. A full Visual Studio solution build also needs a working Qt VS Tools/QtMsBuild setup.
+
+## Tests
+
+`Tests/` holds five projects: `EditorLogicTests` and `HybridConvTests` (unit tests), `EngineOrchestrationTests` (engine routing and config-swap behavior), `AudioRegressionTests` (engine output compared against committed references, also run across SIMD variants in CI), and `TestVst2Plugin` (a self-built plug-in used to test the VST2 host at runtime). Test policy per variant is part of [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md).


### PR DESCRIPTION
## Summary

- README: replace the stale "Current Focus" section (it still listed the original fork goals as future work) with the current project status, and bring every section up to date — Highway portable SIMD, Editor auto-update on exit, the auto-detect installer with `SHA256SUMS.txt` verification, five skins, the five test projects, `setup-build.ps1`, header-only `deps/highway` + `deps/vst3sdk` checkouts, the `simd-variants.psd1` manifest, and the PR-vs-push matrix split.
- New `CHANGELOG.md`: the full release history since the fork point (2026-05-22), grouped by version tag, latest first. PR attributions were verified against the first-parent history of `main` (several early-era changes were direct pushes, not PRs, and are recorded as such). The header explains the auto-bump versioning, the skipped version numbers, and the old `-main.<run>` tag naming.

## Verification

- All file links referenced from the README exist in the tree (`docs/*.md`, `setup-build.ps1`, `CHANGELOG.md`).
- Facts cross-checked against the repo: skin IDs in `Editor/skins/Skins.cpp`, channel names in `.github/simd-variants.psd1`, Highway/VST3 checkout paths in `setup-build.ps1` and `Common.vcxproj`, SHA256SUMS publishing in `build.yml`, audit runner in `biweekly-audit.yml`.
- `git diff --check` clean. Docs-only change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)