### PR TITLE
feat(editor): skin program Phase 0 - interaction fixes, ISkin paint hooks, screenshot gallery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1002,6 +1002,9 @@ jobs:
     # not vary by SIMD variant.
     - name: Run skin gallery (offscreen)
       if: matrix.simd_variant == 'avx2'
+      # A hard step timeout: if the Editor ever blocks on a fatal-error dialog
+      # again, the job must fail in minutes instead of hanging for hours.
+      timeout-minutes: 10
       shell: pwsh
       run: |
         # The import lib embeds the SONAME velopack_libc.dll (see the Package
@@ -1011,6 +1014,14 @@ jobs:
           -Destination "build-Editor-x64\release\velopack_libc.dll" -Force
 
         $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
+        # windeployqt deployed only the qwindows platform plugin next to
+        # Editor.exe, and the deployed Qt6Core.dll in the app dir wins the DLL
+        # search, which limits plugin resolution to the deployed set - the
+        # offscreen plugin then fails to load and Qt parks a fatal-error dialog
+        # forever on the headless runner. Point the platform-plugin search at
+        # the full Qt install instead (verified: without this the gallery
+        # hangs; with it, all 120 PNGs render).
+        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
         $env:QT_QPA_PLATFORM = "offscreen"
         $outDir = "${{ github.workspace }}\skin-gallery"
         # Editor.exe is a GUI-subsystem binary; Start-Process -Wait is the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -996,6 +996,46 @@ jobs:
 
         Write-Host "`nAll Qt applications built successfully!"
 
+    # Offscreen skin gallery: proves the Editor renders every skin headless and
+    # publishes the judging material for the skin program (issues #66-#68).
+    # Primary avx2 variant only: the gallery is QSS/QPainter output and does
+    # not vary by SIMD variant.
+    - name: Run skin gallery (offscreen)
+      if: matrix.simd_variant == 'avx2'
+      shell: pwsh
+      run: |
+        # The import lib embeds the SONAME velopack_libc.dll (see the Package
+        # binaries step); the gallery runs from the build dir, so the renamed
+        # DLL must sit next to Editor.exe here too.
+        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll" `
+          -Destination "build-Editor-x64\release\velopack_libc.dll" -Force
+
+        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
+        $env:QT_QPA_PLATFORM = "offscreen"
+        $outDir = "${{ github.workspace }}\skin-gallery"
+        # Editor.exe is a GUI-subsystem binary; Start-Process -Wait is the
+        # reliable way to collect its exit code from PowerShell.
+        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
+          -ArgumentList @("--skin-gallery", $outDir) -PassThru -Wait -NoNewWindow
+        if ($proc.ExitCode -ne 0) {
+          Write-Error "Skin gallery failed (exit code $($proc.ExitCode))"
+          exit 1
+        }
+        $pngs = @(Get-ChildItem $outDir -Filter *.png)
+        Write-Host "Gallery wrote $($pngs.Count) PNGs"
+        # 5 skins x 2 modes x 4 rows x 3 states
+        if ($pngs.Count -ne 120) {
+          Write-Error "Expected 120 gallery PNGs, got $($pngs.Count)"
+          exit 1
+        }
+
+    - name: Upload skin gallery
+      if: matrix.simd_variant == 'avx2'
+      uses: actions/upload-artifact@v7
+      with:
+        name: skin-gallery
+        path: skin-gallery/*.png
+
     # Package artifacts
     - name: Package binaries
       shell: pwsh

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,21 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- 모던 카드의 Channel 행에서 채널 선택을 카드 안에서 바로 편집할 수 있습니다.
+  장치 채널 칩, ALL 칩, 커스텀/가상 채널 칩과 이름 추가 입력란이 제공되며,
+  원문 편집기나 레거시 대화 상자를 거칠 필요가 없습니다. 같은 선택은 기존
+  대화 상자가 쓰던 것과 바이트 단위로 동일하게 기록됩니다. ([#70])
+- 드롭다운이 너무 작게 그려지던 문제를 고쳤습니다. 모든 스킨이 공용 크기
+  바닥값을 공유하고, 툴바 드롭다운은 시스템 글꼴 크기를 따라가며, 팝업
+  목록은 가장 긴 항목에 맞춰 넓어집니다. ([#70])
+- 5종 스킨 전면 개편(이슈 #66~#68)을 위한 Phase 0 기반 작업이 들어갔습니다.
+  노브 페인팅과 명령 행 chrome이 `ISkin` 훅으로 위임되며(기본 구현은 픽셀
+  단위로 동일함을 검증), 헤드리스 스크린샷 갤러리(`Editor --skin-gallery`)가
+  스킨별 대표 행을 렌더링합니다. CI는 그 이미지를 `skin-gallery` 아티팩트로
+  올립니다. ([#70])
+
 ## v1.17.2 (2026-06-12)
 
 - 쌓여 있던 cppcheck 발견을 전수 분류했습니다. 실제 결함으로는 Include GUI가
@@ -277,3 +292,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#62]: https://github.com/115dkk/EqualizerAPO-XT/pull/62
 [#63]: https://github.com/115dkk/EqualizerAPO-XT/pull/63
 [#64]: https://github.com/115dkk/EqualizerAPO-XT/pull/64
+[#70]: https://github.com/115dkk/EqualizerAPO-XT/pull/70

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- Channel rows on the modern cards now edit their selection in place with
+  checkable chips (device channels, ALL, custom/virtual names, plus a field
+  to add new names) instead of requiring the raw-text editor or the legacy
+  dialog flow. Equivalent selections serialize byte-identically to what the
+  old dialog wrote. ([#70])
+- Dropdowns no longer render undersized: all skins share a readable sizing
+  floor, the toolbar dropdowns follow the system font size, and popup lists
+  widen to their longest entry instead of eliding it. ([#70])
+- Skin program Phase 0 plumbing landed for the five-skin overhaul
+  (issues #66–#68): knob painting and command-row chrome are now delegated
+  through `ISkin` hooks with appearance-preserving defaults (proven
+  pixel-identical), and a headless screenshot gallery
+  (`Editor --skin-gallery`) renders every skin's representative rows; CI
+  uploads the images as the `skin-gallery` artifact. ([#70])
+
 ## v1.17.2 — 2026-06-12
 
 - All accumulated cppcheck findings were triaged. Real defects fixed: a
@@ -288,3 +305,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#62]: https://github.com/115dkk/EqualizerAPO-XT/pull/62
 [#63]: https://github.com/115dkk/EqualizerAPO-XT/pull/63
 [#64]: https://github.com/115dkk/EqualizerAPO-XT/pull/64
+[#70]: https://github.com/115dkk/EqualizerAPO-XT/pull/70

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -182,6 +182,7 @@ SOURCES += main.cpp\
 	skins/Skins.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
+	widgets/SkinComboBox.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \
 	widgets/cards/IncludeCardEditor.cpp \
 	widgets/cards/PreampCardEditor.cpp \
@@ -351,6 +352,7 @@ HEADERS  += \
 	skins/Skins.h \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \
+	widgets/SkinComboBox.h \
 	widgets/cards/FilterCardEditorFactory.h \
 	widgets/cards/IncludeCardEditor.h \
 	widgets/cards/PreampCardEditor.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -176,6 +176,7 @@ SOURCES += main.cpp\
 	../filters/loudnessCorrection/VolumeController.cpp \
 	guis/LoudnessCorrectionFilterGUIDialog.cpp \
 	helpers/QtSndfileHandle.cpp \
+	SkinGallery.cpp \
 	SkinManager.cpp \
 	skins/Skins.cpp \
 	widgets/AudioKnob.cpp \
@@ -341,6 +342,7 @@ HEADERS  += \
 	../filters/loudnessCorrection/VolumeController.h \
 	guis/LoudnessCorrectionFilterGUIDialog.h \
 	helpers/QtSndfileHandle.h \
+	SkinGallery.h \
 	SkinTokens.h \
 	SkinManager.h \
 	skins/ISkin.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -183,6 +183,8 @@ SOURCES += main.cpp\
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
 	widgets/SkinComboBox.cpp \
+	widgets/cards/ChannelCardEditor.cpp \
+	widgets/cards/ChannelSelectionModel.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \
 	widgets/cards/IncludeCardEditor.cpp \
 	widgets/cards/PreampCardEditor.cpp \
@@ -353,6 +355,8 @@ HEADERS  += \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \
 	widgets/SkinComboBox.h \
+	widgets/cards/ChannelCardEditor.h \
+	widgets/cards/ChannelSelectionModel.h \
 	widgets/cards/FilterCardEditorFactory.h \
 	widgets/cards/IncludeCardEditor.h \
 	widgets/cards/PreampCardEditor.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -178,6 +178,7 @@ SOURCES += main.cpp\
 	helpers/QtSndfileHandle.cpp \
 	SkinGallery.cpp \
 	SkinManager.cpp \
+	skins/ISkin.cpp \
 	skins/Skins.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -181,6 +181,7 @@ SOURCES += main.cpp\
 	skins/ISkin.cpp \
 	skins/Skins.cpp \
 	widgets/AudioKnob.cpp \
+	widgets/CommandRowFrame.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \
 	widgets/cards/IncludeCardEditor.cpp \
 	widgets/cards/PreampCardEditor.cpp \
@@ -349,6 +350,7 @@ HEADERS  += \
 	skins/ISkin.h \
 	skins/Skins.h \
 	widgets/AudioKnob.h \
+	widgets/CommandRowFrame.h \
 	widgets/cards/FilterCardEditorFactory.h \
 	widgets/cards/IncludeCardEditor.h \
 	widgets/cards/PreampCardEditor.h \

--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -43,6 +43,7 @@
 #include "helpers/AudioFormatProbe.h"
 #include "Editor/helpers/GUIChannelHelper.h"
 #include "Editor/helpers/GUIHelper.h"
+#include "Editor/widgets/SkinComboBox.h"
 #include "version.h"
 #include "FilterTable.h"
 #include "MainWindow.h"
@@ -122,7 +123,9 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 	deviceLabel->setObjectName(QStringLiteral("ToolBarLabel"));
 	ui->mainToolBar->addWidget(deviceLabel);
 
-	deviceComboBox = new QComboBox;
+	// SkinComboBox enforces a font-aware height floor and widens the popup to
+	// its contents; the toolbar dropdowns were the visibly undersized ones.
+	deviceComboBox = new SkinComboBox;
 	deviceComboBox->setObjectName(QStringLiteral("ToolBarComboBox"));
 	connect(deviceComboBox, QOverload<int>::of(&QComboBox::activated), this, &MainWindow::deviceSelected);
 	ui->mainToolBar->addWidget(deviceComboBox);
@@ -144,7 +147,7 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 	channelLabel->setObjectName(QStringLiteral("ToolBarLabel"));
 	ui->mainToolBar->addWidget(channelLabel);
 
-	channelConfigurationComboBox = new QComboBox;
+	channelConfigurationComboBox = new SkinComboBox;
 	channelConfigurationComboBox->setObjectName(QStringLiteral("ToolBarComboBox"));
 	channelConfigurationComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 	ui->mainToolBar->addWidget(channelConfigurationComboBox);

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -1,0 +1,195 @@
+#include "SkinGallery.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QPixmap>
+#include <QScrollArea>
+#include <QString>
+
+#include "Editor/FilterTable.h"
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+#include "Editor/skins/ISkin.h"
+#include "Editor/skins/Skins.h"
+#include "Editor/widgets/FilterCardRow.h"
+
+namespace
+{
+struct GalleryRow
+{
+	QString name;
+	QString line;
+};
+
+// Representative rows: a parametric filter, a shelf filter (three knobs in
+// the legacy BiQuad GUI hosted by the card body), an Include row and a VST
+// row. The VST library is intentionally unresolvable; the card renders its
+// not-loaded state, which is the chrome the gallery is after.
+QList<GalleryRow> galleryRows()
+{
+	return {
+		{ QStringLiteral("filter"), QStringLiteral("Filter 1: ON PK Fc 1000 Hz Gain 6 dB Q 0.71") },
+		{ QStringLiteral("shelf"), QStringLiteral("Filter 2: ON HSC Fc 8000 Hz Gain -2.5 dB Q 0.71") },
+		{ QStringLiteral("include"), QStringLiteral("Include: example.txt") },
+		{ QStringLiteral("vst"), QStringLiteral("VSTPlugin: Library example.dll") }
+	};
+}
+
+// QSS :hover matches widgets whose Qt::WA_UnderMouse attribute is set, and
+// custom paint code reads the same attribute via underMouse(). Setting it
+// manually lets the offscreen renderer capture the hover look without a real
+// cursor. Pseudo-states are evaluated at paint time, so update() suffices.
+void setHoverEquivalent(QWidget* root, bool on)
+{
+	root->setAttribute(Qt::WA_UnderMouse, on);
+	for (QWidget* child : root->findChildren<QWidget*>())
+		child->setAttribute(Qt::WA_UnderMouse, on);
+	root->update();
+}
+
+bool saveGrab(QWidget* row, const QDir& outDir, const QString& skinId, const QString& mode,
+	const QString& rowName, const QString& state)
+{
+	const QString fileName = QStringLiteral("%1_%2_%3_%4.png").arg(skinId, mode, rowName, state);
+	QPixmap pixmap = row->grab();
+	if (pixmap.isNull())
+	{
+		qWarning("SkinGallery: grab failed for %s", qPrintable(fileName));
+		return false;
+	}
+	if (!pixmap.save(outDir.filePath(fileName), "PNG"))
+	{
+		qWarning("SkinGallery: could not write %s", qPrintable(fileName));
+		return false;
+	}
+	return true;
+}
+
+// Build a fresh FilterTable holding the given lines and return the card row
+// widgets in line order. The table must be built after applySkin so every row
+// is polished once against the active stylesheet, mirroring the real skin
+// switch flow (clearRows + updateGuis).
+QList<FilterCardRow*> buildRows(QScrollArea& scrollArea, const QList<QString>& lines)
+{
+	// Mirror MainWindow's hosting: widgetResizable makes the scroll area drive
+	// the table's width, which FilterCardRow::sizeHint reads back through
+	// getPreferredWidth(). Without it the table never gets a real size and
+	// every row collapses to a few pixels.
+	scrollArea.setWidgetResizable(true);
+	FilterTable* table = new FilterTable(nullptr);
+	scrollArea.setWidget(table);
+	table->updateDeviceAndChannelMask(nullptr, 0);
+	table->initialize(&scrollArea, {}, {});
+	// The config path is synthetic: it only namespaces per-file row prefs in
+	// the registry, and this name can never collide with a real file.
+	table->setLines(QStringLiteral(":skin-gallery:"), lines);
+	table->updateGuis();
+	scrollArea.show();
+	// Flush the posted polish/layout events, then force the grid to assign row
+	// geometry before grabbing.
+	QApplication::processEvents();
+	if (table->layout() != nullptr)
+		table->layout()->activate();
+	QApplication::processEvents();
+	return table->findChildren<FilterCardRow*>(QString(), Qt::FindDirectChildrenOnly);
+}
+
+int renderStates(const QDir& outDir, const QString& skinId, const QString& mode,
+	const QList<GalleryRow>& rows, bool commented)
+{
+	QList<QString> lines;
+	for (const GalleryRow& row : rows)
+		lines.append(commented ? QStringLiteral("# ") + row.line : row.line);
+
+	QScrollArea scrollArea;
+	scrollArea.resize(960, 720);
+	QList<FilterCardRow*> rowWidgets = buildRows(scrollArea, lines);
+	if (rowWidgets.size() != rows.size())
+	{
+		qWarning("SkinGallery: expected %lld rows, got %lld (%s %s)",
+			static_cast<long long>(rows.size()), static_cast<long long>(rowWidgets.size()),
+			qPrintable(skinId), qPrintable(mode));
+		return 1;
+	}
+
+	int failures = 0;
+	for (int i = 0; i < rowWidgets.size(); i++)
+	{
+		FilterCardRow* row = rowWidgets[i];
+		if (commented)
+		{
+			// A commented-out line is the product's real disabled state: power
+			// toggle off, body editor disabled, muted chrome.
+			failures += saveGrab(row, outDir, skinId, mode, rows[i].name, QStringLiteral("disabled")) ? 0 : 1;
+			continue;
+		}
+
+		failures += saveGrab(row, outDir, skinId, mode, rows[i].name, QStringLiteral("normal")) ? 0 : 1;
+		setHoverEquivalent(row, true);
+		failures += saveGrab(row, outDir, skinId, mode, rows[i].name, QStringLiteral("hover")) ? 0 : 1;
+		setHoverEquivalent(row, false);
+	}
+	return failures;
+}
+
+int renderSkin(const QDir& outDir, const QString& skinId, bool dark)
+{
+	SkinManager::instance()->applySkin(skinId, dark);
+	if (SkinManager::instance()->currentSkinId() != skinId)
+	{
+		// Skins::byId silently falls back to studio for unknown ids; a typo in
+		// --skin-gallery-skins must fail loudly instead of producing duplicate
+		// studio shots under a wrong name.
+		qWarning("SkinGallery: unknown skin id '%s'", qPrintable(skinId));
+		return 1;
+	}
+	GUIHelper::applySkinPalette();
+
+	const QString mode = dark ? QStringLiteral("dark") : QStringLiteral("light");
+	int failures = 0;
+	failures += renderStates(outDir, skinId, mode, galleryRows(), false);
+	failures += renderStates(outDir, skinId, mode, galleryRows(), true);
+	return failures;
+}
+}
+
+namespace SkinGallery
+{
+int run(const QStringList& arguments)
+{
+	const int flagIndex = arguments.indexOf(QStringLiteral("--skin-gallery"));
+	if (flagIndex < 0 || flagIndex + 1 >= arguments.size())
+	{
+		qWarning("Usage: Editor --skin-gallery <outDir> [--skin-gallery-skins id,id,...]");
+		return 2;
+	}
+
+	QDir outDir(arguments.at(flagIndex + 1));
+	if (!outDir.mkpath(QStringLiteral(".")))
+	{
+		qWarning("SkinGallery: cannot create output directory %s", qPrintable(outDir.absolutePath()));
+		return 2;
+	}
+
+	QStringList skinIds;
+	const int skinsIndex = arguments.indexOf(QStringLiteral("--skin-gallery-skins"));
+	if (skinsIndex >= 0 && skinsIndex + 1 < arguments.size())
+	{
+		skinIds = arguments.at(skinsIndex + 1).split(QLatin1Char(','), Qt::SkipEmptyParts);
+	}
+	else
+	{
+		for (ISkin* skin : Skins::all())
+			skinIds.append(skin->id());
+	}
+
+	int failures = 0;
+	for (const QString& skinId : skinIds)
+	{
+		failures += renderSkin(outDir, skinId.trimmed(), true);
+		failures += renderSkin(outDir, skinId.trimmed(), false);
+	}
+
+	return failures == 0 ? 0 : 1;
+}
+}

--- a/Editor/SkinGallery.h
+++ b/Editor/SkinGallery.h
@@ -1,0 +1,26 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Offscreen screenshot gallery for the skin program. For each requested skin
+	and dark/light mode it renders representative filter card rows (a simple
+	filter, a shelf filter with its three knobs, an Include row, a VST row) in
+	normal, hover-equivalent and disabled states, and writes deterministic
+	PNGs named <skin>_<dark|light>_<row>_<state>.png to a target directory.
+
+	Runs headless: invoke the Editor with QT_QPA_PLATFORM=offscreen and
+	--skin-gallery <outDir> [--skin-gallery-skins id,id,...]. Used by the skin
+	agents and CI to prove appearance-preserving changes (pixel-identical
+	before/after) and to build judging contact sheets.
+*/
+
+#pragma once
+
+#include <QStringList>
+
+namespace SkinGallery
+{
+// Entry point behind the Editor's --skin-gallery flag. arguments are the full
+// application arguments. Returns a process exit code: 0 when every PNG was
+// written, 1 when rendering failed, 2 on bad usage.
+int run(const QStringList& arguments);
+}

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -106,3 +106,9 @@ IRoutingRenderer* SkinManager::routingRenderer() const
 {
 	return activeSkin != nullptr ? activeSkin->routingRenderer() : nullptr;
 }
+
+void SkinManager::paintKnob(QPainter& painter, const QRect& rect, const KnobState& state) const
+{
+	if (activeSkin != nullptr)
+		activeSkin->paintKnob(painter, rect, state, currentTokens);
+}

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -112,3 +112,25 @@ void SkinManager::paintKnob(QPainter& painter, const QRect& rect, const KnobStat
 	if (activeSkin != nullptr)
 		activeSkin->paintKnob(painter, rect, state, currentTokens);
 }
+
+QString SkinManager::cardFrameStyle(const CommandRowInfo& info) const
+{
+	return activeSkin != nullptr ? activeSkin->cardFrameStyle(info, currentTokens) : QString();
+}
+
+QString SkinManager::cardHeaderStyle(const CommandRowInfo& info) const
+{
+	return activeSkin != nullptr ? activeSkin->cardHeaderStyle(info, currentTokens) : QString();
+}
+
+void SkinManager::prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const
+{
+	if (activeSkin != nullptr)
+		activeSkin->prepareCommandRow(info, card, header, body);
+}
+
+void SkinManager::paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info) const
+{
+	if (activeSkin != nullptr)
+		activeSkin->paintCardChrome(painter, rect, info, currentTokens);
+}

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -7,6 +7,9 @@
 
 class IRoutingRenderer;
 class ISkin;
+class QPainter;
+class QRect;
+struct KnobState;
 
 class SkinManager : public QObject
 {
@@ -25,6 +28,11 @@ public:
 	// graph, ...). Returns nullptr when the skin has no dedicated renderer yet,
 	// in which case the caller falls back to the legacy CopyFilterGUI.
 	IRoutingRenderer* routingRenderer() const;
+
+	// Paint a knob through the active skin (ISkin::paintKnob) with the current
+	// tokens. Called by AudioKnob::paintEvent; the widget keeps all input
+	// handling and hands only the painting to the skin.
+	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state) const;
 
 signals:
 	void skinChanged(const SkinTokens& tokens);

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -9,6 +9,8 @@ class IRoutingRenderer;
 class ISkin;
 class QPainter;
 class QRect;
+class QWidget;
+struct CommandRowInfo;
 struct KnobState;
 
 class SkinManager : public QObject
@@ -33,6 +35,13 @@ public:
 	// tokens. Called by AudioKnob::paintEvent; the widget keeps all input
 	// handling and hands only the painting to the skin.
 	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state) const;
+
+	// Per-command-type row chrome, delegated to the active skin with the
+	// current tokens (see the ISkin hooks for semantics).
+	QString cardFrameStyle(const CommandRowInfo& info) const;
+	QString cardHeaderStyle(const CommandRowInfo& info) const;
+	void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const;
+	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info) const;
 
 signals:
 	void skinChanged(const SkinTokens& tokens);

--- a/Editor/guis/BiQuadFilterGUI.cpp
+++ b/Editor/guis/BiQuadFilterGUI.cpp
@@ -40,6 +40,10 @@ BiQuadFilterGUI::BiQuadFilterGUI(const BiQuadCommand& command)
 	ui->freqDial->setFixedSize(GUIHelper::scale(QSize(100, 66)));
 	ui->gainDial->setFixedSize(GUIHelper::scale(QSize(100, 66)));
 	ui->qDial->setFixedSize(GUIHelper::scale(QSize(100, 66)));
+	// Gain boosts or cuts around 0 dB; frequency and Q are one-directional.
+	// The flag reaches the skin through KnobState so bipolar knobs can read
+	// differently from unipolar ones.
+	ui->gainDial->setBipolar(true);
 
 	ui->typeComboBox->addItem(tr("Peaking filter"), BiQuad::PEAKING);
 	ui->typeComboBox->addItem(tr("Low-pass filter"), BiQuad::LOW_PASS);

--- a/Editor/guis/IncludeFilterGUI.cpp
+++ b/Editor/guis/IncludeFilterGUI.cpp
@@ -20,6 +20,8 @@
 #include <QFileDialog>
 
 #include "helpers/RegistryHelper.h"
+#include "Editor/SkinManager.h"
+#include "Editor/skins/ISkin.h"
 #include "IncludeFilterGUI.h"
 #include "ui_IncludeFilterGUI.h"
 
@@ -29,6 +31,15 @@ IncludeFilterGUI::IncludeFilterGUI(FilterTable* filterTable, const QString& path
 	ui->setupUi(this);
 
 	ui->pathLineEdit->setText(path);
+
+	// Frozen legacy row: it stays functional under every skin, so it consults
+	// the same chrome hook as the card editors (legacyRow marks it for skins
+	// that want to leave the legacy path untouched).
+	CommandRowInfo rowInfo;
+	rowInfo.type = QStringLiteral("include");
+	rowInfo.command = QStringLiteral("include");
+	rowInfo.legacyRow = true;
+	SkinManager::instance()->prepareCommandRow(rowInfo, nullptr, nullptr, this);
 
 	updateFileInfo();
 }

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -30,6 +30,8 @@
 #include "filters/VSTPluginCommand.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "Editor/MainWindow.h"
+#include "Editor/SkinManager.h"
+#include "Editor/skins/ISkin.h"
 #include "VSTPluginFilterGUIDialog.h"
 #include "VSTPluginFilterGUI.h"
 #include "ui_VSTPluginFilterGUI.h"
@@ -59,6 +61,15 @@ VSTPluginFilterGUI::VSTPluginFilterGUI(std::shared_ptr<VSTPluginLibrary> library
 	QMenu* menu = new QMenu(ui->optionsButton);
 	menu->addAction(ui->embedAction);
 	ui->optionsButton->setMenu(menu);
+
+	// Frozen legacy row: it stays functional under every skin, so it consults
+	// the same chrome hook as the card editors (legacyRow marks it for skins
+	// that want to leave the legacy path untouched).
+	CommandRowInfo rowInfo;
+	rowInfo.type = QStringLiteral("vst");
+	rowInfo.command = QStringLiteral("vstplugin");
+	rowInfo.legacyRow = true;
+	SkinManager::instance()->prepareCommandRow(rowInfo, nullptr, nullptr, this);
 }
 
 VSTPluginFilterGUI::~VSTPluginFilterGUI()

--- a/Editor/helpers/GUIHelper.cpp
+++ b/Editor/helpers/GUIHelper.cpp
@@ -23,9 +23,12 @@
 #include <QFont>
 #include <QFontMetrics>
 #include <QPainter>
+#include <QPalette>
 #include <QPixmap>
 #include <QScreen>
 #include <QStyleHints>
+
+#include "Editor/SkinManager.h"
 
 QSize GUIHelper::scale(QSize size)
 {
@@ -94,4 +97,36 @@ QIcon GUIHelper::tintedIcon(const QString& resource, const QColor& color, int si
 	painter.end();
 
 	return QIcon(pixmap);
+}
+
+void GUIHelper::applySkinPalette()
+{
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const bool dark = SkinManager::instance()->isDark();
+	QPalette palette = qApp->palette();
+	QColor background(tokens.background);
+	QColor surface(tokens.surface);
+	QColor card(tokens.card);
+	QColor text(tokens.text);
+	QColor accent(tokens.accent);
+	palette.setColor(QPalette::Window, background);
+	palette.setColor(QPalette::WindowText, text);
+	palette.setColor(QPalette::Base, surface);
+	palette.setColor(QPalette::AlternateBase, card);
+	palette.setColor(QPalette::Text, text);
+	palette.setColor(QPalette::Button, card);
+	palette.setColor(QPalette::ButtonText, text);
+	palette.setColor(QPalette::ToolTipBase, card);
+	palette.setColor(QPalette::ToolTipText, text);
+	palette.setColor(QPalette::Highlight, accent);
+	palette.setColor(QPalette::HighlightedText, dark ? QColor(QStringLiteral("#0c0c16")) : QColor(QStringLiteral("#ffffff")));
+	palette.setColor(QPalette::PlaceholderText, QColor(tokens.mutedText));
+	palette.setColor(QPalette::Light, card.lighter(120));
+	palette.setColor(QPalette::Midlight, card.lighter(105));
+	palette.setColor(QPalette::Mid, surface);
+	palette.setColor(QPalette::Dark, background.darker(120));
+	palette.setColor(QPalette::Shadow, background.darker(160));
+	palette.setColor(QPalette::Link, accent);
+	palette.setColor(QPalette::LinkVisited, accent.darker(110));
+	qApp->setPalette(palette);
 }

--- a/Editor/helpers/GUIHelper.h
+++ b/Editor/helpers/GUIHelper.h
@@ -38,4 +38,9 @@ public:
 	// kept, so the same icon adapts to any dark/light skin without per-theme
 	// duplicate files. size is in logical pixels and is DPI-scaled internally.
 	static QIcon tintedIcon(const QString& resource, const QColor& color, int size = 20);
+	// Derive the application palette from the active skin's tokens and apply
+	// it. Painted (non-QSS) widgets and native popups read these roles, so the
+	// palette must follow the skin. Called at startup and by the offscreen
+	// skin gallery whenever it switches skins.
+	static void applySkinPalette();
 };

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -44,6 +44,7 @@
 
 #include "CustomStyle.h"
 #include "MainWindow.h"
+#include "SkinGallery.h"
 #include "SkinManager.h"
 #include "filters/VSTPluginFilter.h"
 #include "filters/VSTPluginFilterFactory.h"
@@ -406,38 +407,18 @@ int main(int argc, char* argv[])
 		if (application.arguments().contains(QStringLiteral("--selftest-vst")))
 			return runVstRoundTripSelfTest();
 
+		// Headless screenshot gallery (skin program). Runs before the registry
+		// skin/translator setup on purpose: the gallery applies each skin itself
+		// and renders untranslated English strings for deterministic output.
+		if (application.arguments().contains(QStringLiteral("--skin-gallery")))
+			return SkinGallery::run(application.arguments());
+
 		QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
 		{
 			QString skinId = settings.value(QStringLiteral("interface/skin"), QStringLiteral("studio")).toString();
 			bool dark = settings.value(QStringLiteral("interface/dark"), GUIHelper::isDarkMode()).toBool();
 			SkinManager::instance()->applySkin(skinId, dark);
-			const SkinTokens& tokens = SkinManager::instance()->tokens();
-			QPalette palette = application.palette();
-			QColor background(tokens.background);
-			QColor surface(tokens.surface);
-			QColor card(tokens.card);
-			QColor text(tokens.text);
-			QColor accent(tokens.accent);
-			palette.setColor(QPalette::Window, background);
-			palette.setColor(QPalette::WindowText, text);
-			palette.setColor(QPalette::Base, surface);
-			palette.setColor(QPalette::AlternateBase, card);
-			palette.setColor(QPalette::Text, text);
-			palette.setColor(QPalette::Button, card);
-			palette.setColor(QPalette::ButtonText, text);
-			palette.setColor(QPalette::ToolTipBase, card);
-			palette.setColor(QPalette::ToolTipText, text);
-			palette.setColor(QPalette::Highlight, accent);
-			palette.setColor(QPalette::HighlightedText, dark ? QColor(QStringLiteral("#0c0c16")) : QColor(QStringLiteral("#ffffff")));
-			palette.setColor(QPalette::PlaceholderText, QColor(tokens.mutedText));
-			palette.setColor(QPalette::Light, card.lighter(120));
-			palette.setColor(QPalette::Midlight, card.lighter(105));
-			palette.setColor(QPalette::Mid, surface);
-			palette.setColor(QPalette::Dark, background.darker(120));
-			palette.setColor(QPalette::Shadow, background.darker(160));
-			palette.setColor(QPalette::Link, accent);
-			palette.setColor(QPalette::LinkVisited, accent.darker(110));
-			application.setPalette(palette);
+			GUIHelper::applySkinPalette();
 		}
 
 		QVariant languageValue = settings.value("language");

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -1,0 +1,75 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Default knob rendering shared by every skin. The body is the pre-hook
+	AudioKnob::paintEvent moved verbatim behind ISkin::paintKnob, so skins
+	that do not override the hook keep exactly the appearance they had before
+	the hook existed.
+*/
+
+#include "ISkin.h"
+
+#include <QPainter>
+#include <QtMath>
+
+namespace
+{
+QPointF pointOnArc(const QRectF& rect, double degrees)
+{
+	double radians = qDegreesToRadians(degrees);
+	QPointF center = rect.center();
+	double radius = qMin(rect.width(), rect.height()) / 2.0;
+	// Qt measures arc angles counter-clockwise from 3 o'clock, so the matching
+	// screen point subtracts sin for Y (screen Y grows downward). The previous
+	// +sin mirrored the indicator dot vertically, so it never tracked the value
+	// arc and looked like it floated on its own.
+	return QPointF(center.x() + qCos(radians) * radius, center.y() - qSin(radians) * radius);
+}
+}
+
+void ISkin::paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const
+{
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	// Draw inside a centred square so the knob stays circular even when the
+	// hosting widget is not square (promoted legacy dials are 100x66).
+	QRectF inner = QRectF(rect).adjusted(9, 9, -9, -9);
+	double side = qMin(inner.width(), inner.height());
+	QRectF knobRect(inner.center().x() - side / 2.0, inner.center().y() - side / 2.0, side, side);
+	int spanDegrees = 270;
+	int startDegrees = 135;
+	double ratio = state.ratio;
+
+	QPen trackPen(QColor(tokens.border), 6, Qt::SolidLine, Qt::RoundCap);
+	painter.setPen(trackPen);
+	painter.drawArc(knobRect, -startDegrees * 16, -spanDegrees * 16);
+
+	QPen valuePen(QColor(tokens.accent), 6, Qt::SolidLine, Qt::RoundCap);
+	painter.setPen(valuePen);
+	painter.drawArc(knobRect, -startDegrees * 16, -static_cast<int>(spanDegrees * ratio * 16));
+
+	QColor fill(tokens.card);
+	painter.setPen(QPen(QColor(tokens.border), 1));
+	painter.setBrush(fill);
+	painter.drawEllipse(knobRect.adjusted(6, 6, -6, -6));
+
+	double endDegrees = startDegrees + spanDegrees * ratio;
+	QPointF dot = pointOnArc(knobRect.adjusted(3, 3, -3, -3), -endDegrees);
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(QColor(tokens.accent));
+	painter.drawEllipse(dot, 4, 4);
+
+	// Only draw centred text when an explicit value string was supplied (e.g.
+	// the Preamp card). Promoted legacy dials drive a separate spin box for the
+	// real value and map the dial to log-scaled steps, so painting value() here
+	// would show a meaningless step count.
+	if (!state.valueText.isEmpty())
+	{
+		painter.setPen(QColor(tokens.text));
+		QFont valueFont = painter.font();
+		valueFont.setBold(true);
+		valueFont.setPointSizeF(qMax(7.0, valueFont.pointSizeF() - 1.0));
+		painter.setFont(valueFont);
+		painter.drawText(rect, Qt::AlignCenter, state.valueText);
+	}
+}

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -73,3 +73,40 @@ void ISkin::paintKnob(QPainter& painter, const QRect& rect, const KnobState& sta
 		painter.drawText(rect, Qt::AlignCenter, state.valueText);
 	}
 }
+
+// The two style defaults are the strings FilterCardRow::refreshStateProperties
+// computed before the hook existed, moved verbatim, so every skin keeps its
+// previous card chrome until it overrides them.
+QString ISkin::cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const
+{
+	const QString borderColor = info.focused ? tokens.focusRing : (info.selected ? tokens.accent : tokens.border);
+	const QString backgroundColor = info.selected ? tokens.cardSelected : tokens.card;
+	// Signal Matrix uses a coloured rail on the left edge to suggest routing.
+	// All other skins keep a uniform 1px border.
+	return tokens.cardRailWidth > 0
+		? QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-left: %3px solid %4; border-radius: %5px; }")
+		.arg(backgroundColor, borderColor)
+		.arg(tokens.cardRailWidth)
+		.arg(tokens.accent)
+		.arg(tokens.borderRadius)
+		: QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: %3px; }")
+		.arg(backgroundColor, borderColor)
+		.arg(tokens.borderRadius);
+}
+
+QString ISkin::cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tokens) const
+{
+	return QStringLiteral("QWidget#FilterCardHeader { background: %1; border-top-left-radius: %2px; border-top-right-radius: %2px; }")
+		.arg(info.selected ? tokens.surfaceRaised : tokens.cardHover)
+		.arg(tokens.borderRadius);
+}
+
+void ISkin::prepareCommandRow(const CommandRowInfo&, QWidget*, QWidget*, QWidget*) const
+{
+	// Neutral default: rows keep their stock construction.
+}
+
+void ISkin::paintCardChrome(QPainter&, const QRect&, const CommandRowInfo&, const SkinTokens&) const
+{
+	// Neutral default: no painted decoration on top of the QSS chrome.
+}

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -11,11 +11,34 @@
 
 #pragma once
 
+#include <QRect>
 #include <QString>
 
 #include "Editor/SkinTokens.h"
 
 class IRoutingRenderer;
+class QPainter;
+
+// Snapshot of an AudioKnob's state handed to ISkin::paintKnob. The widget owns
+// all input handling; the skin only paints.
+struct KnobState
+{
+	int value = 0;
+	int minimum = 0;
+	int maximum = 0;
+	// value mapped onto 0..1 (0 when the range is empty).
+	double ratio = 0.0;
+	// Gain-style knob: neutral at the range centre (12 o'clock). Skins should
+	// render bipolar and unipolar knobs distinguishably.
+	bool bipolar = false;
+	// Centred text when non-empty (e.g. "3.2 dB"). Empty for promoted legacy
+	// dials, which show their value in a separate spin box.
+	QString valueText;
+	bool enabled = true;
+	bool hovered = false;
+	bool dragging = false;
+	bool focused = false;
+};
 
 class ISkin
 {
@@ -34,4 +57,12 @@ public:
 	// The Copy routing renderer that matches this skin's philosophy. May be
 	// nullptr, in which case the caller falls back to the legacy CopyFilterGUI.
 	virtual IRoutingRenderer* routingRenderer() const = 0;
+
+	// Paint a knob into rect. AudioKnob keeps all input handling (rotary drag,
+	// wheel, keyboard) and delegates only the painting here. The default
+	// implementation (ISkin.cpp) reproduces the shared arc-knob rendering
+	// pixel-identically; it deliberately ignores the hover/drag/focus state
+	// flags so that adding the hook changed nothing visually. Skins override
+	// this to give knobs their own philosophy.
+	virtual void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const;
 };

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -18,6 +18,24 @@
 
 class IRoutingRenderer;
 class QPainter;
+class QWidget;
+
+// Identifies a command row for per-command-type chrome decisions.
+struct CommandRowInfo
+{
+	// FilterCardModel descriptor type ("biquad", "include", "vst", "copy", ...).
+	QString type;
+	// Lower-cased command token ("filter 1", "include", "vstplugin", ...);
+	// matches the "filterKind" dynamic property the card row already sets.
+	QString command;
+	// True when the consulting widget belongs to the frozen legacy row path
+	// (FilterTableRow and the .ui-based filter GUIs it hosts).
+	bool legacyRow = false;
+	bool enabled = true;
+	bool selected = false;
+	bool focused = false;
+	int depth = 0;
+};
 
 // Snapshot of an AudioKnob's state handed to ISkin::paintKnob. The widget owns
 // all input handling; the skin only paints.
@@ -65,4 +83,27 @@ public:
 	// flags so that adding the hook changed nothing visually. Skins override
 	// this to give knobs their own philosophy.
 	virtual void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const;
+
+	// Inline stylesheet for the modern card's frame (QFrame#FilterCardRow),
+	// re-evaluated whenever the row's state changes. The default reproduces
+	// the shared token-driven chrome (uniform 1px border, plus the accent rail
+	// when tokens.cardRailWidth > 0). Skins override to give command types
+	// their own frame treatment.
+	virtual QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const;
+
+	// Inline stylesheet for the card's header strip (QWidget#FilterCardHeader).
+	virtual QString cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tokens) const;
+
+	// Called once when a command row or a command body editor is built, so a
+	// skin can tag widgets with dynamic properties or attach extra chrome.
+	// For modern card rows card/header/body are the frame, header strip and
+	// body stack; for body editors that consult the hook themselves (the
+	// Include/VST card editors and the legacy Include/VST rows) only body is
+	// set. Default: no-op.
+	virtual void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const;
+
+	// Painted decoration over the card frame's QSS background (rails, screws,
+	// per-type markers). Runs after the frame's stylesheet background and
+	// before child widgets paint. Default: no-op.
+	virtual void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens) const;
 };

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -244,7 +244,7 @@ QComboBox {
     border: 1px solid @BORDER@;
     border-radius: 10px;
     padding: 4px 28px 4px 10px;
-    min-height: 22px;
+    min-height: 28px;
 }
 QComboBox:hover {
     border-color: rgba(59, 130, 246, 0.45);
@@ -286,7 +286,7 @@ QComboBox QAbstractItemView {
 QComboBox QAbstractItemView::item {
     padding: 6px 10px;
     border-radius: 8px;
-    min-height: 22px;
+    min-height: 24px;
 }
 QComboBox QAbstractItemView::item:selected {
     background: rgba(59, 130, 246, 0.28);

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -192,7 +192,7 @@ QComboBox {
     border: 1px solid @BORDER@;
     border-radius: 10px;
     padding: 4px 28px 4px 10px;
-    min-height: 22px;
+    min-height: 28px;
 }
 QComboBox:hover { border-color: rgba(59, 130, 246, 0.5); background: @CARD_HOVER@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
@@ -215,7 +215,7 @@ QComboBox QAbstractItemView {
     selection-background-color: rgba(59, 130, 246, 0.18);
     selection-color: @TEXT@;
 }
-QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 22px; }
+QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 24px; }
 QComboBox QAbstractItemView::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -105,7 +105,7 @@ QAbstractSpinBox::down-arrow {
 QComboBox {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 0;
-    padding: 4px 28px 4px 10px; min-height: 22px;
+    padding: 4px 28px 4px 10px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
@@ -122,7 +122,7 @@ QComboBox QAbstractItemView {
     padding: 2px; outline: 0;
     selection-background-color: @CARD_HOVER@; selection-color: #ffffff;
 }
-QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 0; min-height: 22px; }
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 0; min-height: 24px; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
 QCheckBox:disabled, QRadioButton:disabled { color: #555555; }

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -83,7 +83,7 @@ QAbstractSpinBox::down-arrow {
 QComboBox {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 0;
-    padding: 4px 28px 4px 10px; min-height: 22px;
+    padding: 4px 28px 4px 10px; min-height: 28px;
 }
 QComboBox:hover { background: @BG@; border-color: @ACCENT@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
@@ -100,7 +100,7 @@ QComboBox QAbstractItemView {
     padding: 2px; outline: 0;
     selection-background-color: #e0e0e0; selection-color: #000000;
 }
-QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 0; min-height: 22px; }
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 0; min-height: 24px; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
 QCheckBox:disabled, QRadioButton:disabled { color: #999999; }

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -87,7 +87,7 @@ QAbstractSpinBox::down-arrow {
 QComboBox {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 2px;
-    padding: 3px 28px 3px 10px; min-height: 22px;
+    padding: 3px 28px 3px 10px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
@@ -104,7 +104,7 @@ QComboBox QAbstractItemView {
     padding: 2px; outline: 0;
     selection-background-color: @CARD_HOVER@; selection-color: #ffffff;
 }
-QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 22px; }
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 24px; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
 QCheckBox:disabled, QRadioButton:disabled { color: #404054; }

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -83,7 +83,7 @@ QAbstractSpinBox::down-arrow {
 QComboBox {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 2px;
-    padding: 3px 28px 3px 10px; min-height: 22px;
+    padding: 3px 28px 3px 10px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
@@ -100,7 +100,7 @@ QComboBox QAbstractItemView {
     padding: 2px; outline: 0;
     selection-background-color: @SURFACE@; selection-color: #000000;
 }
-QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 22px; }
+QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 24px; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
 QCheckBox:disabled, QRadioButton:disabled { color: #9090a0; }

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -82,7 +82,7 @@ QAbstractSpinBox::down-arrow {
 QComboBox {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 12px;
-    padding: 6px 30px 6px 14px; min-height: 24px;
+    padding: 6px 30px 6px 14px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -82,7 +82,7 @@ QAbstractSpinBox::down-arrow {
 QComboBox {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 12px;
-    padding: 6px 30px 6px 14px; min-height: 24px;
+    padding: 6px 30px 6px 14px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -244,7 +244,7 @@ QComboBox {
     border: 1px solid @BORDER@;
     border-radius: 10px;
     padding: 4px 28px 4px 10px;
-    min-height: 22px;
+    min-height: 28px;
 }
 QComboBox:hover {
     border-color: rgba(59, 130, 246, 0.45);
@@ -286,7 +286,7 @@ QComboBox QAbstractItemView {
 QComboBox QAbstractItemView::item {
     padding: 6px 10px;
     border-radius: 8px;
-    min-height: 22px;
+    min-height: 24px;
 }
 QComboBox QAbstractItemView::item:selected {
     background: rgba(59, 130, 246, 0.28);

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -192,7 +192,7 @@ QComboBox {
     border: 1px solid @BORDER@;
     border-radius: 10px;
     padding: 4px 28px 4px 10px;
-    min-height: 22px;
+    min-height: 28px;
 }
 QComboBox:hover { border-color: rgba(59, 130, 246, 0.5); background: @CARD_HOVER@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
@@ -215,7 +215,7 @@ QComboBox QAbstractItemView {
     selection-background-color: rgba(59, 130, 246, 0.18);
     selection-color: @TEXT@;
 }
-QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 22px; }
+QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 24px; }
 QComboBox QAbstractItemView::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }

--- a/Editor/widgets/AudioKnob.cpp
+++ b/Editor/widgets/AudioKnob.cpp
@@ -5,6 +5,7 @@
 #include <QPainter>
 
 #include "Editor/SkinManager.h"
+#include "Editor/skins/ISkin.h"
 
 AudioKnob::AudioKnob(QWidget* parent)
 	: QDial(parent)
@@ -24,70 +25,38 @@ void AudioKnob::setValueText(const QString& valueText)
 	update();
 }
 
+void AudioKnob::setBipolar(bool value)
+{
+	bipolar = value;
+	update();
+}
+
 QSize AudioKnob::sizeHint() const
 {
 	return QSize(74, 74);
 }
 
-QPointF AudioKnob::pointOnArc(const QRectF& rect, double degrees) const
-{
-	double radians = qDegreesToRadians(degrees);
-	QPointF center = rect.center();
-	double radius = qMin(rect.width(), rect.height()) / 2.0;
-	// Qt measures arc angles counter-clockwise from 3 o'clock, so the matching
-	// screen point subtracts sin for Y (screen Y grows downward). The previous
-	// +sin mirrored the indicator dot vertically, so it never tracked the value
-	// arc and looked like it floated on its own.
-	return QPointF(center.x() + qCos(radians) * radius, center.y() - qSin(radians) * radius);
-}
-
 void AudioKnob::paintEvent(QPaintEvent*)
 {
+	// The widget owns all input handling; painting is delegated to the active
+	// skin (ISkin::paintKnob) so each skin can render knobs with its own
+	// philosophy. The default implementation reproduces the previous rendering
+	// exactly.
 	QPainter painter(this);
-	painter.setRenderHint(QPainter::Antialiasing);
 
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
-	// Draw inside a centred square so the knob stays circular even when the
-	// hosting widget is not square (promoted legacy dials are 100x66).
-	QRectF inner = rect().adjusted(9, 9, -9, -9);
-	double side = qMin(inner.width(), inner.height());
-	QRectF knobRect(inner.center().x() - side / 2.0, inner.center().y() - side / 2.0, side, side);
-	int spanDegrees = 270;
-	int startDegrees = 135;
-	double ratio = maximum() == minimum() ? 0.0 : (value() - minimum()) / static_cast<double>(maximum() - minimum());
+	KnobState state;
+	state.value = value();
+	state.minimum = minimum();
+	state.maximum = maximum();
+	state.ratio = maximum() == minimum() ? 0.0 : (value() - minimum()) / static_cast<double>(maximum() - minimum());
+	state.bipolar = bipolar;
+	state.valueText = text;
+	state.enabled = isEnabled();
+	state.hovered = underMouse();
+	state.dragging = isSliderDown();
+	state.focused = hasFocus();
 
-	QPen trackPen(QColor(tokens.border), 6, Qt::SolidLine, Qt::RoundCap);
-	painter.setPen(trackPen);
-	painter.drawArc(knobRect, -startDegrees * 16, -spanDegrees * 16);
-
-	QPen valuePen(QColor(tokens.accent), 6, Qt::SolidLine, Qt::RoundCap);
-	painter.setPen(valuePen);
-	painter.drawArc(knobRect, -startDegrees * 16, -static_cast<int>(spanDegrees * ratio * 16));
-
-	QColor fill(tokens.card);
-	painter.setPen(QPen(QColor(tokens.border), 1));
-	painter.setBrush(fill);
-	painter.drawEllipse(knobRect.adjusted(6, 6, -6, -6));
-
-	double endDegrees = startDegrees + spanDegrees * ratio;
-	QPointF dot = pointOnArc(knobRect.adjusted(3, 3, -3, -3), -endDegrees);
-	painter.setPen(Qt::NoPen);
-	painter.setBrush(QColor(tokens.accent));
-	painter.drawEllipse(dot, 4, 4);
-
-	// Only draw centred text when an explicit value string was supplied (e.g.
-	// the Preamp card). Promoted legacy dials drive a separate spin box for the
-	// real value and map the dial to log-scaled steps, so painting value() here
-	// would show a meaningless step count.
-	if (!text.isEmpty())
-	{
-		painter.setPen(QColor(tokens.text));
-		QFont valueFont = font();
-		valueFont.setBold(true);
-		valueFont.setPointSizeF(qMax(7.0, valueFont.pointSizeF() - 1.0));
-		painter.setFont(valueFont);
-		painter.drawText(rect(), Qt::AlignCenter, text);
-	}
+	SkinManager::instance()->paintKnob(painter, rect(), state);
 }
 
 void AudioKnob::setValueFromAngle(const QPointF& widgetPos)

--- a/Editor/widgets/AudioKnob.h
+++ b/Editor/widgets/AudioKnob.h
@@ -10,6 +10,10 @@ public:
 	explicit AudioKnob(QWidget* parent = nullptr);
 
 	void setValueText(const QString& text);
+	// Mark this knob as bipolar (gain-style, neutral at the range centre).
+	// Purely descriptive: it is forwarded to the skin through KnobState so
+	// skins can render bipolar and unipolar knobs differently.
+	void setBipolar(bool value);
 	QSize sizeHint() const override;
 
 protected:
@@ -19,8 +23,8 @@ protected:
 	void mouseReleaseEvent(QMouseEvent* event) override;
 
 private:
-	QPointF pointOnArc(const QRectF& rect, double degrees) const;
 	void setValueFromAngle(const QPointF& widgetPos);
 
 	QString text;
+	bool bipolar = false;
 };

--- a/Editor/widgets/CommandRowFrame.cpp
+++ b/Editor/widgets/CommandRowFrame.cpp
@@ -1,0 +1,31 @@
+#include "CommandRowFrame.h"
+
+#include <QPainter>
+
+#include "Editor/SkinManager.h"
+
+CommandRowFrame::CommandRowFrame(QWidget* parent)
+	: QFrame(parent)
+{
+}
+
+void CommandRowFrame::setRowInfo(const CommandRowInfo& rowInfo)
+{
+	info = rowInfo;
+}
+
+const CommandRowInfo& CommandRowFrame::rowInfo() const
+{
+	return info;
+}
+
+void CommandRowFrame::paintEvent(QPaintEvent* event)
+{
+	// QFrame::paintEvent renders the stylesheet background/border exactly as
+	// the plain QFrame did before this subclass existed; the skin hook then
+	// draws on top (no-op in the neutral default).
+	QFrame::paintEvent(event);
+
+	QPainter painter(this);
+	SkinManager::instance()->paintCardChrome(painter, rect(), info);
+}

--- a/Editor/widgets/CommandRowFrame.h
+++ b/Editor/widgets/CommandRowFrame.h
@@ -1,0 +1,31 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Card frame for a command row. Paints its QSS chrome exactly like a plain
+	QFrame and then lets the active skin paint per-command-type decoration on
+	top (ISkin::paintCardChrome). The owning row keeps the embedded
+	CommandRowInfo up to date as selection/enabled state changes.
+*/
+
+#pragma once
+
+#include <QFrame>
+
+#include "Editor/skins/ISkin.h"
+
+class CommandRowFrame : public QFrame
+{
+	Q_OBJECT
+
+public:
+	explicit CommandRowFrame(QWidget* parent = nullptr);
+
+	void setRowInfo(const CommandRowInfo& info);
+	const CommandRowInfo& rowInfo() const;
+
+protected:
+	void paintEvent(QPaintEvent* event) override;
+
+private:
+	CommandRowInfo info;
+};

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -30,7 +30,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	// and force every cell in FilterTable's grid to that width.
 	outerLayout->setSizeConstraint(QLayout::SetNoConstraint);
 
-	cardFrame = new QFrame(this);
+	cardFrame = new CommandRowFrame(this);
 	cardFrame->setObjectName(QStringLiteral("FilterCardRow"));
 	cardFrame->setAttribute(Qt::WA_StyledBackground, true);
 	cardFrame->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
@@ -270,7 +270,23 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 		refreshStateProperties();
 		update();
 	});
+	// Per-command-type chrome hook: rows are recreated on every skin switch
+	// (FilterTable::updateGuis), so construction time is the right moment for
+	// the active skin to tag or extend this row.
+	SkinManager::instance()->prepareCommandRow(currentRowInfo(), cardFrame, headerWidget, bodyStack);
 	rebuildSummary();
+}
+
+CommandRowInfo FilterCardRow::currentRowInfo() const
+{
+	CommandRowInfo info;
+	info.type = descriptor.type;
+	info.command = descriptor.command.toLower();
+	info.enabled = descriptor.enabled;
+	info.selected = table != nullptr && table->getSelectedItems().contains(item);
+	info.focused = table != nullptr && table->getFocusedItem() == item;
+	info.depth = descriptor.depth;
+	return info;
 }
 
 QRect FilterCardRow::getHeaderRect() const
@@ -584,8 +600,8 @@ void FilterCardRow::refreshStateProperties()
 	if (cardFrame == nullptr)
 		return;
 
-	const bool selected = table != nullptr && table->getSelectedItems().contains(item);
-	const bool focused = table != nullptr && table->getFocusedItem() == item;
+	const CommandRowInfo info = currentRowInfo();
+	cardFrame->setRowInfo(info);
 
 	// "enabled" is a real QWidget property, so setting it on cardFrame /
 	// headerWidget was equivalent to calling setEnabled(false) on the whole
@@ -594,11 +610,11 @@ void FilterCardRow::refreshStateProperties()
 	// controls...) so a disabled row could not be re-enabled or even inspected.
 	// Use a dedicated dynamic property name for the styling hook instead.
 	const QList<QPair<const char*, QVariant>> properties = {
-		{ "filterKind", descriptor.command.toLower() },
-		{ "filterEnabled", descriptor.enabled },
-		{ "selected", selected },
-		{ "focused", focused },
-		{ "scopeDepth", descriptor.depth }
+		{ "filterKind", info.command },
+		{ "filterEnabled", info.enabled },
+		{ "selected", info.selected },
+		{ "focused", info.focused },
+		{ "scopeDepth", info.depth }
 	};
 
 	bool changed = false;
@@ -612,23 +628,11 @@ void FilterCardRow::refreshStateProperties()
 		}
 	}
 
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
-	const QString borderColor = focused ? tokens.focusRing : (selected ? tokens.accent : tokens.border);
-	const QString backgroundColor = selected ? tokens.cardSelected : tokens.card;
-	// Signal Matrix uses a coloured rail on the left edge to suggest routing.
-	// All other skins keep a uniform 1px border.
-	const QString frameStyle = tokens.cardRailWidth > 0
-		? QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-left: %3px solid %4; border-radius: %5px; }")
-			.arg(backgroundColor, borderColor)
-			.arg(tokens.cardRailWidth)
-			.arg(tokens.accent)
-			.arg(tokens.borderRadius)
-		: QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: %3px; }")
-			.arg(backgroundColor, borderColor)
-			.arg(tokens.borderRadius);
-	const QString headerStyle = QStringLiteral("QWidget#FilterCardHeader { background: %1; border-top-left-radius: %2px; border-top-right-radius: %2px; }")
-		.arg(selected ? tokens.surfaceRaised : tokens.cardHover)
-		.arg(tokens.borderRadius);
+	// The frame/header chrome is owned by the active skin so each skin can
+	// treat command types differently; the default reproduces the previous
+	// shared token-driven strings (see ISkin::cardFrameStyle).
+	const QString frameStyle = SkinManager::instance()->cardFrameStyle(info);
+	const QString headerStyle = SkinManager::instance()->cardHeaderStyle(info);
 	if (cardFrame->styleSheet() != frameStyle)
 	{
 		cardFrame->setStyleSheet(frameStyle);

--- a/Editor/widgets/FilterCardRow.h
+++ b/Editor/widgets/FilterCardRow.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 
 #include "Editor/FilterTable.h"
+#include "Editor/widgets/CommandRowFrame.h"
 #include "Editor/widgets/FilterCardModel.h"
 
 class RoutingView;
@@ -43,6 +44,7 @@ private:
 	void setEditing(bool editing);
 	void buildChannelBadges(const QStringList& channels);
 	void refreshStateProperties();
+	CommandRowInfo currentRowInfo() const;
 	QString uncommentedLine() const;
 
 	FilterTable* table = nullptr;
@@ -50,7 +52,7 @@ private:
 	IFilterGUI* gui = nullptr;
 	FilterCardDescriptor descriptor;
 
-	QFrame* cardFrame = nullptr;
+	CommandRowFrame* cardFrame = nullptr;
 	QWidget* headerWidget = nullptr;
 	QLabel* numberLabel = nullptr;
 	QLabel* typeBadge = nullptr;

--- a/Editor/widgets/SkinComboBox.cpp
+++ b/Editor/widgets/SkinComboBox.cpp
@@ -1,0 +1,48 @@
+#include "SkinComboBox.h"
+
+#include <QAbstractItemView>
+#include <QFontMetrics>
+
+namespace
+{
+// Logical px scale with Qt's device pixel ratio, so the constant part is
+// DPI-aware by itself; the font term keeps the floor honest when the user
+// runs a larger system font.
+int heightFloor(const QFontMetrics& metrics)
+{
+	return qMax(28, metrics.height() + 12);
+}
+}
+
+SkinComboBox::SkinComboBox(QWidget* parent)
+	: QComboBox(parent)
+{
+}
+
+QSize SkinComboBox::sizeHint() const
+{
+	QSize size = QComboBox::sizeHint();
+	size.setHeight(qMax(size.height(), heightFloor(fontMetrics())));
+	return size;
+}
+
+QSize SkinComboBox::minimumSizeHint() const
+{
+	QSize size = QComboBox::minimumSizeHint();
+	size.setHeight(qMax(size.height(), heightFloor(fontMetrics())));
+	return size;
+}
+
+void SkinComboBox::showPopup()
+{
+	// Make the popup at least as wide as its longest item so entries are not
+	// elided to the closed control's width. The extra padding covers the QSS
+	// item padding plus a vertical scrollbar.
+	const QFontMetrics metrics(font());
+	int widest = 0;
+	for (int i = 0; i < count(); i++)
+		widest = qMax(widest, metrics.horizontalAdvance(itemText(i)));
+	view()->setMinimumWidth(qMax(width(), widest + 40));
+
+	QComboBox::showPopup();
+}

--- a/Editor/widgets/SkinComboBox.h
+++ b/Editor/widgets/SkinComboBox.h
@@ -1,0 +1,27 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	QComboBox with a DPI-aware sizing floor and a popup sized to its
+	contents. The skins' QSS keeps a px floor for every combo box, but that
+	floor cannot follow the user's font size; this subclass derives the
+	control height from the font metrics, and widens the popup so long items
+	(device names, channel configurations) are not elided to the closed
+	control's width. Used by the toolbar dropdowns; promote a QComboBox to
+	this class wherever the same floor is wanted.
+*/
+
+#pragma once
+
+#include <QComboBox>
+
+class SkinComboBox : public QComboBox
+{
+	Q_OBJECT
+
+public:
+	explicit SkinComboBox(QWidget* parent = nullptr);
+
+	QSize sizeHint() const override;
+	QSize minimumSizeHint() const override;
+	void showPopup() override;
+};

--- a/Editor/widgets/cards/ChannelCardEditor.cpp
+++ b/Editor/widgets/cards/ChannelCardEditor.cpp
@@ -1,0 +1,132 @@
+#include "ChannelCardEditor.h"
+
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QToolButton>
+
+ChannelCardEditor::ChannelCardEditor(const QString& parameters, QWidget* parent)
+	: IFilterGUI(parent), parameters(parameters)
+{
+	setObjectName(QStringLiteral("ChannelCardEditor"));
+	setAttribute(Qt::WA_StyledBackground, true);
+
+	QHBoxLayout* layout = new QHBoxLayout(this);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->setSpacing(6);
+
+	allChip = new QToolButton(this);
+	allChip->setObjectName(QStringLiteral("ChannelChip"));
+	allChip->setText(QStringLiteral("ALL"));
+	allChip->setCheckable(true);
+	allChip->setToolTip(tr("Select every channel"));
+	connect(allChip, SIGNAL(toggled(bool)), this, SLOT(allToggled(bool)));
+	layout->addWidget(allChip);
+
+	chipLayout = new QHBoxLayout();
+	chipLayout->setContentsMargins(0, 0, 0, 0);
+	chipLayout->setSpacing(6);
+	layout->addLayout(chipLayout);
+
+	customEdit = new QLineEdit(this);
+	customEdit->setObjectName(QStringLiteral("ChannelChipAdd"));
+	customEdit->setPlaceholderText(tr("Add channel"));
+	customEdit->setToolTip(tr("Add a custom or virtual channel name (e.g. VSL)"));
+	customEdit->setMaximumWidth(110);
+	connect(customEdit, SIGNAL(returnPressed()), this, SLOT(customEntered()));
+	layout->addWidget(customEdit);
+
+	layout->addStretch(1);
+
+	model.load(parameters, deviceChannels);
+	reloadChips();
+}
+
+void ChannelCardEditor::store(QString& command, QString& storedParameters)
+{
+	command = QStringLiteral("Channel");
+	storedParameters = model.serialize();
+}
+
+void ChannelCardEditor::configureChannels(std::vector<std::wstring>& channelNames)
+{
+	deviceChannels = channelNames;
+	// Re-seed the chips with the device's channel set, keeping the current
+	// selection (parameters tracks the latest edit).
+	model.load(parameters, deviceChannels);
+	reloadChips();
+}
+
+void ChannelCardEditor::allToggled(bool checked)
+{
+	if (updating)
+		return;
+
+	model.setAllSelected(checked);
+	// ALL wins over individual selections, exactly like the legacy dialog;
+	// individual chips stay visible but inert while it is checked. Only the
+	// enabled states change here - rebuilding the chip row inside a chip's
+	// own toggled signal would delete the emitting button.
+	for (int i = 0; i < chipLayout->count(); i++)
+	{
+		if (QWidget* chip = chipLayout->itemAt(i)->widget())
+			chip->setEnabled(!checked);
+	}
+	customEdit->setEnabled(!checked);
+	commitSelection();
+}
+
+void ChannelCardEditor::customEntered()
+{
+	if (!model.addCustom(customEdit->text()))
+		return;
+
+	customEdit->clear();
+	// Safe to rebuild: the sender is the line edit, not one of the chips.
+	reloadChips();
+	commitSelection();
+}
+
+void ChannelCardEditor::reloadChips()
+{
+	updating = true;
+
+	while (QLayoutItem* child = chipLayout->takeAt(0))
+	{
+		delete child->widget();
+		delete child;
+	}
+
+	const bool all = model.allSelected();
+	allChip->setChecked(all);
+
+	for (const ChannelChip& chip : model.chips())
+	{
+		QToolButton* button = new QToolButton(this);
+		button->setObjectName(QStringLiteral("ChannelChip"));
+		button->setText(chip.name);
+		button->setCheckable(true);
+		button->setChecked(chip.selected);
+		// Custom/virtual channels are stylable separately (the channel badges
+		// use a dashed outline for them; skins may do the same here).
+		button->setProperty("customChannel", !chip.fromDevice);
+		button->setEnabled(!all);
+		const QString name = chip.name;
+		connect(button, &QToolButton::toggled, this, [this, name](bool) {
+			if (updating)
+				return;
+			model.toggle(name);
+			commitSelection();
+		});
+		chipLayout->addWidget(button);
+	}
+
+	customEdit->setEnabled(!all);
+
+	updating = false;
+}
+
+void ChannelCardEditor::commitSelection()
+{
+	parameters = model.serialize();
+	emit updateModel();
+}

--- a/Editor/widgets/cards/ChannelCardEditor.h
+++ b/Editor/widgets/cards/ChannelCardEditor.h
@@ -1,0 +1,52 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	In-place channel multi-select for "Channel:" card rows. Replaces the
+	change-button-plus-dialog flow with checkable chips directly in the card
+	body: one chip per device channel, an ALL chip, chips for custom/virtual
+	channels named in the line, and a small field to add new custom names.
+	Selection state and serialization live in ChannelSelectionModel; the
+	written line goes through ChannelCommand and stays byte-identical with
+	what the legacy dialog produced for equivalent selections.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "Editor/IFilterGUI.h"
+#include "ChannelSelectionModel.h"
+
+class QHBoxLayout;
+class QLineEdit;
+class QToolButton;
+
+class ChannelCardEditor : public IFilterGUI
+{
+	Q_OBJECT
+
+public:
+	explicit ChannelCardEditor(const QString& parameters, QWidget* parent = nullptr);
+
+	void store(QString& command, QString& parameters) override;
+	void configureChannels(std::vector<std::wstring>& channelNames) override;
+
+private slots:
+	void allToggled(bool checked);
+	void customEntered();
+
+private:
+	void reloadChips();
+	void commitSelection();
+
+	ChannelSelectionModel model;
+	// Current parameter text: the line's original parameters until the first
+	// edit, the model's canonical serialization afterwards.
+	QString parameters;
+	std::vector<std::wstring> deviceChannels;
+	QToolButton* allChip = nullptr;
+	QHBoxLayout* chipLayout = nullptr;
+	QLineEdit* customEdit = nullptr;
+	bool updating = false;
+};

--- a/Editor/widgets/cards/ChannelSelectionModel.cpp
+++ b/Editor/widgets/cards/ChannelSelectionModel.cpp
@@ -1,0 +1,209 @@
+#include "ChannelSelectionModel.h"
+
+#include "filters/ChannelCommand.h"
+
+namespace
+{
+// The legacy multi-select dialog (ChannelFilterGUIDialog) wrote the standard
+// positions in its fixed checkbox order, then the device's non-standard
+// channels, then custom names. Serializing in the same order keeps the
+// written line byte-identical with what the old flow produced for the same
+// selection.
+const QString kStandardOrder[] = {
+	QStringLiteral("C"), QStringLiteral("L"), QStringLiteral("R"),
+	QStringLiteral("SL"), QStringLiteral("SR"), QStringLiteral("RL"),
+	QStringLiteral("RR"), QStringLiteral("RC"), QStringLiteral("LFE")
+};
+
+bool isStandardName(const QString& name)
+{
+	for (const QString& standard : kStandardOrder)
+		if (name == standard)
+			return true;
+	return false;
+}
+}
+
+void ChannelSelectionModel::load(const QString& parameters, const std::vector<std::wstring>& deviceChannels)
+{
+	chipList.clear();
+	deviceNames.clear();
+	all = false;
+
+	for (const std::wstring& channel : deviceChannels)
+		deviceNames.append(QString::fromStdWString(channel));
+
+	// Device chips in canonical order: standard positions first (dialog
+	// checkbox order), then the remaining device channels in device order.
+	for (const QString& standard : kStandardOrder)
+	{
+		if (deviceNames.contains(standard))
+		{
+			ChannelChip chip;
+			chip.name = standard;
+			chip.fromDevice = true;
+			chipList.append(chip);
+		}
+	}
+	for (const QString& name : deviceNames)
+	{
+		if (!isStandardName(name))
+		{
+			ChannelChip chip;
+			chip.name = name;
+			chip.fromDevice = true;
+			chipList.append(chip);
+		}
+	}
+
+	// Selector tokens come from the grammar owner; ChannelCommand::parse
+	// upper-cases and splits on whitespace/commas exactly like the engine.
+	ChannelCommand cmd;
+	ChannelCommand::parse(L"Channel", parameters.toStdWString(), cmd);
+	for (const std::wstring& token : cmd.channels)
+	{
+		const QString name = QString::fromStdWString(token);
+		if (name == QStringLiteral("ALL"))
+		{
+			all = true;
+			continue;
+		}
+
+		int index = resolveDeviceChip(name);
+		if (index < 0)
+			index = chipIndex(name);
+		if (index >= 0)
+		{
+			chipList[index].selected = true;
+			continue;
+		}
+
+		ChannelChip chip;
+		chip.name = name;
+		chip.selected = true;
+		chipList.append(chip);
+	}
+}
+
+const QList<ChannelChip>& ChannelSelectionModel::chips() const
+{
+	return chipList;
+}
+
+bool ChannelSelectionModel::allSelected() const
+{
+	return all;
+}
+
+void ChannelSelectionModel::setAllSelected(bool on)
+{
+	all = on;
+}
+
+void ChannelSelectionModel::toggle(const QString& name)
+{
+	int index = chipIndex(name);
+	if (index >= 0)
+		chipList[index].selected = !chipList[index].selected;
+}
+
+bool ChannelSelectionModel::addCustom(const QString& name)
+{
+	const QString token = name.trimmed().toUpper();
+	if (token.isEmpty())
+		return false;
+	// A selector is a single token; whitespace or commas would split into
+	// several selectors on the next parse and surprise the user.
+	for (const QChar c : token)
+		if (c.isSpace() || c == QLatin1Char(','))
+			return false;
+
+	int index = resolveDeviceChip(token);
+	if (index < 0)
+		index = chipIndex(token);
+	if (index >= 0)
+	{
+		chipList[index].selected = true;
+		return true;
+	}
+
+	ChannelChip chip;
+	chip.name = token;
+	chip.selected = true;
+	chipList.append(chip);
+	return true;
+}
+
+QString ChannelSelectionModel::serialize() const
+{
+	ChannelCommand cmd;
+	if (all)
+	{
+		// The legacy dialog wrote only "ALL" when the all-channels box was
+		// checked, dropping any individual selection.
+		cmd.channels.push_back(L"ALL");
+	}
+	else
+	{
+		for (const ChannelChip& chip : chipList)
+			if (chip.selected)
+				cmd.channels.push_back(chip.name.toStdWString());
+	}
+	return QString::fromStdWString(cmd.serialize());
+}
+
+int ChannelSelectionModel::chipIndex(const QString& name) const
+{
+	for (int i = 0; i < chipList.size(); i++)
+		if (chipList[i].name == name)
+			return i;
+	return -1;
+}
+
+int ChannelSelectionModel::resolveDeviceChip(const QString& token) const
+{
+	if (token.isEmpty())
+		return -1;
+
+	// Mirrors the engine's selector resolution (ChannelHelper::getChannelIndex):
+	// 1-based position numbers index the device order; unmatched names fall
+	// back to the historical SL<->RL / SR<->RR / SUB->LFE aliases. The legacy
+	// dialog instead numbered its own checkbox order and kept unmatched
+	// aliases as custom names; the engine's interpretation is the one that
+	// decides what actually plays, so the chips follow it.
+	QString resolved;
+	if (token[0].isDigit())
+	{
+		bool ok = false;
+		const int number = token.toInt(&ok);
+		if (!ok || number < 1 || number > deviceNames.size())
+			return -1;
+		resolved = deviceNames[number - 1];
+	}
+	else if (deviceNames.contains(token))
+	{
+		resolved = token;
+	}
+	else
+	{
+		QString alias;
+		if (token == QStringLiteral("SL"))
+			alias = QStringLiteral("RL");
+		else if (token == QStringLiteral("SR"))
+			alias = QStringLiteral("RR");
+		else if (token == QStringLiteral("RL"))
+			alias = QStringLiteral("SL");
+		else if (token == QStringLiteral("RR"))
+			alias = QStringLiteral("SR");
+		else if (token == QStringLiteral("SUB")) // old channel name
+			alias = QStringLiteral("LFE");
+		if (alias.isEmpty() || !deviceNames.contains(alias))
+			return -1;
+		resolved = alias;
+	}
+
+	for (int i = 0; i < chipList.size(); i++)
+		if (chipList[i].fromDevice && chipList[i].name == resolved)
+			return i;
+	return -1;
+}

--- a/Editor/widgets/cards/ChannelSelectionModel.h
+++ b/Editor/widgets/cards/ChannelSelectionModel.h
@@ -1,0 +1,60 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Selection logic behind the in-place channel multi-select editor
+	(ChannelCardEditor). Pure Qt Core so EditorLogicTests can exercise it:
+	it maps a "Channel:" parameter string onto a chip list and serializes
+	back through ChannelCommand (the grammar owner) with the same canonical
+	ordering the legacy multi-select dialog produced, so equivalent
+	selections stay byte-identical with configs written by the old flow.
+*/
+
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <string>
+#include <vector>
+
+// One selectable channel chip.
+struct ChannelChip
+{
+	// Upper-cased selector token, used for display and serialization.
+	QString name;
+	bool selected = false;
+	// False for custom/virtual channels that are named in the line (or added
+	// by the user) but not part of the device's channel set.
+	bool fromDevice = false;
+};
+
+class ChannelSelectionModel
+{
+public:
+	// Build the chip list from the line's parameters and the device channel
+	// names (ChannelHelper::getChannelNames order; may be empty when no
+	// device is selected). Device chips come first in the legacy dialog's
+	// canonical order, custom tokens follow in the order they were written.
+	void load(const QString& parameters, const std::vector<std::wstring>& deviceChannels);
+
+	const QList<ChannelChip>& chips() const;
+	bool allSelected() const;
+
+	void setAllSelected(bool on);
+	void toggle(const QString& name);
+	// Select an existing chip matching the token (names, aliases or position
+	// numbers) or append a new custom chip. Returns false when the token is
+	// empty or not a single selector.
+	bool addCustom(const QString& name);
+
+	// Canonical parameter string for the current selection ("ALL" wins, like
+	// the legacy dialog). Serialization goes through ChannelCommand.
+	QString serialize() const;
+
+private:
+	int chipIndex(const QString& name) const;
+	int resolveDeviceChip(const QString& token) const;
+
+	QList<ChannelChip> chipList;
+	QList<QString> deviceNames;
+	bool all = false;
+};

--- a/Editor/widgets/cards/FilterCardEditorFactory.cpp
+++ b/Editor/widgets/cards/FilterCardEditorFactory.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "Editor/IFilterGUI.h"
+#include "ChannelCardEditor.h"
 #include "IncludeCardEditor.h"
 #include "PreampCardEditor.h"
 #include "VSTCardEditor.h"
@@ -18,6 +19,8 @@ IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QStr
 	const QString normalizedCommand = command.trimmed().toLower();
 	if (normalizedCommand == QStringLiteral("preamp"))
 		return new PreampCardEditor(PreampCardEditor::parseGain(parameters));
+	if (normalizedCommand == QStringLiteral("channel"))
+		return new ChannelCardEditor(parameters);
 	if (normalizedCommand == QStringLiteral("include"))
 		return new IncludeCardEditor(filterTable, parameters);
 	if (normalizedCommand == QStringLiteral("vstplugin"))

--- a/Editor/widgets/cards/IncludeCardEditor.cpp
+++ b/Editor/widgets/cards/IncludeCardEditor.cpp
@@ -17,6 +17,7 @@
 
 #include "Editor/FilterTable.h"
 #include "Editor/SkinManager.h"
+#include "Editor/skins/ISkin.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "Editor/import/ConfigDependencyScanner.h"
 #include "Editor/import/ImportDialog.h"
@@ -82,6 +83,13 @@ IncludeCardEditor::IncludeCardEditor(FilterTable* filterTable, const QString& pa
 	importButton->setVisible(false);
 	connect(importButton, SIGNAL(clicked()), this, SLOT(importToConfig()));
 	layout->addWidget(importButton, 0, Qt::AlignTop);
+
+	// Let the active skin decorate this Include body (the row is recreated on
+	// skin switches, so construction is the only moment needed).
+	CommandRowInfo rowInfo;
+	rowInfo.type = QStringLiteral("include");
+	rowInfo.command = QStringLiteral("include");
+	SkinManager::instance()->prepareCommandRow(rowInfo, nullptr, nullptr, this);
 
 	updateFileInfo();
 }

--- a/Editor/widgets/cards/PreampCardEditor.cpp
+++ b/Editor/widgets/cards/PreampCardEditor.cpp
@@ -39,6 +39,7 @@ PreampCardEditor::PreampCardEditor(double dbGain, QWidget* parent)
 
 	knob = new AudioKnob(this);
 	knob->setObjectName(QStringLiteral("PreampCardKnob"));
+	knob->setBipolar(true);
 	knob->setRange(gainToKnobValue(MinimumGain), gainToKnobValue(MaximumGain));
 	knob->setSingleStep(1);
 	knob->setPageStep(10);

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -34,6 +34,7 @@
 #include "helpers/RegistryHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "Editor/SkinManager.h"
+#include "Editor/skins/ISkin.h"
 #include "Editor/MainWindow.h"
 #include "Editor/guis/VSTPluginFilterGUIDialog.h"
 
@@ -116,6 +117,13 @@ VSTCardEditor::VSTCardEditor(shared_ptr<VSTPluginLibrary> library, const wstring
 	if (relativePath.startsWith(QDir::toNativeSeparators("../../")))
 		relativePath = absolutePath;
 	pathEdit->setText(relativePath);
+
+	// Let the active skin decorate this VST body (the row is recreated on
+	// skin switches, so construction is the only moment needed).
+	CommandRowInfo rowInfo;
+	rowInfo.type = QStringLiteral("vst");
+	rowInfo.command = QStringLiteral("vstplugin");
+	SkinManager::instance()->prepareCommandRow(rowInfo, nullptr, nullptr, this);
 
 	updatePermissionWarning();
 }

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -19,6 +19,7 @@
 #include "Editor/import/ImportExecutor.h"
 #include "Editor/import/ImportManifest.h"
 #include "Editor/widgets/FilterCardModel.h"
+#include "Editor/widgets/cards/ChannelSelectionModel.h"
 #include "UpdateChecker/UpdateInfoFormatter.h"
 #include "UpdateChecker/VelopackUpdateInfo.h"
 
@@ -360,6 +361,64 @@ int main(int argc, char** argv)
 		EqAPO::Import::ExecutionResult exec2 = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
 		expectTrue(exec2.success, "second execute should also succeed");
 		expectEqual(exec2.filesCopied, 4, "second execute should still report four copies");
+	}
+
+	{
+		// ChannelSelectionModel serialization identity: for equivalent
+		// selections the in-place chip editor must write the same bytes the
+		// legacy multi-select dialog produced (standard positions in the
+		// dialog's checkbox order, then non-standard device channels, then
+		// custom names).
+		const std::vector<std::wstring> stereo = { L"L", L"R" };
+		const std::vector<std::wstring> surround51 = { L"L", L"R", L"C", L"LFE", L"RL", L"RR" };
+		const std::vector<std::wstring> surround71 = { L"L", L"R", L"C", L"LFE", L"RL", L"RR", L"SL", L"SR" };
+
+		ChannelSelectionModel model;
+		model.load("L R C", surround51);
+		expectEqual(model.serialize(), "C L R", "5.1 selection must serialize in dialog order");
+
+		model.load("R L", stereo);
+		expectEqual(model.serialize(), "L R", "written order canonicalizes like the dialog");
+
+		// Position numbers resolve against the device order (engine
+		// semantics, ChannelHelper::getChannelIndex), and are written back
+		// as names like the dialog did.
+		model.load("2", stereo);
+		expectEqual(model.serialize(), "R", "numeric selector resolves in device order");
+
+		// Historical aliases follow the engine: SUB -> LFE, SL <-> RL.
+		model.load("SUB", surround51);
+		expectEqual(model.serialize(), "LFE", "SUB alias selects the LFE chip");
+		model.load("SL", surround51);
+		expectEqual(model.serialize(), "RL", "SL on a back-channel device selects RL");
+
+		model.load("SR SL LFE", surround71);
+		expectEqual(model.serialize(), "SL SR LFE", "7.1 selection serializes in dialog order");
+
+		// ALL wins over individual selections, exactly like the dialog.
+		model.load("ALL L", surround51);
+		expectTrue(model.allSelected(), "ALL token sets the all-channels state");
+		expectEqual(model.serialize(), "ALL", "ALL serializes alone");
+
+		// Custom/virtual channels keep their written order after the device
+		// chips, matching the dialog's list section.
+		model.load("VSL L VSR", stereo);
+		expectEqual(model.serialize(), "L VSL VSR", "custom names follow device channels");
+		model.toggle("R");
+		expectEqual(model.serialize(), "L R VSL VSR", "toggling keeps canonical order");
+		model.toggle("L");
+		expectEqual(model.serialize(), "R VSL VSR", "deselecting removes the token");
+
+		expectFalse(model.addCustom("  "), "blank custom name is rejected");
+		expectFalse(model.addCustom("A B"), "multi-token custom name is rejected");
+		expectTrue(model.addCustom(" vrr "), "custom name is trimmed and accepted");
+		expectEqual(model.serialize(), "R VSL VSR VRR", "added custom name serializes upper-cased");
+
+		// addCustom resolves aliases against the device set too: SUB selects
+		// the LFE chip instead of duplicating it as a custom name.
+		model.load("", surround51);
+		expectTrue(model.addCustom("sub"), "SUB through addCustom is accepted");
+		expectEqual(model.serialize(), "LFE", "SUB resolves to the device's LFE chip");
 	}
 
 	harness.report();

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -119,7 +119,9 @@
     <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp" />
     <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
+    <ClCompile Include="..\..\Editor\widgets\cards\ChannelSelectionModel.cpp" />
     <ClCompile Include="..\..\filters\BiQuadCommand.cpp" />
+    <ClCompile Include="..\..\filters\ChannelCommand.cpp" />
     <ClCompile Include="..\..\filters\FilterFactoryRegistry.cpp" />
     <ClCompile Include="..\..\UpdateChecker\UpdateInfoFormatter.cpp" />
     <ClCompile Include="..\..\UpdateChecker\VelopackUpdateInfo.cpp" />
@@ -130,8 +132,10 @@
     <ClInclude Include="..\..\Editor\import\ImportExecutor.h" />
     <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
+    <ClInclude Include="..\..\Editor\widgets\cards\ChannelSelectionModel.h" />
     <ClInclude Include="..\..\filters\BiQuad.h" />
     <ClInclude Include="..\..\filters\BiQuadCommand.h" />
+    <ClInclude Include="..\..\filters\ChannelCommand.h" />
     <ClInclude Include="..\..\filters\FilterFactoryRegistry.h" />
     <ClInclude Include="..\..\UpdateChecker\UpdateInfoFormatter.h" />
     <ClInclude Include="..\..\UpdateChecker\VelopackUpdateInfo.h" />

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
@@ -26,6 +26,18 @@
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Editor\widgets\cards\ChannelSelectionModel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\filters\BiQuadCommand.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\filters\ChannelCommand.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\filters\FilterFactoryRegistry.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\UpdateChecker\UpdateInfoFormatter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -47,6 +59,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Editor\widgets\cards\ChannelSelectionModel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\filters\ChannelCommand.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\UpdateChecker\UpdateInfoFormatter.h">

--- a/Tests/HybridConvTests/ChannelCommandTests.cpp
+++ b/Tests/HybridConvTests/ChannelCommandTests.cpp
@@ -79,6 +79,13 @@ void testRoundTrip()
 		harness.expectTrue(first.channels == second.channels, "serialize/parse round trip is stable");
 		harness.expectTrue(second.serialize() == serialized, "second serialization is identical");
 	}
+
+	// Canonical form: single-space separated, upper-cased. This is the exact
+	// text the Editor's in-place channel editor writes back, so it is pinned
+	// here as the serialization-identity contract.
+	ChannelCommand canonical;
+	ChannelCommand::parse(L"Channel", L" c,l  r ", canonical);
+	harness.expectTrue(canonical.serialize() == L"C L R", "canonical serialization is single-spaced and upper-cased");
 }
 }
 

--- a/docs/skin-hooks.md
+++ b/docs/skin-hooks.md
@@ -1,0 +1,102 @@
+# Skin hooks and the screenshot gallery
+
+Phase 0 of the skin program (issue #66) added two structural hooks to `ISkin`
+and an offscreen screenshot gallery. This note is the reference for the Phase 1
+skin agents (issue #67) and the Phase 2 integrator (issue #68).
+
+## Knob paint hook
+
+`AudioKnob` (`Editor/widgets/AudioKnob.{h,cpp}`, a `QDial`) owns **all input
+handling**: rotary drag tracking, wheel, keyboard. Its `paintEvent` only
+collects a `KnobState` and delegates painting:
+
+```cpp
+// ISkin (Editor/skins/ISkin.h)
+virtual void paintKnob(QPainter& painter, const QRect& rect,
+	const KnobState& state, const SkinTokens& tokens) const;
+```
+
+`KnobState` carries `value/minimum/maximum`, the resolved `ratio` (0..1), a
+`bipolar` flag, the optional centred `valueText`, and
+`enabled/hovered/dragging/focused`. Notes:
+
+- **Bipolar vs unipolar.** Gain knobs (Preamp card, BiQuad gain dial) set
+  `bipolar = true`; frequency and Q dials stay unipolar. A skin must render
+  the two kinds distinguishably (e.g. the value arc grows from the centre for
+  bipolar knobs).
+- **`valueText` may be empty.** Promoted legacy dials (BiQuad, Delay,
+  LoudnessCorrection `.ui` files promote `QDial` to `AudioKnob`) display their
+  value in a separate spin box and map the dial to log-scaled steps, so
+  painting `value` for them is wrong. Only paint a number when `valueText` is
+  non-empty, or derive a display value from your own formatting of `ratio`.
+- **Geometry.** Promoted legacy dials are 100x66; the card knob is 74x74. Keep
+  the knob round by working inside a centred square (see the default
+  implementation in `Editor/skins/ISkin.cpp`).
+- The default implementation reproduces the pre-hook rendering
+  pixel-identically and deliberately ignores the hover/drag/focus flags.
+
+`SkinManager::paintKnob` routes the widget to the active skin; a skin
+implements the override on its `ISkin` subclass in `Editor/skins/Skins.cpp`.
+
+## Command-row chrome hook
+
+Rows are recreated on every skin/dark switch (`FilterTable::updateGuis()`), so
+per-row chrome is built at construction time. `CommandRowInfo`
+(`Editor/skins/ISkin.h`) identifies a row: descriptor `type` (`"biquad"`,
+`"include"`, `"vst"`, `"copy"`, ...), lower-cased `command`, a `legacyRow`
+flag, and `enabled/selected/focused/depth`. Four hooks, all with
+appearance-preserving defaults:
+
+- `cardFrameStyle(info, tokens)` / `cardHeaderStyle(info, tokens)` — the
+  inline stylesheets for `QFrame#FilterCardRow` and
+  `QWidget#FilterCardHeader`, re-evaluated whenever the row's
+  selected/focused/enabled state changes. The defaults are the shared
+  token-driven strings every skin used before (including the
+  `tokens.cardRailWidth` accent rail). Override these to give command types
+  their own frame/header treatment.
+- `prepareCommandRow(info, card, header, body)` — called once per
+  construction. For modern card rows `card`/`header`/`body` are the
+  `CommandRowFrame`, the header strip and the body stack. The Include/VST
+  card editors and the legacy Include/VST rows also consult the hook with
+  only `body` set (and `legacyRow = true` for the legacy pair). Use it to set
+  dynamic properties for QSS or to attach extra chrome widgets.
+- `paintCardChrome(painter, rect, info, tokens)` — painted decoration drawn
+  by `CommandRowFrame` (`Editor/widgets/CommandRowFrame.{h,cpp}`) after the
+  QSS background/border and before child widgets. Use for rails, screws,
+  per-type markers that QSS cannot express.
+
+QSS can already target rows per command type without code: the card frame and
+header carry dynamic properties `filterKind` (lower-cased command),
+`filterEnabled`, `selected`, `focused`, `scopeDepth`.
+
+## Screenshot gallery
+
+The Editor has a headless gallery mode used to prove appearance-preserving
+changes and to produce judging material:
+
+```powershell
+$env:QT_QPA_PLATFORM = "offscreen"
+# Qt bin + fftw/libsndfile DLL directories must be on PATH; velopack_libc.dll
+# must sit next to Editor.exe (copy deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll).
+.\build-Editor-x64\release\Editor.exe --skin-gallery <outDir> [--skin-gallery-skins studio,rack]
+```
+
+For every skin × {dark, light} it renders four representative rows — a
+parametric filter (`Filter 1: ON PK ...`), a high-shelf with its three knobs,
+an `Include:` row and a `VSTPlugin:` row — in three states: `normal`, `hover`
+(hover-equivalent via `Qt::WA_UnderMouse`), and `disabled` (the line
+commented out, which is the product's real disabled state). Output names are
+stable: `<skin>_<dark|light>_<row>_<state>.png`, 5 × 2 × 4 × 3 = 120 PNGs for
+a full run. Exit code 0 means every PNG was written; unknown skin ids fail
+loudly instead of falling back to studio.
+
+CI runs the gallery on the primary x64-avx2 variant and uploads the PNGs as
+the `skin-gallery` artifact, so a PR's visual state can be reviewed without a
+local build.
+
+Determinism notes: the gallery runs before translators load (English strings),
+applies each skin itself (stylesheet + palette via
+`GUIHelper::applySkinPalette`), and renders at device pixel ratio 1 on the
+offscreen platform. PNGs from the same machine and build are byte-stable, so
+`Get-FileHash` comparisons prove pixel identity; PNGs from different machines
+may differ slightly in font rasterization.

--- a/docs/skin-hooks.md
+++ b/docs/skin-hooks.md
@@ -78,6 +78,11 @@ changes and to produce judging material:
 $env:QT_QPA_PLATFORM = "offscreen"
 # Qt bin + fftw/libsndfile DLL directories must be on PATH; velopack_libc.dll
 # must sit next to Editor.exe (copy deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll).
+# If windeployqt has run on the build dir, the deployed app dir only carries
+# the qwindows platform plugin and the offscreen platform fails to load (the
+# Editor then hangs on a fatal-error dialog). Point the plugin search at the
+# full Qt install in that case:
+#   $env:QT_QPA_PLATFORM_PLUGIN_PATH = "<QT_ROOT>\plugins\platforms"
 .\build-Editor-x64\release\Editor.exe --skin-gallery <outDir> [--skin-gallery-skins studio,rack]
 ```
 

--- a/helpers/VSTPluginLibrary.cpp
+++ b/helpers/VSTPluginLibrary.cpp
@@ -73,8 +73,27 @@ wstring VSTPluginLibrary::getDefaultPluginPath()
 
 	if (defaultPluginPath == L"")
 	{
-		wstring installPath = RegistryHelper::readValue(APP_REGPATH, L"InstallPath");
-		defaultPluginPath = installPath + L"\\VSTPlugins";
+		try
+		{
+			wstring installPath = RegistryHelper::readValue(APP_REGPATH, L"InstallPath");
+			defaultPluginPath = installPath + L"\\VSTPlugins";
+		}
+		catch (const RegistryException& e)
+		{
+			// No installed EqualizerAPO (dev tree, CI runner). The exception
+			// used to escape through callers that never expected it - parsing
+			// any VSTPlugin line with a relative path, or building a VST row
+			// editor, terminated the Editor outright. Fall back to a
+			// VSTPlugins folder beside the executable; installed systems have
+			// the registry value and never take this path.
+			LogFStatic(L"%s - falling back to the executable directory for VST plugins", e.getMessage().c_str());
+			wchar_t modulePath[MAX_PATH];
+			modulePath[0] = L'\0';
+			GetModuleFileNameW(nullptr, modulePath, MAX_PATH);
+			wstring exePath = modulePath;
+			size_t separator = exePath.find_last_of(L'\\');
+			defaultPluginPath = (separator != wstring::npos ? exePath.substr(0, separator) : L".") + L"\\VSTPlugins";
+		}
 	}
 
 	return defaultPluginPath;


### PR DESCRIPTION
## Summary

Phase 0 groundwork for the five-skin visual overhaul (closes #66). Five deliverables, one commit per concern; behavior changes (TASK 1) and appearance-preserving plumbing (TASK 2/3) are never mixed.

- **In-place channel multi-select (TASK 1a, `feat`).** `Channel:` card rows now edit their selection with checkable chips directly in the card body (device channels, ALL, custom/virtual names, plus an add-field). `ChannelSelectionModel` owns the logic and serializes through `ChannelCommand` in the legacy dialog's canonical order, so equivalent selections stay byte-identical with configs written by the old flow. Selector tokens resolve with engine semantics (`ChannelHelper::getChannelIndex`: device-order numbers, SL/RL SR/RR/SUB aliases).
- **Dropdown sizing floor (TASK 1b, `fix`).** All ten skin sheets raise the shared `QComboBox` floor (control 28px, popup items 24px); new `SkinComboBox` derives its height floor from font metrics and widens the popup to its longest item. The two toolbar dropdowns use it.
- **Knob paint hook (TASK 2a, `refactor`).** `AudioKnob` keeps all input handling and delegates painting to `ISkin::paintKnob(QPainter&, QRect, KnobState, SkinTokens)`. The default is the previous `paintEvent` moved verbatim. `KnobState` carries value/range/ratio, hover/drag/focus/disabled, optional value text, and a bipolar flag (set on the Preamp knob and BiQuad gain dial).
- **Command-row chrome hook (TASK 2b, `refactor`).** `CommandRowInfo` + four `ISkin` hooks with neutral defaults: `cardFrameStyle`/`cardHeaderStyle` (the inline stylesheets `FilterCardRow` used to compute, moved verbatim), `prepareCommandRow` (wired into `FilterCardRow`, the Include/VST card editors and the legacy Include/VST rows), and `paintCardChrome` (drawn by the new `CommandRowFrame`).
- **Offscreen screenshot gallery (TASK 3, `feat` + `ci`).** `Editor --skin-gallery <outDir>` renders 4 representative rows (filter / 3-knob shelf / Include / VST) x 5 skins x dark/light x normal/hover/disabled = 120 deterministic PNGs headless. CI runs it on the avx2 variant and uploads the `skin-gallery` artifact. `docs/skin-hooks.md` documents the hooks and gallery for the Phase 1/2 agents (#67/#68).

## Verification

- **Pixel identity (core gate):** gallery run before vs after the two hook commits — 120/120 PNGs SHA-256 identical, proving the neutral defaults change nothing visually.
- `EditorLogicTests` 102 checks pass (includes the new serialization-identity tests); `HybridConvTests` all suites pass (includes the pinned canonical `ChannelCommand` form).
- Local cppcheck 2.21.0 with the CI gate flags: zero findings.
- Editor clean-built (MSVC 14.51) after header changes; gallery exit 0 with exactly 120 PNGs at HEAD.
- The new channel chip editor was rendered offscreen across skins as a sanity check (chips, ALL, custom add-field all visible and toggleable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)