### PR TITLE
ci: skip the build matrix when a main push does not bump the version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,11 @@ jobs:
     outputs:
       bumped_sha: ${{ steps.commit.outputs.sha }}
       base_version: ${{ steps.commit.outputs.base_version }}
+      # 'true' when this push raised version.h. When it stays 'false' the push
+      # cannot produce a new release (the tag already exists), so the build
+      # matrix and release jobs are skipped entirely. Use workflow_dispatch to
+      # force a full-matrix build of such a push when needed.
+      bumped: ${{ steps.commit.outputs.bumped }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -84,6 +89,11 @@ jobs:
           # this commit; the current workflow keeps going regardless.
           git commit -m "chore(version): bump version [skip ci]"
           git push
+          "bumped=true" >> $env:GITHUB_OUTPUT
+        }
+        else {
+          "bumped=false" >> $env:GITHUB_OUTPUT
+          Write-Host "::notice::No version bump for this push, so no new release is possible. Skipping the build matrix; use workflow_dispatch to build it anyway."
         }
 
         $sha = (& git rev-parse HEAD).Trim()
@@ -122,15 +132,20 @@ jobs:
 
   build:
     needs: [version-bump, prepare-matrix]
-    # Build for PRs and pushes. On main the bump job must finish first so the
-    # build picks up the bumped version.h; on every other branch the bump job
-    # is skipped (its `if` requires main) which is fine — we still build.
+    # Build for PRs, dispatches, and version-bumping main pushes. On main the
+    # bump job must finish first so the build picks up the bumped version.h;
+    # when it decides nothing bumps (docs/ci/chore/refactor-only pushes) the
+    # push cannot produce a new release, so the whole matrix is skipped. A
+    # skipped bump job on main means a manual `chore(version):` commit — the
+    # maintainer set a version by hand, so build it. On every other event the
+    # bump job is skipped by its own `if` and we always build. Full-matrix
+    # coverage for a no-bump push stays available via workflow_dispatch.
     if: |
       always() && needs.prepare-matrix.result == 'success' && (
         github.event_name != 'push' ||
         github.ref != 'refs/heads/main' ||
-        needs.version-bump.result == 'success' ||
-        needs.version-bump.result == 'skipped'
+        needs.version-bump.result == 'skipped' ||
+        (needs.version-bump.result == 'success' && needs.version-bump.outputs.bumped == 'true')
       )
     strategy:
       fail-fast: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Tests\HybridConvTests\x64\Release\HybridConvTests.exe
 
 ### CI
 
-CI는 x64 `sse2`, `avx`, `avx2`, `avx512`, `avx10_1`, ARM64 `neon` 조합을 빌드하고 산출물과 설치 파일을 업로드합니다. PR에서는 AVX2만 빌드하고, `main` push에서는 전체 조합을 빌드합니다.
+CI는 x64 `sse2`, `avx`, `avx2`, `avx512`, `avx10_1`, ARM64 `neon` 조합을 빌드하고 산출물과 설치 파일을 업로드합니다. PR에서는 AVX2만 빌드하고, `main` push에서는 버전이 올라갈 때만 전체 조합을 빌드합니다. 버전이 오르지 않는 push(docs/ci/chore/refactor 등)는 새 릴리스를 만들 수 없으므로 빌드 매트릭스 자체를 건너뜁니다. 그런 push에 전체 빌드가 필요하면 `gh workflow run build.yml`(workflow_dispatch)로 직접 실행합니다.
 
 `main`에 push되면 CI가 모든 변형 빌드를 끝낸 뒤 GitHub Release를 만듭니다. Release에는 Velopack으로 감싼 설치 파일과 `git archive`로 만든 소스 코드 zip이 올라갑니다. Velopack Release job은 빌드 산출물을 payload로 삼아 패키징합니다.
 
@@ -148,7 +148,7 @@ CI가 만드는 GitHub Release 본문은 `.github/scripts/New-ReleaseNotes.ps1`�
 - 새 기능, 새 필터, 새 SIMD/아키텍처 릴리스 채널, 사용자에게 보이는 동작 변경은 `feat:`로 커밋해 `MINOR`를 올립니다.
 - 설정 파일 형식, 설치 방식, 업데이트 채널, 공개 동작이 기존 사용자에게 수동 조치를 요구할 만큼 바뀌면 BREAKING CHANGE로 표시해 `MAJOR`를 올립니다.
 
-`version.h`가 올라가지 않은 push는 같은 태그의 릴리스가 이미 있으므로 release job이 재패키징을 건너뜁니다.
+`version.h`가 올라가지 않은 push는 같은 태그의 릴리스가 이미 있으므로 빌드 매트릭스와 release job을 통째로 건너뜁니다. 코드가 바뀌는 no-bump push(refactor 등)에 전체 매트릭스 검증이 필요하면 workflow_dispatch로 빌드를 직접 실행합니다.
 
 ## 코드 작업 기준
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The SIMD variant set is defined once in `.github/simd-variants.psd1`. That manif
 - `windows-x64-avx10_1`
 - `windows-arm64`
 
-Pull requests build only the primary `avx2` variant; pushes to `main` and manual `workflow_dispatch` runs build all six. The SIMD matrix, dependency artifact names, installer artifact names, and test policy are tracked in [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md).
+Pull requests build only the primary `avx2` variant. Pushes to `main` build all six when the automatic version bump produces a new version; pushes that cannot produce a release (docs, CI, refactor-only changes) skip the build matrix. Manual `workflow_dispatch` runs always build all six. The SIMD matrix, dependency artifact names, installer artifact names, and test policy are tracked in [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md).
 
 Qt tools are built through qmake in CI and in the documented local setup. A full Visual Studio solution build also needs a working Qt VS Tools/QtMsBuild setup.
 


### PR DESCRIPTION
## Summary

A `main` push whose commits do not bump `version.h` (docs/ci/chore/refactor-only) cannot produce a new release — the tag already exists — yet CI still built all six variants for ~15 minutes before the release job skipped repackaging. Now:

- The `version-bump` job outputs `bumped=true/false` (decided by the existing `git diff -- version.h` check).
- The `build` job runs on main pushes only when `bumped == true`. `cross-variant-compare` and `create-release` depend on `build`, so they skip with it.
- A `::notice::` annotation on the run states why the matrix was skipped and points to `workflow_dispatch` as the way to force a full build.

Behavior preserved:

- PRs still build the primary avx2 variant (the bump job is skipped for non-push events, which the condition allows).
- Manual `chore(version):` pushes still build — the bump job skips itself for those, and a skipped bump on main is treated as "maintainer set the version by hand".
- `workflow_dispatch` still builds all six variants unconditionally.

Trade-off, stated in CLAUDE.md and README: a code-changing no-bump push (e.g. `refactor:`) no longer gets the post-merge full-matrix build. Full coverage stays one `gh workflow run build.yml` away, which is already the documented pattern for risky branches.

## Validation

- YAML parses; `needs.version-bump` consumers checked (`bumped_sha || github.sha` fallbacks untouched).
- This PR's CI run validates the PR path. After merge, the push itself is a no-bump `ci:` commit, which live-validates the skip path on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)