### PR TITLE
docs: add Korean versions of the README and changelog

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -1,0 +1,264 @@
+# 변경 이력
+
+[English](CHANGELOG.md) | **한국어**
+
+TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트림 커밋 `7156020`, 2025-12-16) EqualizerAPO-XT에 들어간 주요 변경 사항입니다. 포크 작업은 2026-05-22에 시작됐습니다.
+
+버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
+
+## 미공개 (Unreleased)
+
+- `Channel:`과 `Convolution:` 설정 문법을 엔진과 Editor가 함께 쓰는 공용 명령
+  코덱으로 옮기고 왕복(round-trip) 테스트를 붙였습니다. 이 과정에서 Channel
+  GUI가 쉼표로 구분한 선택자를 무시하던 문제도 함께 고쳤습니다. `IFilterFactory`의
+  소비 계약과, Editor/UpdateChecker 업데이트 경로를 의도적으로 분리해 둔 사실을
+  코드에 주석으로 문서화했습니다. ([#57])
+- 격주 감사가 Git Bash를 쓰는 Windows 러너에서, 미리 준비된 빌드 가능한 트리로
+  실행됩니다. 이제 감사가 코드를 읽기만 하는 대신 직접 컴파일하고 테스트를
+  돌릴 수 있습니다. ([#58])
+- 버전이 오르지 않는 `main` push는 새 릴리스를 만들 수 없으므로 빌드 매트릭스를
+  건너뜁니다. 전체 매트릭스 빌드는 workflow_dispatch로 언제든 직접 실행할 수
+  있습니다. ([#61])
+- README를 현재 상태에 맞게 새로 썼고, 이 변경 이력 문서를 추가했으며, 두 문서의
+  한국어판을 만들었습니다. ([#60])
+
+## v1.17.1 (2026-06-11)
+
+격주 감사 이슈 #53에서 나온 첫 수정 묶음입니다.
+
+- 자동 감지 설치기가 내려받은 설치 파일을 실행하기 전에 릴리스 자산
+  `SHA256SUMS.txt`로 검증합니다. CI는 릴리스마다 체크섬 파일을 함께
+  게시합니다. ([#56])
+- libHybridConv의 버퍼 소유권을 보호 장치 없는 프로세스 전역 map에서 컨볼루션
+  구조체 내부로 옮겨, APO 인스턴스 간에 잠재해 있던 데이터 경쟁을 없앴습니다.
+  오디오 출력은 비트 단위로 동일합니다. ([#56])
+- 새 테스트 스위트 `EngineOrchestrationTests`가 채널 이름 라우팅, `Copy` 명령의
+  동작, 설정 교체 시 crossfade를 공개 엔진 API로 검증합니다. ([#56])
+- CI 빌드 매트릭스를 `.github/simd-variants.psd1` 매니페스트에서 생성하고,
+  바이너리 의존성 다운로드를 태그와 SHA-256으로 고정해 검증하며, 설치기 채널
+  이름이 매니페스트와 어긋나면 lint 단계가 CI를 실패시킵니다. PR은 이제 정말로
+  기본 avx2 변형만 빌드합니다(옛 PR 필터는 동작하지 않아 여섯 개를 모두
+  빌드하고 있었습니다). ([#55])
+- 격주 감사가 Claude Fable 5로 실행됩니다. ([#54])
+
+## v1.17.0 (2026-06-10)
+
+- **자동 감지 설치기**: 새 진입용 설치 파일 `EqualizerAPO-XT-Setup.exe`가
+  CPU(아키텍처와 AVX 수준)를 감지해 맞는 빌드를 내려받습니다. 사용자가 SIMD
+  변형을 직접 고를 필요가 없어졌습니다. ARM64 업데이트 채널 이름을 실제로
+  게시되는 `arm64-neon`과 맞췄습니다. ([#52])
+- 감사 이슈 #48의 두 번째 수정 묶음입니다. 공용 테스트 하니스를 만들어
+  회귀/헬퍼/파서 커버리지를 늘리고, 자체 빌드 테스트 플러그인으로 VST2 호스트를
+  런타임에 검증하는 테스트를 더했습니다. 비대해진 `VSTPluginInstance` 파일을
+  응집된 단위로 나누고, BiQuad 설정 줄의 파싱 루틴을 하나로 합쳤으며,
+  MainWindow에서 설정 파일 코덱을 분리해 냈습니다. Preamp·Delay·GraphicEQ·
+  Copy·VSTPlugin GUI의 파싱/직렬화는 공용 코덱으로 묶었고, SIMD 변형 집합은
+  `simd-variants.psd1` 한 곳에 정의했으며, SIMD 플래그 없이 qmake를 실행하면
+  조용히 잘못 빌드되는 대신 즉시 실패합니다. ([#51])
+
+## v1.15.3 (2026-06-09)
+
+감사 이슈 #48의 첫 수정 묶음입니다. ([#50])
+
+- 컨볼루션 IR 캐시에 크기 상한을 두고 `ConvolutionFilter`의 자원 처리를
+  강화했습니다.
+- 필터 factory가 중앙 레지스트리를 통해 등록되고, 할당은 타입을 검사하는
+  할당자를 거치며, 인식된 명령이 필터를 만들지 못하면 엔진이 경고를 남깁니다.
+  VST 플러그인 초기화 실패는 원인과 함께 기록됩니다.
+- Editor의 알려진 명령 목록을 손으로 관리하던 사본 대신 factory 레지스트리에서
+  생성하고, 레거시 필터 목록 UI 경로는 동결해 문서화했습니다. 릴리스 노트의
+  SIMD 채널 표는 한 곳에서 생성합니다.
+
+## v1.15.2 (2026-06-09)
+
+- 감사 워크플로우의 actions를 Node 24로 올렸습니다. ([#49])
+
+## v1.15.1 (2026-06-08)
+
+- 격주 자동 코드 감사 워크플로우를 추가했습니다. Claude가 코드베이스를 점검하고
+  발견 사항을 GitHub 이슈로 올립니다. ([#46], [#47])
+- 런타임 SIMD dispatch(B안) 장기 계획을 `docs/RuntimeDispatchEpic.md`에
+  기록했습니다. ([#45])
+
+## v1.15.0 (2026-06-08)
+
+- **Google Highway 포터블 SIMD**: 손으로 작성한 SIMD 네 곳(컨볼루션 커널,
+  BiQuadFilter, PreampFilter, float↔double 변환)을 ISA별 intrinsic에서 변형별로
+  컴파일되는 Highway 커널 한 벌로 이식했습니다. ARM64는 스칼라 폴백에서 실제
+  NEON으로 올라갑니다. 새 회귀 케이스 `convolution_short`와 커밋된 참조
+  데이터가 이식을 검증하며, 모든 변형에서 출력이 회귀 허용 오차 안에 있습니다.
+  ([#43], [#44])
+- Qt 응용 프로그램 실행 파일이 빠졌는데도 불완전한 릴리스를 패키징하는 대신,
+  CI가 빌드를 실패시킵니다. ([#44])
+
+## v1.13.1 (2026-06-08)
+
+- VST 플러그인 라이브러리의 로드/언로드가 스레드 안전해졌습니다. ([#42])
+- 사용자 문서를 영어와 한국어로 새로 썼고, CI가 GitHub Wiki에 게시합니다.
+  ([#36], [#37], [#38], [#39])
+- 오디오 회귀 참조 데이터를 커밋했고, 변형 간 비교가 출력이 없을 때 조용히
+  통과하는 대신 실패합니다. ([#40], [#41])
+
+## v1.13.0 (2026-06-07)
+
+- **네이티브 VST3 호스팅**: Steinberg VST3 SDK pluginterfaces를 통해 VST3
+  플러그인을 호스팅하며, 플러그인이 지원하면 double 정밀도로 처리합니다.
+  ([#35])
+
+## v1.12.x (2026-06-03 ~ 2026-06-06)
+
+- 스킨과 테마를 전환할 때 위젯 트리 전체를 다시 polish하지 않아 전환이 거의
+  즉시 끝납니다. (v1.12.5, [#34])
+- 모던 필터 카드 아이콘이 제대로 그려지고 Copy 게인 라벨이 겹치지 않습니다.
+  (v1.12.4, [#33])
+- 필터 노브가 커서를 따라가는 진짜 회전 컨트롤이 됐고, 릴리스 파이프라인은 CI
+  concurrency 그룹으로 직렬화됩니다. (v1.12.3, [#32])
+- CI를 `windows-2025-vs2026` 러너 이미지로 옮기고 러너별 플랫폼 도구 집합을
+  선택하며, GitHub Actions를 지원 종료된 Node.js 20에서 벗어나게 했습니다.
+  `velopack_libc.dll`을 앱이 실제로 찾는 이름으로 배포해, 패키징된 빌드가
+  시작되지 않던 문제를 고쳤습니다. (v1.12.2, [#29], [#30], [#31])
+- 레거시 필터 카드가 모던 AudioKnob을 쓰고, 채널 선택 배지에 색이 입혀지며,
+  Qt 고해상도 스케일링이 켜져 4K 화면에서 UI가 작게 나오지 않습니다.
+  (v1.12.0, [#28])
+
+## v1.11.0 (2026-06-03)
+
+- **자동 업데이트**: Editor가 Velopack SDK로 새 릴리스를 백그라운드에서
+  내려받아 두었다가 종료할 때 적용합니다. ([#27])
+- 폰트 weight가 제대로 그려지고, 스킨을 바꾸면 Copy 라우팅 렌더러도 함께
+  바뀝니다. ([#27])
+
+## v1.10.x (2026-06-02)
+
+- APO가 `IAudioSystemEffects2::GetEffectsList`로 자신의 효과를 보고해, Windows가
+  어떤 처리가 켜져 있는지 표시할 수 있습니다. (v1.10.0, [#25])
+- Copy 라우팅 편집기가 빈 캔버스 대신 장치의 채널 목록으로 시작합니다.
+  (v1.10.1, [#26])
+
+## v1.8.0 (2026-05-31 ~ 2026-06-02)
+
+- **스킨별 Copy 라우팅 렌더러**: Editor의 다섯 스킨이 각자의 시각 언어로 채널
+  라우팅을 그리며, 새 `ISkin` 위임 엔진이 이를 담당합니다. DM Sans, DM Mono,
+  Pretendard 폰트를 내장하고 QSS 폰트를 토큰화했습니다. ([#22])
+- FFTW planner 접근을 직렬화해 Editor 시작 시 간헐적으로 나던 크래시를
+  고쳤습니다. ([#22])
+- 비실시간 COM/Win32 자원을 RAII로 감싸고, APO가 regsvr32를 호출하는 대신
+  프로세스 안에서 직접 등록합니다. ([#23])
+
+## v1.6.0 (2026-05-26 ~ 2026-05-27)
+
+- 샘플 형식이 IEEE_FLOAT 32/64가 아닐 때 APO가 오디오를 깨뜨리는 대신 그대로
+  통과시키고, EQ가 꺼져 있다는 사실을 Editor가 표시해 사용자가 알 수 있습니다.
+  ([#21])
+- 변형 진단으로 찾은 Modern Card 렌더링 버그 3건을 고쳤고, Modern Card 오른쪽
+  헤더 도구 모음이 다시 보입니다. ([#19], [#20])
+
+## v1.5.x (2026-05-24 ~ 2026-05-25)
+
+- **Editor 스킨 5종**(studio, minimal, soft, rack, matrix)이 스킨별 토큰 QSS로
+  뚜렷이 구분되는 모습을 갖췄고, Conventional Commits 기반 자동 버전 bump가
+  들어왔습니다. (v1.5.0, [#11], [#12])
+- 모든 필터 factory가 Common.lib에서 링크됩니다(이전에는 일부 필터가 조용히
+  동작하지 않았습니다). FFTW wisdom을 캐시합니다. (v1.5.1, [#13])
+- DSP 핫패스, Editor 분석 패널, 컨볼루션에 성능 패스를 돌렸습니다. 디코딩한
+  임펄스 응답을 필터 타입별로 캐시하고, 켜기/끄기 시 해당 행만 새로 그리며,
+  Velopack 업데이트 확인을 시작 후 60초로 미뤘습니다. (v1.5.1, [#14], [#15],
+  [#16], [#17])
+- 주석 처리된 행이 카드 전체를 회색으로 만들지 않고, BiQuad 카드 요약이 더
+  풍부해졌습니다. (v1.5.2, [#18])
+
+## v1.4.3 (2026-05-22 ~ 2026-05-24)
+
+- **Velopack 이행(1~5단계)**: 헤드리스 APO 등록, Editor의 Velopack
+  설치/업데이트/제거 훅, 원시 바이너리를 Velopack에 직접 패키징, 백그라운드
+  업데이트를 트리거하는 런타임 헬퍼, 그리고 NSIS 설치기와 작업 스케줄러 기반
+  업데이트 경로 제거까지 끝냈습니다. ([#4])
+- **AudioRegressionTests**: DSP 시나리오를 렌더링해 커밋된 참조 데이터와
+  비교하는 회귀 스위트를 만들고, CI에서 변형 간 비교, cppcheck과 함께
+  돌립니다. PR 빌드와 push 빌드를 분리했습니다. ([#6])
+- SSE2와 AVX 릴리스 채널을 추가하고(SIMD 수준이 낮은 빌드는 스레드 FFTW 사용),
+  AVX용
+  Velopack 피드 자산을 인식하며, 레거시 카드 편집기를 교체하고, Editor UI에서
+  Qt 기본 스타일을 걷어냈습니다([#3]).
+- Benchmark에 오디오 파이프라인의 단계별 프로파일러가 들어왔습니다. ([#5])
+- Include 카드에서 참조된 설정의 의존성을 스캔해 설정 디렉터리로 복사해 오는
+  가져오기 흐름을 추가했습니다. ([#7])
+- audiodg가 APO를 로드할 수 있도록 설치 디렉터리에 LOCAL SERVICE 권한을 주고,
+  진단·복구 스크립트를 `tools/`에 두었습니다. ([#9], [#10])
+- `setup-build.ps1`이 로컬 빌드 환경을 준비합니다. ([#8])
+
+## v1.4.2 (2026-05-22)
+
+TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
+
+- **컨볼루션 꼬리 수정**: 프레임 크기가 바뀐 뒤 리버브 꼬리가 1000ms 부근에서
+  끊기던 문제를 고치고, 새 하이브리드 컨볼루션 회귀 테스트로 보호했습니다.
+  ([#2])
+- 광범위한 현대화 리팩토링을 진행했습니다. 필터 설정 저장소와 COM 객체를
+  RAII로 바꾸고, `nullptr`와 타입을 명시한 캐스트·버퍼 복사를 도입했으며, 큰
+  구현 파일을 책임별로 나누고, 필터 factory 등록을 FilterEngine 밖으로
+  옮겼으며, FilterEngine 동기화를 현대화했습니다. ([#1], [#2])
+- 컨볼루션 파일 경로 처리를 다듬고 경로 파싱을 확장했습니다. ([#2])
+- Velopack 릴리스 워크플로우와 업데이트 피드 연동이 들어왔습니다([#1], [#2]).
+  GitHub Actions 빌드를 안정화했습니다. 의존성은 릴리스 자산에서 내려받고, Qt는
+  CI에서 직접 설치하며, actions는 Node 24로 돌고, ARM64 빌드는 네이티브 MSVC
+  환경을 씁니다.
+- 카드 기반 모던 Editor UI의 첫 버전이 들어왔습니다.
+
+[#1]: https://github.com/115dkk/EqualizerAPO-XT/pull/1
+[#2]: https://github.com/115dkk/EqualizerAPO-XT/pull/2
+[#3]: https://github.com/115dkk/EqualizerAPO-XT/pull/3
+[#4]: https://github.com/115dkk/EqualizerAPO-XT/pull/4
+[#5]: https://github.com/115dkk/EqualizerAPO-XT/pull/5
+[#6]: https://github.com/115dkk/EqualizerAPO-XT/pull/6
+[#7]: https://github.com/115dkk/EqualizerAPO-XT/pull/7
+[#8]: https://github.com/115dkk/EqualizerAPO-XT/pull/8
+[#9]: https://github.com/115dkk/EqualizerAPO-XT/pull/9
+[#10]: https://github.com/115dkk/EqualizerAPO-XT/pull/10
+[#11]: https://github.com/115dkk/EqualizerAPO-XT/pull/11
+[#12]: https://github.com/115dkk/EqualizerAPO-XT/pull/12
+[#13]: https://github.com/115dkk/EqualizerAPO-XT/pull/13
+[#14]: https://github.com/115dkk/EqualizerAPO-XT/pull/14
+[#15]: https://github.com/115dkk/EqualizerAPO-XT/pull/15
+[#16]: https://github.com/115dkk/EqualizerAPO-XT/pull/16
+[#17]: https://github.com/115dkk/EqualizerAPO-XT/pull/17
+[#18]: https://github.com/115dkk/EqualizerAPO-XT/pull/18
+[#19]: https://github.com/115dkk/EqualizerAPO-XT/pull/19
+[#20]: https://github.com/115dkk/EqualizerAPO-XT/pull/20
+[#21]: https://github.com/115dkk/EqualizerAPO-XT/pull/21
+[#22]: https://github.com/115dkk/EqualizerAPO-XT/pull/22
+[#23]: https://github.com/115dkk/EqualizerAPO-XT/pull/23
+[#25]: https://github.com/115dkk/EqualizerAPO-XT/pull/25
+[#26]: https://github.com/115dkk/EqualizerAPO-XT/pull/26
+[#27]: https://github.com/115dkk/EqualizerAPO-XT/pull/27
+[#28]: https://github.com/115dkk/EqualizerAPO-XT/pull/28
+[#29]: https://github.com/115dkk/EqualizerAPO-XT/pull/29
+[#30]: https://github.com/115dkk/EqualizerAPO-XT/pull/30
+[#31]: https://github.com/115dkk/EqualizerAPO-XT/pull/31
+[#32]: https://github.com/115dkk/EqualizerAPO-XT/pull/32
+[#33]: https://github.com/115dkk/EqualizerAPO-XT/pull/33
+[#34]: https://github.com/115dkk/EqualizerAPO-XT/pull/34
+[#35]: https://github.com/115dkk/EqualizerAPO-XT/pull/35
+[#36]: https://github.com/115dkk/EqualizerAPO-XT/pull/36
+[#37]: https://github.com/115dkk/EqualizerAPO-XT/pull/37
+[#38]: https://github.com/115dkk/EqualizerAPO-XT/pull/38
+[#39]: https://github.com/115dkk/EqualizerAPO-XT/pull/39
+[#40]: https://github.com/115dkk/EqualizerAPO-XT/pull/40
+[#41]: https://github.com/115dkk/EqualizerAPO-XT/pull/41
+[#42]: https://github.com/115dkk/EqualizerAPO-XT/pull/42
+[#43]: https://github.com/115dkk/EqualizerAPO-XT/pull/43
+[#44]: https://github.com/115dkk/EqualizerAPO-XT/pull/44
+[#45]: https://github.com/115dkk/EqualizerAPO-XT/pull/45
+[#46]: https://github.com/115dkk/EqualizerAPO-XT/pull/46
+[#47]: https://github.com/115dkk/EqualizerAPO-XT/pull/47
+[#49]: https://github.com/115dkk/EqualizerAPO-XT/pull/49
+[#50]: https://github.com/115dkk/EqualizerAPO-XT/pull/50
+[#51]: https://github.com/115dkk/EqualizerAPO-XT/pull/51
+[#52]: https://github.com/115dkk/EqualizerAPO-XT/pull/52
+[#54]: https://github.com/115dkk/EqualizerAPO-XT/pull/54
+[#55]: https://github.com/115dkk/EqualizerAPO-XT/pull/55
+[#56]: https://github.com/115dkk/EqualizerAPO-XT/pull/56
+[#57]: https://github.com/115dkk/EqualizerAPO-XT/pull/57
+[#58]: https://github.com/115dkk/EqualizerAPO-XT/pull/58
+[#60]: https://github.com/115dkk/EqualizerAPO-XT/pull/60
+[#61]: https://github.com/115dkk/EqualizerAPO-XT/pull/61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+**English** | [한국어](CHANGELOG.ko.md)
+
 All notable changes to EqualizerAPO-XT since it was forked from TheFireKahuna's
 equalizerAPO64 tree (last upstream commit `7156020`, 2025-12-16). Work on this
 fork started on 2026-05-22.
@@ -20,7 +22,11 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 - The biweekly audit now runs on a Windows runner with Git Bash and a
   pre-provisioned buildable tree, so audits can compile and execute the test
   suites instead of reading the code blind. ([#58])
-- README refreshed to the current project state, and this changelog added.
+- `main` pushes that do not bump the version cannot produce a new release, so
+  they now skip the build matrix entirely; a full-matrix build stays available
+  via `workflow_dispatch`. ([#61])
+- README refreshed to the current project state, this changelog added, and
+  Korean translations of both provided. ([#60])
 
 ## v1.17.1 — 2026-06-11
 
@@ -263,3 +269,5 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#56]: https://github.com/115dkk/EqualizerAPO-XT/pull/56
 [#57]: https://github.com/115dkk/EqualizerAPO-XT/pull/57
 [#58]: https://github.com/115dkk/EqualizerAPO-XT/pull/58
+[#60]: https://github.com/115dkk/EqualizerAPO-XT/pull/60
+[#61]: https://github.com/115dkk/EqualizerAPO-XT/pull/61

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,90 @@
+# EqualizerAPO-XT
+
+[English](README.md) | **한국어**
+
+EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO 1.4.2](https://sourceforge.net/p/equalizerapo/)를 바탕으로 활발히 개발 중인 포크입니다. Equalizer APO의 시스템 전체 오디오 처리 모델은 그대로 두고, 오디오 엔진과 빌드 파이프라인, GUI 도구를 현대화했습니다.
+
+이 포크는 [equalizer-apo-64](https://github.com/chebum/equalizer-apo-64)의 double 정밀도 작업과, 그 뒤를 이은 TheFireKahuna의 Equalizer APO 포크들의 SIMD/빌드 작업을 이어받았습니다.
+
+## 프로젝트 현황
+
+포크가 처음 목표로 잡았던 작업은 모두 끝났습니다. 컨볼루션 꼬리가 끊기던 버그를 고쳤고, 엔진 코드를 리팩토링해 회귀 테스트로 보호했으며, Editor UI를 새로 만들었고, SIMD 지원을 정리했습니다. 릴리스는 자동 업데이트가 되는 Velopack 패키지로 나갑니다. 포크 이후의 전체 이력은 [CHANGELOG.ko.md](CHANGELOG.ko.md)에 있습니다.
+
+지금 진행 중인 작업은 다음과 같습니다.
+
+1. 남은 필터 설정 파서를 엔진과 Editor가 함께 쓰는 공용 명령 코덱으로 옮깁니다.
+2. 변형별 릴리스 채널을 단일 바이너리 런타임 SIMD dispatch로 대체합니다([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
+3. 격주 자동 코드 감사가 찾아낸 문제를 처리합니다.
+
+## 주요 기능
+
+- 오디오를 내부에서 double 정밀도로 처리해 복잡한 필터 체인에서도 정밀도를 잃지 않습니다.
+- Convolution, GraphicEQ, 파라메트릭 EQ, VST2/VST3와 기존 Equalizer APO 필터를 지원합니다.
+- Steinberg VST3 SDK(MIT 라이선스 pluginterfaces)로 VST3를 네이티브 호스팅하며, 플러그인이 지원하면 64비트(double)로 처리합니다.
+- SIMD 커널은 [Google Highway](https://github.com/google/highway)로 한 번만 작성해 변형별로 컴파일합니다. x64는 SSE2, AVX, AVX2, AVX-512, AVX10.1, ARM64는 NEON입니다.
+- Qt Editor를 현대화했습니다. 카드 기반 필터 UI, 스킨별 Copy 라우팅 렌더러를 갖춘 5종 스킨, 내장 폰트, 고해상도(High-DPI) 대응이 들어 있습니다.
+- Editor가 새 릴리스를 백그라운드에서 내려받아 종료할 때 적용하는 자동 업데이트가 들어 있습니다. 알림만 하는 UpdateChecker 도구도 따로 있습니다.
+- 자동 감지 설치기가 로컬 CPU에 맞는 SIMD 빌드를 골라 내려받고, 실행 전에 릴리스 체크섬으로 검증합니다.
+- 오디오 처리는 AOCL-FFTW, libsndfile, muparserx, TCLAP을 쓰고, GUI 도구는 Qt로 만들었습니다.
+- Windows 호환성을 위해 공유 VC++ 런타임 DLL을 함께 배포합니다.
+- GitHub Actions 파이프라인이 빌드, 테스트, 설치 파일, 릴리스를 만들고, 격주 자동 코드 감사가 트리를 직접 빌드해 테스트까지 돌립니다.
+
+## 설치
+
+[Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에서 설치합니다. `main`에 push되면 CI가 지원하는 모든 변형을 빌드하고, Velopack으로 감싼 설치 파일과 소스 코드 zip을 담은 GitHub Release를 만듭니다.
+
+권장 다운로드는 자동 감지 설치기인 **EqualizerAPO-XT-Setup.exe**입니다. CPU(아키텍처와 AVX 수준)를 감지해 맞는 빌드를 내려받으므로 SIMD 변형을 직접 고를 필요가 없으며, 내려받은 파일은 실행 전에 릴리스의 `SHA256SUMS.txt`로 검증합니다. 특정 빌드를 골라 설치하고 싶다면 채널별 `…-Setup.exe` 파일도 그대로 받을 수 있습니다. [docs/AutoDetectInstaller.md](docs/AutoDetectInstaller.md)를 참고하십시오.
+
+설치 후에는 Editor가 스스로 최신 상태를 유지합니다. 새 릴리스를 백그라운드에서 내려받아 두었다가 Editor를 닫을 때 적용합니다. 자세한 흐름은 [docs/VelopackUpdates.md](docs/VelopackUpdates.md)에 있습니다.
+
+## 문서
+
+사용자 문서는 [GitHub Wiki](https://github.com/115dkk/EqualizerAPO-XT/wiki)에 영어판과 한국어판이 있으며, 이 저장소의 `Wiki/github-wiki/`에서 동기화됩니다. 개발자 문서는 [docs/](docs/) 아래에 있습니다(영어).
+
+## 빌드
+
+프로젝트는 Visual Studio, Qt, Velopack과 몇 가지 외부 라이브러리를 사용합니다. [setup-build.ps1](setup-build.ps1)을 실행하면 로컬 빌드에 필요한 것(바이너리 의존성, 헤더 전용 체크아웃, Qt 6.10.1)이 모두 준비됩니다. 수동 배치 방법은 [docs/LocalDependencySetup.md](docs/LocalDependencySetup.md)에 있습니다.
+
+포크된 의존성 저장소는 다음과 같습니다.
+
+- [AOCL-FFTW 5.1 / FFTW 3.3.10](https://github.com/thefirekahuna/amd-fftw)
+- [muparserx 4.0.13](https://github.com/thefirekahuna/muparserx)
+- [libsndfile 1.2.2](https://github.com/thefirekahuna/libsndfile)
+- [tclap 1.2.5](https://github.com/thefirekahuna/tclap)
+
+헤더 전용 의존성 두 개는 저장소에 넣지 않고 체크아웃합니다. [Google Highway](https://github.com/google/highway)는 `deps/highway`에, Steinberg [VST3 pluginterfaces](https://github.com/steinbergmedia/vst3_pluginterfaces)는 `deps/vst3sdk/pluginterfaces`에 둡니다.
+
+프로젝트 파일은 기본적으로 저장소 안의 `deps/` 디렉터리에서 의존성을 찾습니다.
+
+- `deps/fftw`
+- `deps/libsndfile`
+- `deps/muparserx`
+- `deps/tclap`
+- `deps/highway`
+- `deps/vst3sdk`
+
+같은 기본값을 다음 환경 변수로 덮어쓸 수 있습니다.
+
+- `FFTW_INCLUDE`, `FFTW_LIB`
+- `LIBSNDFILE_INCLUDE`, `LIBSNDFILE_LIB`
+- `MUPARSERX_INCLUDE`, `MUPARSERX_LIB`
+- `TCLAP_ROOT`
+- `HIGHWAY_INCLUDE`
+- `VST3_SDK`
+
+SIMD 변형 집합은 `.github/simd-variants.psd1` 한 곳에 정의합니다. 이 매니페스트가 CI 매트릭스, 태그와 SHA-256으로 고정한 의존성 다운로드, 설치 파일 채널 이름, 릴리스 노트를 모두 결정합니다. CI는 현재 다음 변형을 빌드합니다.
+
+- `windows-x64-sse2`
+- `windows-x64-avx`
+- `windows-x64-avx2`
+- `windows-x64-avx512`
+- `windows-x64-avx10_1`
+- `windows-arm64`
+
+PR은 기본 변형인 `avx2`만 빌드합니다. `main` push는 자동 버전 bump로 새 버전이 나올 때만 여섯 개를 모두 빌드하며, 릴리스를 만들 수 없는 push(docs, CI, 리팩토링만 있는 변경)는 빌드 매트릭스를 건너뜁니다. 수동 `workflow_dispatch` 실행은 항상 여섯 개를 모두 빌드합니다. SIMD 매트릭스, 의존성 산출물 이름, 설치 파일 이름, 테스트 정책은 [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md)에서 관리합니다.
+
+Qt 도구는 CI에서도, 문서화된 로컬 설정에서도 qmake로 빌드합니다. Visual Studio 솔루션 전체를 빌드하려면 Qt VS Tools/QtMsBuild도 제대로 설정되어 있어야 합니다.
+
+## 테스트
+
+`Tests/`에는 프로젝트 다섯 개가 있습니다. `EditorLogicTests`와 `HybridConvTests`(단위 테스트), `EngineOrchestrationTests`(엔진 라우팅과 설정 교체 동작), `AudioRegressionTests`(엔진 출력을 커밋된 참조 데이터와 비교하며, CI에서는 SIMD 변형별로도 실행), `TestVst2Plugin`(VST2 호스트를 런타임에 시험하기 위한 자체 빌드 플러그인)입니다. 변형별 테스트 정책은 [docs/SimdBuildMatrix.md](docs/SimdBuildMatrix.md)에 함께 있습니다.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # EqualizerAPO-XT
 
+**English** | [한국어](README.ko.md)
+
 EqualizerAPO-XT is an active fork of [Equalizer APO 1.4.2](https://sourceforge.net/p/equalizerapo/) for Windows. It keeps Equalizer APO's system-wide audio processing model while modernizing the audio engine, build pipeline, and GUI tools.
 
 This fork builds on earlier double-precision work from [equalizer-apo-64](https://github.com/chebum/equalizer-apo-64) and later SIMD/build work from TheFireKahuna's Equalizer APO forks.


### PR DESCRIPTION
## Summary

- New `README.ko.md` and `CHANGELOG.ko.md` mirror the English files. They do not replace them — each file carries a language switcher line at the top (`English | 한국어`) linking the two versions both ways, and the Korean README links to the Korean changelog.
- Both changelogs gain Unreleased entries for the build-skip change (#61) and this documentation round (#60), so the two languages stay in sync.

## Verification

- A three-agent adversarial review checked translation fidelity against the English sources, Korean style against the CLAUDE.md rules, and link integrity (every relative target exists; every `[#NN]` usage has a definition and vice versa, verified programmatically). All 19 findings were applied, including two factual corrections the review caught: the auto-detect installer sentence had attached "no need to pick a variant" to checksum verification instead of CPU detection, and the AudioRegressionTests note had substituted cross-variant comparison for per-variant execution.
- No em-dash remains in the Korean files; reference-link definitions match usages in both changelogs.

Docs-only change: after merge, the push will not bump the version, so the build matrix is skipped per #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)