### PR TITLE
docs: track the skin program issues and codify the docs upkeep convention

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -91,6 +91,7 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 Equalizer APO 
 - 지원 아키텍처, SIMD 변형, 필요 도구, 의존성 경로, 설치 파일 이름처럼 빌드와 설치에 영향을 주는 이름은 실제 파일명과 맞춥니다.
 - 추측한 내용은 사실처럼 쓰지 않습니다. 확인하지 못한 부분은 확인하지 못했다고 씁니다.
 - 기존 영어 문서를 고칠 때도 문장을 짧게 쓰고, 과장된 홍보 문구보다 정확한 설명을 우선합니다.
+- README와 CHANGELOG는 영어판과 한국어판(README.md/README.ko.md, CHANGELOG.md/CHANGELOG.ko.md) 네 파일을 항상 함께 갱신합니다. 사용자에게 보이는 변경이 main에 들어가면 CHANGELOG의 Unreleased 절에 PR 링크와 함께 기록하고, 릴리스가 만들어지면 Unreleased 절을 해당 버전 절로 옮깁니다. README의 '지금 진행 중인 작업' 목록은 작업이 시작되거나 끝날 때 같은 PR 또는 직후의 docs PR로 갱신합니다.
 
 ## 한국어 응답과 최종사용자 대상 글 기준
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,8 @@ README, 릴리스 노트, 사용자 안내 문서는 사용자가 바로 실행�
 
 기존 영어 문서를 고칠 때도 문장을 짧게 쓰고, 과장된 홍보 문구보다 정확한 설명을 우선합니다.
 
+README와 CHANGELOG는 영어판과 한국어판(README.md/README.ko.md, CHANGELOG.md/CHANGELOG.ko.md) 네 파일을 항상 함께 갱신합니다. 사용자에게 보이는 변경이 main에 들어가면 CHANGELOG의 Unreleased 절에 PR 링크와 함께 기록하고, 릴리스가 만들어지면 Unreleased 절을 해당 버전 절로 옮깁니다. README의 '지금 진행 중인 작업' 목록은 작업이 시작되거나 끝날 때 같은 PR 또는 직후의 docs PR로 갱신합니다.
+
 ---
 
 # 글로벌 응답 스타일

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 
 지금 진행 중인 작업은 다음과 같습니다.
 
-1. 남은 필터 설정 파서를 엔진과 Editor가 함께 쓰는 공용 명령 코덱으로 옮깁니다.
+1. Editor의 5개 스킨 전면 개편을 3단계 프로그램(공용 기반 작업, 스킨별 격리 구현 5건, 심사와 통합)으로 진행합니다. 이슈 [#66](https://github.com/115dkk/EqualizerAPO-XT/issues/66), [#67](https://github.com/115dkk/EqualizerAPO-XT/issues/67), [#68](https://github.com/115dkk/EqualizerAPO-XT/issues/68)에서 추적합니다.
 2. 변형별 릴리스 채널을 단일 바이너리 런타임 SIMD dispatch로 대체합니다([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
 3. 격주 자동 코드 감사가 찾아낸 문제를 처리합니다.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The original fork goals are complete: the convolution tail bug is fixed, the eng
 
 Current work areas:
 
-1. Migrating the remaining filter config parsers to shared command codecs used by both the engine and the Editor.
+1. A five-skin visual overhaul of the Editor, run as a three-phase program (shared groundwork, five isolated skin implementations, judging and integration) — tracked in issues [#66](https://github.com/115dkk/EqualizerAPO-XT/issues/66), [#67](https://github.com/115dkk/EqualizerAPO-XT/issues/67), and [#68](https://github.com/115dkk/EqualizerAPO-XT/issues/68).
 2. Runtime SIMD dispatch in a single binary, replacing the per-variant release channels ([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
 3. Acting on findings from the biweekly automated code audit.
 


### PR DESCRIPTION
## Summary

- The five-skin visual overhaul is now tracked as a three-phase program: #66 (Phase 0, shared groundwork), #67 (Phase 1, five isolated skin implementations — the full brief is attached there as an orchestrator-only comment) and #68 (Phase 2, judging and integration). Each issue is self-contained for a cold session and requires result reports in Korean.
- README.md / README.ko.md list the program as a current work area, replacing the completed codec-migration item (#63 finished it).
- CLAUDE.md and Agent.md now codify the documentation upkeep convention: README and CHANGELOG are maintained in both languages; user-visible changes land in the Unreleased section with PR links; releases move Unreleased under the version heading; the current-work list is updated when work starts or finishes.

Docs-only: the post-merge push will skip the build matrix by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)