### PR TITLE
fix: clear the cppcheck baseline and turn the CI job into a gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1108,34 +1108,73 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Install cppcheck
-      run: sudo apt-get update && sudo apt-get install -y cppcheck
+    # cppcheck is built from a pinned release tag instead of apt because the
+    # apt package version drifts with the runner image and the finding set
+    # changes between cppcheck releases. The gate below must stay reproducible
+    # against the same version developers run locally.
+    - name: Cache cppcheck
+      id: cache-cppcheck
+      uses: actions/cache@v4
+      with:
+        path: ~/cppcheck-install
+        key: cppcheck-2.21.0-${{ runner.os }}
 
+    - name: Build cppcheck 2.21.0
+      if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+      run: |
+        git clone --depth 1 --branch 2.21.0 https://github.com/danmar/cppcheck.git "$HOME/cppcheck-src"
+        cmake -S "$HOME/cppcheck-src" -B "$HOME/cppcheck-build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$HOME/cppcheck-install"
+        cmake --build "$HOME/cppcheck-build" -j"$(nproc)"
+        cmake --install "$HOME/cppcheck-build"
+
+    # The baseline is zero findings and the step fails on any new one.
+    # Policy suppressions (kept out of the code on purpose):
+    # - cstyleCast/shadow*: Win32/COM/VST interop casts and the upstream
+    #   naming style (Qt parent/signal names, ctor parameters named like
+    #   members) would mean churn across long-standing upstream code.
+    # - useStlAlgorithm/postfixOperator: raw loops and it++ are the house
+    #   style inherited from upstream; no behavior or measurable perf impact.
+    # - noExplicitConstructor: single-argument constructors (Qt widgets,
+    #   exception types, filters) are intentionally implicit upstream.
+    # - LocalAllocCalled: LocalAlloc/LocalFree pairs are mandated by the
+    #   Win32 security APIs used (SetEntriesInAcl, GetNamedSecurityInfoW).
+    # - unknownMacro on the two VST3 host files: QUERY_INTERFACE comes from
+    #   the VST3 SDK under deps/, which is excluded from analysis.
     - name: Run cppcheck
       run: |
-        cppcheck \
+        "$HOME/cppcheck-install/bin/cppcheck" \
           --enable=warning,style,performance,portability \
           --inline-suppr \
+          --library=qt \
+          --library=windows \
           --suppress=missingIncludeSystem \
           --suppress=unusedFunction \
           --suppress=unmatchedSuppression \
+          --suppress=cstyleCast \
+          --suppress=shadowFunction \
+          --suppress=shadowVariable \
+          --suppress=shadowMember \
+          --suppress=useStlAlgorithm \
+          --suppress=postfixOperator \
+          --suppress=noExplicitConstructor \
+          --suppress=LocalAllocCalled \
+          --suppress=unknownMacro:helpers/VSTPluginInstance.cpp \
+          --suppress=unknownMacro:helpers/VSTPluginInstanceInternal.h \
           --suppress=*:libHybridConv-0.1.1/* \
           --suppress=*:deps/* \
-          --error-exitcode=0 \
+          --error-exitcode=1 \
           --quiet \
           --std=c++17 \
           -i libHybridConv-0.1.1 \
           -i deps \
-          -i build-Editor-Desktop_Qt_6_7_2_MSVC2022_32bit \
-          -i build-Editor-Desktop_Qt_6_7_2_MSVC2022_64bit \
-          -i build-Editor-Desktop_Qt_6_7_2_MSVC2019_ARM64 \
           --output-file=cppcheck-report.txt \
-          .
+          . || failed=1
         echo "--- cppcheck report ---"
         cat cppcheck-report.txt || true
-        if [ -s cppcheck-report.txt ]; then
+        if [ "${failed:-0}" = "1" ]; then
           line_count=$(wc -l < cppcheck-report.txt)
-          echo "::warning::cppcheck reported ${line_count} lines of findings (currently non-blocking; treated as baseline)"
+          echo "::error::cppcheck found new issues (${line_count} lines). Fix them or, for a justified false positive, add an inline or job-level suppression with a rationale."
+          exit 1
         fi
 
     - name: Upload cppcheck report

--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
 			if (profileEnabled)
 				PerfProfile::disable();
 
-			double totalAudio = length * repeatCount;
+			double totalAudio = static_cast<double>(length) * repeatCount;
 
 			cout << frameCount * channelCount * repeatCount << " samples processed in " << time << " seconds\n";
 			cout << "This is equivalent to " << 100.0f * time / totalAudio << "% CPU load (one core) when processing in real time\n";
@@ -270,17 +270,20 @@ int main(int argc, char** argv)
 			}
 
 			unsigned clipCount = 0;
-			float max = 0;
+			float maxLevel = 0;
 			for (unsigned i = 0; i < frameCount * channelCount; i++)
 			{
 				float f = fabs(buf2[i]);
-				if (f > max)
-					max = f;
+				if (f > maxLevel)
+					maxLevel = f;
 				if (f > 1.0f)
 					clipCount++;
 			}
 
-			cout << "Max output level: " << max << " (" << log10(max) * 20.0f << " dB)";
+			if (maxLevel > 0.0f)
+				cout << "Max output level: " << maxLevel << " (" << log10(maxLevel) * 20.0f << " dB)";
+			else
+				cout << "Max output level: 0 (silence)";
 			if (clipCount > 0)
 				cout << " (" << clipCount << " samples clipped!)";
 			cout << "\n";

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ CI는 x64 `sse2`, `avx`, `avx2`, `avx512`, `avx10_1`, ARM64 `neon` 조합을 빌
 
 CI annotation도 작업 범위입니다. warning이나 notice가 다음 릴리스에서 사용자에게 혼란을 줄 수 있거나 곧 실패로 바뀔 예정이면 방치하지 않습니다.
 
+cppcheck job은 베이스라인 0 기준의 차단 게이트입니다. CI는 cppcheck 2.21.0을 태그 고정으로 소스 빌드해 쓰므로, 로컬에서도 같은 버전으로 build.yml의 cppcheck 호출 플래그를 그대로 사용하면 결과가 재현됩니다. 새 발견은 코드로 고치는 것이 기본이고, 정당한 거짓 양성만 근거 주석과 함께 inline 또는 job 수준 suppress로 처리합니다. 정책적으로 억제한 규칙(cstyleCast, shadow*, useStlAlgorithm, postfixOperator, noExplicitConstructor, LocalAllocCalled)의 근거는 build.yml의 주석에 있습니다.
+
 테스트를 건너뛰는 판단은 명시적인 이유가 있어야 합니다. GitHub-hosted x64 runner가 AVX-512/AVX10.1 실행을 보장하지 않아 `HybridConvTests` 실행을 건너뛰는 경우처럼, 빌드는 유지하되 런타임 실행만 제한합니다.
 
 회귀가 발견되면 먼저 재현 가능한 테스트나 검증 명령을 추가합니다. 오디오 처리 내부처럼 버그를 잡기 어려운 부분은 더 좁은 테스트를 먼저 만들고, 테스트가 가리키는 범위만 수정합니다.

--- a/DeviceAPOInfo.h
+++ b/DeviceAPOInfo.h
@@ -103,13 +103,13 @@ private:
 	std::wstring deviceName;
 	std::wstring connectionName;
 	std::wstring deviceGuid;
-	unsigned channelCount;
-	unsigned sampleRate;
-	unsigned long channelMask;
-	bool defaultDevice;
-	bool enhancementsDisabled;
-	bool disabled;
-	bool unplugged;
+	unsigned channelCount = 0;
+	unsigned sampleRate = 0;
+	unsigned long channelMask = 0;
+	bool defaultDevice = false;
+	bool enhancementsDisabled = false;
+	bool disabled = false;
+	bool unplugged = false;
 
 	// used for creating child APO
 	std::wstring preMixChildGuid;
@@ -118,8 +118,8 @@ private:
 	// used for uninstallation
 	std::wstring originalApoGuids[5];
 
-	bool input;
-	bool installed;
+	bool input = false;
+	bool installed = false;
 	std::wstring version;
 	InstallState currentInstallState;
 	// selection in GUI
@@ -134,7 +134,7 @@ public:
 	{
 	}
 
-	std::wstring getMessage() const
+	const std::wstring& getMessage() const
 	{
 		return message;
 	}

--- a/DeviceSelector/DeviceSelector.cpp
+++ b/DeviceSelector/DeviceSelector.cpp
@@ -102,7 +102,7 @@ DeviceSelector::DeviceSelector(QWidget* parent)
 	}
 }
 
-void DeviceSelector::addDevices(std::vector<std::shared_ptr<AbstractAPOInfo>>& devices, QTreeWidgetItem* parentNode)
+void DeviceSelector::addDevices(const std::vector<std::shared_ptr<AbstractAPOInfo>>& devices, QTreeWidgetItem* parentNode)
 {
 	for (const std::shared_ptr<AbstractAPOInfo>& apoInfo : devices)
 	{
@@ -162,7 +162,7 @@ void DeviceSelector::onDialogAccepted()
 
 			try
 			{
-				DeviceAPOInfo* deviceInfo = dynamic_cast<DeviceAPOInfo*>(info.get());
+				const DeviceAPOInfo* deviceInfo = dynamic_cast<DeviceAPOInfo*>(info.get());
 				if (checked && !info->isInstalled())
 				{
 					info->install();
@@ -297,7 +297,7 @@ void DeviceSelector::onTroubleShootingOptionChanged()
 		DeviceAPOInfo* deviceInfo = dynamic_cast<DeviceAPOInfo*>(info.get());
 		if (deviceInfo != nullptr)
 		{
-			QObject* sender = QObject::sender();
+			const QObject* sender = QObject::sender();
 			if (sender == ui.installPreMixCheckBox)
 				deviceInfo->getSelectedInstallState().installPreMix = ui.installPreMixCheckBox->isChecked();
 			else if (sender == ui.installPostMixCheckBox)

--- a/DeviceSelector/DeviceSelector.h
+++ b/DeviceSelector/DeviceSelector.h
@@ -29,7 +29,7 @@ class DeviceSelector : public QDialog
 
 public:
 	DeviceSelector(QWidget* parent = nullptr);
-	void addDevices(std::vector<std::shared_ptr<AbstractAPOInfo>>& devices, QTreeWidgetItem* parentNode);
+	void addDevices(const std::vector<std::shared_ptr<AbstractAPOInfo>>& devices, QTreeWidgetItem* parentNode);
 
 private:
 	void onDeviceSelectionChanged();

--- a/DeviceSelector/DeviceTestDialog.cpp
+++ b/DeviceSelector/DeviceTestDialog.cpp
@@ -108,7 +108,7 @@ std::vector<std::shared_ptr<DeviceAPOInfo>> DeviceTestDialog::filterDevices(cons
 	return filteredList;
 }
 
-void DeviceTestDialog::addDevices(std::vector<std::shared_ptr<DeviceAPOInfo>>& devices, QTreeWidgetItem* parentNode)
+void DeviceTestDialog::addDevices(const std::vector<std::shared_ptr<DeviceAPOInfo>>& devices, QTreeWidgetItem* parentNode)
 {
 	for (const std::shared_ptr<DeviceAPOInfo>& apoInfo : devices)
 	{

--- a/DeviceSelector/DeviceTestDialog.h
+++ b/DeviceSelector/DeviceTestDialog.h
@@ -32,7 +32,7 @@ class DeviceTestDialog : public QDialog
 public:
 	DeviceTestDialog(QWidget* parent = nullptr);
 	std::vector<std::shared_ptr<DeviceAPOInfo>> filterDevices(const std::vector<std::shared_ptr<AbstractAPOInfo>>& devices);
-	void addDevices(std::vector<std::shared_ptr<DeviceAPOInfo>>& devices, QTreeWidgetItem* parentNode);
+	void addDevices(const std::vector<std::shared_ptr<DeviceAPOInfo>>& devices, QTreeWidgetItem* parentNode);
 
 protected:
 	__override void closeEvent(QCloseEvent* event);

--- a/DeviceSelector/DeviceTestThread.cpp
+++ b/DeviceSelector/DeviceTestThread.cpp
@@ -25,7 +25,6 @@
 #include "DeviceTestThread.h"
 
 using std::find;
-using std::log;
 using std::thread;
 
 DeviceTestThread::DeviceTestThread(QObject* parent, const QVector<std::shared_ptr<DeviceAPOInfo>>& devices)
@@ -114,9 +113,9 @@ void DeviceTestThread::run()
 		}
 
 		const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds{3};
-		std::string message;
 		try
 		{
+			std::string message;
 			while ((message= thread.waitUntil(timeout)) != "")
 			{
 				QJsonParseError error;

--- a/DeviceSelector/DeviceTestThread.h
+++ b/DeviceSelector/DeviceTestThread.h
@@ -88,8 +88,8 @@ private:
 		QVector<DeviceAPOInfo::InstallMode> remainingInstallModes;
 		DeviceAPOInfo::InstallMode bestInstallMode;
 		TestResult bestResult;
-		bool wantsOriginalApoPreMix;
-		bool wantsOriginalApoPostMix;
+		bool wantsOriginalApoPreMix = false;
+		bool wantsOriginalApoPostMix = false;
 	};
 
 	QHash<QString, DeviceTestInfo> infoMap;

--- a/DeviceSelector/ReceiveThread.cpp
+++ b/DeviceSelector/ReceiveThread.cpp
@@ -22,7 +22,7 @@
 #include "helpers/StringHelper.h"
 #include "ReceiveThread.h"
 
-ReceiveThread::ReceiveThread(std::wstring pipeName)
+ReceiveThread::ReceiveThread(const std::wstring& pipeName)
 	:pipeName(pipeName)
 {
 	thread = std::thread(&ReceiveThread::run, this);

--- a/DeviceSelector/ReceiveThread.h
+++ b/DeviceSelector/ReceiveThread.h
@@ -42,7 +42,7 @@ public:
 		return message.empty();
 	}
 
-	std::wstring getMessage() const
+	const std::wstring& getMessage() const
 	{
 		return message;
 	}
@@ -54,7 +54,7 @@ private:
 class ReceiveThread
 {
 public:
-	ReceiveThread(std::wstring pipeName);
+	ReceiveThread(const std::wstring& pipeName);
 	~ReceiveThread();
 	template<class Clock, class Duration> std::string waitUntil(const std::chrono::time_point<Clock, Duration>& time)
 	{

--- a/Editor/AnalysisThread.cpp
+++ b/Editor/AnalysisThread.cpp
@@ -57,7 +57,7 @@ AnalysisThread::~AnalysisThread()
 		fftw_destroy_plan(planForward);
 }
 
-void AnalysisThread::setParameters(shared_ptr<AbstractAPOInfo> device, int channelMask, int channelIndex, QString configPath, int frameCount)
+void AnalysisThread::setParameters(shared_ptr<AbstractAPOInfo> device, int channelMask, int channelIndex, const QString& configPath, int frameCount)
 {
 	QMutexLocker mutexLocker(&mutex);
 	this->device = device;

--- a/Editor/AnalysisThread.h
+++ b/Editor/AnalysisThread.h
@@ -33,7 +33,7 @@ class AnalysisThread : public QThread
 public:
 	AnalysisThread();
 	~AnalysisThread();
-	void setParameters(std::shared_ptr<AbstractAPOInfo> device, int channelMask, int channelIndex, QString configPath, int frameCount);
+	void setParameters(std::shared_ptr<AbstractAPOInfo> device, int channelMask, int channelIndex, const QString& configPath, int frameCount);
 	void beginGetResult();
 	void endGetResult();
 
@@ -59,20 +59,20 @@ private:
 
 	// input
 	std::shared_ptr<AbstractAPOInfo> device;
-	int channelMask;
-	int channelIndex;
+	int channelMask = 0;
+	int channelIndex = 0;
 	QString configPath;
 	int frameCount = 0;
 
 	// output
 	fftw_complex* resultFreqData = nullptr;
 	int freqDataLength = 0;
-	int freqDataSampleRate;
-	double peakGain;
-	int latency;
-	double initializationTime;
-	double processingTime;
-	int processedFrames;
+	int freqDataSampleRate = 0;
+	double peakGain = 0.0;
+	int latency = 0;
+	double initializationTime = 0.0;
+	double processingTime = 0.0;
+	int processedFrames = 0;
 
 	// internal (not protected by mutex)
 	int lastFrameCount = -1;

--- a/Editor/ConfigFileCodec.cpp
+++ b/Editor/ConfigFileCodec.cpp
@@ -61,7 +61,7 @@ QByteArray ConfigFileCodec::encodeLines(const QList<QString>& lines)
 {
 	bool first = true;
 	QByteArray byteArray;
-	for (QString line : lines)
+	for (const QString& line : lines)
 	{
 		if (first)
 			first = false;

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -187,7 +187,6 @@ void FilterTable::updateGuis()
 	{
 		QString line = item->text;
 		IFilterGUI* gui = nullptr;
-		bool usingCardEditor = false;
 		int pos = line.indexOf(':');
 		if (pos != -1)
 		{
@@ -209,6 +208,7 @@ void FilterTable::updateGuis()
 
 			if (gui != nullptr)
 			{
+				bool usingCardEditor = false;
 				if (renderMode == ModernCards)
 				{
 					// factoryKey is the command after CommentFilterGUIFactory strips a leading '#',
@@ -319,7 +319,6 @@ void FilterTable::updateSingleRowGui(Item* item)
 	// the factories track stays valid.
 	QString line = item->text;
 	IFilterGUI* gui = nullptr;
-	bool usingCardEditor = false;
 	int colonPos = line.indexOf(':');
 	if (colonPos != -1)
 	{
@@ -337,6 +336,7 @@ void FilterTable::updateSingleRowGui(Item* item)
 
 		if (gui != nullptr)
 		{
+			bool usingCardEditor = false;
 			if (renderMode == ModernCards)
 			{
 				IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -178,7 +178,7 @@ private:
 	RenderMode renderMode = ModernCards;
 };
 
-template<typename T> inline uint qHash(QList<T> list)
+template<typename T> inline uint qHash(const QList<T>& list)
 {
 	uint hashValue = 0;
 

--- a/Editor/FilterTableMimeData.cpp
+++ b/Editor/FilterTableMimeData.cpp
@@ -23,7 +23,7 @@ FilterTableMimeData::FilterTableMimeData()
 {
 }
 
-QList<QVariantMap> FilterTableMimeData::getPrefsList() const
+const QList<QVariantMap>& FilterTableMimeData::getPrefsList() const
 {
 	return prefsList;
 }

--- a/Editor/FilterTableMimeData.h
+++ b/Editor/FilterTableMimeData.h
@@ -28,7 +28,7 @@ class FilterTableMimeData : public QMimeData
 public:
 	FilterTableMimeData();
 
-	QList<QVariantMap> getPrefsList() const;
+	const QList<QVariantMap>& getPrefsList() const;
 	void setPrefsList(const QList<QVariantMap>& value);
 
 private:

--- a/Editor/FilterTableParts/FilterTable.Clipboard.cpp
+++ b/Editor/FilterTableParts/FilterTable.Clipboard.cpp
@@ -206,8 +206,8 @@ void FilterTable::savePreferences()
 					command = item->text.left(index).trimmed();
 
 				QByteArray byteArray = QJsonDocument::fromVariant(item->prefs).toJson(QJsonDocument::Compact);
-				QString string = QString("%0:%1:%2").arg(i + 1).arg(command).arg(QString::fromUtf8(byteArray));
-				prefLines.append(string);
+				QString prefLine = QString("%0:%1:%2").arg(i + 1).arg(command).arg(QString::fromUtf8(byteArray));
+				prefLines.append(prefLine);
 			}
 		}
 

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -113,15 +113,13 @@ void FilterTable::setLines(const QString& configPath, const QList<QString>& line
 			continue;
 		lineNumber = prefLine.left(index).toInt();
 
-		QString prefCommand;
-		QString prefString;
 		if (lineNumber > 0)
 		{
 			int index2 = prefLine.indexOf(':', index + 1);
 			if (index2 != -1)
 			{
-				prefCommand = prefLine.mid(index + 1, index2 - index - 1);
-				prefString = prefLine.mid(index2 + 1);
+				QString prefCommand = prefLine.mid(index + 1, index2 - index - 1);
+				QString prefString = prefLine.mid(index2 + 1);
 
 				if (lineNumber <= items.size())
 				{

--- a/Editor/FilterTemplate.cpp
+++ b/Editor/FilterTemplate.cpp
@@ -19,12 +19,12 @@
 
 #include "FilterTemplate.h"
 
-FilterTemplate::FilterTemplate(QString name, QString line, QStringList path)
+FilterTemplate::FilterTemplate(QString name, QString line, const QStringList& path)
 	: name(name), line(line), path(path)
 {
 }
 
-QString FilterTemplate::getName() const
+const QString& FilterTemplate::getName() const
 {
 	return name;
 }
@@ -44,7 +44,7 @@ void FilterTemplate::setLine(const QString& value)
 	line = value;
 }
 
-QStringList FilterTemplate::getPath() const
+const QStringList& FilterTemplate::getPath() const
 {
 	return path;
 }

--- a/Editor/FilterTemplate.h
+++ b/Editor/FilterTemplate.h
@@ -26,15 +26,15 @@ class FilterTemplate
 {
 public:
 	FilterTemplate() {}
-	FilterTemplate(QString name, QString line, QStringList path);
+	FilterTemplate(QString name, QString line, const QStringList& path);
 
-	QString getName() const;
+	const QString& getName() const;
 	void setName(const QString& value);
 
 	virtual QString getLine() const;
 	void setLine(const QString& value);
 
-	QStringList getPath() const;
+	const QStringList& getPath() const;
 	void setPath(const QStringList& value);
 
 private:

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -26,7 +26,7 @@ const SkinTokens& SkinManager::tokens() const
 	return currentTokens;
 }
 
-QString SkinManager::currentSkinId() const
+const QString& SkinManager::currentSkinId() const
 {
 	return skinId;
 }
@@ -44,7 +44,7 @@ QString substituteTokens(QString qss, const SkinTokens& tokens)
 	// style sheet parser intact (a literal '@' is not meaningful in QSS) and
 	// stand out in the source files. Order does not matter because every
 	// sentinel is unique.
-	struct Substitution { const char* placeholder; QString value; };
+	struct Substitution { const char* placeholder = nullptr; QString value; };
 	const Substitution table[] = {
 		{ "@BG@", tokens.background },
 		{ "@SURFACE@", tokens.surface },

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -16,7 +16,7 @@ public:
 	static SkinManager* instance();
 
 	const SkinTokens& tokens() const;
-	QString currentSkinId() const;
+	const QString& currentSkinId() const;
 	bool isDark() const;
 	void applySkin(const QString& skinId, bool dark);
 

--- a/Editor/guis/ChannelFilterGUIDialog.cpp
+++ b/Editor/guis/ChannelFilterGUIDialog.cpp
@@ -32,7 +32,7 @@
 using std::vector;
 using std::wstring;
 
-ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, QStringList selectedChannels, int selectedChannelMask, const vector<wstring>& channelNames)
+ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, const QStringList& selectedChannels, int selectedChannelMask, const vector<wstring>& channelNames)
 	: QDialog(parent),
 	ui(new Ui::ChannelFilterGUIDialog)
 {
@@ -104,7 +104,7 @@ ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, QStringList sele
 	}
 
 	ui->listWidget->clear();
-	for (wstring channelName : remainingChannelNames)
+	for (const wstring& channelName : remainingChannelNames)
 	{
 		QListWidgetItem* item = new QListWidgetItem(QString::fromStdWString(channelName));
 		item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable);
@@ -123,7 +123,7 @@ ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, QStringList sele
 		ui->listWidget->addItem(item);
 	}
 
-	ui->stackedWidget->setCurrentIndex(selectedChannelMask & SPEAKER_BACK_CENTER ? 1 : 0);
+	ui->stackedWidget->setCurrentIndex((selectedChannelMask & SPEAKER_BACK_CENTER) ? 1 : 0);
 }
 
 ChannelFilterGUIDialog::~ChannelFilterGUIDialog()

--- a/Editor/guis/ChannelFilterGUIDialog.h
+++ b/Editor/guis/ChannelFilterGUIDialog.h
@@ -31,7 +31,7 @@ class ChannelFilterGUIDialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit ChannelFilterGUIDialog(QWidget* parent, QStringList selectedChannels, int selectedChannelMask, const std::vector<std::wstring>& channelNames);
+	explicit ChannelFilterGUIDialog(QWidget* parent, const QStringList& selectedChannels, int selectedChannelMask, const std::vector<std::wstring>& channelNames);
 	~ChannelFilterGUIDialog();
 
 	QStringList getSelectedChannels() const;

--- a/Editor/guis/ChannelFilterGUIFactory.h
+++ b/Editor/guis/ChannelFilterGUIFactory.h
@@ -35,5 +35,5 @@ public:
 	IFilterGUI* createFilterGUI(QString& command, QString& parameters) override;
 
 private:
-	FilterTable* filterTable;
+	FilterTable* filterTable = nullptr;
 };

--- a/Editor/guis/ChannelFilterGUIScene.cpp
+++ b/Editor/guis/ChannelFilterGUIScene.cpp
@@ -28,7 +28,7 @@ ChannelFilterGUIScene::ChannelFilterGUIScene()
 {
 }
 
-void ChannelFilterGUIScene::load(vector<wstring> channelNames, QStringList selectedChannels)
+void ChannelFilterGUIScene::load(vector<wstring> channelNames, const QStringList& selectedChannels)
 {
 	blockSignals(true);
 	clear();

--- a/Editor/guis/ChannelFilterGUIScene.h
+++ b/Editor/guis/ChannelFilterGUIScene.h
@@ -30,6 +30,6 @@ class ChannelFilterGUIScene : public ChannelGraphScene
 public:
 	explicit ChannelFilterGUIScene();
 
-	void load(std::vector<std::wstring> channelNames, QStringList selectedChannels);
+	void load(std::vector<std::wstring> channelNames, const QStringList& selectedChannels);
 	QStringList getSelectedChannels();
 };

--- a/Editor/guis/CommentFilterGUIFactory.h
+++ b/Editor/guis/CommentFilterGUIFactory.h
@@ -34,5 +34,5 @@ public:
 	IFilterGUI* decorateFilterGUI(IFilterGUI* gui) override;
 
 private:
-	bool lastWasComment;
+	bool lastWasComment = false;
 };

--- a/Editor/guis/ConvolutionFilterGUIFactory.h
+++ b/Editor/guis/ConvolutionFilterGUIFactory.h
@@ -36,5 +36,5 @@ public:
 
 private:
 	QString configPath;
-	unsigned deviceSampleRate;
+	unsigned deviceSampleRate = 0;
 };

--- a/Editor/guis/CopyFilterGUIFactory.h
+++ b/Editor/guis/CopyFilterGUIFactory.h
@@ -34,5 +34,5 @@ public:
 	IFilterGUI* createFilterGUI(QString& command, QString& parameters) override;
 
 private:
-	FilterTable* filterTable;
+	FilterTable* filterTable = nullptr;
 };

--- a/Editor/guis/CopyFilterGUIForm.cpp
+++ b/Editor/guis/CopyFilterGUIForm.cpp
@@ -36,7 +36,7 @@ CopyFilterGUIForm::CopyFilterGUIForm(QWidget* parent)
 {
 }
 
-void CopyFilterGUIForm::load(vector<Assignment> assignments)
+void CopyFilterGUIForm::load(const vector<Assignment>& assignments)
 {
 	if (gridLayout != nullptr)
 		delete gridLayout;
@@ -70,7 +70,7 @@ void CopyFilterGUIForm::load(vector<Assignment> assignments)
 
 				QComboBox* targetComboBox = new QComboBox(this);
 				targetComboBox->setEditable(true);
-				for (wstring channelName : inputChannelNames)
+				for (const wstring& channelName : inputChannelNames)
 					targetComboBox->addItem(QString::fromStdWString(channelName));
 				targetComboBox->setEditText(oc);
 				connect(targetComboBox, SIGNAL(editTextChanged(QString)), this, SIGNAL(updateModel()));
@@ -133,7 +133,7 @@ void CopyFilterGUIForm::setChannelNames(const vector<wstring>& channelNames)
 			targetComboBox->blockSignals(true);
 			QString text = targetComboBox->currentText();
 			targetComboBox->clear();
-			for (wstring channelName : channelNames)
+			for (const wstring& channelName : channelNames)
 				targetComboBox->addItem(QString::fromStdWString(channelName));
 			targetComboBox->setEditText(text);
 			targetComboBox->blockSignals(false);
@@ -166,7 +166,7 @@ vector<Assignment> CopyFilterGUIForm::buildAssignments(QWidget* pressedButton)
 		{
 			if (pressedButton != nullptr)
 			{
-				QWidget* removeButton = gridLayout->itemAtPosition(row, 5)->widget();
+				const QWidget* removeButton = gridLayout->itemAtPosition(row, 5)->widget();
 				if (removeButton == pressedButton)
 				{
 					continue;
@@ -179,7 +179,7 @@ vector<Assignment> CopyFilterGUIForm::buildAssignments(QWidget* pressedButton)
 
 			if (pressedButton != nullptr)
 			{
-				QWidget* addSummandButton = gridLayout->itemAtPosition(row, 4)->widget();
+				const QWidget* addSummandButton = gridLayout->itemAtPosition(row, 4)->widget();
 				if (addSummandButton == pressedButton)
 				{
 					Assignment::Summand newSummand;

--- a/Editor/guis/CopyFilterGUIForm.h
+++ b/Editor/guis/CopyFilterGUIForm.h
@@ -31,7 +31,7 @@ class CopyFilterGUIForm : public QWidget
 public:
 	explicit CopyFilterGUIForm(QWidget* parent = 0);
 
-	void load(std::vector<Assignment> assignments);
+	void load(const std::vector<Assignment>& assignments);
 	void setChannelNames(const std::vector<std::wstring>& channelNames);
 	std::vector<Assignment> buildAssignments(QWidget* pressedButton = nullptr);
 

--- a/Editor/guis/CopyFilterGUIRow.cpp
+++ b/Editor/guis/CopyFilterGUIRow.cpp
@@ -24,7 +24,7 @@ using std::abs;
 using std::vector;
 using std::wstring;
 
-CopyFilterGUIRow::CopyFilterGUIRow(Assignment::Summand summand, std::vector<wstring> channelNames, QWidget* parent)
+CopyFilterGUIRow::CopyFilterGUIRow(Assignment::Summand summand, const std::vector<wstring>& channelNames, QWidget* parent)
 	: QWidget(parent),
 	ui(new Ui::CopyFilterGUIRow)
 {
@@ -49,7 +49,7 @@ CopyFilterGUIRow::CopyFilterGUIRow(Assignment::Summand summand, std::vector<wstr
 
 	ui->factorSpinBox->setValue(summand.factor);
 
-	for (wstring channelName : channelNames)
+	for (const wstring& channelName : channelNames)
 		ui->channelComboBox->addItem(QString::fromStdWString(channelName));
 	ui->channelComboBox->setEditText(QString::fromStdWString(summand.channel).trimmed());
 
@@ -69,7 +69,7 @@ void CopyFilterGUIRow::setChannelNames(const vector<wstring>& channelNames)
 	ui->channelComboBox->blockSignals(true);
 	QString text = ui->channelComboBox->currentText();
 	ui->channelComboBox->clear();
-	for (wstring channelName : channelNames)
+	for (const wstring& channelName : channelNames)
 		ui->channelComboBox->addItem(QString::fromStdWString(channelName));
 	ui->channelComboBox->setEditText(text);
 	ui->channelComboBox->blockSignals(false);

--- a/Editor/guis/CopyFilterGUIRow.h
+++ b/Editor/guis/CopyFilterGUIRow.h
@@ -32,7 +32,7 @@ class CopyFilterGUIRow : public QWidget
 	Q_OBJECT
 
 public:
-	explicit CopyFilterGUIRow(Assignment::Summand summand, std::vector<std::wstring> channelNames, QWidget* parent = 0);
+	explicit CopyFilterGUIRow(Assignment::Summand summand, const std::vector<std::wstring>& channelNames, QWidget* parent = 0);
 	~CopyFilterGUIRow();
 
 	void setChannelNames(const std::vector<std::wstring>& channelNames);

--- a/Editor/guis/CopyFilterGUIScene.cpp
+++ b/Editor/guis/CopyFilterGUIScene.cpp
@@ -32,7 +32,7 @@ using std::list;
 using std::vector;
 using std::wstring;
 
-void CopyFilterGUIScene::load(const vector<wstring>& channelNames, vector<Assignment> assignments)
+void CopyFilterGUIScene::load(const vector<wstring>& channelNames, const vector<Assignment>& assignments)
 {
 	clear();
 
@@ -155,7 +155,7 @@ std::vector<Assignment> CopyFilterGUIScene::buildAssignments()
 
 	std::vector<Assignment> assignments;
 	QHash<QString, Assignment*> channelAssignmentMap;
-	for (CopyFilterGUIConnectionItem* connItem : connItems)
+	for (const CopyFilterGUIConnectionItem* connItem : connItems)
 	{
 		QString oc = connItem->getTarget()->getName();
 		Assignment* assignment = channelAssignmentMap.value(oc);

--- a/Editor/guis/CopyFilterGUIScene.h
+++ b/Editor/guis/CopyFilterGUIScene.h
@@ -30,7 +30,7 @@ class CopyFilterGUIScene : public ChannelGraphScene
 	Q_OBJECT
 
 public:
-	void load(const std::vector<std::wstring>& channelNames, std::vector<Assignment> assignments);
+	void load(const std::vector<std::wstring>& channelNames, const std::vector<Assignment>& assignments);
 	std::vector<Assignment> buildAssignments();
 
 signals:
@@ -46,6 +46,6 @@ private slots:
 	void lineEditEditingCanceled();
 
 private:
-	QGraphicsItem* lastOutputItem;
-	QGraphicsProxyWidget* addProxyItem;
+	QGraphicsItem* lastOutputItem = nullptr;
+	QGraphicsProxyWidget* addProxyItem = nullptr;
 };

--- a/Editor/guis/GraphicEQFilterGUI.cpp
+++ b/Editor/guis/GraphicEQFilterGUI.cpp
@@ -40,7 +40,7 @@ using std::vector;
 
 QRegularExpression GraphicEQFilterGUI::numberRegEx("[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?");
 
-GraphicEQFilterGUI::GraphicEQFilterGUI(const std::vector<FilterNode>& nodes, QString configPath, FilterTable* filterTable)
+GraphicEQFilterGUI::GraphicEQFilterGUI(const std::vector<FilterNode>& nodes, const QString& configPath, FilterTable* filterTable)
 	: ui(new Ui::GraphicEQFilterGUI), configPath(configPath)
 {
 	ui->setupUi(this);

--- a/Editor/guis/GraphicEQFilterGUI.h
+++ b/Editor/guis/GraphicEQFilterGUI.h
@@ -38,7 +38,7 @@ class GraphicEQFilterGUI : public IFilterGUI
 	Q_OBJECT
 
 public:
-	explicit GraphicEQFilterGUI(const std::vector<FilterNode>& nodes, QString configPath, FilterTable* filterTable);
+	explicit GraphicEQFilterGUI(const std::vector<FilterNode>& nodes, const QString& configPath, FilterTable* filterTable);
 	~GraphicEQFilterGUI();
 
 	void store(QString& command, QString& parameters) override;

--- a/Editor/guis/GraphicEQFilterGUIFactory.h
+++ b/Editor/guis/GraphicEQFilterGUIFactory.h
@@ -37,5 +37,5 @@ public:
 
 private:
 	QString configPath;
-	FilterTable* filterTable;
+	FilterTable* filterTable = nullptr;
 };

--- a/Editor/guis/GraphicEQFilterGUIScene.cpp
+++ b/Editor/guis/GraphicEQFilterGUIScene.cpp
@@ -269,7 +269,7 @@ void GraphicEQFilterGUIScene::keyPressEvent(QKeyEvent* event)
 		{
 			for (QGraphicsItem* item : selectedItems())
 			{
-				GraphicEQFilterGUIItem* plotItem = qgraphicsitem_cast<GraphicEQFilterGUIItem*>(item);
+				const GraphicEQFilterGUIItem* plotItem = qgraphicsitem_cast<GraphicEQFilterGUIItem*>(item);
 				if (plotItem != nullptr)
 				{
 					// this works for multiple items because the index of the other items is updated inside removeNode
@@ -286,7 +286,7 @@ void GraphicEQFilterGUIScene::keyPressEvent(QKeyEvent* event)
 	case Qt::Key_Right:
 		for (QGraphicsItem* item : selectedItems())
 		{
-			GraphicEQFilterGUIItem* plotItem = qgraphicsitem_cast<GraphicEQFilterGUIItem*>(item);
+			const GraphicEQFilterGUIItem* plotItem = qgraphicsitem_cast<GraphicEQFilterGUIItem*>(item);
 			if (plotItem != nullptr)
 			{
 				int index = plotItem->getIndex();

--- a/Editor/guis/IncludeFilterGUIFactory.h
+++ b/Editor/guis/IncludeFilterGUIFactory.h
@@ -34,5 +34,5 @@ public:
 	IFilterGUI* createFilterGUI(QString& command, QString& parameters) override;
 
 private:
-	FilterTable* filterTable;
+	FilterTable* filterTable = nullptr;
 };

--- a/Editor/guis/LoudnessCorrectionFilterGUIFactory.h
+++ b/Editor/guis/LoudnessCorrectionFilterGUIFactory.h
@@ -30,7 +30,7 @@ class LoudnessCorrectionFilterGUIFactory : public IFilterGUIFactory
 
 public:
 	explicit LoudnessCorrectionFilterGUIFactory();
-	~LoudnessCorrectionFilterGUIFactory();
+	~LoudnessCorrectionFilterGUIFactory() override;
 
 	void initialize(FilterTable* filterTable) override;
 	QList<FilterTemplate> createFilterTemplates() override;
@@ -40,7 +40,7 @@ private slots:
 	void checkVolume();
 
 private:
-	FilterTable* filterTable;
+	FilterTable* filterTable = nullptr;
 	QTimer* timer = nullptr;
 	VolumeController* volumeController = nullptr;
 	double lastVolume = -1;

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -432,9 +432,9 @@ void VSTPluginFilterGUI::updatePermissionWarning()
 	if (chunkData != L"" && chunkData.length() < 100000)
 	{
 		QByteArray bytes = QByteArray::fromBase64(QString::fromStdWString(chunkData).toUtf8());
-		QString string = QString::fromUtf8(bytes.data(), bytes.length());
+		QString chunkText = QString::fromUtf8(bytes.data(), bytes.length());
 		QRegularExpression regexp("[A-Za-z]:(?:\\\\[\\w \\(\\)-]+)+\\.[A-Za-z]{3}");
-		QRegularExpressionMatchIterator it = regexp.globalMatch(string);
+		QRegularExpressionMatchIterator it = regexp.globalMatch(chunkText);
 		while (it.hasNext())
 		{
 			QRegularExpressionMatch m = it.next();

--- a/Editor/guis/VSTPluginFilterGUI.h
+++ b/Editor/guis/VSTPluginFilterGUI.h
@@ -34,7 +34,7 @@ class VSTPluginFilterGUI : public IFilterGUI
 
 public:
 	explicit VSTPluginFilterGUI(std::shared_ptr<VSTPluginLibrary> library, const std::wstring& chunkData, const std::unordered_map<std::wstring, float>& paramMap);
-	~VSTPluginFilterGUI();
+	~VSTPluginFilterGUI() override;
 
 	void store(QString& command, QString& parameters) override;
 	void loadPreferences(const QVariantMap& prefs) override;

--- a/Editor/helpers/GUIChannelHelper.h
+++ b/Editor/helpers/GUIChannelHelper.h
@@ -31,7 +31,7 @@ public:
 
 	struct ChannelConfigurationInfo
 	{
-		int channelMask;
+		int channelMask = 0;
 		QString name;
 	};
 

--- a/Editor/helpers/QtSndfileHandle.cpp
+++ b/Editor/helpers/QtSndfileHandle.cpp
@@ -21,7 +21,7 @@
 
 sf_count_t getFileLenDevice(void* user_data)
 {
-	QIODevice* device = (QIODevice*)user_data;
+	const QIODevice* device = (QIODevice*)user_data;
 	return device->size();
 }
 

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -66,7 +66,7 @@ namespace
 // GUI without losing plugin state. Returns 0 on success, 1 on any loss.
 int runVstRoundTripSelfTest()
 {
-	struct Case { const wchar_t* name; std::wstring params; };
+	struct Case { const wchar_t* name = nullptr; std::wstring params; };
 	const Case cases[] = {
 		{ L"chunkData", L"Library \"fake plugin.dll\" ChunkData \"QUJDREVGR0g=\"" },
 		{ L"paramMap", L"Library fake.dll Gain 0.5 Mix 0.25 Width 1" },

--- a/Editor/widgets/ChBadge.cpp
+++ b/Editor/widgets/ChBadge.cpp
@@ -20,7 +20,7 @@ ChBadge::ChBadge(const QString& channel, QWidget* parent)
 	setChannel(channel);
 }
 
-QString ChBadge::channel() const
+const QString& ChBadge::channel() const
 {
 	return currentChannel;
 }

--- a/Editor/widgets/ChBadge.h
+++ b/Editor/widgets/ChBadge.h
@@ -10,7 +10,7 @@ public:
 	explicit ChBadge(QWidget* parent = nullptr);
 	explicit ChBadge(const QString& channel, QWidget* parent = nullptr);
 
-	QString channel() const;
+	const QString& channel() const;
 	void setChannel(const QString& channel);
 	QSize sizeHint() const override;
 

--- a/Editor/widgets/ChannelGraphItem.cpp
+++ b/Editor/widgets/ChannelGraphItem.cpp
@@ -51,7 +51,7 @@ QRectF ChannelGraphItem::boundingRect() const
 	return cachedRect;
 }
 
-QString ChannelGraphItem::getName() const
+const QString& ChannelGraphItem::getName() const
 {
 	return name;
 }

--- a/Editor/widgets/ChannelGraphItem.h
+++ b/Editor/widgets/ChannelGraphItem.h
@@ -28,7 +28,7 @@ public:
 
 	QRectF boundingRect() const override;
 
-	QString getName() const;
+	const QString& getName() const;
 
 protected:
 	virtual void paint(QPainter* painter, QColor color);

--- a/Editor/widgets/EditableValue.cpp
+++ b/Editor/widgets/EditableValue.cpp
@@ -36,7 +36,7 @@ void EditableValue::setValue(double value)
 	refreshText();
 }
 
-QString EditableValue::unit() const
+const QString& EditableValue::unit() const
 {
 	return currentUnit;
 }

--- a/Editor/widgets/EditableValue.h
+++ b/Editor/widgets/EditableValue.h
@@ -14,7 +14,7 @@ public:
 
 	double value() const;
 	void setValue(double value);
-	QString unit() const;
+	const QString& unit() const;
 	void setUnit(const QString& unit);
 
 signals:

--- a/Editor/widgets/EqGraphView.cpp
+++ b/Editor/widgets/EqGraphView.cpp
@@ -61,7 +61,7 @@ void EqGraphView::resizeEvent(QResizeEvent* event)
 	curveDirty = true;
 }
 
-QString EqGraphView::channel() const
+const QString& EqGraphView::channel() const
 {
 	return currentChannel;
 }

--- a/Editor/widgets/EqGraphView.h
+++ b/Editor/widgets/EqGraphView.h
@@ -18,7 +18,7 @@ public:
 
 	void setNodes(const std::vector<FilterNode>& nodes, unsigned sampleRate, const QString& channel);
 	void setChannel(const QString& channel);
-	QString channel() const;
+	const QString& channel() const;
 	QSize sizeHint() const override;
 
 protected:

--- a/Editor/widgets/FilterCardModel.cpp
+++ b/Editor/widgets/FilterCardModel.cpp
@@ -108,7 +108,7 @@ QString summarizeBiquad(const QString& parameters, const QString& code, const QS
 }
 }
 
-QString FilterCardModel::compactWhitespace(QString text)
+QString FilterCardModel::compactWhitespace(const QString& text)
 {
 	return text.simplified();
 }

--- a/Editor/widgets/FilterCardModel.h
+++ b/Editor/widgets/FilterCardModel.h
@@ -29,7 +29,7 @@ public:
 
 private:
 	static QStringList parseChannelList(const QString& text);
-	static QString compactWhitespace(QString text);
+	static QString compactWhitespace(const QString& text);
 	static bool isDisabledCommandLine(const QString& line);
 	static bool isPureCommentLine(const QString& line);
 };

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -16,9 +16,8 @@
 #include "Editor/widgets/routing/CopyRoutingAdapter.h"
 
 FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui, int depth, QWidget* parent)
-	: QWidget(parent), table(table), item(item), gui(gui)
+	: QWidget(parent), table(table), item(item), gui(gui), descriptor(FilterCardModel::describeLine(item->text, depth))
 {
-	descriptor = FilterCardModel::describeLine(item->text, depth);
 	setAttribute(Qt::WA_StyledBackground, false);
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 

--- a/Editor/widgets/FrequencyPlotScene.cpp
+++ b/Editor/widgets/FrequencyPlotScene.cpp
@@ -97,7 +97,7 @@ void FrequencyPlotScene::setZoom(double zoomX, double zoomY)
 
 		for (QGraphicsItem* item : items())
 		{
-			FrequencyPlotItem* plotItem = (FrequencyPlotItem*)item;
+			FrequencyPlotItem* plotItem = static_cast<FrequencyPlotItem*>(item);
 			plotItem->updatePos();
 		}
 	}

--- a/Editor/widgets/FrequencyPlotScene.h
+++ b/Editor/widgets/FrequencyPlotScene.h
@@ -45,7 +45,7 @@ public:
 	virtual void setBandCount(int value);
 
 	const std::vector<double>& getBands();
-	const std::vector<double>& getBands(int count);
+	static const std::vector<double>& getBands(int count);
 
 protected:
 	static std::vector<double> bands15;

--- a/Editor/widgets/ResizeCorner.h
+++ b/Editor/widgets/ResizeCorner.h
@@ -38,8 +38,8 @@ protected:
 	void mouseReleaseEvent(QMouseEvent*) override;
 
 private:
-	int offsetX;
-	int offsetY;
+	int offsetX = 0;
+	int offsetY = 0;
 	QSize minimumSize;
 	QSize maximumSize;
 	FilterTable* filterTable;

--- a/Editor/widgets/routing/BlockChipRoutingRenderer.h
+++ b/Editor/widgets/routing/BlockChipRoutingRenderer.h
@@ -30,7 +30,7 @@ protected:
 	void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
-	struct Hit { int row; int summand; QRect rect; };
+	struct Hit { int row = 0; int summand = 0; QRect rect; };
 	void commitEditor();
 
 	std::vector<Assignment> workingAssignments;

--- a/Editor/widgets/routing/CrosspointMatrixRoutingRenderer.cpp
+++ b/Editor/widgets/routing/CrosspointMatrixRoutingRenderer.cpp
@@ -226,7 +226,6 @@ void CrosspointMatrixView::mouseDoubleClickEvent(QMouseEvent* event)
 	editRow = outRow;
 	editCol = inCol;
 
-	const QString channel = matrix.inputs[inCol];
 	const CopyRoutingAdapter::Cell cell = matrix.cell(outRow, inCol);
 	QString textValue;
 	if (cell.present)

--- a/Editor/widgets/routing/StepListRoutingRenderer.h
+++ b/Editor/widgets/routing/StepListRoutingRenderer.h
@@ -32,7 +32,7 @@ protected:
 	void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
-	struct Hit { int row; int summand; QRect rect; };
+	struct Hit { int row = 0; int summand = 0; QRect rect; };
 
 	void commitEditor();
 

--- a/EqualizerAPO/DllMain.cpp
+++ b/EqualizerAPO/DllMain.cpp
@@ -32,6 +32,7 @@ using std::wstring;
 
 static HINSTANCE hModule;
 
+// cppcheck-suppress constParameterPointer ; the signature is fixed by the Win32 DllMain contract
 BOOL WINAPI DllMain(HINSTANCE hModule, DWORD dwReason, void* lpReserved)
 {
 	if (dwReason == DLL_PROCESS_ATTACH)

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -209,7 +209,7 @@ HRESULT EqualizerAPO::Initialize(UINT32 cbDataSize, BYTE* pbyData)
 
 	resetChild();
 
-	APOInitSystemEffects* initStruct = (APOInitSystemEffects*)pbyData;
+	APOInitSystemEffects* initStruct = reinterpret_cast<APOInitSystemEffects*>(pbyData);
 	GUID apoGuid = initStruct->APOInit.clsid;
 	try
 	{
@@ -652,7 +652,7 @@ void EqualizerAPO::APOProcess(UINT32 u32NumInputConnections,
 			// read past the input buffer. In that rare case we fall back to
 			// silence — it is still better than emitting random memory, and
 			// such a host is non-compliant given APO_FLAG_INPLACE anyway.
-			void* inBuf = reinterpret_cast<void*>(ppInputConnections[0]->pBuffer);
+			const void* inBuf = reinterpret_cast<const void*>(ppInputConnections[0]->pBuffer);
 			void* outBuf = reinterpret_cast<void*>(ppOutputConnections[0]->pBuffer);
 			ppOutputConnections[0]->u32ValidFrameCount = frameCount;
 			if (inBuf == outBuf)

--- a/EqualizerAPO/EqualizerAPO.h
+++ b/EqualizerAPO/EqualizerAPO.h
@@ -80,9 +80,9 @@ public:
 	virtual HRESULT __stdcall GetEffectsList(LPGUID* effects, UINT* numEffects, HANDLE event);
 
 	// INonDelegatingUnknown
-	virtual HRESULT __stdcall NonDelegatingQueryInterface(const IID& iid, void** ppv);
-	virtual ULONG __stdcall NonDelegatingAddRef();
-	virtual ULONG __stdcall NonDelegatingRelease();
+	HRESULT __stdcall NonDelegatingQueryInterface(const IID& iid, void** ppv) override;
+	ULONG __stdcall NonDelegatingAddRef() override;
+	ULONG __stdcall NonDelegatingRelease() override;
 
 	static long instCount;
 	static const CRegAPOProperties<1> regPostMixProperties;

--- a/FilterConfiguration.cpp
+++ b/FilterConfiguration.cpp
@@ -25,7 +25,7 @@
 #include "FilterConfiguration.h"
 #include "helpers/PerfProfile.h"
 
-FilterConfiguration::FilterConfiguration(FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount)
+FilterConfiguration::FilterConfiguration(const FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount)
 {
 	this->allChannelCount = allChannelCount;
 	realChannelCount = engine->getRealChannelCount();
@@ -213,7 +213,7 @@ void FilterConfiguration::write(double* output, unsigned frameCount)
 #define INTERLEAVE_MACRO(ccount)\
 	for (size_t c = 0; c < ccount; c++)\
 	{\
-		double* sampleChannel = allSamples[c];\
+		const double* sampleChannel = allSamples[c];\
 		double* o2 = output + c;\
 		for (unsigned i = 0; i < frameCount; i++)\
 		{\

--- a/FilterConfiguration.h
+++ b/FilterConfiguration.h
@@ -44,7 +44,7 @@ struct FilterInfo
 class FilterConfiguration
 {
 public:
-	FilterConfiguration(FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount);
+	FilterConfiguration(const FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount);
 	~FilterConfiguration();
 
 	void read(double* input, unsigned frameCount);

--- a/FilterEngine.cpp
+++ b/FilterEngine.cpp
@@ -85,12 +85,12 @@ FilterEngine::FilterEngine()
 	  inputChannelCount(0),
       realChannelCount(0),
       outputChannelCount(0),
+	  parser(make_unique<ParserX>()),
 	  lastInputWasSilent(false),
 	  loadPermitAvailable(true),
 	  shutdownRequested(false),
 	  transitionCounter(0)
 {
-	parser = make_unique<ParserX>();
 	parser->EnableAutoCreateVar(true);
 
 	factories = FilterFactoryRegistry::createFactories();

--- a/FilterEngine.h
+++ b/FilterEngine.h
@@ -60,10 +60,10 @@ public:
 	bool isPreMix() const {return preMix;}
 	bool isCapture() const {return capture;}
 	bool isPostMixInstalled() const {return postMixInstalled;}
-	std::wstring getDeviceName() const {return deviceName;}
-	std::wstring getConnectionName() const {return connectionName;}
-	std::wstring getDeviceGuid() const {return deviceGuid;}
-	std::wstring getDeviceString() const {return deviceString;}
+	const std::wstring& getDeviceName() const {return deviceName;}
+	const std::wstring& getConnectionName() const {return connectionName;}
+	const std::wstring& getDeviceGuid() const {return deviceGuid;}
+	const std::wstring& getDeviceString() const {return deviceString;}
 	unsigned getInputChannelCount() const {return inputChannelCount;}
 	unsigned getRealChannelCount() const {return realChannelCount;}
 	unsigned getOutputChannelCount() const {return outputChannelCount;}
@@ -101,14 +101,14 @@ private:
 	std::wstring deviceGuid;
 	std::wstring deviceString;
 	std::wstring configPath;
-	float sampleRate;
+	float sampleRate = 0.0f;
 	// number of input channels that originally existed before child APO processing
 	unsigned inputChannelCount;
 	// number of input channels in process (including channels coming from child APO output)
 	unsigned realChannelCount;
 	unsigned outputChannelCount;
-	unsigned channelMask;
-	unsigned maxFrameCount;
+	unsigned channelMask = 0;
+	unsigned maxFrameCount = 0;
 
 	// only used during loading
 	std::vector<std::unique_ptr<FilterInfo>> filterInfos;
@@ -116,7 +116,7 @@ private:
 	std::vector<std::wstring> lastChannelNames;
 	std::vector<std::wstring> lastNewChannelNames;
 	std::vector<std::wstring> allChannelNames;
-	bool lastInPlace;
+	bool lastInPlace = false;
 	std::unique_ptr<mup::ParserX> parser;
 
 	FilterConfigurationPtr currentConfig;
@@ -124,7 +124,7 @@ private:
 	FilterConfigurationPtr previousConfig;
 
 	unsigned transitionCounter;
-	unsigned transitionLength;
+	unsigned transitionLength = 0;
 	// Precomputed equal-power crossfade factors of length transitionLength.
 	// Recomputed by initialize() whenever transitionLength changes.
 	std::vector<double> transitionFactorTable;

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -36,7 +36,7 @@ std::string toStd(const QString& s)
 	return s.toUtf8().constData();
 }
 
-QString normalized(QString path)
+QString normalized(const QString& path)
 {
 	return QDir::cleanPath(QDir::fromNativeSeparators(path)).toLower();
 }

--- a/Tests/TestVst2Plugin/TestVst2Plugin.cpp
+++ b/Tests/TestVst2Plugin/TestVst2Plugin.cpp
@@ -87,7 +87,7 @@ void VST_FUNCTION_INTERFACE setParameter(vst_effect_t* effect, uint32_t index, f
 
 float VST_FUNCTION_INTERFACE getParameter(vst_effect_t* effect, uint32_t index)
 {
-	PluginState* state = stateOf(effect);
+	const PluginState* state = stateOf(effect);
 	if (state == nullptr || index >= static_cast<uint32_t>(kNumParams))
 		return 0.0f;
 	return state->params[index];
@@ -98,7 +98,7 @@ float VST_FUNCTION_INTERFACE getParameter(vst_effect_t* effect, uint32_t index)
 template<typename Sample>
 void processGeneric(vst_effect_t* effect, const Sample* const* inputs, Sample** outputs, int32_t samples)
 {
-	PluginState* state = stateOf(effect);
+	const PluginState* state = stateOf(effect);
 	const double gain = state != nullptr ? static_cast<double>(state->params[kParamGain]) : 1.0;
 	const bool bypass = state != nullptr && state->params[kParamBypass] >= 0.5f;
 

--- a/VoicemeeterAPOInfo.cpp
+++ b/VoicemeeterAPOInfo.cpp
@@ -83,7 +83,7 @@ void VoicemeeterAPOInfo::prependInfos(vector<shared_ptr<AbstractAPOInfo>>& list)
 			outputCount = 1;
 
 		bool defaultDevice = false;
-		list.erase(remove_if(list.begin(), list.end(), [&defaultDevice](shared_ptr<AbstractAPOInfo>& info) {
+		list.erase(remove_if(list.begin(), list.end(), [&defaultDevice](const shared_ptr<AbstractAPOInfo>& info) {
 			if (info->getDeviceName().find(L"VB-Audio VoiceMeeter") != wstring::npos)
 			{
 				if (info->isDefaultDevice())
@@ -109,7 +109,7 @@ void VoicemeeterAPOInfo::prependInfos(vector<shared_ptr<AbstractAPOInfo>>& list)
 		{
 			for (unsigned i = 0; i < outputCount; i++)
 			{
-				shared_ptr<VoicemeeterAPOInfo>& info = (shared_ptr<VoicemeeterAPOInfo>&)list[i];
+				const shared_ptr<VoicemeeterAPOInfo>& info = (const shared_ptr<VoicemeeterAPOInfo>&)list[i];
 				if (!anyInstalled || info->isInstalled())
 				{
 					info->defaultDevice = true;
@@ -128,7 +128,7 @@ void VoicemeeterAPOInfo::prependInfos(vector<shared_ptr<AbstractAPOInfo>>& list)
 		int i = 0;
 		for (wstring arg : args)
 		{
-			shared_ptr<AbstractAPOInfo> info = *list.insert(list.begin() + i, make_shared<VoicemeeterAPOInfo>(arg, false));
+			list.insert(list.begin() + i, make_shared<VoicemeeterAPOInfo>(arg, false));
 			i++;
 		}
 	}
@@ -317,13 +317,13 @@ wstring VoicemeeterAPOInfo::getClientPath()
 void VoicemeeterAPOInfo::createLink(const wstring& lnkPath, const wstring& path, const wstring& args)
 {
 	IShellLink* shellLink;
-	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, (LPVOID*)&shellLink);
+	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink));
 	if (SUCCEEDED(hr))
 	{
 		shellLink->SetPath(path.c_str());
 		shellLink->SetArguments(args.c_str());
 		IPersistFile* persistFile;
-		hr = shellLink->QueryInterface(IID_IPersistFile, (LPVOID*)&persistFile);
+		hr = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile));
 		if (SUCCEEDED(hr))
 		{
 			hr = persistFile->Save(lnkPath.c_str(), TRUE);
@@ -339,11 +339,11 @@ wstring VoicemeeterAPOInfo::getLinkArgs(const wstring& lnkPath, wstring* path)
 	wstring result;
 
 	IShellLink* shellLink;
-	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, (LPVOID*)&shellLink);
+	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink));
 	if (SUCCEEDED(hr))
 	{
 		IPersistFile* persistFile;
-		hr = shellLink->QueryInterface(IID_IPersistFile, (LPVOID*)&persistFile);
+		hr = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile));
 		if (SUCCEEDED(hr))
 		{
 			hr = persistFile->Load(lnkPath.c_str(), STGM_READ);

--- a/VoicemeeterClient/VoicemeeterClient.cpp
+++ b/VoicemeeterClient/VoicemeeterClient.cpp
@@ -85,7 +85,7 @@ VoicemeeterClient::VoicemeeterClient(const vector<wstring>& outputs)
 
 	size_t index = voicemeeterDirectory.find_last_of(L'\\');
 	if (index != wstring::npos)
-		voicemeeterDirectory = voicemeeterDirectory.substr(0, index);
+		voicemeeterDirectory.resize(index);
 	else
 		throw InitError(L"Voicemeeter is not installed");
 
@@ -328,7 +328,7 @@ bool VoicemeeterClient::isBufferSilent(float** sampleData, long sampleCount)
 
 	for (int j = 0; j < 8; j++)
 	{
-		float* buf = sampleData[j];
+		const float* buf = sampleData[j];
 		for (int k = 0; k < sampleCount; k++)
 		{
 			if (buf[k] != 0.0f)

--- a/VoicemeeterClient/VoicemeeterClient.h
+++ b/VoicemeeterClient/VoicemeeterClient.h
@@ -37,7 +37,7 @@ private:
 	void detectVoicemeeterType();
 	void endSoftware();
 	void handleCommand(WPARAM wparam, LPARAM lparam);
-	bool isBufferSilent(float** sampleData, long sampleCount);
+	static bool isBufferSilent(float** sampleData, long sampleCount);
 
 	std::vector<std::wstring> outputs;
 	unsigned long mainThreadId;
@@ -59,7 +59,7 @@ public:
 	{
 	}
 
-	std::wstring getMessage() const
+	const std::wstring& getMessage() const
 	{
 		return message;
 	}

--- a/devices/DeviceAPOInfo.Load.cpp
+++ b/devices/DeviceAPOInfo.Load.cpp
@@ -97,12 +97,12 @@ bool DeviceAPOInfo::load(const wstring& deviceGuid, wstring defaultDeviceGuid)
 		std::vector<unsigned char> format = RegistryHelper::readBinaryValue(keyPath + L"\\Properties", formatValueName);
 		if (format.size() >= sizeof(WAVEFORMATEX) + 8)
 		{
-			WAVEFORMATEX* waveFormat = reinterpret_cast<WAVEFORMATEX*>(&format[8]);
+			const WAVEFORMATEX* waveFormat = reinterpret_cast<const WAVEFORMATEX*>(&format[8]);
 			channelCount = waveFormat->nChannels;
 			sampleRate = waveFormat->nSamplesPerSec;
 			if (waveFormat->wFormatTag == WAVE_FORMAT_EXTENSIBLE)
 			{
-				WAVEFORMATEXTENSIBLE* waveFormatExtensible = reinterpret_cast<WAVEFORMATEXTENSIBLE*>(waveFormat);
+				const WAVEFORMATEXTENSIBLE* waveFormatExtensible = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(waveFormat);
 				channelMask = waveFormatExtensible->dwChannelMask;
 			}
 		}

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -152,11 +152,11 @@ void FilterEngine::loadConfigFile(const wstring& path)
 			encodedLine.resize(encodedLine.size() - 1);
 
 		wstring line = StringHelper::toWString(encodedLine, CP_UTF8);
-		if (line.find(L'\uFFFD') != -1)
+		if (line.find(L'\uFFFD') != wstring::npos)
 			line = StringHelper::toWString(encodedLine, CP_ACP);
 
 		size_t pos = line.find(L':');
-		if (pos != -1)
+		if (pos != wstring::npos)
 		{
 			wstring key = line.substr(0, pos);
 			wstring value = line.substr(pos + 1);

--- a/filters/BiQuad.h
+++ b/filters/BiQuad.h
@@ -66,7 +66,7 @@ public:
 	}
 
 	__forceinline
-	void setCoefficients(double ain[], const double& a0in)
+	void setCoefficients(const double ain[], const double& a0in)
 	{
 		for (int i = 0; i < 4; i++)
 			a[i] = ain[i];

--- a/filters/BiQuadFilter.cpp
+++ b/filters/BiQuadFilter.cpp
@@ -216,7 +216,7 @@ void BiQuadFilter::process_scalar(double** output, double** input, unsigned fram
         double cur_y1 = y1[i], cur_y2 = y2[i];
         const double c_a0 = a0[i], c_b1 = b1[i], c_b2 = b2[i];
         const double c_a1 = a1[i], c_a2 = a2[i];
-        double* inputChannel = input[i];
+        const double* inputChannel = input[i];
         double* outputChannel = output[i];
         for (unsigned j = 0; j < frameCount; ++j)
         {

--- a/filters/BiQuadFilterFactory.cpp
+++ b/filters/BiQuadFilterFactory.cpp
@@ -81,7 +81,8 @@ BiQuadFilterFactory::BiQuadFilterFactory()
 
 bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& parameters, BiQuadCommand& out)
 {
-	if (command.find(L"Filter") != 0)
+	// starts-with check (rfind at position 0), the pre-C++20 idiom
+	if (command.rfind(L"Filter", 0) != 0)
 		return false;
 
 	// Conversion to period as decimal mark, if needed

--- a/filters/ConvolutionCommand.cpp
+++ b/filters/ConvolutionCommand.cpp
@@ -23,7 +23,7 @@
 
 #include "helpers/StringHelper.h"
 
-std::wstring ConvolutionCommand::serialize() const
+const std::wstring& ConvolutionCommand::serialize() const
 {
 	return path;
 }

--- a/filters/ConvolutionCommand.h
+++ b/filters/ConvolutionCommand.h
@@ -32,7 +32,7 @@ struct ConvolutionCommand
 	std::wstring path;
 
 	// Canonical parameter string: the path itself.
-	std::wstring serialize() const;
+	const std::wstring& serialize() const;
 
 	// Returns true when command names a Convolution line; path is then the
 	// trimmed parameter text and may be empty. Emptiness policy stays with the

--- a/filters/ConvolutionFilePath.cpp
+++ b/filters/ConvolutionFilePath.cpp
@@ -12,7 +12,7 @@ namespace filesystem = std::filesystem;
 
 namespace
 {
-wstring unquote(wstring value)
+wstring unquote(const wstring& value)
 {
 	if (value.length() >= 2 && value.front() == L'"' && value.back() == L'"')
 		return value.substr(1, value.length() - 2);

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -65,8 +65,8 @@ namespace
 	struct IrCacheKey
 	{
 		std::wstring path;
-		unsigned long long mtime;
-		int sampleRate;
+		unsigned long long mtime = 0;
+		int sampleRate = 0;
 
 		bool operator==(const IrCacheKey& o) const
 		{
@@ -196,11 +196,10 @@ void HConvSingleArray::reset()
 	}
 }
 
-ConvolutionFilter::ConvolutionFilter(wstring filename)
+ConvolutionFilter::ConvolutionFilter(const wstring& filename)
 	: filters(channelCount)
 {
 	this->filename = filename;
-	filters = nullptr;
 	filterFrameCount = 0;
 	maxFrameCount = 0;
 	frameCountMismatchLogged = false;

--- a/filters/ConvolutionFilter.h
+++ b/filters/ConvolutionFilter.h
@@ -81,7 +81,7 @@ private:
 class ConvolutionFilter : public IFilter
 {
 public:
-	ConvolutionFilter(std::wstring filename);
+	ConvolutionFilter(const std::wstring& filename);
 	virtual ~ConvolutionFilter();
 	bool getInPlace() override { return true; }
 	std::vector<std::wstring> initialize(float sampleRate, unsigned maxFrameCount, std::vector<std::wstring> channelNames) override;
@@ -89,8 +89,8 @@ public:
 
 protected:
 	virtual void initializeFilters(unsigned frameCount);
-	float sampleRate;
-	unsigned channelCount;
+	float sampleRate = 0.0f;
+	unsigned channelCount = 0;
 	// Declared after channelCount: the holder binds a reference to channelCount in
 	// the initializer list, so channelCount must be constructed first.
 	HConvSingleArray filters;

--- a/filters/CopyFilter.cpp
+++ b/filters/CopyFilter.cpp
@@ -102,7 +102,7 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 		stream << L"to channel " << outChannelNames[ia.targetChannel].c_str() << " ";
 		for (unsigned j = 0; j < ia.sourceCount; j++)
 		{
-			InternalAssignment::InternalSummand& is = ia.sourceSum[j];
+			const InternalAssignment::InternalSummand& is = ia.sourceSum[j];
 			if (j > 0)
 				stream << ", ";
 			if (is.channel != -1)
@@ -142,7 +142,7 @@ void CopyFilter::process(double** output, double** input, unsigned frameCount)
 
 		for (unsigned j = 1; j < ia.sourceCount; j++)
 		{
-			InternalAssignment::InternalSummand& is = ia.sourceSum[j];
+			const InternalAssignment::InternalSummand& is = ia.sourceSum[j];
 
 			if (is.channel == -1)
 				for (unsigned f = 0; f < frameCount; f++)
@@ -177,7 +177,7 @@ void CopyFilter::cleanup()
 	}
 }
 
-std::vector<Assignment> CopyFilter::getAssignments() const
+const std::vector<Assignment>& CopyFilter::getAssignments() const
 {
 	return assignments;
 }

--- a/filters/CopyFilter.h
+++ b/filters/CopyFilter.h
@@ -30,8 +30,8 @@ struct Assignment
 
 	struct Summand
 	{
-		double factor;
-		bool isDecibel;
+		double factor = 0.0;
+		bool isDecibel = false;
 		std::wstring channel;
 	};
 
@@ -70,7 +70,7 @@ public:
 	std::vector<std::wstring> initialize(float sampleRate, unsigned maxFrameCount, std::vector<std::wstring> channelNames) override;
 	void process(double** output, double** input, unsigned frameCount) override;
 
-	std::vector<Assignment> getAssignments() const;
+	const std::vector<Assignment>& getAssignments() const;
 
 private:
 	void cleanup();

--- a/filters/DelayFilter.h
+++ b/filters/DelayFilter.h
@@ -39,9 +39,9 @@ private:
 
 	double delay;
 	bool isMs;
-	unsigned bufferLength;
-	unsigned channelCount;
+	unsigned bufferLength = 0;
+	unsigned channelCount = 0;
 	double** buffers;
-	unsigned bufferOffset;
+	unsigned bufferOffset = 0;
 };
 #pragma AVRT_VTABLES_END

--- a/filters/DeviceFilterFactory.h
+++ b/filters/DeviceFilterFactory.h
@@ -35,6 +35,6 @@ public:
 	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
 
 private:
-	bool deviceMatches;
+	bool deviceMatches = false;
 	std::wstring deviceString;
 };

--- a/filters/ExpressionCommand.cpp
+++ b/filters/ExpressionCommand.cpp
@@ -26,7 +26,7 @@
 using std::vector;
 using std::wstring;
 
-wstring EvalCommand::serialize() const
+const wstring& EvalCommand::serialize() const
 {
 	return expression;
 }

--- a/filters/ExpressionCommand.h
+++ b/filters/ExpressionCommand.h
@@ -30,7 +30,7 @@ struct EvalCommand
 	std::wstring expression;
 
 	// Canonical parameter string: the expression itself.
-	std::wstring serialize() const;
+	const std::wstring& serialize() const;
 
 	// Returns true when command names an Eval line; expression is then filled.
 	static bool parse(const std::wstring& command, const std::wstring& parameters, EvalCommand& out);

--- a/filters/ExpressionFilterFactory.h
+++ b/filters/ExpressionFilterFactory.h
@@ -32,5 +32,5 @@ public:
 	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 private:
-	mup::ParserX* parser;
+	mup::ParserX* parser = nullptr;
 };

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -46,8 +46,8 @@ namespace
 	struct EqIrCacheKey
 	{
 		std::vector<FilterNode> nodes;
-		int sampleRate;
-		unsigned filterLength;
+		int sampleRate = 0;
+		unsigned filterLength = 0;
 
 		bool operator==(const EqIrCacheKey& o) const
 		{

--- a/filters/IIRFilter.cpp
+++ b/filters/IIRFilter.cpp
@@ -79,7 +79,7 @@ void IIRFilter::process(double** output, double** input, unsigned frameCount)
 	PerfScope _ps("IIRFilter::process");
 	for (unsigned i = 0; i < channelCount; i++)
 	{
-		double* inputChannel = input[i];
+		const double* inputChannel = input[i];
 		double* outputChannel = output[i];
 
 		unsigned channelOffset = i * order;

--- a/filters/IIRFilter.h
+++ b/filters/IIRFilter.h
@@ -36,7 +36,7 @@ private:
 	double b0;
 	double* a;
 	double* b;
-	unsigned channelCount;
+	unsigned channelCount = 0;
 	double* x;
 	double* y;
 };

--- a/filters/IIRFilterFactory.cpp
+++ b/filters/IIRFilterFactory.cpp
@@ -50,7 +50,8 @@ IIRFilterFactory::IIRFilterFactory()
 
 bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& parameters, IIRCommand& out)
 {
-	if (command.find(L"Filter") != 0)
+	// starts-with check (rfind at position 0), the pre-C++20 idiom
+	if (command.rfind(L"Filter", 0) != 0)
 		return false;
 
 	wsmatch match;

--- a/filters/IfCommand.cpp
+++ b/filters/IfCommand.cpp
@@ -25,7 +25,7 @@
 
 using std::wstring;
 
-wstring IfCommand::serialize() const
+const wstring& IfCommand::serialize() const
 {
 	return expression;
 }

--- a/filters/IfCommand.h
+++ b/filters/IfCommand.h
@@ -42,7 +42,7 @@ struct IfCommand
 	std::wstring expression;
 
 	// Canonical parameter string: the expression itself.
-	std::wstring serialize() const;
+	const std::wstring& serialize() const;
 
 	// Returns true when command names a line of the If family; kind and
 	// expression are then filled.

--- a/filters/IfFilterFactory.h
+++ b/filters/IfFilterFactory.h
@@ -35,11 +35,11 @@ public:
 	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
 
 private:
-	mup::ParserX* parser;
+	mup::ParserX* parser = nullptr;
 
-	unsigned trueCount;
-	unsigned falseCount;
-	bool executeElse;
+	unsigned trueCount = 0;
+	unsigned falseCount = 0;
+	bool executeElse = false;
 	std::stack<unsigned> trueCountStack;
 
 	bool toBoolean(const mup::Value& value);

--- a/filters/IncludeCommand.cpp
+++ b/filters/IncludeCommand.cpp
@@ -25,7 +25,7 @@
 
 using std::wstring;
 
-wstring IncludeCommand::serialize() const
+const wstring& IncludeCommand::serialize() const
 {
 	return path;
 }

--- a/filters/IncludeCommand.h
+++ b/filters/IncludeCommand.h
@@ -32,7 +32,7 @@ struct IncludeCommand
 	std::wstring path;
 
 	// Canonical parameter string: the path itself.
-	std::wstring serialize() const;
+	const std::wstring& serialize() const;
 
 	// Returns true when command names an Include line; path is then the
 	// parameter text without leading whitespace and may be empty. Emptiness

--- a/filters/IncludeFilterFactory.h
+++ b/filters/IncludeFilterFactory.h
@@ -35,6 +35,6 @@ public:
 	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
 
 private:
-	FilterEngine* engine;
+	FilterEngine* engine = nullptr;
 	int recursionDepth = -1;
 };

--- a/filters/StageFilterFactory.cpp
+++ b/filters/StageFilterFactory.cpp
@@ -33,16 +33,16 @@ using std::wstring;
 
 void StageFilterFactory::initialize(FilterEngine* engine)
 {
-	preMix = engine->isPreMix();
-	capture = engine->isCapture();
-	postMixInstalled = engine->isPostMixInstalled();
+	enginePreMix = engine->isPreMix();
+	engineCapture = engine->isCapture();
+	enginePostMixInstalled = engine->isPostMixInstalled();
 
 	engine->getParser()->DefineConst(L"stage", engine->isCapture() ? L"capture" : engine->isPreMix() ? L"pre-mix" : L"post-mix");
 }
 
 vector<IFilter*> StageFilterFactory::startOfConfiguration()
 {
-	stageMatches = capture || !preMix || !postMixInstalled;
+	stageMatches = engineCapture || !enginePreMix || !enginePostMixInstalled;
 	while (!stageMatchesStack.empty())
 		stageMatchesStack.pop();
 
@@ -68,7 +68,7 @@ vector<IFilter*> StageFilterFactory::createFilter(const wstring& configPath, wst
 		{
 			if (part == StageCommand::preMix)
 			{
-				if (!capture && preMix)
+				if (!engineCapture && enginePreMix)
 				{
 					stageMatches = true;
 					matchingPart = part;
@@ -76,7 +76,7 @@ vector<IFilter*> StageFilterFactory::createFilter(const wstring& configPath, wst
 			}
 			else if (part == StageCommand::postMix)
 			{
-				if (!capture && !preMix)
+				if (!engineCapture && !enginePreMix)
 				{
 					stageMatches = true;
 					matchingPart = part;
@@ -84,7 +84,7 @@ vector<IFilter*> StageFilterFactory::createFilter(const wstring& configPath, wst
 			}
 			else if (part == StageCommand::capture)
 			{
-				if (capture)
+				if (engineCapture)
 				{
 					stageMatches = true;
 					matchingPart = part;

--- a/filters/StageFilterFactory.h
+++ b/filters/StageFilterFactory.h
@@ -35,10 +35,12 @@ public:
 	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
 
 private:
-	bool preMix;
-	bool capture;
-	bool postMixInstalled;
+	// Named with an engine prefix so they cannot be confused with the
+	// StageCommand selector constants of the same stage names.
+	bool enginePreMix = false;
+	bool engineCapture = false;
+	bool enginePostMixInstalled = false;
 
-	bool stageMatches;
+	bool stageMatches = false;
 	std::stack<bool> stageMatchesStack;
 };

--- a/filters/VSTPluginFilter.cpp
+++ b/filters/VSTPluginFilter.cpp
@@ -24,10 +24,9 @@
 
 using std::max;
 
-VSTPluginFilter::VSTPluginFilter(std::shared_ptr<VSTPluginLibrary> library, std::wstring chunkData, std::unordered_map<std::wstring, float> paramMap)
-	: library(library), chunkData(chunkData), paramMap(paramMap)
+VSTPluginFilter::VSTPluginFilter(std::shared_ptr<VSTPluginLibrary> library, std::wstring chunkData, const std::unordered_map<std::wstring, float>& paramMap)
+	: library(library), libPath(library->getLibPath()), chunkData(chunkData), paramMap(paramMap)
 {
-	libPath = library->getLibPath();
 }
 
 VSTPluginFilter::~VSTPluginFilter()
@@ -292,12 +291,12 @@ std::shared_ptr<VSTPluginLibrary> VSTPluginFilter::getLibrary() const
 	return library;
 }
 
-std::wstring VSTPluginFilter::getChunkData() const
+const std::wstring& VSTPluginFilter::getChunkData() const
 {
 	return chunkData;
 }
 
-std::unordered_map<std::wstring, float> VSTPluginFilter::getParamMap() const
+const std::unordered_map<std::wstring, float>& VSTPluginFilter::getParamMap() const
 {
 	return paramMap;
 }

--- a/filters/VSTPluginFilter.h
+++ b/filters/VSTPluginFilter.h
@@ -26,7 +26,7 @@
 class VSTPluginFilter : public IFilter
 {
 public:
-	VSTPluginFilter(std::shared_ptr<VSTPluginLibrary> library, std::wstring chunkData, std::unordered_map<std::wstring, float> paramMap);
+	VSTPluginFilter(std::shared_ptr<VSTPluginLibrary> library, std::wstring chunkData, const std::unordered_map<std::wstring, float>& paramMap);
 	~VSTPluginFilter();
 
 	bool getInPlace() override {return false;}
@@ -35,8 +35,8 @@ public:
 	void process(double** output, double** input, unsigned frameCount) override;
 
 	std::shared_ptr<VSTPluginLibrary> getLibrary() const;
-	std::wstring getChunkData() const;
-	std::unordered_map<std::wstring, float> getParamMap() const;
+	const std::wstring& getChunkData() const;
+	const std::unordered_map<std::wstring, float>& getParamMap() const;
 
 private:
 	void cleanup();
@@ -45,8 +45,8 @@ private:
 	std::wstring libPath;
 	std::wstring chunkData;
 	std::unordered_map<std::wstring, float> paramMap;
-	size_t channelCount;
-	unsigned effectChannelCount;
+	size_t channelCount = 0;
+	unsigned effectChannelCount = 0;
 	size_t effectCount = 0;
 	VSTPluginInstance** effects = nullptr;
 	size_t emptyChannelCount = 0;

--- a/filters/VSTPluginFilterFactory.cpp
+++ b/filters/VSTPluginFilterFactory.cpp
@@ -59,11 +59,6 @@ vector<IFilter*> VSTPluginFilterFactory::createFilter(const wstring& configPath,
 				int res = library->initialize();
 				if (res < 0)
 				{
-#ifdef _WIN64
-					int bitDepth = 64;
-#else
-					int bitDepth = 32;
-#endif
 					if (res == AbstractLibrary::FILE_NOT_FOUND)
 						LogF(L"File %s not found", library->getLibPath());
 					else if (res == AbstractLibrary::LOADING_FAILED)
@@ -71,7 +66,14 @@ vector<IFilter*> VSTPluginFilterFactory::createFilter(const wstring& configPath,
 					else if (res == AbstractLibrary::FUNCTIONS_MISSING)
 						LogF(L"Library %s does not contain needed functions", library->getLibPath());
 					else if (res == AbstractLibrary::WRONG_ARCHITECTURE)
+					{
+#ifdef _WIN64
+						int bitDepth = 64;
+#else
+						int bitDepth = 32;
+#endif
 						LogF(L"Library %s has wrong architecture, must be %d-bit", library->getLibPath(), bitDepth);
+					}
 				}
 				else
 				{

--- a/filters/loudnessCorrection/LoudnessCorrectionFilter.cpp
+++ b/filters/loudnessCorrection/LoudnessCorrectionFilter.cpp
@@ -30,8 +30,8 @@
 #include <math.h>
 
 LoudnessCorrectionFilter::LoudnessCorrectionFilter(const FilterParameters& fParameters)
+	: _parameters(fParameters)
 {
-	_parameters = fParameters;
 	if (_parameters.attenuation > 1.0)
 	{
 		_parameters.attenuation = 1.0;
@@ -191,7 +191,6 @@ void LoudnessCorrectionFilter::process(double** output, double** input, unsigned
 				output[i][j] = input[i][j];
 			}
 		}
-		output = input;
 		return;
 	}
 	if (_parameterChanged.exchange(false))

--- a/helpers/AbstractLibrary.cpp
+++ b/helpers/AbstractLibrary.cpp
@@ -51,13 +51,14 @@ int AbstractLibrary::initialize()
 		if (module == nullptr)
 		{
 			unsigned short arch = getFileArchitecture(libPath);
-#ifdef _WIN64
-			int bitDepth = 64;
+#if defined(_M_ARM64)
+			const unsigned short expectedArch = IMAGE_FILE_MACHINE_ARM64;
+#elif defined(_WIN64)
+			const unsigned short expectedArch = IMAGE_FILE_MACHINE_AMD64;
 #else
-			int bitDepth = 32;
+			const unsigned short expectedArch = IMAGE_FILE_MACHINE_I386;
 #endif
-			if (arch != 0 && (bitDepth == 64 && arch != IMAGE_FILE_MACHINE_AMD64
-				|| bitDepth == 32 && arch != IMAGE_FILE_MACHINE_I386))
+			if (arch != 0 && arch != expectedArch)
 				return WRONG_ARCHITECTURE;
 
 			return LOADING_FAILED;

--- a/helpers/AbstractLibrary.h
+++ b/helpers/AbstractLibrary.h
@@ -43,7 +43,7 @@ protected:
 	HMODULE module = nullptr;
 
 private:
-	unsigned short getFileArchitecture(const std::wstring& filePath);
+	static unsigned short getFileArchitecture(const std::wstring& filePath);
 
 	// Serialises the lazy module load. A single VSTPluginLibrary instance is
 	// shared (via getInstance) between the GUI thread and the AnalysisThread,

--- a/helpers/RegistryHelper.cpp
+++ b/helpers/RegistryHelper.cpp
@@ -38,7 +38,7 @@ using std::wstring;
 
 DWORD RegistryHelper::windowsVersion = 0;
 
-wstring RegistryHelper::readValue(wstring key, wstring valuename)
+wstring RegistryHelper::readValue(const wstring& key, const wstring& valuename)
 {
 	wstring result;
 
@@ -78,7 +78,7 @@ wstring RegistryHelper::readValue(wstring key, wstring valuename)
 	return result;
 }
 
-unsigned long RegistryHelper::readDWORDValue(wstring key, wstring valuename)
+unsigned long RegistryHelper::readDWORDValue(const wstring& key, const wstring& valuename)
 {
 	unsigned long result;
 
@@ -112,7 +112,7 @@ unsigned long RegistryHelper::readDWORDValue(wstring key, wstring valuename)
 	return result;
 }
 
-vector<wstring> RegistryHelper::readMultiValue(wstring key, wstring valuename)
+vector<wstring> RegistryHelper::readMultiValue(const wstring& key, const wstring& valuename)
 {
 	vector<wstring> result;
 
@@ -165,7 +165,7 @@ vector<wstring> RegistryHelper::readMultiValue(wstring key, wstring valuename)
 	return result;
 }
 
-vector<unsigned char> RegistryHelper::readBinaryValue(wstring key, wstring valuename)
+vector<unsigned char> RegistryHelper::readBinaryValue(const wstring& key, const wstring& valuename)
 {
 	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
 
@@ -198,7 +198,7 @@ vector<unsigned char> RegistryHelper::readBinaryValue(wstring key, wstring value
 	return result;
 }
 
-void RegistryHelper::writeValue(wstring key, wstring valuename, wstring value)
+void RegistryHelper::writeValue(const wstring& key, const wstring& valuename, const wstring& value)
 {
 	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
 
@@ -210,11 +210,11 @@ void RegistryHelper::writeValue(wstring key, wstring valuename, wstring value)
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::writeDWORDValue(wstring key, wstring valuename, unsigned long value)
+void RegistryHelper::writeDWORDValue(const wstring& key, const wstring& valuename, unsigned long value)
 {
 	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
 
-	LSTATUS status = RegSetValueExW(keyHandle, valuename.c_str(), 0, REG_DWORD, (const BYTE*)&value, sizeof(unsigned long));
+	LSTATUS status = RegSetValueExW(keyHandle, valuename.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(unsigned long));
 
 	RegCloseKey(keyHandle);
 
@@ -222,7 +222,7 @@ void RegistryHelper::writeDWORDValue(wstring key, wstring valuename, unsigned lo
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::writeMultiValue(wstring key, wstring valuename, wstring value)
+void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuename, const wstring& value)
 {
 	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
 
@@ -238,17 +238,17 @@ void RegistryHelper::writeMultiValue(wstring key, wstring valuename, wstring val
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::writeMultiValue(wstring key, wstring valuename, vector<wstring> values)
+void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuename, const vector<wstring>& values)
 {
 	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
 
 	size_t size = 1;
-	for (wstring value : values)
+	for (const wstring& value : values)
 		size += value.size() + 1;
 
 	wstring data;
 	data.reserve(size);
-	for (wstring value : values)
+	for (const wstring& value : values)
 	{
 		data.append(value);
 		data.push_back(L'\0');
@@ -263,7 +263,7 @@ void RegistryHelper::writeMultiValue(wstring key, wstring valuename, vector<wstr
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::deleteValue(wstring key, wstring valuename)
+void RegistryHelper::deleteValue(const wstring& key, const wstring& valuename)
 {
 	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
 
@@ -275,7 +275,7 @@ void RegistryHelper::deleteValue(wstring key, wstring valuename)
 		throw RegistryException(L"Error while deleting registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::createKey(wstring key)
+void RegistryHelper::createKey(const wstring& key)
 {
 	HKEY rootKey;
 	wstring subKey = splitKey(key, &rootKey);
@@ -288,7 +288,7 @@ void RegistryHelper::createKey(wstring key)
 	RegCloseKey(keyHandle);
 }
 
-void RegistryHelper::deleteKey(wstring key)
+void RegistryHelper::deleteKey(const wstring& key)
 {
 	HKEY rootKey;
 	wstring subKey = splitKey(key, &rootKey);
@@ -298,7 +298,7 @@ void RegistryHelper::deleteKey(wstring key)
 		throw RegistryException(L"Error while deleting registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::makeWritable(wstring key)
+void RegistryHelper::makeWritable(const wstring& key)
 {
 	HKEY keyHandle = openKey(key, READ_CONTROL | WRITE_DAC | KEY_WOW64_64KEY);
 	SCOPE_EXIT{ RegCloseKey(keyHandle); };
@@ -353,7 +353,7 @@ void RegistryHelper::makeWritable(wstring key)
 		throw RegistryException(L"Error while setting security information for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 }
 
-void RegistryHelper::takeOwnership(wstring key)
+void RegistryHelper::takeOwnership(const wstring& key)
 {
 	HANDLE tokenHandle;
 	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tokenHandle))
@@ -403,28 +403,34 @@ void RegistryHelper::takeOwnership(wstring key)
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
 }
 
-ACCESS_MASK RegistryHelper::getFileAccessForUser(std::wstring path, unsigned long rid)
+ACCESS_MASK RegistryHelper::getFileAccessForUser(const std::wstring& path, unsigned long rid)
 {
 	ACCESS_MASK result;
 
+	// Cleanup runs through scope guards so the throwing paths cannot leak the
+	// security descriptor, resource manager, SID or context.
 	PSECURITY_DESCRIPTOR sd;
 	if (GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION
 		| GROUP_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr, &sd) != ERROR_SUCCESS)
 		throw RegistryException(L"Error in GetNamedSecurityInfoW while getting file access");
+	SCOPE_EXIT{ LocalFree(sd); };
 
 	AUTHZ_RESOURCE_MANAGER_HANDLE manager;
 	if (!AuthzInitializeResourceManager(AUTHZ_RM_FLAG_NO_AUDIT, nullptr, nullptr, nullptr, nullptr, &manager))
 		throw RegistryException(L"Error in AuthzInitializeResourceManager while getting file access");
+	SCOPE_EXIT{ AuthzFreeResourceManager(manager); };
 
 	PSID sid = nullptr;
 	SID_IDENTIFIER_AUTHORITY authority = SECURITY_NT_AUTHORITY;
 	if (!AllocateAndInitializeSid(&authority, 1, rid, 0, 0, 0, 0, 0, 0, 0, &sid))
 		throw RegistryException(L"Error in AllocateAndInitializeSid while getting file access");
+	SCOPE_EXIT{ if (sid != nullptr) FreeSid(sid); };
 
 	LUID unusedId = {0};
 	AUTHZ_CLIENT_CONTEXT_HANDLE context;
 	if (!AuthzInitializeContextFromSid(0, sid, manager, nullptr, unusedId, nullptr, &context))
 		throw RegistryException(L"Error in AuthzInitializeContextFromSid while getting file access");
+	SCOPE_EXIT{ AuthzFreeContext(context); };
 
 	AUTHZ_ACCESS_REQUEST request = {0};
 
@@ -438,23 +444,18 @@ ACCESS_MASK RegistryHelper::getFileAccessForUser(std::wstring path, unsigned lon
 	BYTE buf[1024];
 	RtlZeroMemory(buf, sizeof(buf));
 	reply.ResultListLength = 1;
-	reply.GrantedAccessMask = (ACCESS_MASK*)buf;
-	reply.Error = (DWORD*)(buf + sizeof(ACCESS_MASK));
+	reply.GrantedAccessMask = reinterpret_cast<ACCESS_MASK*>(buf);
+	reply.Error = reinterpret_cast<DWORD*>(buf + sizeof(ACCESS_MASK));
 
 	if (!AuthzAccessCheck(0, context, &request, nullptr, sd, nullptr, 0, &reply, nullptr))
 		throw RegistryException(L"Error in AuthzAccessCheck while getting file access");
 
 	result = *reply.GrantedAccessMask;
 
-	AuthzFreeContext(context);
-	FreeSid(sid);
-	AuthzFreeResourceManager(manager);
-	LocalFree(sd);
-
 	return result;
 }
 
-bool RegistryHelper::keyExists(wstring key)
+bool RegistryHelper::keyExists(const wstring& key)
 {
 	bool result;
 
@@ -470,7 +471,7 @@ bool RegistryHelper::keyExists(wstring key)
 	return result;
 }
 
-bool RegistryHelper::valueExists(wstring key, wstring valuename)
+bool RegistryHelper::valueExists(const wstring& key, const wstring& valuename)
 {
 	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
 
@@ -481,7 +482,7 @@ bool RegistryHelper::valueExists(wstring key, wstring valuename)
 	return status == ERROR_SUCCESS;
 }
 
-vector<wstring> RegistryHelper::enumSubKeys(wstring key)
+vector<wstring> RegistryHelper::enumSubKeys(const wstring& key)
 {
 	vector<wstring> result;
 
@@ -507,7 +508,7 @@ vector<wstring> RegistryHelper::enumSubKeys(wstring key)
 	return result;
 }
 
-bool RegistryHelper::keyEmpty(wstring key)
+bool RegistryHelper::keyEmpty(const wstring& key)
 {
 	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
 
@@ -523,7 +524,7 @@ bool RegistryHelper::keyEmpty(wstring key)
 	return keyCount == 0 && valueCount == 0;
 }
 
-void RegistryHelper::saveToFile(wstring key, vector<wstring> valuenames, wstring filepath)
+void RegistryHelper::saveToFile(const wstring& key, const vector<wstring>& valuenames, const wstring& filepath)
 {
 	wofstream stream(filepath);
 	if (!stream.good())
@@ -531,9 +532,9 @@ void RegistryHelper::saveToFile(wstring key, vector<wstring> valuenames, wstring
 
 	stream << L"Windows Registry Editor Version 5.00\n" << endl;
 	stream << L"[HKEY_LOCAL_MACHINE\\" << key << L"]" << endl;
-	for (vector<wstring>::iterator it = valuenames.begin(); it != valuenames.end(); it++)
+	for (vector<wstring>::const_iterator it = valuenames.cbegin(); it != valuenames.cend(); it++)
 	{
-		wstring& valuename = *it;
+		const wstring& valuename = *it;
 		wstring value = readValue(key, valuename);
 
 		stream << L"\"" << valuename << L"\"=\"" << value << L"\"" << endl;
@@ -567,7 +568,7 @@ bool RegistryHelper::isWindowsVersionAtLeast(unsigned major, unsigned minor)
 			{
 				VS_FIXEDFILEINFO* info;
 				UINT len;
-				if (VerQueryValueW(data.data(), L"\\", (LPVOID*)&info, &len))
+				if (VerQueryValueW(data.data(), L"\\", reinterpret_cast<LPVOID*>(&info), &len))
 					windowsVersion = info->dwProductVersionMS;
 			}
 		}

--- a/helpers/RegistryHelper.h
+++ b/helpers/RegistryHelper.h
@@ -36,25 +36,25 @@ const GUID EQUALIZERAPO_POST_MIX_GUID = {0xec1cc9ce, 0xfaed, 0x4822, {0x82, 0x8a
 class RegistryHelper
 {
 public:
-	static std::wstring readValue(std::wstring key, std::wstring valuename);
-	static unsigned long readDWORDValue(std::wstring key, std::wstring valuename);
-	static std::vector<std::wstring> readMultiValue(std::wstring key, std::wstring valuename);
-	static std::vector<unsigned char> readBinaryValue(std::wstring key, std::wstring valuename);
-	static void writeValue(std::wstring key, std::wstring valuename, std::wstring value);
-	static void writeDWORDValue(std::wstring key, std::wstring valuename, unsigned long value);
-	static void writeMultiValue(std::wstring key, std::wstring valuename, std::wstring value);
-	static void writeMultiValue(std::wstring key, std::wstring valuename, std::vector<std::wstring> values);
-	static void deleteValue(std::wstring key, std::wstring valuename);
-	static void createKey(std::wstring key);
-	static void deleteKey(std::wstring key);
-	static void makeWritable(std::wstring key);
-	static void takeOwnership(std::wstring key);
-	static ACCESS_MASK getFileAccessForUser(std::wstring path, unsigned long rid);
-	static std::vector<std::wstring> enumSubKeys(std::wstring key);
-	static bool keyExists(std::wstring key);
-	static bool valueExists(std::wstring key, std::wstring valuename);
-	static bool keyEmpty(std::wstring key);
-	static void saveToFile(std::wstring key, std::vector<std::wstring> valuenames, std::wstring filepath);
+	static std::wstring readValue(const std::wstring& key, const std::wstring& valuename);
+	static unsigned long readDWORDValue(const std::wstring& key, const std::wstring& valuename);
+	static std::vector<std::wstring> readMultiValue(const std::wstring& key, const std::wstring& valuename);
+	static std::vector<unsigned char> readBinaryValue(const std::wstring& key, const std::wstring& valuename);
+	static void writeValue(const std::wstring& key, const std::wstring& valuename, const std::wstring& value);
+	static void writeDWORDValue(const std::wstring& key, const std::wstring& valuename, unsigned long value);
+	static void writeMultiValue(const std::wstring& key, const std::wstring& valuename, const std::wstring& value);
+	static void writeMultiValue(const std::wstring& key, const std::wstring& valuename, const std::vector<std::wstring>& values);
+	static void deleteValue(const std::wstring& key, const std::wstring& valuename);
+	static void createKey(const std::wstring& key);
+	static void deleteKey(const std::wstring& key);
+	static void makeWritable(const std::wstring& key);
+	static void takeOwnership(const std::wstring& key);
+	static ACCESS_MASK getFileAccessForUser(const std::wstring& path, unsigned long rid);
+	static std::vector<std::wstring> enumSubKeys(const std::wstring& key);
+	static bool keyExists(const std::wstring& key);
+	static bool valueExists(const std::wstring& key, const std::wstring& valuename);
+	static bool keyEmpty(const std::wstring& key);
+	static void saveToFile(const std::wstring& key, const std::vector<std::wstring>& valuenames, const std::wstring& filepath);
 	static std::wstring getGuidString(GUID guid);
 	static bool isWindowsVersionAtLeast(unsigned major, unsigned minor);
 	static HKEY openKey(const std::wstring& key, REGSAM samDesired);
@@ -71,7 +71,7 @@ public:
 	RegistryException(const std::wstring& message)
 		: message(message) {}
 
-	std::wstring getMessage() const
+	const std::wstring& getMessage() const
 	{
 		return message;
 	}

--- a/helpers/ServiceHelper.cpp
+++ b/helpers/ServiceHelper.cpp
@@ -45,7 +45,7 @@ void ServiceHelper::restartService(const wstring& serviceName)
 	if (mainState == SERVICE_RUNNING)
 	{
 		vector<wstring> dependentServices = mainService->getActiveDependentServices();
-		for (wstring dependentServiceName : dependentServices)
+		for (const wstring& dependentServiceName : dependentServices)
 		{
 			shared_ptr<Service> dependentService = make_shared<Service>(scManager, dependentServiceName.c_str(), false);
 			services.insert(prev(services.end()), dependentService);

--- a/helpers/ServiceHelper.h
+++ b/helpers/ServiceHelper.h
@@ -54,7 +54,7 @@ public:
 	{
 	}
 
-	std::wstring getMessage() const
+	const std::wstring& getMessage() const
 	{
 		return message;
 	}

--- a/helpers/StringHelper.cpp
+++ b/helpers/StringHelper.cpp
@@ -38,7 +38,7 @@ wstring StringHelper::replaceCharacters(const wstring& s, const wstring& chars, 
 	for (unsigned i = 0; i < s.length(); i++)
 	{
 		wchar_t c = s[i];
-		if (chars.find(c) == -1)
+		if (chars.find(c) == wstring::npos)
 			result += c;
 		else
 			result += replacement;
@@ -164,9 +164,10 @@ wstring StringHelper::join(const vector<wstring>& strings, const wstring& separa
 
 wstring StringHelper::getSystemErrorString(long status)
 {
-	wchar_t* buf;
+	wchar_t* buf = nullptr;
 
-	if (FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, status, 0, (LPTSTR)&buf, 0, nullptr) != 0)
+	// cppcheck-suppress knownConditionTrueFalse ; FormatMessageW allocates into buf through the casted out pointer
+	if (FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, status, 0, (LPTSTR)&buf, 0, nullptr) != 0 && buf != nullptr)
 	{
 		wstring result(buf);
 		LocalFree(buf);

--- a/helpers/VSTPluginInstance.VST2.cpp
+++ b/helpers/VSTPluginInstance.VST2.cpp
@@ -51,7 +51,8 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 		return 1;
 
 	case VST_EFFECT_OPCODE_VENDOR_VERSION:
-		return (intptr_t) (MAJOR << 24 | MINOR << 16 | REVISION << 8 | 0);
+		// The low byte (a fourth version component) is always zero.
+		return (intptr_t) (MAJOR << 24 | MINOR << 16 | REVISION << 8);
 
 	case VST_HOST_OPCODE_PIN_CONNECTED:
 		if (instance != NULL)
@@ -100,7 +101,7 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 
 	case VST_HOST_OPCODE_SUPPORTS:
 		{
-			char* s = (char*)ptr;
+			const char* s = (const char*)ptr;
 #ifdef _DEBUG
 			printf("VST canDo: %s\n", s);
 			fflush(stdout);

--- a/helpers/VSTPluginLibrary.h
+++ b/helpers/VSTPluginLibrary.h
@@ -39,7 +39,7 @@ public:
 	bool isVST3() const;
 
 	typedef vst_effect_t* (* vstPluginMain)(vst_host_callback_t audioMaster);
-	vstPluginMain VSTPluginMain;
+	vstPluginMain VSTPluginMain = nullptr;
 	typedef Steinberg::IPluginFactory* (PLUGIN_API* getPluginFactoryFunc)();
 	getPluginFactoryFunc GetPluginFactory;
 	Steinberg::IPluginFactory* getFactory() const;

--- a/parser/LogicalOperators.h
+++ b/parser/LogicalOperators.h
@@ -27,6 +27,6 @@ class NotOperator : public mup::IOprtInfix
 public:
 	NotOperator();
 	void Eval(mup::ptr_val_type& ret, const mup::ptr_val_type* arg, int argc) override;
-	const mup::char_type* GetDesc() const;
+	const mup::char_type* GetDesc() const override;
 	mup::IToken* Clone() const override;
 };

--- a/parser/RegexFunctions.cpp
+++ b/parser/RegexFunctions.cpp
@@ -45,11 +45,11 @@ void RegexSearchFunction::Eval(ptr_val_type& ret, const ptr_val_type* arg, int a
 		throw ParserError(ErrorContext(ecTYPE_CONFLICT_FUN, -1, GetIdent(), arg[1]->GetType(), 's', 2));
 
 	wstring regexString = arg[0]->GetString();
-	wstring string = arg[1]->GetString();
+	wstring text = arg[1]->GetString();
 
 	wregex regex(regexString);
 	wsmatch match;
-	bool found = regex_search(string, match, regex);
+	bool found = regex_search(text, match, regex);
 
 	vector<Value> result;
 	if (found)
@@ -87,11 +87,11 @@ void RegexReplaceFunction::Eval(ptr_val_type& ret, const ptr_val_type* arg, int 
 		throw ParserError(ErrorContext(ecTYPE_CONFLICT_FUN, -1, GetIdent(), arg[2]->GetType(), 's', 3));
 
 	wstring regexString = arg[0]->GetString();
-	wstring string = arg[1]->GetString();
+	wstring text = arg[1]->GetString();
 	wstring replacement = arg[2]->GetString();
 
 	wregex regex(regexString);
-	wstring result = regex_replace(string, regex, replacement);
+	wstring result = regex_replace(text, regex, replacement);
 
 	*ret = result;
 }

--- a/parser/RegexFunctions.h
+++ b/parser/RegexFunctions.h
@@ -26,7 +26,7 @@ class RegexSearchFunction : public mup::ICallback
 public:
 	RegexSearchFunction();
 	void Eval(mup::ptr_val_type& ret, const mup::ptr_val_type* arg, int argc) override;
-	const mup::char_type* GetDesc() const;
+	const mup::char_type* GetDesc() const override;
 	mup::IToken* Clone() const override;
 };
 
@@ -35,6 +35,6 @@ class RegexReplaceFunction : public mup::ICallback
 public:
 	RegexReplaceFunction();
 	void Eval(mup::ptr_val_type& ret, const mup::ptr_val_type* arg, int argc) override;
-	const mup::char_type* GetDesc() const;
+	const mup::char_type* GetDesc() const override;
 	mup::IToken* Clone() const override;
 };

--- a/parser/StringOperators.h
+++ b/parser/StringOperators.h
@@ -26,6 +26,6 @@ class AddOperator : public mup::OprtAdd
 {
 public:
 	void Eval(mup::ptr_val_type& ret, const mup::ptr_val_type* arg, int argc) override;
-	const mup::char_type* GetDesc() const;
+	const mup::char_type* GetDesc() const override;
 	mup::IToken* Clone() const override;
 };


### PR DESCRIPTION
## Summary

The cppcheck job has been accumulating findings as a non-blocking "baseline" since it was added. This PR triages all of them — 277 under the old CI configuration, 289 under the pinned analyzer — fixes what is worth fixing, suppresses what is not, and flips the job into a blocking gate at a baseline of zero.

### Real defects fixed

- `RegistryHelper::getFileAccessForUser` leaked the security descriptor, Authz resource manager, SID and client context on every throwing path. Cleanup now runs through the `SCOPE_EXIT` guards the file already uses elsewhere.
- `AbstractLibrary` misreported ARM64-native VST DLLs as `WRONG_ARCHITECTURE` because the expected machine type only distinguished `_WIN64` from x86. ARM64 builds now expect `IMAGE_FILE_MACHINE_ARM64`.
- `Benchmark` called `log10(0)` for all-silent output and printed `-inf dB`; silence now prints as such.

### Mechanical hardening (identical behavior)

Member variables gained default initializers (~65), string parameters and getters pass/return by const reference (~70 signatures, including all of `RegistryHelper`), const/override/static specifiers added, dead stores removed, `wstring::npos` comparisons spelled out instead of `!= -1`, and locals named after std symbols (`string`, `max`, a lambda named `log`) renamed away from the collisions that confused both readers and the analyzer.

### Rejected with rationale (suppressed in the workflow)

`cstyleCast` and the `shadow*` family (Win32/COM/VST interop casts and inherited upstream naming), `useStlAlgorithm` and `postfixOperator` (house loop style, no behavior impact), `noExplicitConstructor` (intentional single-argument constructors), `LocalAllocCalled` (allocator mandated by the Win32 security APIs). The rationale lives as comments in `build.yml`. Two per-site false positives carry inline suppressions (`DllMain` signature, `FormatMessageW` out-pointer allocation).

### CI gate

The job previously installed cppcheck from apt, so the version — and the finding set — drifted with the runner image, and findings never failed the build. It now builds cppcheck 2.21.0 from the pinned release tag (cached across runs), loads the Qt and Windows library configurations (which removes 30 `unknownMacro` false errors on `Q_DECLARE_METATYPE`/`slots`), and fails on any new finding. The same version and flags reproduce the result locally; CLAUDE.md documents this.

## Validation

- Local cppcheck 2.21.0 with the exact gate flags: 0 findings, exit 0.
- Builds: Common, EqualizerAPO DLL, Benchmark, VoicemeeterClient, HybridConvTests, EditorLogicTests, AudioRegressionTests (MSBuild) plus Editor and DeviceSelector (qmake/nmake), all x64 Release.
- Tests: HybridConvTests 18 suites green, EditorLogicTests 85 checks, AudioRegressionTests 9/9 with maxAbsError=0 (bit-identical engine output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)