### PR TITLE
feat(editor): five differentiated Editor skins (skin program Phases 1-2)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,18 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- Editor의 5개 스킨이 색만 다른 변형이 아니라 서로 다른 시각 정체성이
+  됐습니다. 명령 종류 표시, 호버, 비활성 상태, Include/VST 표현, 모서리
+  언어, 위계를 스킨마다 고유한 형태·질감·타이포그래피로 답합니다. 유리
+  카드와 발광 아크 노브(studio), 라운드 0의 헤어라인 터미널(minimal),
+  여백이 넉넉한 둥근 설정 화면(soft), 나사·명판·포인터 노브까지 그려 넣은
+  랙 하드웨어(rack), LED 링 인코더와 크로스포인트 호버를 갖춘 격자
+  계기판(matrix)입니다. 격리된 구현 에이전트 5개가 만들고 차별화 심사를
+  거쳐 통합했으며, 전체 기록은 docs/skin-integration-report.md에
+  있습니다. ([#73])
+
 ## v1.18.0 (2026-06-12)
 
 - 모던 카드의 Channel 행에서 채널 선택을 카드 안에서 바로 편집할 수 있습니다.
@@ -293,3 +305,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#63]: https://github.com/115dkk/EqualizerAPO-XT/pull/63
 [#64]: https://github.com/115dkk/EqualizerAPO-XT/pull/64
 [#70]: https://github.com/115dkk/EqualizerAPO-XT/pull/70
+[#73]: https://github.com/115dkk/EqualizerAPO-XT/pull/73

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- The five Editor skins are now fully differentiated visual identities
+  instead of palette variations. Each answers command-type marking, hover,
+  disabled state, Include/VST presentation, corner language and hierarchy
+  with its own shapes, textures and typography — glass cards with glowing
+  arc knobs (studio), a zero-radius hairline terminal (minimal), a roomy
+  rounded settings look (soft), skeuomorphic rack hardware with painted
+  screws, nameplates and pointer knobs (rack), and a grid instrument panel
+  with LED-ring encoders and crosspoint hover (matrix). Built by five
+  isolated implementation agents and integrated after a differentiation
+  review; the full record is in docs/skin-integration-report.md. ([#73])
+
 ## v1.18.0 — 2026-06-12
 
 - Channel rows on the modern cards now edit their selection in place with
@@ -306,3 +319,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#63]: https://github.com/115dkk/EqualizerAPO-XT/pull/63
 [#64]: https://github.com/115dkk/EqualizerAPO-XT/pull/64
 [#70]: https://github.com/115dkk/EqualizerAPO-XT/pull/70
+[#73]: https://github.com/115dkk/EqualizerAPO-XT/pull/73

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -179,6 +179,7 @@ SOURCES += main.cpp\
 	SkinGallery.cpp \
 	SkinManager.cpp \
 	skins/ISkin.cpp \
+	skins/RackChrome.cpp \
 	skins/Skins.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
@@ -351,6 +352,7 @@ HEADERS  += \
 	SkinTokens.h \
 	SkinManager.h \
 	skins/ISkin.h \
+	skins/RackChrome.h \
 	skins/Skins.h \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -123,6 +123,11 @@ QString SkinManager::cardHeaderStyle(const CommandRowInfo& info) const
 	return activeSkin != nullptr ? activeSkin->cardHeaderStyle(info, currentTokens) : QString();
 }
 
+QString SkinManager::typeBadgeStyle(const CommandRowInfo& info, const QString& typeColor) const
+{
+	return activeSkin != nullptr ? activeSkin->typeBadgeStyle(info, typeColor, currentTokens) : QString();
+}
+
 void SkinManager::prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const
 {
 	if (activeSkin != nullptr)

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -40,6 +40,7 @@ public:
 	// current tokens (see the ISkin hooks for semantics).
 	QString cardFrameStyle(const CommandRowInfo& info) const;
 	QString cardHeaderStyle(const CommandRowInfo& info) const;
+	QString typeBadgeStyle(const CommandRowInfo& info, const QString& typeColor) const;
 	void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const;
 	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info) const;
 

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -101,6 +101,19 @@ QString ISkin::cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tok
 		.arg(tokens.borderRadius);
 }
 
+// The default is the string FilterCardRow::rebuildSummary computed before the
+// hook existed, moved verbatim: outline-style skins ink the badge in the type
+// colour, filled-style skins use the type colour as the pill background.
+QString ISkin::typeBadgeStyle(const CommandRowInfo& info, const QString& typeColor, const SkinTokens& tokens) const
+{
+	Q_UNUSED(info);
+	const bool outlineBadge = tokens.badgeStyle == SkinTokens::OutlineOnly || tokens.badgeStyle == SkinTokens::WireframeBorder;
+	return QStringLiteral("color:%1; border-color:%2; background-color:%3;")
+		.arg(outlineBadge ? typeColor : QStringLiteral("white"),
+			typeColor,
+			outlineBadge ? QStringLiteral("transparent") : typeColor);
+}
+
 void ISkin::prepareCommandRow(const CommandRowInfo&, QWidget*, QWidget*, QWidget*) const
 {
 	// Neutral default: rows keep their stock construction.

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -34,6 +34,10 @@ struct CommandRowInfo
 	bool enabled = true;
 	bool selected = false;
 	bool focused = false;
+	// True while the cursor is over the row. Populated at paint time by
+	// CommandRowFrame for ISkin::paintCardChrome; the construction-time hooks
+	// (prepareCommandRow) always see false.
+	bool hovered = false;
 	int depth = 0;
 };
 
@@ -93,6 +97,14 @@ public:
 
 	// Inline stylesheet for the card's header strip (QWidget#FilterCardHeader).
 	virtual QString cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tokens) const;
+
+	// Inline stylesheet for the header's type badge (QLabel#FilterTypeBadge).
+	// typeColor is the per-command-type colour from FilterCardModel. The
+	// default reproduces the shared OutlineOnly/filled treatment every skin
+	// used before the hook existed; skins override it when their constitution
+	// reserves colour for other semantics (e.g. matrix keeps traffic-light
+	// colours for status only and renders a monochrome type cell).
+	virtual QString typeBadgeStyle(const CommandRowInfo& info, const QString& typeColor, const SkinTokens& tokens) const;
 
 	// Called once when a command row or a command body editor is built, so a
 	// skin can tag widgets with dynamic properties or attach extra chrome.

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -34,6 +34,11 @@ struct CommandRowInfo
 	bool enabled = true;
 	bool selected = false;
 	bool focused = false;
+	// Paint-time only: true while the pointer is over the row frame.
+	// CommandRowFrame fills it right before ISkin::paintCardChrome runs, so a
+	// skin can brighten painted decoration on hover. Skins that ignore it keep
+	// their exact pre-hover appearance.
+	bool hovered = false;
 	int depth = 0;
 };
 

--- a/Editor/skins/RackChrome.cpp
+++ b/Editor/skins/RackChrome.cpp
@@ -1,0 +1,503 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	QPainter chrome for the "rack" skin. The tiebreaker for every stroke in
+	this file is "would a hardware faceplate have it?" - screws, machined
+	grooves, LEDs and engraved printing yes; glows, value arcs and abstract
+	decoration no (the only exceptions are the thin keyboard-focus ring and
+	the hover highlight, which are UI necessities kept deliberately small).
+*/
+
+#include "RackChrome.h"
+
+#include <QFontMetricsF>
+#include <QHash>
+#include <QPainter>
+#include <QPainterPath>
+#include <QtMath>
+
+#include "ISkin.h"
+
+namespace
+{
+const int kEarWidth = 20;
+const qreal kNameplateWidth = 78.0;
+const qreal kNameplateHeight = 22.0;
+
+bool isDarkPanel(const SkinTokens& tokens)
+{
+	return QColor(tokens.background).lightness() < 128;
+}
+
+QColor withAlpha(const QColor& color, int alpha)
+{
+	QColor result = color;
+	result.setAlpha(alpha);
+	return result;
+}
+
+// Engraved faceplate printing: a contrast pass offset one pixel down (the
+// recess edge catching the light), then the body color on top.
+void engraveText(QPainter& painter, const QRectF& rect, int flags, const QString& text, const QColor& body, bool dark)
+{
+	painter.setPen(dark ? QColor(0, 0, 0, 170) : QColor(255, 255, 255, 200));
+	painter.drawText(rect.translated(0, 1), flags, text);
+	painter.setPen(body);
+	painter.drawText(rect, flags, text);
+}
+
+// A slotted machine screw: radial-gradient steel body and a slot whose angle
+// varies per screw so four of them never read as a stamped texture.
+void paintScrew(QPainter& painter, const QPointF& center, qreal radius, qreal slotDegrees, bool dark)
+{
+	QRadialGradient body(center - QPointF(radius * 0.35, radius * 0.35), radius * 2.1);
+	if (dark)
+	{
+		body.setColorAt(0.0, QColor(0x9A, 0xA4, 0xAC));
+		body.setColorAt(0.55, QColor(0x4E, 0x57, 0x5E));
+		body.setColorAt(1.0, QColor(0x23, 0x28, 0x2C));
+	}
+	else
+	{
+		body.setColorAt(0.0, QColor(0xFF, 0xFF, 0xFC));
+		body.setColorAt(0.55, QColor(0xC4, 0xBD, 0xAE));
+		body.setColorAt(1.0, QColor(0x8E, 0x86, 0x76));
+	}
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 200) : QColor(0x6B, 0x62, 0x52), 1));
+	painter.setBrush(body);
+	painter.drawEllipse(center, radius, radius);
+
+	const qreal rad = qDegreesToRadians(slotDegrees);
+	const QPointF dir(qCos(rad), qSin(rad));
+	const QPointF a = center - dir * (radius - 1.2);
+	const QPointF b = center + dir * (radius - 1.2);
+	painter.setPen(QPen(dark ? QColor(10, 12, 14, 230) : QColor(60, 54, 44, 220), 1.4, Qt::SolidLine, Qt::RoundCap));
+	painter.drawLine(a, b);
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 60 : 170), 0.8, Qt::SolidLine, Qt::RoundCap));
+	painter.drawLine(a + QPointF(0, 1), b + QPointF(0, 1));
+}
+
+// A panel LED in a bezel ring: lit = glowing dome with a specular dot,
+// unlit = the same dome gone dark.
+void paintLed(QPainter& painter, const QPointF& center, qreal radius, const QColor& litColor, bool lit, bool dark)
+{
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 190) : QColor(70, 62, 50, 190), 1));
+	painter.setBrush(Qt::NoBrush);
+	painter.drawEllipse(center, radius + 1.2, radius + 1.2);
+
+	if (lit)
+	{
+		QRadialGradient halo(center, radius * 3.2);
+		halo.setColorAt(0.0, withAlpha(litColor, 110));
+		halo.setColorAt(1.0, withAlpha(litColor, 0));
+		painter.setPen(Qt::NoPen);
+		painter.setBrush(halo);
+		painter.drawEllipse(center, radius * 3.2, radius * 3.2);
+	}
+
+	QRadialGradient dome(center - QPointF(radius * 0.3, radius * 0.3), radius * 1.6);
+	if (lit)
+	{
+		dome.setColorAt(0.0, litColor.lighter(150));
+		dome.setColorAt(1.0, litColor.darker(125));
+	}
+	else
+	{
+		const QColor off = litColor.darker(330);
+		dome.setColorAt(0.0, off.lighter(140));
+		dome.setColorAt(1.0, off);
+	}
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(dome);
+	painter.drawEllipse(center, radius, radius);
+	painter.setBrush(QColor(255, 255, 255, lit ? 170 : (dark ? 28 : 60)));
+	painter.drawEllipse(center - QPointF(radius * 0.35, radius * 0.35), radius * 0.3, radius * 0.3);
+}
+
+// A 1/4" patchbay insert jack: steel flange around a dark sleeve hole.
+void paintJack(QPainter& painter, const QPointF& center, bool dark)
+{
+	QRadialGradient flange(center - QPointF(1.4, 1.4), 7.5);
+	if (dark)
+	{
+		flange.setColorAt(0.0, QColor(0xA8, 0xB1, 0xB8));
+		flange.setColorAt(0.6, QColor(0x55, 0x5E, 0x64));
+		flange.setColorAt(1.0, QColor(0x26, 0x2B, 0x2F));
+	}
+	else
+	{
+		flange.setColorAt(0.0, QColor(0xFF, 0xFF, 0xFC));
+		flange.setColorAt(0.6, QColor(0xC0, 0xB9, 0xAA));
+		flange.setColorAt(1.0, QColor(0x86, 0x7E, 0x6E));
+	}
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 210) : QColor(0x60, 0x58, 0x48), 1));
+	painter.setBrush(flange);
+	painter.drawEllipse(center, 4.6, 4.6);
+
+	painter.setPen(QPen(QColor(0, 0, 0, 220), 1));
+	painter.setBrush(QColor(8, 9, 10));
+	painter.drawEllipse(center, 2.1, 2.1);
+
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(QColor(255, 255, 255, dark ? 70 : 150));
+	painter.drawEllipse(center + QPointF(-2.5, -2.7), 0.9, 0.9);
+}
+
+// Short engraved unit designation for the left rack ear.
+QString unitLabel(const CommandRowInfo& info)
+{
+	static const struct { const char* type; const char* label; } table[] = {
+		{ "biquad", "FILTER" },
+		{ "graphiceq", "GRAPHIC" },
+		{ "include", "PATCH" },
+		{ "vst", "VST" },
+		{ "copy", "ROUTE" },
+		{ "preamp", "PREAMP" },
+		{ "channel", "CHANNEL" },
+		{ "device", "DEVICE" },
+		{ "stage", "STAGE" },
+		{ "delay", "DELAY" },
+		{ "convolution", "CONV" },
+		{ "loudness", "LOUDNESS" },
+		{ "comment", "NOTE" },
+		{ "text", "AUX" }
+	};
+	for (const auto& entry : table)
+		if (info.type == QLatin1String(entry.type))
+			return QLatin1String(entry.label);
+	return info.command.toUpper().left(8);
+}
+}
+
+namespace RackChrome
+{
+int earWidth()
+{
+	return kEarWidth;
+}
+
+int nameplateReserve()
+{
+	return int(kNameplateWidth) + 14;
+}
+
+void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens)
+{
+	// Blank lines are gaps in the rack, not units: no faceplate.
+	if (info.type == QLatin1String("spacer"))
+		return;
+
+	const bool dark = isDarkPanel(tokens);
+	painter.save();
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	// Stay inside the 1px QSS border (the machined plate edge) and clip all
+	// painting to the plate so nothing bleeds past the rounded corners.
+	const QRectF r = QRectF(rect).adjusted(1, 1, -1, -1);
+	const qreal radius = qMax(2, tokens.borderRadius - 1);
+	QPainterPath plate;
+	plate.addRoundedRect(r, radius, radius);
+	painter.setClipPath(plate);
+
+	// Brushed-metal sheen: a bright rolled top edge falling into shadow.
+	QLinearGradient sheen(r.topLeft(), r.bottomLeft());
+	if (dark)
+	{
+		sheen.setColorAt(0.0, QColor(255, 255, 255, 22));
+		sheen.setColorAt(0.12, QColor(255, 255, 255, 9));
+		sheen.setColorAt(0.55, QColor(255, 255, 255, 0));
+		sheen.setColorAt(1.0, QColor(0, 0, 0, 46));
+	}
+	else
+	{
+		sheen.setColorAt(0.0, QColor(255, 255, 255, 110));
+		sheen.setColorAt(0.5, QColor(255, 255, 255, 0));
+		sheen.setColorAt(1.0, QColor(0, 0, 0, 26));
+	}
+	painter.fillRect(r, sheen);
+
+	// Per-type finish: Include units wear patchbay black, VST units a warm
+	// charcoal; filters keep the bare aluminium.
+	if (info.type == QLatin1String("include"))
+		painter.fillRect(r, QColor(0, 0, 0, dark ? 64 : 28));
+	else if (info.type == QLatin1String("vst"))
+		painter.fillRect(r, dark ? QColor(34, 20, 6, 50) : QColor(74, 50, 14, 18));
+
+	// Horizontal brushing texture.
+	painter.setPen(QPen(dark ? QColor(255, 255, 255, 5) : QColor(96, 84, 64, 8), 1));
+	for (qreal y = r.top() + 3; y < r.bottom() - 1; y += 3)
+		painter.drawLine(QPointF(r.left() + 2, y), QPointF(r.right() - 2, y));
+
+	// Rack ears, separated from the panel by a machined groove.
+	const QRectF leftEar(r.left(), r.top(), kEarWidth, r.height());
+	const QRectF rightEar(r.right() - kEarWidth, r.top(), kEarWidth, r.height());
+	const QColor earFill(0, 0, 0, dark ? 52 : 20);
+	painter.fillRect(leftEar, earFill);
+	painter.fillRect(rightEar, earFill);
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 120 : 60), 1));
+	painter.drawLine(QPointF(leftEar.right(), r.top()), QPointF(leftEar.right(), r.bottom()));
+	painter.drawLine(QPointF(rightEar.left(), r.top()), QPointF(rightEar.left(), r.bottom()));
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 26 : 120), 1));
+	painter.drawLine(QPointF(leftEar.right() + 1, r.top()), QPointF(leftEar.right() + 1, r.bottom()));
+	painter.drawLine(QPointF(rightEar.left() + 1, r.top()), QPointF(rightEar.left() + 1, r.bottom()));
+
+	// Bezel edges: lit on top, shadowed at the bottom.
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 36 : 150), 1));
+	painter.drawLine(QPointF(r.left() + radius, r.top() + 0.5), QPointF(r.right() - radius, r.top() + 0.5));
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 140 : 70), 1));
+	painter.drawLine(QPointF(r.left() + radius, r.bottom() - 0.5), QPointF(r.right() - radius, r.bottom() - 0.5));
+
+	// Module groove under the control strip whenever the unit is opened (the
+	// body below it then reads as controls mounted on the same module).
+	if (r.height() >= tokens.rowHeight + 26)
+	{
+		const qreal y = r.top() + tokens.rowHeight;
+		painter.setPen(QPen(QColor(0, 0, 0, dark ? 110 : 55), 1));
+		painter.drawLine(QPointF(leftEar.right() + 2, y), QPointF(rightEar.left() - 2, y));
+		painter.setPen(QPen(QColor(255, 255, 255, dark ? 24 : 110), 1));
+		painter.drawLine(QPointF(leftEar.right() + 2, y + 1), QPointF(rightEar.left() - 2, y + 1));
+	}
+
+	// Four corner screws (two on very low rows).
+	const uint seed = uint(qHash(info.command));
+	const QPointF screws[] = {
+		QPointF(r.left() + 10, r.top() + 9),
+		QPointF(r.right() - 10, r.top() + 9),
+		QPointF(r.left() + 10, r.bottom() - 9),
+		QPointF(r.right() - 10, r.bottom() - 9)
+	};
+	const int screwCount = r.height() >= 40 ? 4 : 2;
+	for (int i = 0; i < screwCount; i++)
+		paintScrew(painter, screws[i], 4.0, qreal((seed + uint(i) * 73u) % 180u), dark);
+
+	// Status LEDs on the left ear: green power LED (lit = line active), amber
+	// SELECT LED below it.
+	paintLed(painter, QPointF(r.left() + 10, r.top() + 21), 3.0, QColor(tokens.accent2), info.enabled, dark);
+	if (r.height() >= 44)
+		paintLed(painter, QPointF(r.left() + 10, r.top() + 31.5), 2.4, QColor(tokens.accent), info.selected, dark);
+
+	// Include: patchbay insert jacks on the right ear.
+	if (info.type == QLatin1String("include"))
+	{
+		paintJack(painter, QPointF(r.right() - 10, r.top() + 21), dark);
+		if (r.height() >= 46)
+			paintJack(painter, QPointF(r.right() - 10, r.top() + 32.5), dark);
+	}
+
+	// VST: riveted brass brand nameplate right of the control strip. The
+	// header layout reserves this area (see RackSkin::prepareCommandRow).
+	if (info.type == QLatin1String("vst") && r.width() >= 320)
+	{
+		const QRectF plateRect(rightEar.left() - 8 - kNameplateWidth,
+			r.top() + (tokens.rowHeight - kNameplateHeight) / 2.0, kNameplateWidth, kNameplateHeight);
+		QLinearGradient brass(plateRect.topLeft(), plateRect.bottomLeft());
+		if (dark)
+		{
+			brass.setColorAt(0.0, QColor(0xD6, 0xB2, 0x6A));
+			brass.setColorAt(0.5, QColor(0xA8, 0x85, 0x46));
+			brass.setColorAt(1.0, QColor(0x86, 0x67, 0x30));
+		}
+		else
+		{
+			brass.setColorAt(0.0, QColor(0xE8, 0xC8, 0x86));
+			brass.setColorAt(0.5, QColor(0xC4, 0xA0, 0x5C));
+			brass.setColorAt(1.0, QColor(0x9A, 0x7A, 0x3C));
+		}
+		painter.setPen(QPen(QColor(0x5A, 0x44, 0x16), 1));
+		painter.setBrush(brass);
+		painter.drawRoundedRect(plateRect, 3, 3);
+
+		QFont plateFont(tokens.fontFamily);
+		plateFont.setPixelSize(9);
+		plateFont.setBold(true);
+		plateFont.setLetterSpacing(QFont::AbsoluteSpacing, 2.5);
+		painter.setFont(plateFont);
+		// Engraved into the brass itself, so the passes are brass-tinted in
+		// both modes rather than following the panel's engraving direction.
+		painter.setPen(QColor(255, 240, 200, 160));
+		painter.drawText(plateRect.translated(1, 1), Qt::AlignCenter, QStringLiteral("VST"));
+		painter.setPen(QColor(0x3A, 0x2A, 0x0C));
+		painter.drawText(plateRect, Qt::AlignCenter, QStringLiteral("VST"));
+
+		painter.setPen(QPen(QColor(0x55, 0x40, 0x14), 0.8));
+		painter.setBrush(QColor(0xE9, 0xD3, 0x9A));
+		painter.drawEllipse(QPointF(plateRect.left() + 6, plateRect.center().y()), 1.6, 1.6);
+		painter.drawEllipse(QPointF(plateRect.right() - 6, plateRect.center().y()), 1.6, 1.6);
+	}
+
+	// Engraved unit designation running up the left ear on tall units.
+	const QString label = unitLabel(info);
+	if (!label.isEmpty() && r.height() >= 96)
+	{
+		QFont earFont(tokens.fontFamily);
+		earFont.setPixelSize(8);
+		earFont.setBold(true);
+		earFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.5);
+		painter.save();
+		painter.translate(r.left() + 14.5, r.bottom() - 16);
+		painter.rotate(-90);
+		painter.setFont(earFont);
+		const QRectF textRect(0, -10, r.height() - 64, 20);
+		engraveText(painter, textRect, Qt::AlignLeft | Qt::AlignVCenter, label, withAlpha(QColor(tokens.mutedText), 200), dark);
+		painter.restore();
+	}
+
+	// Commented-out line: the whole unit is powered down behind a dim film.
+	if (!info.enabled)
+		painter.fillPath(plate, dark ? QColor(0, 0, 0, 80) : QColor(255, 252, 244, 120));
+
+	// Keyboard focus: a thin amber line along the inner bezel (UI necessity,
+	// kept as small as a hardware unit's rail light).
+	if (info.focused)
+	{
+		painter.setPen(QPen(withAlpha(QColor(tokens.focusRing), 190), 1));
+		painter.setBrush(Qt::NoBrush);
+		painter.drawRoundedRect(r.adjusted(1.5, 1.5, -1.5, -1.5), radius - 1, radius - 1);
+	}
+
+	painter.restore();
+}
+
+void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens)
+{
+	const bool dark = isDarkPanel(tokens);
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	// Work inside a centred square (promoted legacy dials are 100x66).
+	const QRectF inner = QRectF(rect).adjusted(4, 4, -4, -4);
+	const qreal side = qMin(inner.width(), inner.height());
+	const QPointF center = inner.center();
+	const qreal scaleRadius = side / 2.0;        // printed panel scale
+	const qreal bodyRadius = scaleRadius - 9.0;  // physical knob body
+
+	// Value geometry matches AudioKnob's input mapping: minimum at 135
+	// degrees (bottom-left), 270-degree clockwise sweep, maximum at the
+	// bottom-right, dead zone across the bottom.
+	auto pointAt = [center](qreal ratio, qreal radius) {
+		const qreal a = qDegreesToRadians(135.0 + 270.0 * ratio);
+		return center + QPointF(qCos(a) * radius, qSin(a) * radius);
+	};
+
+	// Scale ticks are printed on the PANEL around the knob, never on the
+	// knob - they do not move and there is no value arc; the pointer alone
+	// carries the value, as on real hardware.
+	const QColor inkBase(tokens.mutedText);
+	const int inkAlpha = state.enabled ? 200 : 90;
+	for (int i = 0; i <= 10; i++)
+	{
+		const qreal ratio = i / 10.0;
+		const bool centerTick = state.bipolar && i == 5;
+		const bool major = i == 0 || i == 10 || centerTick;
+		// The bipolar neutral (0 dB at 12 o'clock) is a bold accent tick.
+		QColor ink = centerTick ? QColor(tokens.accent) : inkBase;
+		ink.setAlpha(inkAlpha);
+		painter.setPen(QPen(ink, major ? 2.0 : 1.0, Qt::SolidLine, Qt::FlatCap));
+		painter.drawLine(pointAt(ratio, bodyRadius + 3.5), pointAt(ratio, major ? scaleRadius + 0.5 : scaleRadius - 1.5));
+	}
+
+	// Bipolar knobs print the cut/boost glyphs in the dead zone under the
+	// scale ends, like a gain pot's faceplate. Unipolar knobs stay plain, so
+	// the two kinds never look alike.
+	if (state.bipolar)
+	{
+		QFont glyphFont(tokens.fontFamily);
+		glyphFont.setPixelSize(9);
+		glyphFont.setBold(true);
+		painter.setFont(glyphFont);
+		painter.setPen(withAlpha(inkBase, inkAlpha));
+		const QPointF minusAt = pointAt(-0.07, scaleRadius - 2.0);
+		const QPointF plusAt = pointAt(1.07, scaleRadius - 2.0);
+		painter.drawText(QRectF(minusAt.x() - 6, minusAt.y() - 6, 12, 12), Qt::AlignCenter, QStringLiteral("-"));
+		painter.drawText(QRectF(plusAt.x() - 6, plusAt.y() - 6, 12, 12), Qt::AlignCenter, QStringLiteral("+"));
+	}
+
+	// Knob body: bakelite (dark mode) / machined aluminium (light mode) with
+	// an offset highlight suggesting the work light.
+	QRadialGradient bodyGrad(center - QPointF(bodyRadius * 0.4, bodyRadius * 0.4), bodyRadius * 2.2);
+	const QColor cap(tokens.card);
+	if (dark)
+	{
+		bodyGrad.setColorAt(0.0, cap.lighter(190));
+		bodyGrad.setColorAt(0.6, cap.lighter(115));
+		bodyGrad.setColorAt(1.0, cap.darker(160));
+	}
+	else
+	{
+		bodyGrad.setColorAt(0.0, QColor(0xFF, 0xFF, 0xFF));
+		bodyGrad.setColorAt(0.6, QColor(0xDE, 0xD7, 0xC6));
+		bodyGrad.setColorAt(1.0, QColor(0xA8, 0x9F, 0x8C));
+	}
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 200) : QColor(0x7E, 0x75, 0x62), 1));
+	painter.setBrush(bodyGrad);
+	painter.drawEllipse(center, bodyRadius, bodyRadius);
+
+	// Machined cap step and the specular arc on its top edge.
+	const qreal capRadius = bodyRadius - 3.5;
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 90 : 50), 1));
+	painter.setBrush(Qt::NoBrush);
+	painter.drawEllipse(center, capRadius, capRadius);
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 70 : 150), 1.2));
+	painter.drawArc(QRectF(center.x() - capRadius, center.y() - capRadius, capRadius * 2, capRadius * 2), 60 * 16, 60 * 16);
+
+	// The pointer: a physical painted line. Hover/drag turns it amber (the
+	// hand is on the knob), disabled grays it out.
+	QColor pointerColor;
+	if (!state.enabled)
+		pointerColor = withAlpha(inkBase, 130);
+	else if (state.dragging || state.hovered)
+		pointerColor = QColor(tokens.accent);
+	else
+		pointerColor = dark ? QColor(0xF2, 0xEC, 0xDC) : QColor(0x2E, 0x29, 0x22);
+	painter.setPen(QPen(pointerColor, 2.4, Qt::SolidLine, Qt::RoundCap));
+	painter.drawLine(pointAt(state.ratio, bodyRadius * 0.30), pointAt(state.ratio, bodyRadius - 3.0));
+
+	// Hover/drag: the knob rim catches the light.
+	if (state.enabled && (state.hovered || state.dragging))
+	{
+		painter.setPen(QPen(withAlpha(QColor(tokens.accent), 90), 1.4));
+		painter.setBrush(Qt::NoBrush);
+		painter.drawEllipse(center, bodyRadius + 0.8, bodyRadius + 0.8);
+	}
+
+	// Keyboard focus: thin ring around the printed scale.
+	if (state.focused)
+	{
+		painter.setPen(QPen(withAlpha(QColor(tokens.focusRing), 180), 1));
+		painter.setBrush(Qt::NoBrush);
+		painter.drawEllipse(center, scaleRadius + 2.0, scaleRadius + 2.0);
+	}
+
+	// Powered-down knob: dim film over the body.
+	if (!state.enabled)
+	{
+		painter.setPen(Qt::NoPen);
+		painter.setBrush(dark ? QColor(0, 0, 0, 90) : QColor(255, 252, 244, 130));
+		painter.drawEllipse(center, bodyRadius, bodyRadius);
+	}
+
+	// LED display window set into the knob cap; it brightens while the knob
+	// is touched (hover/drag/focus). Promoted legacy dials pass an empty
+	// valueText (their value lives in a spin box) - then no window is shown.
+	if (!state.valueText.isEmpty())
+	{
+		QFont ledFont(tokens.monoFontFamily);
+		ledFont.setPixelSize(9);
+		ledFont.setBold(true);
+		const QFontMetricsF metrics(ledFont);
+		const qreal w = qMin(side - 4.0, metrics.horizontalAdvance(state.valueText) + 10.0);
+		const QRectF window(center.x() - w / 2.0, center.y() - 7.0, w, 14.0);
+		painter.setPen(QPen(QColor(0, 0, 0, 220), 1));
+		painter.setBrush(QColor(10, 14, 11, 235));
+		painter.drawRoundedRect(window, 2, 2);
+
+		QColor ledInk = dark ? QColor(0x86, 0xF2, 0xBA) : QColor(0x3E, 0xD6, 0x8E);
+		if (!state.enabled)
+			ledInk = withAlpha(ledInk, 70);
+		else if (!(state.hovered || state.dragging || state.focused))
+			ledInk = withAlpha(ledInk, 175);
+		painter.setFont(ledFont);
+		painter.setPen(ledInk);
+		painter.drawText(window, Qt::AlignCenter, state.valueText);
+	}
+}
+}

--- a/Editor/skins/RackChrome.h
+++ b/Editor/skins/RackChrome.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Painted chrome for the "rack" skin ("The amplifier faceplate",
+	skeuomorphic 19-inch rack hardware). Every command row is dressed as a
+	rack unit: brushed faceplate, rack ears, four corner screws, status LEDs,
+	patchbay jacks on Include units and a brass nameplate on VST units. Knobs
+	are physical pointer knobs whose scale is printed on the panel around
+	them, as real hardware does. Everything is QPainter-drawn - no image
+	resources - so the chrome stays DPI independent. Kept out of Skins.cpp so
+	the skin class stays a thin registration shim.
+*/
+
+#pragma once
+
+#include <QRect>
+
+struct CommandRowInfo;
+struct KnobState;
+struct SkinTokens;
+class QPainter;
+
+namespace RackChrome
+{
+// Width of the rack-ear zone reserved on both faceplate edges; row content
+// is inset past it (see RackSkin::prepareCommandRow).
+int earWidth();
+
+// Extra header inset reserved on VST rows for the painted brand nameplate.
+int nameplateReserve();
+
+// Faceplate decoration drawn by CommandRowFrame between the QSS background
+// and the child widgets.
+void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens);
+
+// Skeuomorphic pointer knob with a panel-printed scale.
+void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens);
+}

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,14 @@
 
 #include "Skins.h"
 
+#include <QFontMetrics>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPixmap>
+#include <QVBoxLayout>
+#include <QtMath>
+
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -253,7 +261,40 @@ public:
 	}
 };
 
-// ── Matrix (signal matrix / instrument panel) ───────────────────────────────
+// ── Matrix (signal-routing matrix / departure board) ────────────────────────
+//
+// Constitution: an airport departure board / broadcast routing matrix.
+// Everything aligns to a grid; numeric values are monospace; 1px rules; rows
+// behave like cells with coordinates. Traffic-light colours (green/amber/red)
+// are reserved for status and never used decoratively. Hover highlights the
+// row band and the coordinate-column band (crosspoint feel). Disabled rows get
+// a dashed border. Knobs are rotary encoders with a stepped LED ring and a
+// boxed mono numeric cell as the authoritative reading.
+
+namespace MatrixMetrics
+{
+// The grid the whole skin aligns to (card grid pitch, coordinate column).
+constexpr int gridPitch = 24;
+// Width of the coordinate-column band (expand + number + type cells of the
+// header) used by the crosspoint hover highlight.
+constexpr int coordinateBandWidth = 120;
+// Left inset of the card content: 3px status rail (border-left) + 1px gutter.
+constexpr int railInset = 4;
+// Height of the boxed numeric readout cell under a card knob.
+constexpr int knobCellHeight = 16;
+}
+
+namespace
+{
+// Point on the 270-degree value arc; fraction 0 is bottom-left (7:30), 0.5 is
+// 12 o'clock, 1 is bottom-right (4:30). Same sweep as the shared default knob.
+QPointF matrixRadialPoint(const QPointF& center, double radius, double fraction)
+{
+	const double radians = qDegreesToRadians(-(135.0 + 270.0 * fraction));
+	return QPointF(center.x() + qCos(radians) * radius, center.y() - qSin(radians) * radius);
+}
+}
+
 class MatrixSkin : public ISkin
 {
 public:
@@ -272,9 +313,11 @@ public:
 		SkinTokens t;
 		t.fontFamily = QStringLiteral("DM Sans");
 		t.monoFontFamily = QStringLiteral("DM Mono");
-		t.borderRadius = 10;
-		t.rowHeight = 38;
-		t.channelGroupIndent = 22;
+		// Square cells and 1px rules only; 36px rows keep the board dense and
+		// on the 12px grid (gridPitch 24 = two rows of 12).
+		t.borderRadius = 0;
+		t.rowHeight = 36;
+		t.channelGroupIndent = 24;
 		t.channelGroupStyle = SkinTokens::GradientBar;
 		t.badgeStyle = SkinTokens::OutlineOnly;
 		t.cardRailWidth = 3;
@@ -305,9 +348,285 @@ public:
 			t.border = QStringLiteral("#D4E2E8");
 			t.graph = QStringLiteral("#F9FCFD");
 			t.graphGridMinor = QStringLiteral("#D4E2E8");
+			// Traffic-light status colours tuned for contrast on light surfaces.
+			t.success = QStringLiteral("#15803D");
+			t.warning = QStringLiteral("#B45309");
+			t.danger = QStringLiteral("#DC2626");
 		}
 		finishTokens(t);
 		return t;
+	}
+
+	// Rotary encoder with an LED ring: the value reads as discrete lit
+	// segments, the exact value as text in a boxed mono cell. Bipolar knobs
+	// light segments left or right of a centre gap (12 o'clock detent);
+	// unipolar knobs fill clockwise from the minimum.
+	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
+	{
+		const QColor borderColor(tokens.border);
+		const QColor accentColor(tokens.accent);
+		const QColor cutColor(tokens.accent2);
+		const QColor mutedColor(tokens.mutedText);
+
+		// Reserve the bottom strip for the boxed numeric cell when the widget
+		// supplies an authoritative value text (e.g. the Preamp card). Promoted
+		// legacy dials show their value in the adjacent spin box instead.
+		QRect knobArea = rect;
+		if (!state.valueText.isEmpty())
+			knobArea.adjust(0, 0, 0, -(MatrixMetrics::knobCellHeight + 2));
+
+		QRectF inner = QRectF(knobArea).adjusted(5, 5, -5, -5);
+		const double side = qMin(inner.width(), inner.height());
+		const QRectF ringRect(inner.center().x() - side / 2.0, inner.center().y() - side / 2.0, side, side);
+		const QPointF center = ringRect.center();
+		const double outerRadius = side / 2.0;
+		const double innerRadius = qMax(outerRadius - 6.0, 1.0);
+		const double bodyRadius = qMax(innerRadius - 3.0, 1.0);
+
+		painter.setRenderHint(QPainter::Antialiasing);
+
+		// Segment ring. An even count gives bipolar knobs a natural centre gap
+		// at 12 o'clock; unipolar knobs use an odd count so a segment sits at
+		// every position including the centre.
+		const int segmentCount = state.bipolar ? 14 : 15;
+		const int half = segmentCount / 2;
+		int litFrom = 0;
+		int litCount = 0;
+		bool boost = true;
+		if (state.bipolar)
+		{
+			const double deviation = state.ratio - 0.5;
+			boost = deviation >= 0.0;
+			litCount = qMin(half, qRound(qAbs(deviation) * 2.0 * half));
+			litFrom = boost ? half : half - litCount;
+		}
+		else
+		{
+			litCount = qBound(0, qRound(state.ratio * segmentCount), segmentCount);
+		}
+
+		QColor litColor = state.bipolar && !boost ? cutColor : accentColor;
+		if (state.dragging)
+			litColor = litColor.lighter(130);
+		else if (state.hovered)
+			litColor = litColor.lighter(115);
+		QColor trackColor = borderColor;
+		trackColor.setAlpha(state.enabled ? 170 : 70);
+
+		for (int i = 0; i < segmentCount; i++)
+		{
+			const double fraction = (i + 0.5) / segmentCount;
+			const bool lit = state.enabled && i >= litFrom && i < litFrom + litCount;
+			QPen segmentPen(lit ? litColor : trackColor, 3.0, Qt::SolidLine, Qt::FlatCap);
+			painter.setPen(segmentPen);
+			painter.drawLine(matrixRadialPoint(center, innerRadius, fraction),
+				matrixRadialPoint(center, outerRadius, fraction));
+		}
+
+		// Centre detent tick: marks the 0-position gap of bipolar knobs so the
+		// two knob kinds read differently even at rest.
+		if (state.bipolar)
+		{
+			painter.setPen(QPen(state.enabled ? mutedColor : trackColor, 1.0, Qt::SolidLine, Qt::FlatCap));
+			painter.drawLine(matrixRadialPoint(center, outerRadius + 1.0, 0.5),
+				matrixRadialPoint(center, outerRadius + 4.0, 0.5));
+		}
+
+		// Encoder body and pointer.
+		QColor bodyColor(state.enabled ? tokens.card : tokens.surface);
+		painter.setPen(QPen(borderColor, 1.0, state.enabled ? Qt::SolidLine : Qt::DashLine));
+		painter.setBrush(bodyColor);
+		painter.drawEllipse(center, bodyRadius, bodyRadius);
+		painter.setPen(QPen(state.enabled ? litColor : QColor(mutedColor), 2.0, Qt::SolidLine, Qt::FlatCap));
+		painter.drawLine(matrixRadialPoint(center, bodyRadius * 0.45, state.ratio),
+			matrixRadialPoint(center, bodyRadius - 1.5, state.ratio));
+
+		painter.setRenderHint(QPainter::Antialiasing, false);
+
+		// Keyboard focus: a square cell bracket, not a glow - this skin's
+		// corner language is the rectangle.
+		if (state.focused && state.enabled)
+		{
+			painter.setPen(QPen(accentColor, 1));
+			painter.setBrush(Qt::NoBrush);
+			painter.drawRect(ringRect.toRect().adjusted(-3, -3, 3, 3));
+		}
+
+		// Boxed mono numeric cell: the authoritative reading.
+		if (!state.valueText.isEmpty())
+		{
+			QFont monoFont(tokens.monoFontFamily);
+			monoFont.setPointSizeF(7.5);
+			monoFont.setBold(true);
+			const QFontMetrics metrics(monoFont);
+			const int cellWidth = qMin(rect.width(), metrics.horizontalAdvance(state.valueText) + 12);
+			const QRect cellRect(rect.center().x() - cellWidth / 2,
+				rect.bottom() - MatrixMetrics::knobCellHeight + 1, cellWidth, MatrixMetrics::knobCellHeight - 1);
+			painter.setPen(QPen(state.dragging ? accentColor : borderColor, 1));
+			painter.setBrush(QColor(tokens.surfaceSunken));
+			painter.drawRect(cellRect);
+			painter.setFont(monoFont);
+			if (!state.enabled)
+				painter.setPen(QColor(mutedColor));
+			else if (state.dragging || state.hovered)
+				painter.setPen(accentColor);
+			else
+				painter.setPen(QColor(tokens.text));
+			painter.drawText(cellRect, Qt::AlignCenter, state.valueText);
+		}
+	}
+
+	// Departure-board cell: square corners, 1px rule, and a 3px status rail in
+	// traffic-light semantics (green = active, amber = bypassed). A commented
+	// out row additionally swaps the outer rule for a dashed one.
+	QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		const QString railColor = info.enabled ? tokens.success : tokens.warning;
+		const QString borderColor = info.focused ? tokens.focusRing : (info.selected ? tokens.accent : tokens.border);
+		const QString backgroundColor = info.selected ? tokens.cardSelected : tokens.card;
+		const QString borderStyle = info.enabled ? QStringLiteral("solid") : QStringLiteral("dashed");
+		QString style = QStringLiteral(
+			"QFrame#FilterCardRow { background: %1; border: 1px %2 %3; border-left: 3px solid %4; border-radius: 0px; }")
+			.arg(backgroundColor, borderStyle, borderColor, railColor);
+		// The :hover rule both signals the row crosspoint and makes Qt repaint
+		// the frame on enter/leave, which drives the painted column band.
+		style += QStringLiteral(
+			" QFrame#FilterCardRow:hover { border: 1px %1 %2; border-left: 3px solid %3; }")
+			.arg(borderStyle, tokens.accent, railColor);
+		return style;
+	}
+
+	// The header strip stays transparent: paintCardChrome owns the band fill,
+	// the 1px header rule and the faint column grid behind it.
+	QString cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		Q_UNUSED(info);
+		Q_UNUSED(tokens);
+		return QStringLiteral("QWidget#FilterCardHeader { background: transparent; border-radius: 0px; }");
+	}
+
+	// Monochrome type cell: the command type reads from the mono code text
+	// (BQUAD/INC/VST/...), not from a per-type colour. Traffic-light colours
+	// stay reserved for status.
+	QString typeBadgeStyle(const CommandRowInfo& info, const QString& typeColor, const SkinTokens& tokens) const override
+	{
+		Q_UNUSED(typeColor);
+		const QString ink = info.enabled ? tokens.text : tokens.mutedText;
+		return QStringLiteral("color:%1; border-color:%2; background-color:transparent;")
+			.arg(ink, tokens.border);
+	}
+
+	// Per-type body treatments. The frozen legacy rows keep their stock
+	// construction; only the modern card editors are decorated.
+	void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const override
+	{
+		Q_UNUSED(card);
+		Q_UNUSED(header);
+		if (info.legacyRow || body == nullptr)
+			return;
+
+		if (info.type == QStringLiteral("include"))
+		{
+			// Include row: a single "> source: <path>" board line. The stock
+			// file icon becomes a mono feed marker (QSS #IncludeCardGlyph
+			// styles it); the path field is already the <path> cell. ASCII ">"
+			// instead of U+25B8: DM Mono has no glyph for the triangle and the
+			// offscreen platform renders tofu.
+			QLabel* glyph = body->findChild<QLabel*>(QStringLiteral("IncludeCardGlyph"));
+			if (glyph != nullptr)
+				glyph->setText(QStringLiteral("> source:"));
+		}
+		else if (info.type == QStringLiteral("vst") && body->objectName() == QStringLiteral("VSTCardEditor"))
+		{
+			// VST row: an external-device entry. A port strip with IN/OUT
+			// markings heads the body, so the plugin reads as outboard gear
+			// patched into the signal path.
+			QVBoxLayout* bodyLayout = qobject_cast<QVBoxLayout*>(body->layout());
+			if (bodyLayout == nullptr)
+				return;
+			QWidget* strip = new QWidget(body);
+			strip->setObjectName(QStringLiteral("MatrixVstPortStrip"));
+			QHBoxLayout* stripLayout = new QHBoxLayout(strip);
+			stripLayout->setContentsMargins(0, 0, 0, 0);
+			stripLayout->setSpacing(8);
+			QLabel* inPort = new QLabel(QStringLiteral("> IN"), strip);
+			inPort->setObjectName(QStringLiteral("MatrixVstPortLabel"));
+			stripLayout->addWidget(inPort);
+			stripLayout->addStretch(1);
+			QLabel* device = new QLabel(QStringLiteral("EXTERNAL DEVICE"), strip);
+			device->setObjectName(QStringLiteral("MatrixVstDeviceLabel"));
+			stripLayout->addWidget(device);
+			stripLayout->addStretch(1);
+			QLabel* outPort = new QLabel(QStringLiteral("OUT >"), strip);
+			outPort->setObjectName(QStringLiteral("MatrixVstPortLabel"));
+			stripLayout->addWidget(outPort);
+			bodyLayout->insertWidget(0, strip);
+		}
+	}
+
+	// Painted board chrome: header band, 1px header rule, faint column grid,
+	// status lamp, and the crosspoint hover (row band + coordinate-column
+	// band). Drawn under the transparent header/body so children stay crisp.
+	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		if (info.type == QStringLiteral("spacer"))
+			return;
+
+		painter.setRenderHint(QPainter::Antialiasing, false);
+
+		const QRect content = rect.adjusted(MatrixMetrics::railInset, 1, -1, -1);
+		if (content.width() <= 0 || content.height() <= 0)
+			return;
+		const int headerHeight = qMin(tokens.rowHeight, content.height());
+		const QRect headerBand(content.left(), content.top(), content.width(), headerHeight);
+
+		// Header band fill (the header widget itself is transparent).
+		painter.fillRect(headerBand, QColor(info.selected ? tokens.surfaceRaised : tokens.cardHover));
+
+		// Faint column grid: the graph paper the board sits on.
+		QColor gridColor(tokens.border);
+		gridColor.setAlpha(info.enabled ? 60 : 30);
+		painter.setPen(QPen(gridColor, 1));
+		for (int x = content.left() + MatrixMetrics::gridPitch; x < content.right(); x += MatrixMetrics::gridPitch)
+			painter.drawLine(x, content.top(), x, content.bottom());
+
+		// 1px rule between the header cell and the body cell.
+		if (content.height() > headerHeight)
+		{
+			painter.setPen(QPen(QColor(tokens.border), 1));
+			painter.drawLine(content.left(), content.top() + headerHeight, content.right(), content.top() + headerHeight);
+		}
+
+		// Crosspoint hover: the row band and the coordinate-column band light
+		// up; their intersection is the crosspoint.
+		if (info.hovered && info.enabled)
+		{
+			QColor rowBand(tokens.accent);
+			rowBand.setAlpha(22);
+			painter.fillRect(headerBand, rowBand);
+			const QRect columnBand(content.left(), content.top(),
+				qMin(MatrixMetrics::coordinateBandWidth, content.width()), content.height());
+			QColor columnColor(tokens.accent);
+			columnColor.setAlpha(14);
+			painter.fillRect(columnBand, columnColor);
+			QColor crosspoint(tokens.accent);
+			crosspoint.setAlpha(26);
+			painter.fillRect(QRect(columnBand.left(), headerBand.top(), columnBand.width(), headerBand.height()), crosspoint);
+		}
+
+		// Status lamp in the left gutter: solid green = active, hollow amber =
+		// bypassed (traffic-light semantics, never decorative).
+		const QRect lampRect(content.left() + 1, content.top() + headerHeight / 2 - 3, 5, 5);
+		if (info.enabled)
+		{
+			painter.fillRect(lampRect, QColor(tokens.success));
+		}
+		else
+		{
+			painter.setPen(QPen(QColor(tokens.warning), 1));
+			painter.setBrush(Qt::NoBrush);
+			painter.drawRect(lampRect.adjusted(0, 0, -1, -1));
+		}
 	}
 };
 

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,9 @@
 
 #include "Skins.h"
 
+#include <QPainter>
+#include <QtMath>
+
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -23,7 +26,36 @@ void finishTokens(SkinTokens& t)
 	t.focusRing = t.accent;
 }
 
-// ── Studio (glass, FabFilter-like) ──────────────────────────────────────────
+// ── Studio (glass over the instrument, FabFilter-like) ──────────────────────
+// The UI recedes behind the data: deep solid backgrounds, panels as glass
+// (solid colour with alpha plus a single 1px lighter top edge), one glowing
+// accent. Glow is faked with layered strokes and gradient borders, never
+// effects. Tiebreaker: if an element is not the arc, the label or the value,
+// it gets removed.
+
+// QSS colour with alpha derived from a token hex string.
+QString studioRgba(const QString& hex, double alpha)
+{
+	const QColor color(hex);
+	return QStringLiteral("rgba(%1, %2, %3, %4)")
+		.arg(color.red()).arg(color.green()).arg(color.blue())
+		.arg(alpha, 0, 'f', 2);
+}
+
+QColor studioAlpha(const QString& hex, int alpha)
+{
+	QColor color(hex);
+	color.setAlpha(alpha);
+	return color;
+}
+
+// The hooks receive tokens but not the mode flag; the background luminance is
+// an unambiguous proxy because studio's dark background is near-black.
+bool studioIsDark(const SkinTokens& tokens)
+{
+	return QColor(tokens.background).lightness() < 128;
+}
+
 class StudioSkin : public ISkin
 {
 public:
@@ -37,12 +69,226 @@ public:
 		static CurvedNodeRoutingRenderer renderer;
 		return &renderer;
 	}
+
+	// "The arc IS the value": no knob body, only a thin track circle, a
+	// glowing accent arc from the reference point to the current value and a
+	// small indicator dot. Bipolar (gain) knobs anchor at 12 o'clock and grow
+	// left or right; unipolar knobs grow from the track start. The numeric
+	// readout fades in while hovering or dragging; glow intensifies during a
+	// drag; disabled knobs drop to reduced opacity with the glow off.
+	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
+	{
+		painter.setRenderHint(QPainter::Antialiasing);
+
+		// Centred square so the knob stays round in non-square hosts
+		// (promoted legacy dials are 100x66, the card knob is 74x74).
+		const QRectF inner = QRectF(rect).adjusted(9, 9, -9, -9);
+		const double side = qMin(inner.width(), inner.height());
+		const QRectF track(inner.center().x() - side / 2.0, inner.center().y() - side / 2.0, side, side);
+
+		const double span = 270.0;
+		const double start = 135.0;     // degrees clockwise from 3 o'clock
+		const double ratio = qBound(0.0, state.ratio, 1.0);
+
+		if (!state.enabled)
+			painter.setOpacity(0.35);
+
+		// Track: the full range geometry as a thin circle segment.
+		painter.setBrush(Qt::NoBrush);
+		painter.setPen(QPen(QColor(tokens.border), 2.0, Qt::SolidLine, Qt::RoundCap));
+		painter.drawArc(track, qRound(-start * 16), qRound(-span * 16));
+
+		// Reference tick: bipolar knobs mark 0 dB at 12 o'clock so the anchor
+		// stays visible even with an empty arc; unipolar knobs carry no tick.
+		if (state.bipolar)
+		{
+			const QPointF top(track.center().x(), track.top());
+			painter.setPen(QPen(QColor(tokens.mutedText), 1.5));
+			painter.drawLine(QPointF(top.x(), top.y() - 3.0), QPointF(top.x(), top.y() + 3.0));
+		}
+
+		double arcFrom = start;
+		double sweep = span * ratio;
+		if (state.bipolar)
+		{
+			arcFrom = start + span / 2.0;  // 12 o'clock
+			sweep = span * (ratio - 0.5);  // signed: cut grows left, boost right
+		}
+
+		// Fake glow: the same arc repainted with wider, more transparent
+		// strokes. Hover brightens it, dragging brightens it further.
+		const int halo = state.dragging ? 88 : (state.hovered ? 58 : 32);
+		const QColor accent(tokens.accent);
+		const struct { double width; int alpha; } layers[] = {
+			{ 9.0, halo / 3 },
+			{ 5.5, halo },
+			{ 2.5, 255 }
+		};
+		for (const auto& layer : layers)
+		{
+			QColor stroke = accent;
+			stroke.setAlpha(layer.alpha);
+			painter.setPen(QPen(stroke, layer.width, Qt::SolidLine, Qt::RoundCap));
+			painter.drawArc(track, qRound(-arcFrom * 16), qRound(-sweep * 16));
+		}
+
+		// Indicator dot on the track at the arc end, with its own halo.
+		const double endRadians = qDegreesToRadians(-(arcFrom + sweep));
+		const QPointF dot(track.center().x() + qCos(endRadians) * side / 2.0,
+			track.center().y() - qSin(endRadians) * side / 2.0);
+		QColor dotHalo = accent;
+		dotHalo.setAlpha(halo);
+		painter.setPen(Qt::NoPen);
+		painter.setBrush(dotHalo);
+		painter.drawEllipse(dot, 6.0, 6.0);
+		painter.setBrush(accent);
+		painter.drawEllipse(dot, 3.0, 3.0);
+
+		// Keyboard focus: a thin ring just outside the track.
+		if (state.focused)
+		{
+			QColor ring = accent;
+			ring.setAlpha(110);
+			painter.setPen(QPen(ring, 1.0));
+			painter.setBrush(Qt::NoBrush);
+			painter.drawEllipse(track.adjusted(-4, -4, 4, 4));
+		}
+
+		// Numeric readout, mono, fading in on hover and solid while dragging.
+		// Only painted when the host supplied a display string (promoted
+		// legacy dials show their value in a separate spin box instead).
+		if (!state.valueText.isEmpty() && state.enabled && (state.hovered || state.dragging))
+		{
+			QColor textColor(tokens.text);
+			textColor.setAlpha(state.dragging ? 255 : 210);
+			painter.setPen(textColor);
+			QFont valueFont(tokens.monoFontFamily);
+			valueFont.setPointSizeF(qMax(7.0, painter.font().pointSizeF() - 1.0));
+			valueFont.setWeight(QFont::DemiBold);
+			painter.setFont(valueFont);
+			painter.drawText(rect, Qt::AlignCenter, state.valueText);
+		}
+	}
+
+	// Glass card: solid colour with alpha over the deep background plus a 1px
+	// lighter top edge (the reflection). Command types keep one silhouette but
+	// announce themselves through the border treatment: DSP rows solid,
+	// Include rows dashed (a reference to elsewhere), VST rows a vertical
+	// accent gradient (the module radiates its own light). Hover brightens;
+	// disabled rows lose the reflection and most of their opacity.
+	QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		const bool dark = studioIsDark(tokens);
+
+		if (!info.enabled)
+		{
+			return QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: 8px; }")
+				.arg(studioRgba(tokens.card, 0.45), studioRgba(tokens.border, 0.55));
+		}
+
+		const QString background = studioRgba(info.selected ? tokens.cardSelected : tokens.card, 0.88);
+		const QString hoverBackground = studioRgba(info.selected ? tokens.cardSelected : tokens.cardHover, 0.94);
+		const QString topEdge = dark ? QStringLiteral("rgba(255, 255, 255, 0.10)") : QStringLiteral("rgba(255, 255, 255, 0.95)");
+		const QString topEdgeHover = dark ? QStringLiteral("rgba(255, 255, 255, 0.17)") : QStringLiteral("#FFFFFF");
+
+		if (info.type == QStringLiteral("vst"))
+		{
+			// The gradient border is the glow; no separate top edge needed.
+			const QString gradient = QStringLiteral("qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 %1, stop:1 %2)")
+				.arg(studioRgba(tokens.accent, info.focused || info.selected ? 0.95 : 0.70),
+					studioRgba(tokens.accent, info.focused || info.selected ? 0.45 : 0.22));
+			const QString hoverGradient = QStringLiteral("qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 %1, stop:1 %2)")
+				.arg(studioRgba(tokens.accent, 0.95), studioRgba(tokens.accent, 0.40));
+			return QStringLiteral(
+				"QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: 8px; }"
+				" QFrame#FilterCardRow:hover { background: %3; border-color: %4; }")
+				.arg(background, gradient, hoverBackground, hoverGradient);
+		}
+
+		const QString borderStyle = info.type == QStringLiteral("include")
+			? QStringLiteral("dashed") : QStringLiteral("solid");
+		const QString borderBrush = info.focused
+			? tokens.focusRing
+			: (info.selected ? studioRgba(tokens.accent, 0.65) : studioRgba(tokens.border, 0.90));
+		const QString hoverBorderBrush = info.focused ? tokens.focusRing : studioRgba(tokens.accent, 0.45);
+
+		return QStringLiteral(
+			"QFrame#FilterCardRow { background: %1; border: 1px %2 %3; border-top-color: %4; border-radius: 8px; }"
+			" QFrame#FilterCardRow:hover { background: %5; border-color: %6; border-top-color: %7; }")
+			.arg(background, borderStyle, borderBrush, topEdge, hoverBackground, hoverBorderBrush, topEdgeHover);
+	}
+
+	QString cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		const bool dark = studioIsDark(tokens);
+		if (!info.enabled)
+		{
+			// Disabled: the sheen is off, the header melts into the glass.
+			return QStringLiteral("QWidget#FilterCardHeader { background: transparent; border-top-left-radius: 8px; border-top-right-radius: 8px; }");
+		}
+		const QString sheen = dark
+			? (info.selected ? QStringLiteral("rgba(255, 255, 255, 0.07)") : QStringLiteral("rgba(255, 255, 255, 0.04)"))
+			: (info.selected ? QStringLiteral("rgba(255, 255, 255, 0.75)") : QStringLiteral("rgba(255, 255, 255, 0.55)"));
+		return QStringLiteral("QWidget#FilterCardHeader { background: %1; border-top-left-radius: 8px; border-top-right-radius: 8px; }")
+			.arg(sheen);
+	}
+
+	// Painted decoration on top of the QSS chrome. DSP rows get a short
+	// "signal lamp": a glowing accent segment on the left edge, vertically
+	// centred on the header strip. VST rows get a halo hugging the border so
+	// the module reads as lit from within. Include/comment/raw rows stay
+	// unlit; disabled rows paint nothing (the lamp is off).
+	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		if (!info.enabled)
+			return;
+		if (info.type == QStringLiteral("spacer") || info.type == QStringLiteral("comment")
+			|| info.type == QStringLiteral("text") || info.type == QStringLiteral("include"))
+			return;
+
+		painter.save();
+		painter.setRenderHint(QPainter::Antialiasing);
+
+		if (info.type == QStringLiteral("vst"))
+		{
+			// Two strokes hugging the border fake an outer glow without
+			// effects; hover turns the light up.
+			const QRectF edge = QRectF(rect).adjusted(0.5, 0.5, -0.5, -0.5);
+			painter.setBrush(Qt::NoBrush);
+			painter.setPen(QPen(studioAlpha(tokens.accent, info.hovered ? 120 : 80), 1.0));
+			painter.drawRoundedRect(edge, 8.0, 8.0);
+			painter.setPen(QPen(studioAlpha(tokens.accent, info.hovered ? 60 : 36), 3.0));
+			painter.drawRoundedRect(edge.adjusted(1.5, 1.5, -1.5, -1.5), 6.5, 6.5);
+		}
+		else
+		{
+			const double segment = 18.0;
+			const double y0 = rect.top() + (tokens.rowHeight - segment) / 2.0;
+			QLinearGradient lamp(0, y0, 0, y0 + segment);
+			QColor mid = studioAlpha(tokens.accent, info.hovered ? 235 : 185);
+			QColor fade = studioAlpha(tokens.accent, 0);
+			lamp.setColorAt(0.0, fade);
+			lamp.setColorAt(0.5, mid);
+			lamp.setColorAt(1.0, fade);
+			painter.setPen(Qt::NoPen);
+			// Bloom first (wider, fainter), then the lamp core on the edge.
+			QLinearGradient bloom(0, y0 - 3.0, 0, y0 + segment + 3.0);
+			bloom.setColorAt(0.0, fade);
+			bloom.setColorAt(0.5, studioAlpha(tokens.accent, info.hovered ? 70 : 42));
+			bloom.setColorAt(1.0, fade);
+			painter.fillRect(QRectF(rect.left(), y0 - 3.0, 4.0, segment + 6.0), bloom);
+			painter.fillRect(QRectF(rect.left(), y0, 2.0, segment), lamp);
+		}
+
+		painter.restore();
+	}
+
 	SkinTokens tokens(bool dark) const override
 	{
 		SkinTokens t;
 		t.fontFamily = QStringLiteral("DM Sans");
 		t.monoFontFamily = QStringLiteral("DM Mono");
-		t.borderRadius = 16;
+		t.borderRadius = 8;
 		t.rowHeight = 40;
 		t.channelGroupIndent = 18;
 		t.channelGroupStyle = SkinTokens::GradientBar;

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,10 @@
 
 #include "Skins.h"
 
+#include <QLayout>
+#include <QWidget>
+
+#include "Editor/skins/RackChrome.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -196,7 +200,7 @@ public:
 	}
 };
 
-// ── Rack (skeuomorphic 19" hardware) ────────────────────────────────────────
+// ── Rack ("The amplifier faceplate", skeuomorphic 19" hardware) ─────────────
 class RackSkin : public ISkin
 {
 public:
@@ -210,12 +214,67 @@ public:
 		static HardwarePatchbayRoutingRenderer renderer;
 		return &renderer;
 	}
+
+	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
+	{
+		RackChrome::paintKnob(painter, rect, state, tokens);
+	}
+
+	QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		// QSS only provides the machined base plate and the hover brightening;
+		// the faceplate texture, ears, screws and LEDs are painted on top by
+		// RackChrome::paintCardChrome (the sheen overlays are translucent, so
+		// the hover state shines through them).
+		const QString borderColor = info.focused ? tokens.focusRing : (info.selected ? tokens.accent : tokens.border);
+		const QString background = info.selected ? tokens.cardSelected : tokens.card;
+		return QStringLiteral(
+			"QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: %3px; }"
+			"QFrame#FilterCardRow:hover { background: %4; }")
+			.arg(background, borderColor)
+			.arg(tokens.borderRadius)
+			.arg(info.selected ? tokens.cardSelected : tokens.cardHover);
+	}
+
+	QString cardHeaderStyle(const CommandRowInfo&, const SkinTokens&) const override
+	{
+		// The header strip is part of the painted faceplate; a transparent
+		// background lets the brushed metal, ears and LEDs show through.
+		return QStringLiteral("QWidget#FilterCardHeader { background: transparent; }");
+	}
+
+	void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const override
+	{
+		// Reserve the rack-ear zones along the faceplate edges so the painted
+		// chrome (screws, LEDs, patchbay jacks, the VST nameplate) never
+		// collides with row content. Rows are rebuilt on every skin switch, so
+		// this only ever runs while the rack skin is active.
+		if (header != nullptr && header->layout() != nullptr)
+		{
+			const int right = RackChrome::earWidth() + 6
+				+ (info.type == QStringLiteral("vst") ? RackChrome::nameplateReserve() : 0);
+			header->layout()->setContentsMargins(RackChrome::earWidth() + 6, 4, right, 4);
+		}
+		// Only the modern card's body stack is inset; body-only consultations
+		// (Include/VST editors, legacy rows) already sit inside that stack.
+		if (card != nullptr && body != nullptr)
+			body->setContentsMargins(RackChrome::earWidth() + 4, 0, RackChrome::earWidth() + 4, 6);
+	}
+
+	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		RackChrome::paintCardChrome(painter, rect, info, tokens);
+	}
+
 	SkinTokens tokens(bool dark) const override
 	{
 		SkinTokens t;
 		t.fontFamily = QStringLiteral("DM Sans");
 		t.monoFontFamily = QStringLiteral("DM Mono");
-		t.borderRadius = 6;
+		// Machined plate corners; raw config lines stay off the faceplate (the
+		// "..." raw editor still reaches them) - hardware prints no raw text.
+		t.borderRadius = 3;
+		t.showRawPreview = false;
 		t.rowHeight = 36;
 		t.channelGroupIndent = 16;
 		t.channelGroupStyle = SkinTokens::DottedLine;

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,10 @@
 
 #include "Skins.h"
 
+#include <QFontMetricsF>
+#include <QPainter>
+#include <QtMath>
+
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -21,6 +25,24 @@ void finishTokens(SkinTokens& t)
 	if (t.graphGridMinor.isEmpty())
 		t.graphGridMinor = t.border;
 	t.focusRing = t.accent;
+}
+
+// Linear blend between two token colours; t = 0 returns a, t = 1 returns b.
+// The Soft skin fakes its elevation steps and pastel arcs by mixing token
+// colours instead of introducing extra palette entries, so both modes stay
+// consistent with their two-value-step "shadow" rule.
+QColor softMix(const QColor& a, const QColor& b, double t)
+{
+	return QColor(
+		qRound(a.red() + (b.red() - a.red()) * t),
+		qRound(a.green() + (b.green() - a.green()) * t),
+		qRound(a.blue() + (b.blue() - a.blue()) * t));
+}
+
+QColor softAlpha(QColor color, int alpha)
+{
+	color.setAlpha(alpha);
+	return color;
 }
 
 // ── Studio (glass, FabFilter-like) ──────────────────────────────────────────
@@ -141,7 +163,11 @@ public:
 	}
 };
 
-// ── Soft (macOS-like, rounded, soft shadows) ────────────────────────────────
+// ── Soft ("The iPhone settings screen": macOS System Settings calm) ─────────
+// Round, roomy, impossible to fear. Shadows are faked with two background
+// value steps plus a very light 1px border; hierarchy comes from size and
+// whitespace, never from density. Hover lifts a surface exactly one value
+// step. Tiebreaker: when in doubt, remove elements and add whitespace.
 class SoftSkin : public ISkin
 {
 public:
@@ -161,12 +187,18 @@ public:
 		t.accent = QStringLiteral("#3B82F6");
 		t.fontFamily = QStringLiteral("DM Sans");
 		t.monoFontFamily = QStringLiteral("DM Mono");
-		t.borderRadius = 18;
-		t.rowHeight = 44;
+		// Constitution: radius 10-12px, generous line spacing. The tallest row
+		// of the five skins; whitespace is the hierarchy device.
+		t.borderRadius = 12;
+		t.rowHeight = 48;
 		t.channelGroupIndent = 20;
 		t.density = 2;
 		t.channelGroupStyle = SkinTokens::SoftShadow;
 		t.badgeStyle = SkinTokens::SoftPill;
+		// Tiebreaker rule applied: the raw monospace preview strip under every
+		// card is exactly the kind of element that makes a screen feel anxious,
+		// so this skin removes it and keeps the whitespace.
+		t.showRawPreview = false;
 		if (dark)
 		{
 			t.background = QStringLiteral("#171923");
@@ -193,6 +225,178 @@ public:
 		}
 		finishTokens(t);
 		return t;
+	}
+
+	// One calm silhouette for every command type: a 12px rounded card one
+	// value step above the window, "shadowed" only by that step and a very
+	// light 1px border. Hover lifts the whole card one more value step
+	// (QSS :hover re-evaluates at paint time, so the inline rule is enough).
+	// A commented-out row sinks flush into the window background and keeps
+	// only a dashed outline - an empty slot, not an alarm.
+	QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& t) const override
+	{
+		if (!info.enabled)
+		{
+			return QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px dashed %2; border-radius: %3px; }")
+				.arg(t.background, t.border)
+				.arg(t.borderRadius);
+		}
+
+		const QString borderColor = info.focused ? t.focusRing : (info.selected ? t.accent : t.border);
+		const QString backgroundColor = info.selected ? t.cardSelected : t.card;
+		const QString hoverColor = info.selected ? t.cardSelected : t.cardHover;
+		return QStringLiteral(
+			"QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: %3px; }"
+			"QFrame#FilterCardRow:hover { background: %4; }")
+			.arg(backgroundColor, borderColor)
+			.arg(t.borderRadius)
+			.arg(hoverColor);
+	}
+
+	// No header strip: the header shares the card surface so the row reads as
+	// one roomy rounded object (macOS System Settings rows have no banded
+	// title bar). Hierarchy inside the header comes from type tile, title size
+	// and whitespace, all handled in the QSS sheets.
+	QString cardHeaderStyle(const CommandRowInfo&, const SkinTokens&) const override
+	{
+		return QStringLiteral("QWidget#FilterCardHeader { background: transparent; }");
+	}
+
+	// Annex K, soft: "a handle you cannot fumble". The largest knob of the
+	// five skins. Two-step elevation body, rounded dot indicator (no sharp
+	// line), pastel range arc, value in a rounded badge below, centre detent
+	// as a gentle notch. Bipolar knobs grow their arc from the 12 o'clock
+	// detent (boost right in accent, cut left in accent2); unipolar knobs
+	// grow from the minimum, so the two kinds differ at a glance.
+	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
+	{
+		painter.setRenderHint(QPainter::Antialiasing);
+
+		const QColor card(tokens.card);
+		const QColor windowBg(tokens.background);
+		const QColor border(tokens.border);
+		const QColor muted(tokens.mutedText);
+
+		// Reserve a strip at the bottom for the rounded value badge so it sits
+		// below the handle instead of floating on the face. Promoted legacy
+		// dials hand in an empty valueText (their value lives in a spin box),
+		// so they keep the full height for the handle.
+		const bool hasBadge = !state.valueText.isEmpty();
+		QRectF area(rect);
+		qreal badgeHeight = 0;
+		if (hasBadge)
+		{
+			badgeHeight = qMin<qreal>(18.0, area.height() * 0.26);
+			area.setBottom(area.bottom() - badgeHeight - 1.0);
+		}
+
+		// Largest knob of the five: only a 4px inset, centred square so the
+		// handle stays circular in the 100x66 legacy dial slots.
+		QRectF inner = area.adjusted(4, 4, -4, -4);
+		const double side = qMin(inner.width(), inner.height());
+		QRectF knobRect(inner.center().x() - side / 2.0, inner.center().y() - side / 2.0, side, side);
+
+		const int spanDegrees = 270;
+		const int startDegrees = 135;
+		const double ratio = qBound(0.0, state.ratio, 1.0);
+		const double endDegrees = startDegrees + spanDegrees * ratio;
+
+		const double arcWidth = qMax(5.0, side * 0.10);
+		QRectF arcRect = knobRect.adjusted(arcWidth / 2.0, arcWidth / 2.0, -arcWidth / 2.0, -arcWidth / 2.0);
+
+		// Keyboard focus: a quiet halo around the whole handle, not a hard ring.
+		if (state.focused && state.enabled)
+		{
+			painter.setPen(QPen(softAlpha(QColor(tokens.focusRing), 90), 3));
+			painter.setBrush(Qt::NoBrush);
+			painter.drawEllipse(knobRect.adjusted(-2, -2, 2, 2));
+		}
+
+		// Pastel range track: the full travel is always visible.
+		const QColor trackColor = state.enabled ? softMix(border, windowBg, 0.25) : softAlpha(border, 110);
+		painter.setPen(QPen(trackColor, arcWidth, Qt::SolidLine, Qt::RoundCap));
+		painter.drawArc(arcRect, -startDegrees * 16, -spanDegrees * 16);
+
+		// Pastel value arc (accent softened one step toward the card colour).
+		if (state.enabled)
+		{
+			const bool cutSide = state.bipolar && ratio < 0.5;
+			const QColor valueColor = softMix(QColor(cutSide ? tokens.accent2 : tokens.accent), card, 0.30);
+			painter.setPen(QPen(valueColor, arcWidth, Qt::SolidLine, Qt::RoundCap));
+			if (state.bipolar)
+			{
+				const double centerDegrees = startDegrees + spanDegrees / 2.0;
+				painter.drawArc(arcRect, qRound(-centerDegrees * 16.0), qRound(-(endDegrees - centerDegrees) * 16.0));
+			}
+			else
+			{
+				painter.drawArc(arcRect, -startDegrees * 16, qRound(-spanDegrees * ratio * 16.0));
+			}
+		}
+
+		// Two-step elevation body: a base disc one value step below the face,
+		// then the face one step above with a very light 1px border. Hover
+		// lifts the face exactly one value step; no real shadow effects.
+		const double faceInset = arcWidth + 2.5;
+		QRectF baseRect = knobRect.adjusted(faceInset, faceInset, -faceInset, -faceInset);
+		painter.setPen(Qt::NoPen);
+		painter.setBrush(softMix(card, windowBg, 0.55));
+		painter.drawEllipse(baseRect);
+
+		QColor faceColor = card;
+		if (!state.enabled)
+			faceColor = softMix(card, windowBg, 0.5);
+		else if (state.hovered || state.dragging)
+			faceColor = QColor(tokens.cardHover);
+		QRectF faceRect = baseRect.adjusted(2.5, 2.5, -2.5, -2.5);
+		painter.setPen(QPen(border, 1));
+		painter.setBrush(faceColor);
+		painter.drawEllipse(faceRect);
+
+		// Centre detent as a gentle notch: a short rounded tick at 12 o'clock
+		// on the face, only for bipolar (gain) knobs where the centre means
+		// 0 dB.
+		if (state.bipolar)
+		{
+			painter.setPen(QPen(softAlpha(muted, state.enabled ? 170 : 90), 2, Qt::SolidLine, Qt::RoundCap));
+			const QPointF center = faceRect.center();
+			const double notchOuter = faceRect.width() / 2.0 - 2.0;
+			const double notchInner = qMax(0.0, notchOuter - 4.5);
+			painter.drawLine(QPointF(center.x(), center.y() - notchOuter), QPointF(center.x(), center.y() - notchInner));
+		}
+
+		// Rounded dot indicator instead of a sharp line; it grows slightly on
+		// hover and again while dragging, the calmest possible "I am held" cue.
+		double dotRadius = qMax(3.5, side * 0.065);
+		if (state.dragging)
+			dotRadius += 1.0;
+		else if (state.hovered)
+			dotRadius += 0.5;
+		const double dotTrack = faceRect.width() / 2.0 - dotRadius - 2.5;
+		const double radians = qDegreesToRadians(-endDegrees);
+		const QPointF dotPos(faceRect.center().x() + qCos(radians) * dotTrack,
+			faceRect.center().y() - qSin(radians) * dotTrack);
+		painter.setPen(Qt::NoPen);
+		painter.setBrush(state.enabled ? QColor(tokens.accent) : softAlpha(muted, 120));
+		painter.drawEllipse(dotPos, dotRadius, dotRadius);
+
+		// Value in a rounded badge below the handle.
+		if (hasBadge)
+		{
+			QFont badgeFont = painter.font();
+			badgeFont.setWeight(QFont::DemiBold);
+			badgeFont.setPointSizeF(qMax(7.0, badgeFont.pointSizeF() - 1.5));
+			painter.setFont(badgeFont);
+			const QFontMetricsF metrics(badgeFont);
+			const qreal badgeWidth = qMin<qreal>(QRectF(rect).width(), metrics.horizontalAdvance(state.valueText) + 14.0);
+			QRectF badgeRect(QRectF(rect).center().x() - badgeWidth / 2.0,
+				QRectF(rect).bottom() - badgeHeight - 0.5, badgeWidth, badgeHeight);
+			painter.setPen(QPen(border, 1));
+			painter.setBrush(state.enabled ? QColor(tokens.surfaceRaised) : softMix(card, windowBg, 0.5));
+			painter.drawRoundedRect(badgeRect, badgeHeight / 2.0, badgeHeight / 2.0);
+			painter.setPen(state.enabled ? QColor(tokens.text) : muted);
+			painter.drawText(badgeRect, Qt::AlignCenter, state.valueText);
+		}
 	}
 };
 

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,12 @@
 
 #include "Skins.h"
 
+#include <QFontMetrics>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QtMath>
+
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -82,6 +88,152 @@ public:
 	}
 };
 
+// ── Minimal ("The bank teller's terminal") helpers ──────────────────────────
+
+// Screen point on a circle around center; degrees follow the shared knob
+// convention (Qt-style angles, counter-clockwise from 3 o'clock, screen Y
+// grows downward so sin is subtracted). Pass the negated clockwise sweep
+// angle, exactly like ISkin.cpp's default renderer does.
+QPointF minimalPointOnArc(const QPointF& center, double radius, double degrees)
+{
+	const double radians = qDegreesToRadians(degrees);
+	return QPointF(center.x() + qCos(radians) * radius, center.y() - qSin(radians) * radius);
+}
+
+// ANNEX K minimal: "the number is the control". The always-visible mono
+// numeric is primary; beside it sits a small flat circle with a 1px indicator
+// line and a hairline range arc, monochrome until dragged (accent while
+// active). Bipolar knobs measure the indicator from a centre tick. Promoted
+// legacy dials supply no valueText (their number lives in the adjacent spin
+// box), so they render only the confirmation circle plus a ratio-derived
+// position readout while hovered or dragged.
+void paintMinimalKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens)
+{
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	const QColor hairline(tokens.border);
+	const QColor primary(state.enabled ? tokens.text : tokens.mutedText);
+	const QColor secondary(tokens.mutedText);
+	const QColor active(tokens.accent);
+	const QColor indicatorColor = (state.enabled && state.dragging) ? active : primary;
+
+	const bool hasNumber = !state.valueText.isEmpty();
+	const double circleRadius = hasNumber ? 9.0 : 12.0;
+	const double arcRadius = circleRadius + 4.0;
+
+	QFont numberFont(tokens.monoFontFamily);
+	numberFont.setBold(true);
+	numberFont.setPointSizeF(9.0);
+
+	QPointF circleCenter;
+	QRectF numberRect;
+	if (hasNumber)
+	{
+		// Number left (primary), confirmation circle beside it; the pair is
+		// centred in the widget. Shrink the font instead of clipping when a
+		// long value (e.g. "-100.0") meets a narrow widget.
+		const double gap = 6.0;
+		double available = rect.width() - 2.0 * arcRadius - gap - 4.0;
+		double textWidth = QFontMetricsF(numberFont).horizontalAdvance(state.valueText);
+		while (textWidth > available && numberFont.pointSizeF() > 6.5)
+		{
+			numberFont.setPointSizeF(numberFont.pointSizeF() - 0.5);
+			textWidth = QFontMetricsF(numberFont).horizontalAdvance(state.valueText);
+		}
+		const double pairWidth = textWidth + gap + 2.0 * arcRadius;
+		const double left = rect.left() + (rect.width() - pairWidth) / 2.0;
+		numberRect = QRectF(left, rect.top(), textWidth, rect.height());
+		circleCenter = QPointF(left + textWidth + gap + arcRadius, QRectF(rect).center().y());
+	}
+	else
+	{
+		// Circle only; keep a constant bottom strip free for the hover/drag
+		// readout so the circle does not jump when the readout appears.
+		circleCenter = QPointF(QRectF(rect).center().x(), rect.top() + (rect.height() - 14.0) / 2.0);
+	}
+
+	// Hairline range arc: the full 270-degree value range, 1px.
+	const QRectF arcRect(circleCenter.x() - arcRadius, circleCenter.y() - arcRadius, arcRadius * 2.0, arcRadius * 2.0);
+	painter.setPen(QPen(hairline, 1));
+	painter.setBrush(Qt::NoBrush);
+	painter.drawArc(arcRect, -135 * 16, -270 * 16);
+
+	if (state.bipolar)
+	{
+		// Centre tick at 12 o'clock (the bipolar neutral) and a 1px deviation
+		// arc measured from it: boost grows clockwise, cut counter-clockwise.
+		// Unipolar knobs draw neither, so the two kinds read differently.
+		painter.setPen(QPen(secondary, 1));
+		painter.drawLine(minimalPointOnArc(circleCenter, arcRadius - 1.5, -270.0),
+			minimalPointOnArc(circleCenter, arcRadius + 2.5, -270.0));
+		const double deviationDegrees = 270.0 * (state.ratio - 0.5);
+		painter.setPen(QPen(indicatorColor, 1));
+		painter.drawArc(arcRect, -270 * 16, -qRound(deviationDegrees * 16.0));
+	}
+
+	// Small flat circle: flat fill, 1px border, hover = one background step.
+	const QString fill = (state.enabled && (state.hovered || state.dragging)) ? tokens.cardHover : tokens.card;
+	painter.setPen(QPen(hairline, 1));
+	painter.setBrush(QColor(fill));
+	painter.drawEllipse(circleCenter, circleRadius, circleRadius);
+
+	// 1px indicator line from the hub to the rim at the value angle.
+	const double valueDegrees = -(135.0 + 270.0 * state.ratio);
+	painter.setPen(QPen(indicatorColor, 1));
+	painter.drawLine(circleCenter, minimalPointOnArc(circleCenter, circleRadius - 1.0, valueDegrees));
+
+	if (hasNumber)
+	{
+		painter.setFont(numberFont);
+		painter.setPen((state.enabled && state.dragging) ? active : primary);
+		painter.drawText(numberRect, Qt::AlignVCenter | Qt::AlignLeft, state.valueText);
+	}
+	else if (state.enabled && (state.hovered || state.dragging))
+	{
+		// No supplied value text: show the dial position derived from ratio.
+		// The real value sits in the adjacent spin box, so a percentage is the
+		// only honest readout for log-scaled legacy dials.
+		QFont readoutFont(tokens.monoFontFamily);
+		readoutFont.setPointSizeF(7.5);
+		painter.setFont(readoutFont);
+		painter.setPen(state.dragging ? active : secondary);
+		const QRectF readoutRect(rect.left(), rect.bottom() - 14.0, rect.width(), 14.0);
+		painter.drawText(readoutRect, Qt::AlignCenter, QStringLiteral("%1%").arg(qRound(state.ratio * 100.0)));
+	}
+
+	// Keyboard focus: a square hairline frame (radius 0 corner language).
+	if (state.focused)
+	{
+		painter.setPen(QPen(QColor(tokens.focusRing), 1));
+		painter.setBrush(Qt::NoBrush);
+		painter.drawRect(QRectF(rect).adjusted(0.5, 0.5, -0.5, -0.5));
+	}
+}
+
+// Leading type glyph for the line head, plain ASCII for the mapped types so
+// every mono fallback font covers it. The glyph is shape information ("which
+// kind of line is this"); the colour tag next to it stays the badge token.
+QString minimalTypeGlyph(const QString& type)
+{
+	if (type == QStringLiteral("biquad"))
+		return QStringLiteral("~");
+	if (type == QStringLiteral("include"))
+		return QStringLiteral(">>");
+	if (type == QStringLiteral("vst"))
+		return QStringLiteral("[]");
+	if (type == QStringLiteral("copy"))
+		return QStringLiteral("->");
+	if (type == QStringLiteral("comment"))
+		return QStringLiteral("#");
+	if (type == QStringLiteral("spacer"))
+		return QString();
+	// Unmapped commands keep the fixed-width column so line heads stay
+	// aligned; the middle dot (U+00B7) deliberately carries no further
+	// meaning. Built from a code point so the source stays pure ASCII (no
+	// /utf-8 flag is set for MSVC).
+	return QString(QChar(0x00B7));
+}
+
 // ── Minimal (Ableton-like terminal, monospace) ──────────────────────────────
 class MinimalSkin : public ISkin
 {
@@ -95,6 +247,58 @@ public:
 	{
 		static StepListRoutingRenderer renderer;
 		return &renderer;
+	}
+	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
+	{
+		paintMinimalKnob(painter, rect, state, tokens);
+	}
+	QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override
+	{
+		// One flat line per command: 1px hairline box, square corners, and
+		// state expressed as background-value steps only. Disabled rows fall
+		// one step below the resting card; selection is the accent-value
+		// background step; hover is exactly one step up from rest.
+		const QString background = !info.enabled ? tokens.surface
+			: (info.selected ? tokens.cardSelected : tokens.card);
+		const QString borderColor = info.focused ? tokens.focusRing
+			: (info.selected ? tokens.accent : tokens.border);
+		QString style = QStringLiteral("QFrame#FilterCardRow { background: %1; border: 1px solid %2; border-radius: 0; }")
+			.arg(background, borderColor);
+		if (!info.selected)
+		{
+			style += QStringLiteral(" QFrame#FilterCardRow:hover { background: %1; }")
+				.arg(!info.enabled ? tokens.card : tokens.cardHover);
+		}
+		return style;
+	}
+	QString cardHeaderStyle(const CommandRowInfo&, const SkinTokens&) const override
+	{
+		// No separate header plate: the row reads as a single text line, so
+		// the header inherits the frame's background through transparency.
+		return QStringLiteral("QWidget#FilterCardHeader { background: transparent; border-radius: 0; }");
+	}
+	void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const override
+	{
+		Q_UNUSED(card);
+		Q_UNUSED(body);
+		// Leading type glyph at the line head. Only modern card rows carry a
+		// header here; the Include/VST body editors and the frozen legacy
+		// rows consult the hook with header == nullptr and stay untouched.
+		if (header == nullptr)
+			return;
+		QHBoxLayout* headerLayout = qobject_cast<QHBoxLayout*>(header->layout());
+		if (headerLayout == nullptr)
+			return;
+		// A commented-out line leads with the comment marker it actually
+		// carries in the config file; the marker is information, not decor.
+		const QString glyph = info.enabled ? minimalTypeGlyph(info.type) : QStringLiteral("#");
+		if (glyph.isEmpty())
+			return;
+		QLabel* glyphLabel = new QLabel(glyph, header);
+		glyphLabel->setObjectName(QStringLiteral("MinimalTypeGlyph"));
+		glyphLabel->setAlignment(Qt::AlignCenter);
+		glyphLabel->setMinimumWidth(18);
+		headerLayout->insertWidget(0, glyphLabel);
 	}
 	SkinTokens tokens(bool dark) const override
 	{

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -1,14 +1,17 @@
 /* ====================================================================
-   Skin: Glassy Dark
+   Skin: Matrix Dark
+   Identity: signal-routing matrix / airport departure board. Square
+   cells, 1px rules, monospace numerics, traffic-light colours reserved
+   for status (never decorative). Everything aligns to the grid.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 16 / row 40
+           accent @ACCENT@ / borderRadius 0 / row 36
    ==================================================================== */
 
 * {
     outline: 0;
     selection-background-color: @ACCENT@;
-    selection-color: #f8fafc;
+    selection-color: #06141A;
 }
 
 QWidget {
@@ -24,62 +27,63 @@ QDialog {
 }
 
 QMainWindow::separator {
-    background: @CARD@;
-    width: 4px;
-    height: 4px;
+    background: @BORDER@;
+    width: 1px;
+    height: 1px;
 }
 
 QToolTip {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-radius: 0;
     padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 
 /* ===== Menu Bar / Menus ===== */
 QMenuBar {
     background: @SURFACE@;
     color: @TEXT@;
-    padding: 4px 6px;
+    padding: 2px 4px;
     border: 0;
     border-bottom: 1px solid @BORDER@;
 }
 QMenuBar::item {
     background: transparent;
     padding: 6px 12px;
-    border-radius: 10px;
+    border-radius: 0;
 }
 QMenuBar::item:selected,
 QMenuBar::item:pressed {
-    background: rgba(59, 130, 246, 0.22);
+    background: rgba(34, 211, 238, 0.18);
     color: @TEXT@;
 }
 
 QMenu {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
-    padding: 6px;
+    border-radius: 0;
+    padding: 2px;
 }
 QMenu::item {
     background: transparent;
     padding: 6px 22px 6px 22px;
-    border-radius: 8px;
+    border-radius: 0;
     min-width: 140px;
 }
 QMenu::item:selected {
-    background: rgba(59, 130, 246, 0.25);
+    background: rgba(34, 211, 238, 0.20);
     color: @TEXT@;
 }
 QMenu::item:disabled {
-    color: #5a5a72;
+    color: #4A6470;
 }
 QMenu::separator {
     height: 1px;
     background: @BORDER@;
-    margin: 6px 8px;
+    margin: 4px 6px;
 }
 QMenu::indicator {
     width: 14px;
@@ -88,7 +92,7 @@ QMenu::indicator {
 }
 QMenu::indicator:checked {
     background: @ACCENT@;
-    border-radius: 3px;
+    border-radius: 0;
 }
 QMenu::icon {
     padding-left: 8px;
@@ -109,26 +113,26 @@ QToolBar::separator {
 }
 QToolBar::handle {
     background: @BORDER@;
-    width: 6px;
+    width: 4px;
     margin: 4px 2px;
-    border-radius: 3px;
+    border-radius: 0;
 }
 QToolButton {
     background: transparent;
     color: @TEXT@;
     border: 1px solid transparent;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 4px 8px;
     min-height: 22px;
 }
 QToolButton:hover {
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(34, 211, 238, 0.08);
+    border: 1px solid @BORDER@;
 }
 QToolButton:pressed,
 QToolButton:checked {
-    background: rgba(59, 130, 246, 0.25);
-    border: 1px solid rgba(59, 130, 246, 0.5);
+    background: rgba(34, 211, 238, 0.22);
+    border: 1px solid @ACCENT@;
 }
 QToolButton::menu-indicator {
     image: none;
@@ -141,6 +145,9 @@ QLabel#ToolBarLabel {
     background: transparent;
     padding: 0 4px 0 8px;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
 }
 
 /* ===== Push Buttons ===== */
@@ -148,51 +155,55 @@ QPushButton {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 6px 14px;
     min-height: 22px;
 }
 QPushButton:hover {
     background: @CARD_HOVER@;
-    border-color: rgba(59, 130, 246, 0.45);
+    border-color: @ACCENT@;
 }
 QPushButton:pressed {
-    background: rgba(59, 130, 246, 0.3);
+    background: rgba(34, 211, 238, 0.25);
     border-color: @ACCENT@;
 }
 QPushButton:default {
     border: 1px solid @ACCENT@;
 }
 QPushButton:disabled {
-    color: #5a5a72;
-    background: #14141f;
-    border-color: #1f1f2c;
+    color: #4A6470;
+    background: #0B1218;
+    border: 1px dashed #1A2933;
 }
 
-/* ===== Inputs ===== */
+/* ===== Inputs (numeric values in monospace) ===== */
 QLineEdit,
 QPlainTextEdit,
 QTextEdit,
 QAbstractSpinBox {
-    background: #08080f;
+    background: @GRAPH@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 4px 8px;
     selection-background-color: @ACCENT@;
-    selection-color: #f8fafc;
+    selection-color: #06141A;
+}
+QAbstractSpinBox {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QLineEdit:focus,
 QPlainTextEdit:focus,
 QTextEdit:focus,
 QAbstractSpinBox:focus {
     border: 1px solid @ACCENT@;
-    background: #0e0e18;
+    background: #081820;
 }
 QLineEdit:disabled,
 QAbstractSpinBox:disabled {
-    color: #5a5a72;
-    background: #0a0a14;
+    color: #4A6470;
+    background: #0A1014;
+    border: 1px dashed #1A2933;
 }
 
 QAbstractSpinBox::up-button,
@@ -204,16 +215,16 @@ QAbstractSpinBox::down-button {
 }
 QAbstractSpinBox::up-button {
     subcontrol-position: top right;
-    border-top-right-radius: 9px;
+    border-top-right-radius: 0;
 }
 QAbstractSpinBox::down-button {
     subcontrol-position: bottom right;
-    border-bottom-right-radius: 9px;
+    border-bottom-right-radius: 0;
     border-top: 1px solid @BORDER@;
 }
 QAbstractSpinBox::up-button:hover,
 QAbstractSpinBox::down-button:hover {
-    background: rgba(59, 130, 246, 0.22);
+    background: rgba(34, 211, 238, 0.18);
 }
 QAbstractSpinBox::up-arrow {
     image: none;
@@ -242,12 +253,12 @@ QComboBox {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 4px 28px 4px 10px;
     min-height: 28px;
 }
 QComboBox:hover {
-    border-color: rgba(59, 130, 246, 0.45);
+    border-color: @ACCENT@;
     background: @CARD_HOVER@;
 }
 QComboBox:focus,
@@ -259,6 +270,7 @@ QComboBox::drop-down {
     subcontrol-position: top right;
     width: 22px;
     border: 0;
+    border-left: 1px solid @BORDER@;
     background: transparent;
 }
 QComboBox::down-arrow {
@@ -274,22 +286,22 @@ QComboBox::down-arrow:on {
     border-top-color: @ACCENT@;
 }
 QComboBox QAbstractItemView {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
-    padding: 4px;
+    border-radius: 0;
+    padding: 2px;
     outline: 0;
-    selection-background-color: rgba(59, 130, 246, 0.28);
+    selection-background-color: rgba(34, 211, 238, 0.22);
     selection-color: @TEXT@;
 }
 QComboBox QAbstractItemView::item {
     padding: 6px 10px;
-    border-radius: 8px;
+    border-radius: 0;
     min-height: 24px;
 }
 QComboBox QAbstractItemView::item:selected {
-    background: rgba(59, 130, 246, 0.28);
+    background: rgba(34, 211, 238, 0.22);
     color: @TEXT@;
 }
 
@@ -303,16 +315,16 @@ QRadioButton {
 }
 QCheckBox:disabled,
 QRadioButton:disabled {
-    color: #5a5a72;
+    color: #4A6470;
 }
 QCheckBox::indicator,
 QRadioButton::indicator {
     width: 16px;
     height: 16px;
-    background: #08080f;
+    background: @GRAPH@;
     border: 1px solid @BORDER@;
 }
-QCheckBox::indicator { border-radius: 4px; }
+QCheckBox::indicator { border-radius: 0; }
 QRadioButton::indicator { border-radius: 8px; }
 QCheckBox::indicator:hover,
 QRadioButton::indicator:hover {
@@ -337,12 +349,12 @@ QScrollBar:vertical {
     border: 0;
 }
 QScrollBar::handle:vertical {
-    background: rgba(255, 255, 255, 0.10);
+    background: rgba(127, 160, 174, 0.25);
     min-height: 32px;
-    border-radius: 4px;
+    border-radius: 0;
 }
 QScrollBar::handle:vertical:hover {
-    background: rgba(59, 130, 246, 0.45);
+    background: rgba(34, 211, 238, 0.45);
 }
 QScrollBar::handle:vertical:pressed {
     background: @ACCENT@;
@@ -354,12 +366,12 @@ QScrollBar:horizontal {
     border: 0;
 }
 QScrollBar::handle:horizontal {
-    background: rgba(255, 255, 255, 0.10);
+    background: rgba(127, 160, 174, 0.25);
     min-width: 32px;
-    border-radius: 4px;
+    border-radius: 0;
 }
 QScrollBar::handle:horizontal:hover {
-    background: rgba(59, 130, 246, 0.45);
+    background: rgba(34, 211, 238, 0.45);
 }
 QScrollBar::handle:horizontal:pressed {
     background: @ACCENT@;
@@ -414,19 +426,20 @@ QDockWidget::title {
     border-bottom: 1px solid @BORDER@;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 2px;
+    font-size: 9pt;
 }
 QDockWidget::close-button,
 QDockWidget::float-button {
     background: transparent;
     border: 0;
-    border-radius: 6px;
+    border-radius: 0;
     padding: 2px;
     icon-size: 12px;
 }
 QDockWidget::close-button:hover,
 QDockWidget::float-button:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: rgba(34, 211, 238, 0.15);
 }
 
 /* ===== Tab Widget / Tab Bar ===== */
@@ -452,7 +465,7 @@ QTabBar::tab {
 }
 QTabBar::tab:hover {
     color: @TEXT@;
-    background: rgba(255, 255, 255, 0.04);
+    background: rgba(34, 211, 238, 0.06);
 }
 QTabBar::tab:selected {
     color: @TEXT@;
@@ -465,7 +478,7 @@ QTabBar::tab:!selected {
 QTabBar::close-button {
     image: none;
     background: transparent;
-    border-radius: 6px;
+    border-radius: 0;
     padding: 2px;
     margin: 2px;
     subcontrol-position: right;
@@ -476,7 +489,7 @@ QTabBar::close-button:hover {
 QTabBar QToolButton {
     background: @SURFACE@;
     border: 1px solid @BORDER@;
-    border-radius: 6px;
+    border-radius: 0;
     margin: 4px 2px;
 }
 
@@ -485,7 +498,7 @@ QGroupBox {
     background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-radius: 0;
     margin-top: 14px;
     padding: 14px 12px 10px 12px;
 }
@@ -497,7 +510,8 @@ QGroupBox::title {
     background: @BG@;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 2px;
+    font-size: 9pt;
 }
 
 /* ===== Headers / Item Views ===== */
@@ -514,6 +528,9 @@ QHeaderView::section {
     border-bottom: 1px solid @BORDER@;
     padding: 6px 10px;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
 }
 QHeaderView::section:hover {
     color: @TEXT@;
@@ -524,9 +541,9 @@ QTableView {
     background: @BG@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     alternate-background-color: @SURFACE@;
-    selection-background-color: rgba(59, 130, 246, 0.28);
+    selection-background-color: rgba(34, 211, 238, 0.22);
     selection-color: @TEXT@;
     gridline-color: @BORDER@;
 }
@@ -534,17 +551,17 @@ QTreeView::item,
 QListView::item,
 QTableView::item {
     padding: 4px 6px;
-    border-radius: 6px;
+    border-radius: 0;
 }
 QTreeView::item:hover,
 QListView::item:hover,
 QTableView::item:hover {
-    background: rgba(255, 255, 255, 0.05);
+    background: rgba(34, 211, 238, 0.07);
 }
 QTreeView::item:selected,
 QListView::item:selected,
 QTableView::item:selected {
-    background: rgba(59, 130, 246, 0.28);
+    background: rgba(34, 211, 238, 0.22);
     color: @TEXT@;
 }
 QTreeView::branch {
@@ -554,49 +571,49 @@ QTreeView::branch {
 /* ===== Sliders ===== */
 QSlider::groove:horizontal {
     background: @BORDER@;
-    height: 4px;
-    border-radius: 2px;
+    height: 2px;
+    border-radius: 0;
     margin: 0 6px;
 }
 QSlider::sub-page:horizontal {
     background: @ACCENT@;
-    height: 4px;
-    border-radius: 2px;
+    height: 2px;
+    border-radius: 0;
 }
 QSlider::handle:horizontal {
     background: @TEXT@;
-    border: 2px solid @ACCENT@;
-    width: 14px;
-    height: 14px;
-    margin: -6px 0;
-    border-radius: 9px;
+    border: 1px solid @ACCENT@;
+    width: 8px;
+    height: 16px;
+    margin: -8px 0;
+    border-radius: 0;
 }
 QSlider::handle:horizontal:hover {
-    background: #f8fafc;
+    background: @ACCENT@;
 }
 QSlider::groove:vertical {
     background: @BORDER@;
-    width: 4px;
-    border-radius: 2px;
+    width: 2px;
+    border-radius: 0;
     margin: 6px 0;
 }
 QSlider::sub-page:vertical {
     background: @BORDER@;
-    width: 4px;
-    border-radius: 2px;
+    width: 2px;
+    border-radius: 0;
 }
 QSlider::add-page:vertical {
     background: @ACCENT@;
-    width: 4px;
-    border-radius: 2px;
+    width: 2px;
+    border-radius: 0;
 }
 QSlider::handle:vertical {
     background: @TEXT@;
-    border: 2px solid @ACCENT@;
-    width: 14px;
-    height: 14px;
-    margin: 0 -6px;
-    border-radius: 9px;
+    border: 1px solid @ACCENT@;
+    width: 16px;
+    height: 8px;
+    margin: 0 -8px;
+    border-radius: 0;
 }
 
 /* ===== Splitter ===== */
@@ -613,6 +630,8 @@ QStatusBar {
     color: @MUTED@;
     border: 0;
     border-top: 1px solid @BORDER@;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
 }
 QStatusBar::item {
     border: 0;
@@ -620,15 +639,16 @@ QStatusBar::item {
 
 /* ===== Progress Bar ===== */
 QProgressBar {
-    background: #08080f;
+    background: @GRAPH@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-radius: 0;
     text-align: center;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QProgressBar::chunk {
     background: @ACCENT@;
-    border-radius: 6px;
+    border-radius: 0;
 }
 
 /* ===== Frame separators ===== */
@@ -646,7 +666,7 @@ QFrame[frameShape="5"]  /* VLine */ {
 QFrame#analysisControlBar {
     background: @SURFACE@;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-radius: 0;
 }
 QLabel#AnalysisFormLabel {
     color: @MUTED@;
@@ -655,14 +675,15 @@ QLabel#AnalysisFormLabel {
     text-transform: uppercase;
     letter-spacing: 1px;
     padding: 0 4px;
+    font-size: 9pt;
 }
 QComboBox#AnalysisFormCombo {
     min-width: 110px;
 }
 QFrame#AnalysisStatChip {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 10px;
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
 }
 QLabel#AnalysisStatLabel {
     color: @MUTED@;
@@ -682,33 +703,40 @@ QLabel#AnalysisStatValue[severity="warning"] { color: @WARNING@; }
 QLabel#AnalysisStatValue[severity="critical"] { color: @DANGER@; }
 
 QWidget#ModernAnalysisGraph {
-    background: #08080f;
+    background: @GRAPH@;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-radius: 0;
 }
 
-/* ===== Filter Card Components ===== */
+/* ===== Filter Card Components =====
+   The card frame/header inline chrome is owned by MatrixSkin
+   (cardFrameStyle / cardHeaderStyle / paintCardChrome): square cells,
+   3px traffic-light status rail, dashed border when bypassed, painted
+   header band + faint column grid + crosspoint hover. The rules below
+   cover what QSS can express. */
 QFrame#FilterCardRow {
     background: @CARD@;
     border: 1px solid @BORDER@;
-    border-radius: 16px;
+    border-radius: 0;
 }
 QWidget#FilterCardHeader {
-    background: rgba(255, 255, 255, 0.03);
-    border-top-left-radius: 16px;
-    border-top-right-radius: 16px;
+    background: transparent;
+    border-radius: 0;
 }
 QWidget#FilterCardBody,
 QWidget#FilterCardEditor {
-    background: rgba(255, 255, 255, 0.02);
-    border-bottom-left-radius: 16px;
-    border-bottom-right-radius: 16px;
+    background: transparent;
+    border-radius: 0;
 }
+/* Type cell: a square outlined monospace code (BQUAD/INC/VST/...). The
+   ink colour is supplied inline by MatrixSkin::typeBadgeStyle - the type
+   reads from the code text, never from a decorative colour. */
 QLabel#FilterTypeBadge {
-    color: white;
-    border-radius: 10px;
-    font-weight: 800;
-    padding: 2px 8px;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
+    padding: 2px 6px;
     min-height: 18px;
     font-size: 9pt;
     letter-spacing: 1px;
@@ -719,40 +747,54 @@ QLabel#FilterCardTitle {
     font-weight: 700;
     font-size: 10pt;
 }
+/* A bypassed (commented-out) row reads as a cancelled departure:
+   struck-through title on top of the dashed frame and amber lamp. */
+QWidget#FilterCardHeader[filterEnabled="false"] QLabel#FilterCardTitle {
+    color: @MUTED@;
+    text-decoration: line-through;
+}
+QWidget#FilterCardHeader[filterEnabled="false"] QLabel#FilterCardSummary {
+    color: #4A6470;
+}
 QLabel#FilterCardSummary,
 QLabel#FilterCardRawText {
     color: @MUTED@;
     background: transparent;
 }
+/* Row coordinate: a boxed monospace cell, like a board line number. */
 QLabel#FilterCardNumber {
-    color: @MUTED@;
-    background: transparent;
+    color: @ACCENT@;
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 1px 4px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-weight: 700;
 }
 QToolButton#FilterCardIconButton {
-    background: rgba(255, 255, 255, 0.04);
+    background: transparent;
     color: @TEXT@;
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    border-radius: 8px;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
     min-width: 24px;
     min-height: 24px;
     padding: 2px 4px;
     font-weight: 700;
 }
 QToolButton#FilterCardIconButton:hover {
-    background: rgba(59, 130, 246, 0.20);
-    border-color: rgba(59, 130, 246, 0.4);
+    background: rgba(34, 211, 238, 0.15);
+    border-color: @ACCENT@;
 }
 QToolButton#FilterCardIconButton:checked {
-    background: rgba(59, 130, 246, 0.30);
+    background: rgba(34, 211, 238, 0.25);
     border-color: @ACCENT@;
 }
 QLineEdit#FilterCardRawEditor {
-    background: #08080f;
+    background: @GRAPH@;
     border: 1px solid @ACCENT@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QCheckBox#FilterCardEnabled {
     background: transparent;
@@ -761,8 +803,8 @@ QCheckBox#FilterCardEnabled {
 /* ===== Card Editors ===== */
 QWidget#PreampCardEditor,
 QWidget#IncludeCardEditor,
+QWidget#VSTCardEditor,
 QWidget#PreampCardValueBlock,
-QLabel#IncludeCardGlyph,
 QLabel#IncludeCardStatus,
 QLabel#PreampCardCaption {
     background: transparent;
@@ -776,52 +818,73 @@ QLabel#PreampCardCaption {
     font-size: 9pt;
 }
 QLabel#EditableValue {
-    background: rgba(255, 255, 255, 0.04);
+    background: @GRAPH@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-radius: 0;
     padding: 6px 10px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
-    background: #08080f;
+    background: @GRAPH@;
     border: 1px solid @ACCENT@;
-    border-radius: 8px;
+    border-radius: 0;
     padding: 6px 10px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-weight: 700;
 }
+/* Include row: a single "> source: <path>" board line. */
+QLabel#IncludeCardGlyph {
+    background: transparent;
+    border: 0;
+    color: @ACCENT@;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
+}
 QLineEdit#IncludeCardPath {
-    background: #08080f;
+    background: @GRAPH@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-radius: 0;
     padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QLabel#IncludeCardStatus {
     color: @DANGER@;
     font-size: 9pt;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+/* VST row: an external-device entry with IN/OUT port markings. */
+QWidget#MatrixVstPortStrip {
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid @BORDER@;
+}
+QLabel#MatrixVstPortLabel {
+    color: @ACCENT@;
+    background: transparent;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
+    font-size: 9pt;
+    letter-spacing: 1px;
+}
+QLabel#MatrixVstDeviceLabel {
+    color: @MUTED@;
+    background: transparent;
+    font-weight: 600;
+    font-size: 8pt;
+    letter-spacing: 2px;
+}
+QLineEdit#VSTCardPath {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+QLineEdit#CrosspointEditor {
+    background: @GRAPH@;
+    border: 1px solid @ACCENT@;
+    border-radius: 0;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
-
-/* ===== Matrix-specific overrides =====
-   Signal Matrix distinguishes itself from Studio Glass by emphasising the
-   routing structure: a coloured rail on the left of every filter card and a
-   small connector mark before each card. The rail uses the matrix accent
-   (cyan) so the visual flow reads as "data moving through nodes". */
-QFrame#FilterCardRow {
-    border-left: 3px solid @ACCENT@;
-}
-QLabel#FilterCardNumber {
-    color: @ACCENT@;
-    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
-    font-weight: 700;
-}
-QLabel#FilterTypeBadge {
-    border-color: @ACCENT@;
-    color: @ACCENT@;
-    background: transparent;
-}

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -1,14 +1,17 @@
 /* ====================================================================
-   Skin: Glassy Light
+   Skin: Matrix Light
+   Identity: signal-routing matrix / airport departure board. Square
+   cells, 1px rules, monospace numerics, traffic-light colours reserved
+   for status (never decorative). Everything aligns to the grid.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 16 / row 40
+           accent @ACCENT@ / borderRadius 0 / row 36
    ==================================================================== */
 
 * {
     outline: 0;
     selection-background-color: @ACCENT@;
-    selection-color: @CARD@;
+    selection-color: #FFFFFF;
 }
 
 QWidget {
@@ -25,60 +28,62 @@ QDialog {
 
 QMainWindow::separator {
     background: @BORDER@;
-    width: 4px;
-    height: 4px;
+    width: 1px;
+    height: 1px;
 }
 
 QToolTip {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-radius: 0;
     padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 
+/* ===== Menu Bar / Menus ===== */
 QMenuBar {
     background: @SURFACE@;
     color: @TEXT@;
-    padding: 4px 6px;
+    padding: 2px 4px;
     border: 0;
     border-bottom: 1px solid @BORDER@;
 }
 QMenuBar::item {
     background: transparent;
     padding: 6px 12px;
-    border-radius: 10px;
+    border-radius: 0;
 }
 QMenuBar::item:selected,
 QMenuBar::item:pressed {
-    background: rgba(59, 130, 246, 0.18);
+    background: rgba(0, 142, 170, 0.14);
     color: @TEXT@;
 }
 
 QMenu {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
-    padding: 6px;
+    border-radius: 0;
+    padding: 2px;
 }
 QMenu::item {
     background: transparent;
     padding: 6px 22px;
-    border-radius: 8px;
+    border-radius: 0;
     min-width: 140px;
 }
 QMenu::item:selected {
-    background: rgba(59, 130, 246, 0.18);
+    background: rgba(0, 142, 170, 0.14);
     color: @TEXT@;
 }
 QMenu::item:disabled {
-    color: #a0a0b4;
+    color: #9DB4BD;
 }
 QMenu::separator {
     height: 1px;
     background: @BORDER@;
-    margin: 6px 8px;
+    margin: 4px 6px;
 }
 QMenu::indicator {
     width: 14px;
@@ -87,9 +92,13 @@ QMenu::indicator {
 }
 QMenu::indicator:checked {
     background: @ACCENT@;
-    border-radius: 3px;
+    border-radius: 0;
+}
+QMenu::icon {
+    padding-left: 8px;
 }
 
+/* ===== Toolbars ===== */
 QToolBar {
     background: @SURFACE@;
     border: 0;
@@ -102,66 +111,100 @@ QToolBar::separator {
     width: 1px;
     margin: 6px 8px;
 }
+QToolBar::handle {
+    background: @BORDER@;
+    width: 4px;
+    margin: 4px 2px;
+    border-radius: 0;
+}
 QToolButton {
     background: transparent;
     color: @TEXT@;
     border: 1px solid transparent;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 4px 8px;
     min-height: 22px;
 }
 QToolButton:hover {
-    background: rgba(0, 0, 0, 0.05);
-    border: 1px solid rgba(0, 0, 0, 0.07);
+    background: rgba(0, 142, 170, 0.08);
+    border: 1px solid @BORDER@;
 }
 QToolButton:pressed,
 QToolButton:checked {
-    background: rgba(59, 130, 246, 0.18);
-    border: 1px solid rgba(59, 130, 246, 0.5);
+    background: rgba(0, 142, 170, 0.16);
+    border: 1px solid @ACCENT@;
 }
-QToolButton::menu-indicator { image: none; width: 0; height: 0; }
+QToolButton::menu-indicator {
+    image: none;
+    width: 0;
+    height: 0;
+}
 
 QLabel#ToolBarLabel {
     color: @MUTED@;
     background: transparent;
     padding: 0 4px 0 8px;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
 }
 
+/* ===== Push Buttons ===== */
 QPushButton {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 6px 14px;
     min-height: 22px;
 }
-QPushButton:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.5); }
-QPushButton:pressed { background: rgba(59, 130, 246, 0.16); border-color: @ACCENT@; }
-QPushButton:default { border: 1px solid @ACCENT@; }
-QPushButton:disabled { color: #a0a0b4; background: @CARD_HOVER@; border-color: #e6e8ee; }
+QPushButton:hover {
+    background: @CARD_HOVER@;
+    border-color: @ACCENT@;
+}
+QPushButton:pressed {
+    background: rgba(0, 142, 170, 0.16);
+    border-color: @ACCENT@;
+}
+QPushButton:default {
+    border: 1px solid @ACCENT@;
+}
+QPushButton:disabled {
+    color: #9DB4BD;
+    background: #EDF2F4;
+    border: 1px dashed #D4E2E8;
+}
 
+/* ===== Inputs (numeric values in monospace) ===== */
 QLineEdit,
 QPlainTextEdit,
 QTextEdit,
 QAbstractSpinBox {
-    background: @CARD_HOVER@;
+    background: #FFFFFF;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 4px 8px;
     selection-background-color: @ACCENT@;
-    selection-color: @CARD@;
+    selection-color: #FFFFFF;
+}
+QAbstractSpinBox {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QLineEdit:focus,
 QPlainTextEdit:focus,
 QTextEdit:focus,
 QAbstractSpinBox:focus {
     border: 1px solid @ACCENT@;
-    background: @CARD@;
+    background: #FFFFFF;
 }
 QLineEdit:disabled,
-QAbstractSpinBox:disabled { color: #a0a0b4; background: #ececf2; }
+QAbstractSpinBox:disabled {
+    color: #9DB4BD;
+    background: #EDF2F4;
+    border: 1px dashed #D4E2E8;
+}
 
 QAbstractSpinBox::up-button,
 QAbstractSpinBox::down-button {
@@ -170,85 +213,209 @@ QAbstractSpinBox::down-button {
     width: 18px;
     border-left: 1px solid @BORDER@;
 }
-QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 9px; }
-QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 9px; border-top: 1px solid @BORDER@; }
-QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.16); }
+QAbstractSpinBox::up-button {
+    subcontrol-position: top right;
+    border-top-right-radius: 0;
+}
+QAbstractSpinBox::down-button {
+    subcontrol-position: bottom right;
+    border-bottom-right-radius: 0;
+    border-top: 1px solid @BORDER@;
+}
+QAbstractSpinBox::up-button:hover,
+QAbstractSpinBox::down-button:hover {
+    background: rgba(0, 142, 170, 0.12);
+}
 QAbstractSpinBox::up-arrow {
-    image: none; width: 0; height: 0;
+    image: none;
+    width: 0;
+    height: 0;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
     border-bottom: 5px solid @MUTED@;
 }
 QAbstractSpinBox::down-arrow {
-    image: none; width: 0; height: 0;
+    image: none;
+    width: 0;
+    height: 0;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
     border-top: 5px solid @MUTED@;
 }
+QAbstractSpinBox::up-arrow:hover,
+QAbstractSpinBox::down-arrow:hover {
+    border-bottom-color: @TEXT@;
+    border-top-color: @TEXT@;
+}
 
+/* ===== Combo Box ===== */
 QComboBox {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 0;
     padding: 4px 28px 4px 10px;
     min-height: 28px;
 }
-QComboBox:hover { border-color: rgba(59, 130, 246, 0.5); background: @CARD_HOVER@; }
-QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
-QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
+QComboBox:hover {
+    border-color: @ACCENT@;
+    background: @CARD_HOVER@;
+}
+QComboBox:focus,
+QComboBox:on {
+    border: 1px solid @ACCENT@;
+}
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 22px;
+    border: 0;
+    border-left: 1px solid @BORDER@;
+    background: transparent;
+}
 QComboBox::down-arrow {
-    image: none; width: 0; height: 0;
+    image: none;
+    width: 0;
+    height: 0;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     border-top: 5px solid @MUTED@;
     margin-right: 8px;
 }
-QComboBox::down-arrow:on { border-top-color: @ACCENT@; }
+QComboBox::down-arrow:on {
+    border-top-color: @ACCENT@;
+}
 QComboBox QAbstractItemView {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
-    padding: 4px;
+    border-radius: 0;
+    padding: 2px;
     outline: 0;
-    selection-background-color: rgba(59, 130, 246, 0.18);
+    selection-background-color: rgba(0, 142, 170, 0.14);
     selection-color: @TEXT@;
 }
-QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 24px; }
-QComboBox QAbstractItemView::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
-
-QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
-QCheckBox:disabled, QRadioButton:disabled { color: #a0a0b4; }
-QCheckBox::indicator, QRadioButton::indicator {
-    width: 16px; height: 16px;
-    background: @CARD@;
-    border: 1px solid #c0c4d0;
+QComboBox QAbstractItemView::item {
+    padding: 6px 10px;
+    border-radius: 0;
+    min-height: 24px;
 }
-QCheckBox::indicator { border-radius: 4px; }
+QComboBox QAbstractItemView::item:selected {
+    background: rgba(0, 142, 170, 0.14);
+    color: @TEXT@;
+}
+
+/* ===== Check / Radio ===== */
+QCheckBox,
+QRadioButton {
+    color: @TEXT@;
+    background: transparent;
+    spacing: 8px;
+    padding: 2px;
+}
+QCheckBox:disabled,
+QRadioButton:disabled {
+    color: #9DB4BD;
+}
+QCheckBox::indicator,
+QRadioButton::indicator {
+    width: 16px;
+    height: 16px;
+    background: #FFFFFF;
+    border: 1px solid #B8CBD3;
+}
+QCheckBox::indicator { border-radius: 0; }
 QRadioButton::indicator { border-radius: 8px; }
-QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: @ACCENT@; }
-QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
+QCheckBox::indicator:hover,
+QRadioButton::indicator:hover {
+    border-color: @ACCENT@;
+}
+QCheckBox::indicator:checked,
+QRadioButton::indicator:checked {
+    background: @ACCENT@;
+    border-color: @ACCENT@;
+}
+QCheckBox::indicator:checked:disabled,
+QRadioButton::indicator:checked:disabled {
+    background: @BORDER@;
+    border-color: @BORDER@;
+}
 
-QScrollBar:vertical { background: transparent; width: 12px; margin: 4px 2px; border: 0; }
-QScrollBar::handle:vertical { background: rgba(0, 0, 0, 0.12); min-height: 32px; border-radius: 4px; }
-QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
-QScrollBar::handle:vertical:pressed { background: @ACCENT@; }
-QScrollBar:horizontal { background: transparent; height: 12px; margin: 2px 4px; border: 0; }
-QScrollBar::handle:horizontal { background: rgba(0, 0, 0, 0.12); min-width: 32px; border-radius: 4px; }
-QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
-QScrollBar::handle:horizontal:pressed { background: @ACCENT@; }
-QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
-QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
-QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
+/* ===== Scroll Bars ===== */
+QScrollBar:vertical {
+    background: transparent;
+    width: 12px;
+    margin: 4px 2px;
+    border: 0;
+}
+QScrollBar::handle:vertical {
+    background: rgba(16, 36, 47, 0.18);
+    min-height: 32px;
+    border-radius: 0;
+}
+QScrollBar::handle:vertical:hover {
+    background: rgba(0, 142, 170, 0.45);
+}
+QScrollBar::handle:vertical:pressed {
+    background: @ACCENT@;
+}
+QScrollBar:horizontal {
+    background: transparent;
+    height: 12px;
+    margin: 2px 4px;
+    border: 0;
+}
+QScrollBar::handle:horizontal {
+    background: rgba(16, 36, 47, 0.18);
+    min-width: 32px;
+    border-radius: 0;
+}
+QScrollBar::handle:horizontal:hover {
+    background: rgba(0, 142, 170, 0.45);
+}
+QScrollBar::handle:horizontal:pressed {
+    background: @ACCENT@;
+}
+QScrollBar::add-line,
+QScrollBar::sub-line {
+    background: transparent;
+    border: 0;
+    width: 0;
+    height: 0;
+}
+QScrollBar::add-page,
+QScrollBar::sub-page {
+    background: transparent;
+}
+QScrollBar::up-arrow,
+QScrollBar::down-arrow,
+QScrollBar::left-arrow,
+QScrollBar::right-arrow {
+    background: transparent;
+    width: 0;
+    height: 0;
+}
 
-QAbstractScrollArea { background: @BG@; color: @TEXT@; border: 0; }
-QScrollArea { background: @BG@; border: 0; }
-QScrollArea > QWidget > QWidget { background: @BG@; }
+/* ===== ScrollArea / AbstractScrollArea ===== */
+QAbstractScrollArea {
+    background: @BG@;
+    color: @TEXT@;
+    border: 0;
+}
+QScrollArea {
+    background: @BG@;
+    border: 0;
+}
+QScrollArea > QWidget > QWidget {
+    background: @BG@;
+}
 
+/* ===== Dock Widgets ===== */
 QDockWidget {
-    color: @TEXT@; background: @BG@;
-    titlebar-close-icon: none; titlebar-normal-icon: none;
+    color: @TEXT@;
+    background: @BG@;
+    titlebar-close-icon: none;
+    titlebar-normal-icon: none;
 }
 QDockWidget::title {
     background: @SURFACE@;
@@ -259,213 +426,461 @@ QDockWidget::title {
     border-bottom: 1px solid @BORDER@;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 2px;
+    font-size: 9pt;
 }
-QDockWidget::close-button, QDockWidget::float-button {
-    background: transparent; border: 0; border-radius: 6px; padding: 2px; icon-size: 12px;
+QDockWidget::close-button,
+QDockWidget::float-button {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    padding: 2px;
+    icon-size: 12px;
 }
-QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: rgba(0, 0, 0, 0.08); }
+QDockWidget::close-button:hover,
+QDockWidget::float-button:hover {
+    background: rgba(0, 142, 170, 0.10);
+}
 
-QTabWidget::pane { background: @BG@; border: 0; border-top: 1px solid @BORDER@; top: -1px; }
-QTabBar { background: @BG@; border: 0; qproperty-drawBase: 0; }
-QTabBar::tab {
-    background: transparent; color: @MUTED@;
-    padding: 8px 18px; border: 0; border-radius: 0;
-    min-width: 80px; margin: 0;
+/* ===== Tab Widget / Tab Bar ===== */
+QTabWidget::pane {
+    background: @BG@;
+    border: 0;
+    border-top: 1px solid @BORDER@;
+    top: -1px;
 }
-QTabBar::tab:hover { color: @TEXT@; background: rgba(0, 0, 0, 0.04); }
+QTabBar {
+    background: @BG@;
+    border: 0;
+    qproperty-drawBase: 0;
+}
+QTabBar::tab {
+    background: transparent;
+    color: @MUTED@;
+    padding: 8px 18px;
+    border: 0;
+    border-radius: 0;
+    min-width: 80px;
+    margin: 0;
+}
+QTabBar::tab:hover {
+    color: @TEXT@;
+    background: rgba(0, 142, 170, 0.06);
+}
 QTabBar::tab:selected {
-    color: @TEXT@; background: @CARD@;
+    color: @TEXT@;
+    background: @SURFACE@;
     border-top: 2px solid @ACCENT@;
 }
-QTabBar::tab:!selected { border-bottom: 1px solid @BORDER@; }
-QTabBar::close-button {
-    image: none; background: transparent; border-radius: 6px;
-    padding: 2px; margin: 2px; subcontrol-position: right;
+QTabBar::tab:!selected {
+    border-bottom: 1px solid @BORDER@;
 }
-QTabBar::close-button:hover { background: rgba(239, 68, 68, 0.25); }
-QTabBar QToolButton { background: @CARD@; border: 1px solid @BORDER@; border-radius: 6px; margin: 4px 2px; }
+QTabBar::close-button {
+    image: none;
+    background: transparent;
+    border-radius: 0;
+    padding: 2px;
+    margin: 2px;
+    subcontrol-position: right;
+}
+QTabBar::close-button:hover {
+    background: rgba(220, 38, 38, 0.25);
+}
+QTabBar QToolButton {
+    background: @SURFACE@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    margin: 4px 2px;
+}
 
+/* ===== Group Box ===== */
 QGroupBox {
-    background: @CARD@;
+    background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-radius: 0;
     margin-top: 14px;
     padding: 14px 12px 10px;
 }
 QGroupBox::title {
-    subcontrol-origin: margin; subcontrol-position: top left;
-    padding: 0 8px; color: @MUTED@; background: @BG@;
-    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0 8px;
+    color: @MUTED@;
+    background: @BG@;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-size: 9pt;
 }
 
-QHeaderView { background: @SURFACE@; color: @MUTED@; border: 0; }
+/* ===== Headers / Item Views ===== */
+QHeaderView {
+    background: @SURFACE@;
+    color: @MUTED@;
+    border: 0;
+}
 QHeaderView::section {
-    background: @SURFACE@; color: @MUTED@; border: 0;
+    background: @SURFACE@;
+    color: @MUTED@;
+    border: 0;
     border-right: 1px solid @BORDER@;
     border-bottom: 1px solid @BORDER@;
-    padding: 6px 10px; font-weight: 600;
+    padding: 6px 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
 }
-QTreeView, QListView, QTableView {
-    background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 10px;
+QHeaderView::section:hover {
+    color: @TEXT@;
+}
+QTreeView,
+QListView,
+QTableView {
+    background: @SURFACE@;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
     alternate-background-color: @CARD_HOVER@;
-    selection-background-color: rgba(59, 130, 246, 0.18);
+    selection-background-color: rgba(0, 142, 170, 0.14);
     selection-color: @TEXT@;
     gridline-color: @BORDER@;
 }
-QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 6px; }
-QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: rgba(0, 0, 0, 0.04); }
-QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
-QTreeView::branch { background: transparent; }
+QTreeView::item,
+QListView::item,
+QTableView::item {
+    padding: 4px 6px;
+    border-radius: 0;
+}
+QTreeView::item:hover,
+QListView::item:hover,
+QTableView::item:hover {
+    background: rgba(0, 142, 170, 0.06);
+}
+QTreeView::item:selected,
+QListView::item:selected,
+QTableView::item:selected {
+    background: rgba(0, 142, 170, 0.14);
+    color: @TEXT@;
+}
+QTreeView::branch {
+    background: transparent;
+}
 
-QSlider::groove:horizontal { background: @BORDER@; height: 4px; border-radius: 2px; margin: 0 6px; }
-QSlider::sub-page:horizontal { background: @ACCENT@; height: 4px; border-radius: 2px; }
+/* ===== Sliders ===== */
+QSlider::groove:horizontal {
+    background: @BORDER@;
+    height: 2px;
+    border-radius: 0;
+    margin: 0 6px;
+}
+QSlider::sub-page:horizontal {
+    background: @ACCENT@;
+    height: 2px;
+    border-radius: 0;
+}
 QSlider::handle:horizontal {
-    background: @CARD@; border: 2px solid @ACCENT@;
-    width: 14px; height: 14px; margin: -6px 0; border-radius: 9px;
+    background: @CARD@;
+    border: 1px solid @ACCENT@;
+    width: 8px;
+    height: 16px;
+    margin: -8px 0;
+    border-radius: 0;
 }
-QSlider::handle:horizontal:hover { background: @CARD_HOVER@; }
-QSlider::groove:vertical { background: @BORDER@; width: 4px; border-radius: 2px; margin: 6px 0; }
-QSlider::add-page:vertical { background: @ACCENT@; width: 4px; border-radius: 2px; }
-QSlider::sub-page:vertical { background: @BORDER@; width: 4px; border-radius: 2px; }
+QSlider::handle:horizontal:hover {
+    background: @ACCENT@;
+}
+QSlider::groove:vertical {
+    background: @BORDER@;
+    width: 2px;
+    border-radius: 0;
+    margin: 6px 0;
+}
+QSlider::add-page:vertical {
+    background: @ACCENT@;
+    width: 2px;
+    border-radius: 0;
+}
+QSlider::sub-page:vertical {
+    background: @BORDER@;
+    width: 2px;
+    border-radius: 0;
+}
 QSlider::handle:vertical {
-    background: @CARD@; border: 2px solid @ACCENT@;
-    width: 14px; height: 14px; margin: 0 -6px; border-radius: 9px;
+    background: @CARD@;
+    border: 1px solid @ACCENT@;
+    width: 16px;
+    height: 8px;
+    margin: 0 -8px;
+    border-radius: 0;
 }
 
+/* ===== Splitter ===== */
 QSplitter::handle { background: @BORDER@; }
 QSplitter::handle:horizontal { width: 1px; }
 QSplitter::handle:vertical { height: 1px; }
 QSplitter::handle:hover { background: @ACCENT@; }
 
-QStatusBar { background: @SURFACE@; color: @MUTED@; border: 0; border-top: 1px solid @BORDER@; }
+/* ===== Status Bar ===== */
+QStatusBar {
+    background: @SURFACE@;
+    color: @MUTED@;
+    border: 0;
+    border-top: 1px solid @BORDER@;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+}
 QStatusBar::item { border: 0; }
 
+/* ===== Progress Bar ===== */
 QProgressBar {
-    background: @CARD_HOVER@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 8px;
-    text-align: center;
-}
-QProgressBar::chunk { background: @ACCENT@; border-radius: 6px; }
-
-QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0; }
-
-/* Analysis Dock */
-QFrame#analysisControlBar {
-    background: rgba(255, 255, 255, 0.8);
+    background: #FFFFFF;
+    color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-radius: 0;
+    text-align: center;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+QProgressBar::chunk {
+    background: @ACCENT@;
+    border-radius: 0;
+}
+
+/* ===== Frame separators ===== */
+QFrame[frameShape="4"],
+QFrame[frameShape="5"] {
+    background: @BORDER@;
+    border: 0;
+}
+
+/* ====================================================================
+   Application-specific object names
+   ==================================================================== */
+
+/* ===== Analysis Dock Control Bar ===== */
+QFrame#analysisControlBar {
+    background: @SURFACE@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
 }
 QLabel#AnalysisFormLabel {
-    color: @MUTED@; background: transparent;
-    font-weight: 600; text-transform: uppercase; letter-spacing: 1px; padding: 0 4px;
+    color: @MUTED@;
+    background: transparent;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 0 4px;
+    font-size: 9pt;
 }
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo {
+    min-width: 110px;
+}
 QFrame#AnalysisStatChip {
-    background: rgba(0, 0, 0, 0.04);
-    border: 1px solid rgba(0, 0, 0, 0.06);
-    border-radius: 10px;
+    background: #FFFFFF;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
 }
 QLabel#AnalysisStatLabel {
-    color: @MUTED@; background: transparent;
-    font-weight: 600; font-size: 9pt;
-    text-transform: uppercase; letter-spacing: 1px;
+    color: @MUTED@;
+    background: transparent;
+    font-weight: 600;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
 }
 QLabel#AnalysisStatValue {
-    color: @TEXT@; background: transparent;
-    font-weight: 700; font-family: "@MONO@", "Consolas", "JetBrains Mono", "Malgun Gothic", monospace;
+    color: @TEXT@;
+    background: transparent;
+    font-weight: 700;
+    font-family: "@MONO@", "Consolas", "JetBrains Mono", "Malgun Gothic", monospace;
 }
-QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
-QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
+QLabel#AnalysisStatValue[severity="warning"] { color: @WARNING@; }
+QLabel#AnalysisStatValue[severity="critical"] { color: @DANGER@; }
 
 QWidget#ModernAnalysisGraph {
-    background: @CARD_HOVER@;
+    background: @GRAPH@;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-radius: 0;
 }
 
-/* Filter Cards */
+/* ===== Filter Card Components =====
+   The card frame/header inline chrome is owned by MatrixSkin
+   (cardFrameStyle / cardHeaderStyle / paintCardChrome): square cells,
+   3px traffic-light status rail, dashed border when bypassed, painted
+   header band + faint column grid + crosspoint hover. The rules below
+   cover what QSS can express. */
 QFrame#FilterCardRow {
     background: @CARD@;
     border: 1px solid @BORDER@;
-    border-radius: 16px;
+    border-radius: 0;
 }
 QWidget#FilterCardHeader {
-    background: rgba(255, 255, 255, 0.4);
-    border-top-left-radius: 16px; border-top-right-radius: 16px;
+    background: transparent;
+    border-radius: 0;
 }
-QWidget#FilterCardBody, QWidget#FilterCardEditor {
-    background: rgba(255, 255, 255, 0.6);
-    border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;
+QWidget#FilterCardBody,
+QWidget#FilterCardEditor {
+    background: transparent;
+    border-radius: 0;
 }
+/* Type cell: a square outlined monospace code (BQUAD/INC/VST/...). The
+   ink colour is supplied inline by MatrixSkin::typeBadgeStyle - the type
+   reads from the code text, never from a decorative colour. */
 QLabel#FilterTypeBadge {
-    color: white; border-radius: 10px;
-    font-weight: 800; padding: 2px 8px; min-height: 18px;
-    font-size: 9pt; letter-spacing: 1px;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
+    padding: 2px 6px;
+    min-height: 18px;
+    font-size: 9pt;
+    letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 700; font-size: 10pt; }
-QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
+QLabel#FilterCardTitle {
+    color: @TEXT@;
+    background: transparent;
+    font-weight: 700;
+    font-size: 10pt;
+}
+/* A bypassed (commented-out) row reads as a cancelled departure:
+   struck-through title on top of the dashed frame and amber lamp. */
+QWidget#FilterCardHeader[filterEnabled="false"] QLabel#FilterCardTitle {
+    color: @MUTED@;
+    text-decoration: line-through;
+}
+QWidget#FilterCardHeader[filterEnabled="false"] QLabel#FilterCardSummary {
+    color: #9DB4BD;
+}
+QLabel#FilterCardSummary,
+QLabel#FilterCardRawText {
+    color: @MUTED@;
+    background: transparent;
+}
+/* Row coordinate: a boxed monospace cell, like a board line number. */
 QLabel#FilterCardNumber {
-    color: @MUTED@; background: transparent;
-    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
+    color: @ACCENT@;
+    background: #FFFFFF;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 1px 4px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
 }
 QToolButton#FilterCardIconButton {
-    background: rgba(255, 255, 255, 0.5);
+    background: transparent;
     color: @TEXT@;
-    border: 1px solid rgba(0, 0, 0, 0.08);
-    border-radius: 8px;
-    min-width: 24px; min-height: 24px;
-    padding: 2px 4px; font-weight: 700;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    min-width: 24px;
+    min-height: 24px;
+    padding: 2px 4px;
+    font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: rgba(59, 130, 246, 0.14); border-color: rgba(59, 130, 246, 0.5); }
-QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.22); border-color: @ACCENT@; }
+QToolButton#FilterCardIconButton:hover {
+    background: rgba(0, 142, 170, 0.10);
+    border-color: @ACCENT@;
+}
+QToolButton#FilterCardIconButton:checked {
+    background: rgba(0, 142, 170, 0.16);
+    border-color: @ACCENT@;
+}
 QLineEdit#FilterCardRawEditor {
-    background: @CARD_HOVER@; border: 1px solid @ACCENT@;
-    border-radius: 10px; padding: 6px 10px;
+    background: #FFFFFF;
+    border: 1px solid @ACCENT@;
+    border-radius: 0;
+    padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
-QCheckBox#FilterCardEnabled { background: transparent; }
+QCheckBox#FilterCardEnabled {
+    background: transparent;
+}
 
-QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
-QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
-QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
+/* ===== Card Editors ===== */
+QWidget#PreampCardEditor,
+QWidget#IncludeCardEditor,
+QWidget#VSTCardEditor,
+QWidget#PreampCardValueBlock,
+QLabel#IncludeCardStatus,
 QLabel#PreampCardCaption {
-    color: @MUTED@; font-weight: 600;
-    text-transform: uppercase; letter-spacing: 1px; font-size: 9pt;
+    background: transparent;
+    border: 0;
+}
+QLabel#PreampCardCaption {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
 }
 QLabel#EditableValue {
-    background: rgba(0, 0, 0, 0.04); color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 8px;
+    background: #FFFFFF;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
     padding: 6px 10px;
-    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
-    background: @CARD_HOVER@; border: 1px solid @ACCENT@;
-    border-radius: 8px; padding: 6px 10px;
-    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
+    background: #FFFFFF;
+    border: 1px solid @ACCENT@;
+    border-radius: 0;
+    padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
 }
-QLineEdit#IncludeCardPath {
-    background: @CARD_HOVER@; border: 1px solid @BORDER@;
-    border-radius: 8px; padding: 6px 10px;
-}
-QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
-
-/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
-QLabel { background: transparent; }
-QWidget#ToolBarSpacer { background: transparent; }
-
-/* ===== Matrix-specific overrides ===== */
-QFrame#FilterCardRow {
-    border-left: 3px solid @ACCENT@;
-}
-QLabel#FilterCardNumber {
+/* Include row: a single "> source: <path>" board line. */
+QLabel#IncludeCardGlyph {
+    background: transparent;
+    border: 0;
     color: @ACCENT@;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-weight: 700;
 }
-QLabel#FilterTypeBadge {
-    border-color: @ACCENT@;
+QLineEdit#IncludeCardPath {
+    background: #FFFFFF;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+QLabel#IncludeCardStatus {
+    color: @DANGER@;
+    font-size: 9pt;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+/* VST row: an external-device entry with IN/OUT port markings. */
+QWidget#MatrixVstPortStrip {
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid @BORDER@;
+}
+QLabel#MatrixVstPortLabel {
     color: @ACCENT@;
     background: transparent;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700;
+    font-size: 9pt;
+    letter-spacing: 1px;
 }
+QLabel#MatrixVstDeviceLabel {
+    color: @MUTED@;
+    background: transparent;
+    font-weight: 600;
+    font-size: 8pt;
+    letter-spacing: 2px;
+}
+QLineEdit#VSTCardPath {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+QLineEdit#CrosspointEditor {
+    background: #FFFFFF;
+    border: 1px solid @ACCENT@;
+    border-radius: 0;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+
+/* Toolbar/Tab spacers and labels transparent so parent bg shows through */
+QLabel { background: transparent; }
+QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -1,8 +1,11 @@
 /* ====================================================================
-   Skin: Minimal Dark
+   Skin: minimal - "The bank teller's terminal" (Dark)
+   Zero decoration; every pixel is information; color carries meaning
+   only. Radius 0, shadows 0, gradients 0; separators are 1px hairlines
+   or a single background-value step.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 0 / row 32 / font Consolas
+           accent @ACCENT@ / borderRadius 0 / row 32 / font DM Mono
    ==================================================================== */
 
 * {
@@ -269,19 +272,45 @@ QWidget#ModernAnalysisGraph {
 QFrame#FilterCardRow {
     background: @CARD@; border: 1px solid #2e2e2e; border-radius: 0;
 }
-QWidget#FilterCardHeader { background: @SURFACE@; border-radius: 0; }
-QWidget#FilterCardBody, QWidget#FilterCardEditor { background: @SURFACE@; border-radius: 0; }
+/* No separate header plate: a row is one flat text line on one background. */
+QWidget#FilterCardHeader { background: transparent; border-radius: 0; }
+/* The body is a second strip on the same line, cut off by a 1px hairline.
+   A shelf's three label+number pairs share this one strip and read as one
+   filter unit. */
+QWidget#FilterCardBody { background: @SURFACE@; border: 0; border-top: 1px solid @BORDER@; border-radius: 0; }
+QWidget#FilterCardEditor { background: @SURFACE@; border-radius: 0; }
+/* Type tag: a bare colored mono token, no box. The per-type color comes from
+   the row descriptor (inline); together with the leading glyph it is the only
+   type marker a line gets. */
 QLabel#FilterTypeBadge {
     background: transparent; color: @TEXT@;
-    border: 1px solid @TEXT@; border-radius: 0;
-    font-weight: 700; padding: 1px 6px; min-height: 18px;
+    border: 0; border-radius: 0;
+    font-weight: 700; padding: 1px 2px; min-height: 18px;
     font-size: 9pt; text-transform: uppercase; letter-spacing: 1px;
+}
+/* Leading type glyph (inserted by MinimalSkin::prepareCommandRow). */
+QLabel#MinimalTypeGlyph {
+    background: transparent; color: @MUTED@;
+    font-weight: 700; font-size: 9pt;
 }
 QLabel#FilterCardTitle {
     color: @TEXT@; background: transparent;
-    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+    font-weight: 400; text-transform: uppercase; letter-spacing: 1px;
 }
 QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
+/* Include and VST rows are single text lines whose payload is the file name:
+   the data is bright (primary), the command word drops to grey (secondary).
+   Hierarchy by text value, not by size. */
+QFrame#FilterCardRow[filterKind="include"] QLabel#FilterCardTitle,
+QFrame#FilterCardRow[filterKind="vstplugin"] QLabel#FilterCardTitle { color: @MUTED@; }
+QFrame#FilterCardRow[filterKind="include"] QLabel#FilterCardSummary,
+QFrame#FilterCardRow[filterKind="vstplugin"] QLabel#FilterCardSummary { color: @TEXT@; }
+/* A commented-out line: every text value falls to secondary grey (the frame
+   itself drops one background step via MinimalSkin::cardFrameStyle). */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardTitle,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardSummary,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardNumber,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#MinimalTypeGlyph { color: @MUTED@; }
 QLabel#FilterCardNumber {
     color: @MUTED@; background: transparent;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -1,8 +1,11 @@
 /* ====================================================================
-   Skin: Minimal Light
+   Skin: minimal - "The bank teller's terminal" (Light)
+   Zero decoration; every pixel is information; color carries meaning
+   only. Radius 0, shadows 0, gradients 0; separators are 1px hairlines
+   or a single background-value step.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @BG@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 0 / row 32 / font Consolas
+           accent @ACCENT@ / borderRadius 0 / row 32 / font DM Mono
    ==================================================================== */
 
 * {
@@ -221,16 +224,42 @@ QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
 QWidget#ModernAnalysisGraph { background: #ffffff; border: 1px solid @BORDER@; border-radius: 0; }
 
 QFrame#FilterCardRow { background: @CARD@; border: 1px solid #d0d0d0; border-radius: 0; }
-QWidget#FilterCardHeader { background: @BG@; border-radius: 0; }
-QWidget#FilterCardBody, QWidget#FilterCardEditor { background: @BG@; border-radius: 0; }
+/* No separate header plate: a row is one flat text line on one background. */
+QWidget#FilterCardHeader { background: transparent; border-radius: 0; }
+/* The body is a second strip on the same line, cut off by a 1px hairline.
+   A shelf's three label+number pairs share this one strip and read as one
+   filter unit. */
+QWidget#FilterCardBody { background: @BG@; border: 0; border-top: 1px solid @BORDER@; border-radius: 0; }
+QWidget#FilterCardEditor { background: @BG@; border-radius: 0; }
+/* Type tag: a bare colored mono token, no box. The per-type color comes from
+   the row descriptor (inline); together with the leading glyph it is the only
+   type marker a line gets. */
 QLabel#FilterTypeBadge {
     background: transparent; color: @TEXT@;
-    border: 1px solid @TEXT@; border-radius: 0;
-    font-weight: 700; padding: 1px 6px; min-height: 18px;
+    border: 0; border-radius: 0;
+    font-weight: 700; padding: 1px 2px; min-height: 18px;
     font-size: 9pt; text-transform: uppercase; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+/* Leading type glyph (inserted by MinimalSkin::prepareCommandRow). */
+QLabel#MinimalTypeGlyph {
+    background: transparent; color: @MUTED@;
+    font-weight: 700; font-size: 9pt;
+}
+QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 400; text-transform: uppercase; letter-spacing: 1px; }
 QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
+/* Include and VST rows are single text lines whose payload is the file name:
+   the data is dark (primary), the command word drops to grey (secondary).
+   Hierarchy by text value, not by size. */
+QFrame#FilterCardRow[filterKind="include"] QLabel#FilterCardTitle,
+QFrame#FilterCardRow[filterKind="vstplugin"] QLabel#FilterCardTitle { color: @MUTED@; }
+QFrame#FilterCardRow[filterKind="include"] QLabel#FilterCardSummary,
+QFrame#FilterCardRow[filterKind="vstplugin"] QLabel#FilterCardSummary { color: @TEXT@; }
+/* A commented-out line: every text value falls to secondary grey (the frame
+   itself drops one background step via MinimalSkin::cardFrameStyle). */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardTitle,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardSummary,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardNumber,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#MinimalTypeGlyph { color: @MUTED@; }
 QLabel#FilterCardNumber { color: @MUTED@; background: transparent; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700; }
 QToolButton#FilterCardIconButton {
     background: @BG@; color: @TEXT@;

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -1,14 +1,19 @@
 /* ====================================================================
-   Skin: Industrial Dark
+   Skin: Rack Dark - "The amplifier faceplate"
+   Skeuomorphic 19-inch rack hardware: machined plates, switch-like
+   controls (raised gradient caps with a lit top edge), recessed display
+   wells, LED readouts, uppercase faceplate printing. The painted chrome
+   (screws, rack ears, LEDs, jacks, nameplates, pointer knobs) lives in
+   Editor/skins/RackChrome.cpp.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 2 / row 30
+           accent @ACCENT@ / accent2 @ACCENT2@ / borderRadius 3 / row 36
    ==================================================================== */
 
 * {
     outline: 0;
     selection-background-color: @ACCENT@;
-    selection-color: #f8fafc;
+    selection-color: #1A1208;
 }
 
 QWidget {
@@ -25,12 +30,12 @@ QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border
 
 QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@; }
 QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 2px; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: @CARD_HOVER@; color: #ffffff; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: @CARD_HOVER@; color: #FFFFFF; }
 
 QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; padding: 2px; }
 QMenu::item { background: transparent; padding: 5px 22px; border-radius: 2px; min-width: 140px; }
-QMenu::item:selected { background: @CARD_HOVER@; color: #ffffff; }
-QMenu::item:disabled { color: #404054; }
+QMenu::item:selected { background: @CARD_HOVER@; color: #FFFFFF; }
+QMenu::item:disabled { color: #4E4A40; }
 QMenu::separator { height: 1px; background: @BORDER@; margin: 4px 6px; }
 QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
 QMenu::indicator:checked { background: @ACCENT@; }
@@ -39,42 +44,61 @@ QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; 
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 4px 6px; }
 QToolButton {
     background: transparent; color: @TEXT@;
-    border: 1px solid transparent; border-radius: 2px;
+    border: 1px solid transparent; border-radius: 3px;
     padding: 3px 8px; min-height: 22px;
 }
-QToolButton:hover { background: @CARD@; border: 1px solid @BORDER@; }
-QToolButton:pressed, QToolButton:checked { background: #1a3358; border: 1px solid @ACCENT@; }
+QToolButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #343C44, stop:1 #20272D);
+    border: 1px solid #11161A; border-top-color: #3E474F;
+}
+QToolButton:pressed, QToolButton:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2B2210, stop:1 #3A2F18);
+    border: 1px solid @ACCENT@;
+}
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 
 QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
 
+/* Push buttons are raised switch caps: lit top edge, shadowed base; pressing
+   inverts the gradient (the cap goes in). */
 QPushButton {
-    background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    color: @TEXT@;
+    border: 1px solid #11161A; border-top-color: #3E474F;
+    border-radius: 3px;
     padding: 4px 14px; min-height: 22px;
     text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QPushButton:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
-QPushButton:pressed { background: #1a3358; border-color: @ACCENT@; }
+QPushButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #343C44, stop:1 #20272D);
+    border-color: @ACCENT@; border-top-color: #3E474F;
+}
+QPushButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #161B1F, stop:1 #242B31);
+    border-color: @ACCENT@;
+}
 QPushButton:default { border: 1px solid @ACCENT@; }
-QPushButton:disabled { color: #404054; background: @SURFACE@; border-color: @CARD_HOVER@; }
+QPushButton:disabled { color: #4E4A40; background: @SURFACE@; border-color: #22282D; }
 
+/* Inputs are recessed display wells milled into the plate. */
 QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
-    background: #050508; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: #0A0D0F; color: @TEXT@;
+    border: 1px solid #060809; border-bottom-color: #39424A;
+    border-radius: 2px;
     padding: 3px 8px;
-    selection-background-color: @ACCENT@; selection-color: #f8fafc;
+    selection-background-color: @ACCENT@; selection-color: #1A1208;
 }
 QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid @ACCENT@; }
-QLineEdit:disabled, QAbstractSpinBox:disabled { color: #404054; background: @BG@; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #4E4A40; background: @BG@; }
 
 QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
-    subcontrol-origin: border; background: @SURFACE@;
-    width: 16px; border-left: 1px solid @BORDER@;
+    subcontrol-origin: border;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    width: 16px; border-left: 1px solid #060809;
 }
 QAbstractSpinBox::up-button { subcontrol-position: top right; }
-QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid @BORDER@; }
-QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: @CARD_HOVER@; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid #060809; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #343C44; }
 QAbstractSpinBox::up-arrow {
     image: none; width: 0; height: 0;
     border-left: 3px solid transparent; border-right: 3px solid transparent; border-bottom: 4px solid @MUTED@;
@@ -84,12 +108,15 @@ QAbstractSpinBox::down-arrow {
     border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 4px solid @MUTED@;
 }
 
+/* Combo boxes are rotary-selector wells with a switch-cap face. */
 QComboBox {
-    background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    color: @TEXT@;
+    border: 1px solid #11161A; border-top-color: #3E474F;
+    border-radius: 3px;
     padding: 3px 28px 3px 10px; min-height: 28px;
 }
-QComboBox:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
+QComboBox:hover { border-color: @ACCENT@; border-top-color: #3E474F; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
 QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
 QComboBox::down-arrow {
@@ -102,26 +129,38 @@ QComboBox QAbstractItemView {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 2px;
     padding: 2px; outline: 0;
-    selection-background-color: @CARD_HOVER@; selection-color: #ffffff;
+    selection-background-color: @CARD_HOVER@; selection-color: #FFFFFF;
 }
 QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 24px; }
 
+/* Check/radio indicators are little panel switches; checked = lit amber. */
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
-QCheckBox:disabled, QRadioButton:disabled { color: #404054; }
+QCheckBox:disabled, QRadioButton:disabled { color: #4E4A40; }
 QCheckBox::indicator, QRadioButton::indicator {
-    width: 14px; height: 14px; background: #050508; border: 1px solid @BORDER@;
+    width: 15px; height: 15px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #161B1F);
+    border: 1px solid #11161A; border-top-color: #3E474F;
 }
 QCheckBox::indicator { border-radius: 2px; }
-QRadioButton::indicator { border-radius: 7px; }
+QRadioButton::indicator { border-radius: 8px; }
 QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: @ACCENT@; }
-QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFD89A, stop:1 #E8A33C);
+    border: 1px solid #8A5C12;
+}
 
 QScrollBar:vertical { background: transparent; width: 10px; margin: 2px; border: 0; }
-QScrollBar::handle:vertical { background: @BORDER@; min-height: 32px; border-radius: 2px; }
-QScrollBar::handle:vertical:hover { background: @ACCENT@; }
+QScrollBar::handle:vertical {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #39424A, stop:1 #232A30);
+    border: 1px solid #11161A; min-height: 32px; border-radius: 2px;
+}
+QScrollBar::handle:vertical:hover { border-color: @ACCENT@; }
 QScrollBar:horizontal { background: transparent; height: 10px; margin: 2px; border: 0; }
-QScrollBar::handle:horizontal { background: @BORDER@; min-width: 32px; border-radius: 2px; }
-QScrollBar::handle:horizontal:hover { background: @ACCENT@; }
+QScrollBar::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #39424A, stop:1 #232A30);
+    border: 1px solid #11161A; min-width: 32px; border-radius: 2px;
+}
+QScrollBar::handle:horizontal:hover { border-color: @ACCENT@; }
 QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
 QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
 QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
@@ -140,24 +179,35 @@ QDockWidget::title {
 QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 2px; padding: 2px; icon-size: 12px; }
 QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: @CARD_HOVER@; }
 
+/* Tabs are a row of channel-select switch caps; the engaged one sits pressed
+   in with a lit amber strip under it. */
 QTabWidget::pane { background: @BG@; border: 0; border-top: 1px solid @BORDER@; top: -1px; }
 QTabBar { background: @BG@; border: 0; qproperty-drawBase: 0; }
 QTabBar::tab {
-    background: transparent; color: @MUTED@;
-    padding: 6px 16px; border: 0; border-radius: 0;
-    min-width: 80px; margin: 0;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    color: @MUTED@;
+    border: 1px solid #11161A; border-top-color: #3E474F; border-bottom: 0;
+    border-top-left-radius: 3px; border-top-right-radius: 3px;
+    padding: 5px 14px; min-width: 80px; margin: 2px 2px 0 0;
     text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QTabBar::tab:hover { color: @TEXT@; background: @SURFACE@; }
-QTabBar::tab:selected { color: #ffffff; background: @SURFACE@; border-top: 2px solid @ACCENT@; }
-QTabBar::tab:!selected { border-bottom: 1px solid @BORDER@; }
+QTabBar::tab:hover { color: @TEXT@; }
+QTabBar::tab:selected {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #161B1F, stop:1 #242B31);
+    color: #FFFFFF;
+    border-bottom: 2px solid @ACCENT@;
+}
 QTabBar::close-button { image: none; background: transparent; border-radius: 2px; padding: 2px; margin: 2px; subcontrol-position: right; }
-QTabBar::close-button:hover { background: #5a1a1a; }
-QTabBar QToolButton { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 2px; margin: 4px 2px; }
+QTabBar::close-button:hover { background: #5A1A1A; }
+QTabBar QToolButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    border: 1px solid #11161A; border-top-color: #3E474F; border-radius: 2px; margin: 4px 2px;
+}
 
+/* Group boxes are sub-module plates with printed designations. */
 QGroupBox {
     background: @SURFACE@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    border: 1px solid @BORDER@; border-radius: 3px;
     margin-top: 14px; padding: 14px 10px 10px;
 }
 QGroupBox::title {
@@ -176,22 +226,34 @@ QHeaderView::section {
 QTreeView, QListView, QTableView {
     background: @BG@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 2px;
-    alternate-background-color: #0a0a10;
-    selection-background-color: @CARD_HOVER@; selection-color: #ffffff;
+    alternate-background-color: #0E1113;
+    selection-background-color: @CARD_HOVER@; selection-color: #FFFFFF;
     gridline-color: @BORDER@;
 }
 QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 2px; }
-QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #12121c; }
-QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: @CARD_HOVER@; color: #ffffff; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #161B1F; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: @CARD_HOVER@; color: #FFFFFF; }
 QTreeView::branch { background: transparent; }
 
-QSlider::groove:horizontal { background: @BORDER@; height: 2px; border-radius: 1px; margin: 0 6px; }
-QSlider::sub-page:horizontal { background: @ACCENT@; height: 2px; border-radius: 1px; }
-QSlider::handle:horizontal { background: @TEXT@; border: 1px solid @ACCENT@; width: 12px; height: 12px; margin: -6px 0; border-radius: 1px; }
-QSlider::groove:vertical { background: @BORDER@; width: 2px; border-radius: 1px; margin: 6px 0; }
-QSlider::add-page:vertical { background: @ACCENT@; width: 2px; border-radius: 1px; }
-QSlider::sub-page:vertical { background: @BORDER@; width: 2px; border-radius: 1px; }
-QSlider::handle:vertical { background: @TEXT@; border: 1px solid @ACCENT@; width: 12px; height: 12px; margin: 0 -6px; border-radius: 1px; }
+/* Sliders are channel faders: a milled slot and a metal cap with a white
+   index line across it (the gradient stop at 0.5). */
+QSlider::groove:horizontal { background: #0A0D0F; height: 6px; border: 1px solid #060809; border-radius: 2px; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #6E5524; border: 1px solid #060809; border-radius: 2px; }
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 #3E474F, stop:0.45 #262D33, stop:0.5 #E6E0D4, stop:0.55 #262D33, stop:1 #181D21);
+    border: 1px solid #0B0F12; width: 16px; height: 16px; margin: -6px 0; border-radius: 2px;
+}
+QSlider::handle:horizontal:hover { border-color: @ACCENT@; }
+QSlider::groove:vertical { background: #0A0D0F; width: 6px; border: 1px solid #060809; border-radius: 2px; margin: 6px 0; }
+QSlider::add-page:vertical { background: #6E5524; border: 1px solid #060809; border-radius: 2px; }
+QSlider::sub-page:vertical { background: #0A0D0F; border: 1px solid #060809; border-radius: 2px; }
+QSlider::handle:vertical {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #3E474F, stop:0.45 #262D33, stop:0.5 #E6E0D4, stop:0.55 #262D33, stop:1 #181D21);
+    border: 1px solid #0B0F12; width: 16px; height: 16px; margin: 0 -6px; border-radius: 2px;
+}
+QSlider::handle:vertical:hover { border-color: @ACCENT@; }
 
 QSplitter::handle { background: @BORDER@; }
 QSplitter::handle:horizontal { width: 1px; }
@@ -201,32 +263,42 @@ QSplitter::handle:hover { background: @ACCENT@; }
 QStatusBar { background: @SURFACE@; color: @MUTED@; border: 0; border-top: 1px solid @BORDER@; }
 QStatusBar::item { border: 0; }
 
-QProgressBar { background: #050508; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; text-align: center; }
-QProgressBar::chunk { background: @ACCENT@; border-radius: 1px; }
+/* The progress bar is a VU strip sweeping toward amber. */
+QProgressBar { background: #0A0D0F; color: @TEXT@; border: 1px solid #060809; border-radius: 2px; text-align: center; }
+QProgressBar::chunk { background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #8A6A28, stop:1 @ACCENT@); border-radius: 1px; }
 
 QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0; }
 
-QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 2px; }
+QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 3px; }
 QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
 }
 QComboBox#AnalysisFormCombo { min-width: 110px; }
-QFrame#AnalysisStatChip { background: @CARD@; border: 1px solid @BORDER@; border-radius: 2px; }
+QFrame#AnalysisStatChip { background: #0A0D0F; border: 1px solid #060809; border-radius: 2px; }
 QLabel#AnalysisStatLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; font-size: 8pt;
     text-transform: uppercase; letter-spacing: 2px;
 }
-QLabel#AnalysisStatValue { color: @TEXT@; background: transparent; font-weight: 700; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; }
+QLabel#AnalysisStatValue { color: #86F2BA; background: transparent; font-weight: 700; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; }
 QLabel#AnalysisStatValue[severity="warning"] { color: @WARNING@; }
 QLabel#AnalysisStatValue[severity="critical"] { color: @DANGER@; }
 
-QWidget#ModernAnalysisGraph { background: #050508; border: 1px solid @BORDER@; border-radius: 2px; }
+QWidget#ModernAnalysisGraph { background: #060807; border: 1px solid #060809; border-radius: 2px; }
 
-QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 2px; }
-QWidget#FilterCardHeader { background: @SURFACE@; border-radius: 2px; }
-QWidget#FilterCardBody, QWidget#FilterCardEditor { background: @SURFACE@; border-radius: 2px; }
+/* The command row is a rack unit. RackChrome paints the faceplate (brushed
+   metal, ears, screws, LEDs) over the frame's base plate, so the header and
+   body stay transparent: every control sits directly on the metal. */
+QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 3px; }
+QWidget#FilterCardHeader { background: transparent; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: transparent; border: 0; }
+QScrollArea#FilterCardEditorScroll,
+QScrollArea#FilterCardEditorScroll > QWidget > QWidget { background: transparent; }
+/* Powered-down unit (commented-out line): the printing fades with the film
+   RackChrome draws over the plate. */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel { color: @MUTED@; }
+
 QLabel#FilterTypeBadge {
     background: transparent; color: @TEXT@;
     border: 1px solid @TEXT@; border-radius: 1px;
@@ -237,13 +309,20 @@ QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 70
 QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
 QLabel#FilterCardNumber { color: @MUTED@; background: transparent; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700; }
 QToolButton#FilterCardIconButton {
-    background: @BG@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 1px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    color: @TEXT@;
+    border: 1px solid #11161A; border-top-color: #3E474F; border-radius: 2px;
     min-width: 24px; min-height: 24px; padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
-QToolButton#FilterCardIconButton:checked { background: #1a3358; border-color: @ACCENT@; }
-QLineEdit#FilterCardRawEditor { background: #050508; border: 1px solid @ACCENT@; border-radius: 2px; padding: 4px 8px; }
+QToolButton#FilterCardIconButton:hover { border-color: @ACCENT@; border-top-color: #3E474F; }
+QToolButton#FilterCardIconButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #161B1F, stop:1 #242B31);
+}
+QToolButton#FilterCardIconButton:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2B2210, stop:1 #3A2F18);
+    border-color: @ACCENT@;
+}
+QLineEdit#FilterCardRawEditor { background: #0A0D0F; border: 1px solid @ACCENT@; border-radius: 2px; padding: 4px 8px; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; }
 QCheckBox#FilterCardEnabled { background: transparent; }
 
 QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
@@ -253,18 +332,19 @@ QLabel#PreampCardCaption {
     color: @MUTED@; font-weight: 700;
     text-transform: uppercase; letter-spacing: 2px; font-size: 8pt;
 }
+/* Value readouts are LED display windows set into the plate. */
 QLabel#EditableValue {
-    background: @BG@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: #0B0F0C; color: #86F2BA;
+    border: 1px solid #050807; border-radius: 2px;
     padding: 4px 8px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
-    background: #050508; border: 1px solid @ACCENT@;
+    background: #0B0F0C; color: #86F2BA; border: 1px solid @ACCENT@;
     border-radius: 2px; padding: 4px 8px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
-QLineEdit#IncludeCardPath { background: #050508; border: 1px solid @BORDER@; border-radius: 2px; padding: 4px 8px; }
+QLineEdit#IncludeCardPath { background: #0A0D0F; border: 1px solid #060809; border-bottom-color: #39424A; border-radius: 2px; padding: 4px 8px; }
 QLabel#IncludeCardStatus { color: @DANGER@; font-size: 8pt; }
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -1,14 +1,19 @@
 /* ====================================================================
-   Skin: Industrial Light
+   Skin: Rack Light - "The amplifier faceplate"
+   Skeuomorphic 19-inch rack hardware on cream/aluminium panels: machined
+   plates, switch-like controls (raised gradient caps with a lit top
+   edge), recessed display wells, LED readouts, uppercase faceplate
+   printing. The painted chrome (screws, rack ears, LEDs, jacks,
+   nameplates, pointer knobs) lives in Editor/skins/RackChrome.cpp.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 2 / row 30
+           accent @ACCENT@ / accent2 @ACCENT2@ / borderRadius 3 / row 36
    ==================================================================== */
 
 * {
     outline: 0;
     selection-background-color: @ACCENT@;
-    selection-color: #ffffff;
+    selection-color: #FFF8EA;
 }
 
 QWidget {
@@ -25,52 +30,75 @@ QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border
 
 QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@; }
 QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 2px; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: #c0c0d0; color: #000000; }
+QMenuBar::item:selected, QMenuBar::item:pressed { background: #E2D8C2; color: #000000; }
 
 QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; padding: 2px; }
 QMenu::item { background: transparent; padding: 5px 22px; border-radius: 2px; min-width: 140px; }
-QMenu::item:selected { background: @SURFACE@; color: #000000; }
-QMenu::item:disabled { color: #9090a0; }
+QMenu::item:selected { background: #EFE5CE; color: #000000; }
+QMenu::item:disabled { color: #A99F8E; }
 QMenu::separator { height: 1px; background: @BORDER@; margin: 4px 6px; }
 QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
 QMenu::indicator:checked { background: @ACCENT@; }
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 2px 4px; spacing: 2px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 4px 6px; }
-QToolButton { background: transparent; color: @TEXT@; border: 1px solid transparent; border-radius: 2px; padding: 3px 8px; min-height: 22px; }
-QToolButton:hover { background: #c8c8d4; border: 1px solid @BORDER@; }
-QToolButton:pressed, QToolButton:checked { background: #c4d4f0; border: 1px solid @ACCENT@; }
+QToolButton {
+    background: transparent; color: @TEXT@;
+    border: 1px solid transparent; border-radius: 3px;
+    padding: 3px 8px; min-height: 22px;
+}
+QToolButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #F0E8D6);
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
+}
+QToolButton:pressed, QToolButton:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #EBCF96, stop:1 #F7E3B8);
+    border: 1px solid @ACCENT@;
+}
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 
 QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
 
+/* Push buttons are raised switch caps: lit top edge, shadowed base; pressing
+   inverts the gradient (the cap goes in). */
 QPushButton {
-    background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    color: @TEXT@;
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
+    border-radius: 3px;
     padding: 4px 14px; min-height: 22px;
     text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QPushButton:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
-QPushButton:pressed { background: #c4d4f0; border-color: @ACCENT@; }
+QPushButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #F0E8D6);
+    border-color: @ACCENT@; border-top-color: #FFFFFF;
+}
+QPushButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #D8CFBB, stop:1 #EFE8D8);
+    border-color: @ACCENT@;
+}
 QPushButton:default { border: 1px solid @ACCENT@; }
-QPushButton:disabled { color: #9090a0; background: #dadade; border-color: #c4c4d0; }
+QPushButton:disabled { color: #A99F8E; background: #E2DCCE; border-color: #C9C0AC; }
 
+/* Inputs are recessed wells milled into the plate. */
 QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
-    background: #f2f2f8; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: #FCF8EE; color: @TEXT@;
+    border: 1px solid #8F8268; border-bottom-color: #FFFFFF;
+    border-radius: 2px;
     padding: 3px 8px;
-    selection-background-color: @ACCENT@; selection-color: #ffffff;
+    selection-background-color: @ACCENT@; selection-color: #FFF8EA;
 }
 QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid @ACCENT@; }
-QLineEdit:disabled, QAbstractSpinBox:disabled { color: #9090a0; background: #d8d8e0; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: #A99F8E; background: #E2DCCE; }
 
 QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
-    subcontrol-origin: border; background: @SURFACE@;
-    width: 16px; border-left: 1px solid @BORDER@;
+    subcontrol-origin: border;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    width: 16px; border-left: 1px solid #8F8268;
 }
 QAbstractSpinBox::up-button { subcontrol-position: top right; }
-QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid @BORDER@; }
-QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #c0c0d0; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-top: 1px solid #8F8268; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: #F0E8D6; }
 QAbstractSpinBox::up-arrow {
     image: none; width: 0; height: 0;
     border-left: 3px solid transparent; border-right: 3px solid transparent; border-bottom: 4px solid @MUTED@;
@@ -80,12 +108,15 @@ QAbstractSpinBox::down-arrow {
     border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 4px solid @MUTED@;
 }
 
+/* Combo boxes are rotary-selector wells with a switch-cap face. */
 QComboBox {
-    background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    color: @TEXT@;
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
+    border-radius: 3px;
     padding: 3px 28px 3px 10px; min-height: 28px;
 }
-QComboBox:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
+QComboBox:hover { border-color: @ACCENT@; border-top-color: #FFFFFF; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
 QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
 QComboBox::down-arrow {
@@ -98,26 +129,38 @@ QComboBox QAbstractItemView {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 2px;
     padding: 2px; outline: 0;
-    selection-background-color: @SURFACE@; selection-color: #000000;
+    selection-background-color: #EFE5CE; selection-color: #000000;
 }
 QComboBox QAbstractItemView::item { padding: 4px 10px; border-radius: 2px; min-height: 24px; }
 
+/* Check/radio indicators are little panel switches; checked = lit amber. */
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
-QCheckBox:disabled, QRadioButton:disabled { color: #9090a0; }
+QCheckBox:disabled, QRadioButton:disabled { color: #A99F8E; }
 QCheckBox::indicator, QRadioButton::indicator {
-    width: 14px; height: 14px; background: #f2f2f8; border: 1px solid @BORDER@;
+    width: 15px; height: 15px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #DED6C2);
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
 }
 QCheckBox::indicator { border-radius: 2px; }
-QRadioButton::indicator { border-radius: 7px; }
+QRadioButton::indicator { border-radius: 8px; }
 QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: @ACCENT@; }
-QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFC96A, stop:1 #D88E1E);
+    border: 1px solid #8A5C12;
+}
 
 QScrollBar:vertical { background: transparent; width: 10px; margin: 2px; border: 0; }
-QScrollBar::handle:vertical { background: @BORDER@; min-height: 32px; border-radius: 2px; }
-QScrollBar::handle:vertical:hover { background: @ACCENT@; }
+QScrollBar::handle:vertical {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #FFFFFF, stop:1 #D5CCB8);
+    border: 1px solid #AFA288; min-height: 32px; border-radius: 2px;
+}
+QScrollBar::handle:vertical:hover { border-color: @ACCENT@; }
 QScrollBar:horizontal { background: transparent; height: 10px; margin: 2px; border: 0; }
-QScrollBar::handle:horizontal { background: @BORDER@; min-width: 32px; border-radius: 2px; }
-QScrollBar::handle:horizontal:hover { background: @ACCENT@; }
+QScrollBar::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #D5CCB8);
+    border: 1px solid #AFA288; min-width: 32px; border-radius: 2px;
+}
+QScrollBar::handle:horizontal:hover { border-color: @ACCENT@; }
 QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
 QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
 QScrollBar::up-arrow, QScrollBar::down-arrow, QScrollBar::left-arrow, QScrollBar::right-arrow { background: transparent; width: 0; height: 0; }
@@ -134,26 +177,37 @@ QDockWidget::title {
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px;
 }
 QDockWidget::close-button, QDockWidget::float-button { background: transparent; border: 0; border-radius: 2px; padding: 2px; icon-size: 12px; }
-QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: #c0c0d0; }
+QDockWidget::close-button:hover, QDockWidget::float-button:hover { background: #E2D8C2; }
 
+/* Tabs are a row of channel-select switch caps; the engaged one sits pressed
+   in with a lit amber strip under it. */
 QTabWidget::pane { background: @BG@; border: 0; border-top: 1px solid @BORDER@; top: -1px; }
 QTabBar { background: @BG@; border: 0; qproperty-drawBase: 0; }
 QTabBar::tab {
-    background: transparent; color: @MUTED@;
-    padding: 6px 16px; border: 0; border-radius: 0;
-    min-width: 80px; margin: 0;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    color: @MUTED@;
+    border: 1px solid #AFA288; border-top-color: #FFFFFF; border-bottom: 0;
+    border-top-left-radius: 3px; border-top-right-radius: 3px;
+    padding: 5px 14px; min-width: 80px; margin: 2px 2px 0 0;
     text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
 }
-QTabBar::tab:hover { color: @TEXT@; background: @SURFACE@; }
-QTabBar::tab:selected { color: #000000; background: @CARD@; border-top: 2px solid @ACCENT@; }
-QTabBar::tab:!selected { border-bottom: 1px solid @BORDER@; }
+QTabBar::tab:hover { color: @TEXT@; }
+QTabBar::tab:selected {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #D8CFBB, stop:1 #EFE8D8);
+    color: #000000;
+    border-bottom: 2px solid @ACCENT@;
+}
 QTabBar::close-button { image: none; background: transparent; border-radius: 2px; padding: 2px; margin: 2px; subcontrol-position: right; }
-QTabBar::close-button:hover { background: #f4baba; }
-QTabBar QToolButton { background: @CARD@; border: 1px solid @BORDER@; border-radius: 2px; margin: 4px 2px; }
+QTabBar::close-button:hover { background: #F4BABA; }
+QTabBar QToolButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    border: 1px solid #AFA288; border-top-color: #FFFFFF; border-radius: 2px; margin: 4px 2px;
+}
 
+/* Group boxes are sub-module plates with printed designations. */
 QGroupBox {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    border: 1px solid @BORDER@; border-radius: 3px;
     margin-top: 14px; padding: 14px 10px 10px;
 }
 QGroupBox::title {
@@ -172,22 +226,34 @@ QHeaderView::section {
 QTreeView, QListView, QTableView {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 2px;
-    alternate-background-color: #e8e8e0;
-    selection-background-color: @SURFACE@; selection-color: #000000;
+    alternate-background-color: #F0EADC;
+    selection-background-color: #EFE5CE; selection-color: #000000;
     gridline-color: @BORDER@;
 }
 QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 2px; }
-QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #e0e0d8; }
-QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: @SURFACE@; color: #000000; }
+QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: #F0E8D6; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: #EFE5CE; color: #000000; }
 QTreeView::branch { background: transparent; }
 
-QSlider::groove:horizontal { background: @BORDER@; height: 2px; border-radius: 1px; margin: 0 6px; }
-QSlider::sub-page:horizontal { background: @ACCENT@; height: 2px; border-radius: 1px; }
-QSlider::handle:horizontal { background: @TEXT@; border: 1px solid @ACCENT@; width: 12px; height: 12px; margin: -6px 0; border-radius: 1px; }
-QSlider::groove:vertical { background: @BORDER@; width: 2px; border-radius: 1px; margin: 6px 0; }
-QSlider::add-page:vertical { background: @ACCENT@; width: 2px; border-radius: 1px; }
-QSlider::sub-page:vertical { background: @BORDER@; width: 2px; border-radius: 1px; }
-QSlider::handle:vertical { background: @TEXT@; border: 1px solid @ACCENT@; width: 12px; height: 12px; margin: 0 -6px; border-radius: 1px; }
+/* Sliders are channel faders: a milled slot and a metal cap with a dark
+   index line across it (the gradient stop at 0.5). */
+QSlider::groove:horizontal { background: #D9D2C0; height: 6px; border: 1px solid #8F8268; border-radius: 2px; margin: 0 6px; }
+QSlider::sub-page:horizontal { background: #E0B568; border: 1px solid #8F8268; border-radius: 2px; }
+QSlider::handle:horizontal {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 #FFFFFF, stop:0.45 #E2DAC8, stop:0.5 #4A443A, stop:0.55 #E2DAC8, stop:1 #C9C0AC);
+    border: 1px solid #8F8268; width: 16px; height: 16px; margin: -6px 0; border-radius: 2px;
+}
+QSlider::handle:horizontal:hover { border-color: @ACCENT@; }
+QSlider::groove:vertical { background: #D9D2C0; width: 6px; border: 1px solid #8F8268; border-radius: 2px; margin: 6px 0; }
+QSlider::add-page:vertical { background: #E0B568; border: 1px solid #8F8268; border-radius: 2px; }
+QSlider::sub-page:vertical { background: #D9D2C0; border: 1px solid #8F8268; border-radius: 2px; }
+QSlider::handle:vertical {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 #FFFFFF, stop:0.45 #E2DAC8, stop:0.5 #4A443A, stop:0.55 #E2DAC8, stop:1 #C9C0AC);
+    border: 1px solid #8F8268; width: 16px; height: 16px; margin: 0 -6px; border-radius: 2px;
+}
+QSlider::handle:vertical:hover { border-color: @ACCENT@; }
 
 QSplitter::handle { background: @BORDER@; }
 QSplitter::handle:horizontal { width: 1px; }
@@ -197,32 +263,42 @@ QSplitter::handle:hover { background: @ACCENT@; }
 QStatusBar { background: @SURFACE@; color: @MUTED@; border: 0; border-top: 1px solid @BORDER@; }
 QStatusBar::item { border: 0; }
 
-QProgressBar { background: #f2f2f8; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; text-align: center; }
-QProgressBar::chunk { background: @ACCENT@; border-radius: 1px; }
+/* The progress bar is a VU strip sweeping toward amber. */
+QProgressBar { background: #FCF8EE; color: @TEXT@; border: 1px solid #8F8268; border-radius: 2px; text-align: center; }
+QProgressBar::chunk { background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #D9A647, stop:1 @ACCENT@); border-radius: 1px; }
 
 QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0; }
 
-QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 2px; }
+QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 3px; }
 QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
 }
 QComboBox#AnalysisFormCombo { min-width: 110px; }
-QFrame#AnalysisStatChip { background: #e8e8e0; border: 1px solid @BORDER@; border-radius: 2px; }
+QFrame#AnalysisStatChip { background: #11150F; border: 1px solid #4A4438; border-radius: 2px; }
 QLabel#AnalysisStatLabel {
-    color: @MUTED@; background: transparent;
+    color: #9AA08E; background: transparent;
     font-weight: 700; font-size: 8pt;
     text-transform: uppercase; letter-spacing: 2px;
 }
-QLabel#AnalysisStatValue { color: @TEXT@; background: transparent; font-weight: 700; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; }
-QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
-QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
+QLabel#AnalysisStatValue { color: #3ED68E; background: transparent; font-weight: 700; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; }
+QLabel#AnalysisStatValue[severity="warning"] { color: #F2B95C; }
+QLabel#AnalysisStatValue[severity="critical"] { color: #FF7A6A; }
 
-QWidget#ModernAnalysisGraph { background: #f2f2f8; border: 1px solid @BORDER@; border-radius: 2px; }
+QWidget#ModernAnalysisGraph { background: #FFF7E6; border: 1px solid #8F8268; border-radius: 2px; }
 
-QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 2px; }
-QWidget#FilterCardHeader { background: #d8d8e2; border-radius: 2px; }
-QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #d8d8e2; border-radius: 2px; }
+/* The command row is a rack unit. RackChrome paints the faceplate (brushed
+   metal, ears, screws, LEDs) over the frame's base plate, so the header and
+   body stay transparent: every control sits directly on the metal. */
+QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 3px; }
+QWidget#FilterCardHeader { background: transparent; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: transparent; border: 0; }
+QScrollArea#FilterCardEditorScroll,
+QScrollArea#FilterCardEditorScroll > QWidget > QWidget { background: transparent; }
+/* Powered-down unit (commented-out line): the printing fades with the film
+   RackChrome draws over the plate. */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel { color: @MUTED@; }
+
 QLabel#FilterTypeBadge {
     background: transparent; color: @TEXT@;
     border: 1px solid @TEXT@; border-radius: 1px;
@@ -233,13 +309,20 @@ QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 70
 QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
 QLabel#FilterCardNumber { color: @MUTED@; background: transparent; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700; }
 QToolButton#FilterCardIconButton {
-    background: #d8d8e2; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 1px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    color: @TEXT@;
+    border: 1px solid #AFA288; border-top-color: #FFFFFF; border-radius: 2px;
     min-width: 24px; min-height: 24px; padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: @CARD_HOVER@; border-color: @ACCENT@; }
-QToolButton#FilterCardIconButton:checked { background: #c4d4f0; border-color: @ACCENT@; }
-QLineEdit#FilterCardRawEditor { background: #f2f2f8; border: 1px solid @ACCENT@; border-radius: 2px; padding: 4px 8px; }
+QToolButton#FilterCardIconButton:hover { border-color: @ACCENT@; border-top-color: #FFFFFF; }
+QToolButton#FilterCardIconButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #D8CFBB, stop:1 #EFE8D8);
+}
+QToolButton#FilterCardIconButton:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #EBCF96, stop:1 #F7E3B8);
+    border-color: @ACCENT@;
+}
+QLineEdit#FilterCardRawEditor { background: #FCF8EE; border: 1px solid @ACCENT@; border-radius: 2px; padding: 4px 8px; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; }
 QCheckBox#FilterCardEnabled { background: transparent; }
 
 QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
@@ -249,19 +332,21 @@ QLabel#PreampCardCaption {
     color: @MUTED@; font-weight: 700;
     text-transform: uppercase; letter-spacing: 2px; font-size: 8pt;
 }
+/* Value readouts are LED display windows set into the plate: dark glass with
+   lit green digits, even on the cream faceplate - as real hardware reads. */
 QLabel#EditableValue {
-    background: #e8e8e0; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 2px;
+    background: #11150F; color: #3ED68E;
+    border: 1px solid #4A4438; border-radius: 2px;
     padding: 4px 8px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
-    background: #f2f2f8; border: 1px solid @ACCENT@;
+    background: #11150F; color: #3ED68E; border: 1px solid @ACCENT@;
     border-radius: 2px; padding: 4px 8px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
-QLineEdit#IncludeCardPath { background: #f2f2f8; border: 1px solid @BORDER@; border-radius: 2px; padding: 4px 8px; }
-QLabel#IncludeCardStatus { color: #dc2626; font-size: 8pt; }
+QLineEdit#IncludeCardPath { background: #FCF8EE; border: 1px solid #8F8268; border-bottom-color: #FFFFFF; border-radius: 2px; padding: 4px 8px; }
+QLabel#IncludeCardStatus { color: #B3261E; font-size: 8pt; }
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -1,8 +1,13 @@
 /* ====================================================================
-   Skin: Soft Dark
+   Skin: Soft Dark — "The iPhone settings screen"
+   (macOS System Settings: round, roomy, impossible to fear)
+   Corner language: cards/containers 12px, controls 10px, chips and value
+   badges full pills, icon buttons circular. Elevation is faked with two
+   background value steps plus a very light 1px border; hover lifts a
+   surface exactly one value step. Hierarchy by size and whitespace.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 18 / row 44
+           accent @ACCENT@ / borderRadius 12 / row 48
    ==================================================================== */
 
 * {
@@ -24,20 +29,20 @@ QMainWindow::separator { background: @SURFACE@; width: 6px; height: 6px; }
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; padding: 6px 12px; }
 
 QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 6px 8px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 12px; }
+QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 10px; }
 QMenuBar::item:selected, QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.22); color: @TEXT@; }
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 14px; padding: 6px; }
+QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 12px; padding: 6px; }
 QMenu::item { background: transparent; padding: 8px 22px; border-radius: 10px; min-width: 140px; }
 QMenu::item:selected { background: rgba(59, 130, 246, 0.25); color: @TEXT@; }
-QMenu::item:disabled { color: #5a5a72; }
+QMenu::item:disabled { color: rgba(167, 174, 194, 0.55); }
 QMenu::separator { height: 1px; background: @BORDER@; margin: 6px 8px; }
 QMenu::indicator { width: 14px; height: 14px; margin-left: 4px; }
 QMenu::indicator:checked { background: @ACCENT@; border-radius: 4px; }
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 6px 8px; spacing: 6px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 6px 8px; }
-QToolButton { background: transparent; color: @TEXT@; border: 1px solid transparent; border-radius: 12px; padding: 5px 12px; min-height: 26px; }
+QToolButton { background: transparent; color: @TEXT@; border: 1px solid transparent; border-radius: 10px; padding: 5px 12px; min-height: 26px; }
 QToolButton:hover { background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.06); }
 QToolButton:pressed, QToolButton:checked { background: rgba(59, 130, 246, 0.25); border: 1px solid rgba(59, 130, 246, 0.55); }
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
@@ -46,29 +51,29 @@ QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 
 
 QPushButton {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 12px;
+    border: 1px solid @BORDER@; border-radius: 10px;
     padding: 8px 18px; min-height: 24px;
 }
 QPushButton:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
 QPushButton:pressed { background: rgba(59, 130, 246, 0.32); border-color: @ACCENT@; }
 QPushButton:default { border: 1px solid @ACCENT@; }
-QPushButton:disabled { color: #5a5a72; background: #1a1a26; border-color: #2a2a38; }
+QPushButton:disabled { color: rgba(167, 174, 194, 0.55); background: @SURFACE@; border-color: @BORDER@; }
 
 QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
-    background: #101018; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 12px;
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 10px;
     padding: 6px 12px;
     selection-background-color: @ACCENT@; selection-color: #f8fafc;
 }
-QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid @ACCENT@; background: #14141c; }
-QLineEdit:disabled, QAbstractSpinBox:disabled { color: #5a5a72; background: #14141c; }
+QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid @ACCENT@; background: @SURFACE@; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: rgba(167, 174, 194, 0.55); background: @SURFACE@; }
 
 QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
     subcontrol-origin: border; background: @CARD@;
     width: 22px; border-left: 1px solid @BORDER@;
 }
-QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 11px; }
-QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 11px; border-top: 1px solid @BORDER@; }
+QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 9px; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 9px; border-top: 1px solid @BORDER@; }
 QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.25); }
 QAbstractSpinBox::up-arrow {
     image: none; width: 0; height: 0;
@@ -81,7 +86,7 @@ QAbstractSpinBox::down-arrow {
 
 QComboBox {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 12px;
+    border: 1px solid @BORDER@; border-radius: 10px;
     padding: 6px 30px 6px 14px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
@@ -95,16 +100,16 @@ QComboBox::down-arrow {
 QComboBox::down-arrow:on { border-top-color: @ACCENT@; }
 QComboBox QAbstractItemView {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 14px;
+    border: 1px solid @BORDER@; border-radius: 12px;
     padding: 6px; outline: 0;
     selection-background-color: rgba(59, 130, 246, 0.28); selection-color: @TEXT@;
 }
 QComboBox QAbstractItemView::item { padding: 8px 12px; border-radius: 10px; min-height: 26px; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 10px; padding: 4px; }
-QCheckBox:disabled, QRadioButton:disabled { color: #5a5a72; }
+QCheckBox:disabled, QRadioButton:disabled { color: rgba(167, 174, 194, 0.55); }
 QCheckBox::indicator, QRadioButton::indicator {
-    width: 18px; height: 18px; background: #101018; border: 1px solid @BORDER@;
+    width: 18px; height: 18px; background: @SURFACE_SUNKEN@; border: 1px solid @BORDER@;
 }
 QCheckBox::indicator { border-radius: 6px; }
 QRadioButton::indicator { border-radius: 9px; }
@@ -112,11 +117,11 @@ QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: @ACCEN
 QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
 
 QScrollBar:vertical { background: transparent; width: 14px; margin: 6px 2px; border: 0; }
-QScrollBar::handle:vertical { background: rgba(255, 255, 255, 0.10); min-height: 36px; border-radius: 6px; }
+QScrollBar::handle:vertical { background: rgba(255, 255, 255, 0.10); min-height: 36px; border-radius: 5px; }
 QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
 QScrollBar::handle:vertical:pressed { background: @ACCENT@; }
 QScrollBar:horizontal { background: transparent; height: 14px; margin: 2px 6px; border: 0; }
-QScrollBar::handle:horizontal { background: rgba(255, 255, 255, 0.10); min-width: 36px; border-radius: 6px; }
+QScrollBar::handle:horizontal { background: rgba(255, 255, 255, 0.10); min-width: 36px; border-radius: 5px; }
 QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
 QScrollBar::handle:horizontal:pressed { background: @ACCENT@; }
 QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
@@ -141,7 +146,8 @@ QTabWidget::pane { background: @BG@; border: 0; border-top: 1px solid @BORDER@; 
 QTabBar { background: @BG@; border: 0; qproperty-drawBase: 0; }
 QTabBar::tab {
     background: transparent; color: @MUTED@;
-    padding: 10px 22px; border: 0; border-radius: 0;
+    padding: 10px 22px; border: 0;
+    border-top-left-radius: 10px; border-top-right-radius: 10px;
     min-width: 80px; margin: 0;
 }
 QTabBar::tab:hover { color: @TEXT@; background: rgba(255, 255, 255, 0.04); }
@@ -153,7 +159,7 @@ QTabBar QToolButton { background: @SURFACE@; border: 1px solid @BORDER@; border-
 
 QGroupBox {
     background: @SURFACE@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 14px;
+    border: 1px solid @BORDER@; border-radius: 12px;
     margin-top: 16px; padding: 16px 14px 12px;
 }
 QGroupBox::title {
@@ -196,12 +202,12 @@ QSplitter::handle:hover { background: @ACCENT@; }
 QStatusBar { background: @SURFACE@; color: @MUTED@; border: 0; border-top: 1px solid @BORDER@; }
 QStatusBar::item { border: 0; }
 
-QProgressBar { background: #101018; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; text-align: center; }
+QProgressBar { background: @SURFACE_SUNKEN@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; text-align: center; }
 QProgressBar::chunk { background: @ACCENT@; border-radius: 8px; }
 
 QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0; }
 
-QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 18px; }
+QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 12px; }
 QLabel#AnalysisFormLabel { color: @MUTED@; background: transparent; font-weight: 600; padding: 0 6px; }
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: @CARD@; border: 1px solid @BORDER@; border-radius: 14px; }
@@ -210,27 +216,42 @@ QLabel#AnalysisStatValue { color: @TEXT@; background: transparent; font-weight: 
 QLabel#AnalysisStatValue[severity="warning"] { color: @WARNING@; }
 QLabel#AnalysisStatValue[severity="critical"] { color: @DANGER@; }
 
-QWidget#ModernAnalysisGraph { background: #101018; border: 1px solid @BORDER@; border-radius: 16px; }
+QWidget#ModernAnalysisGraph { background: @SURFACE_SUNKEN@; border: 1px solid @BORDER@; border-radius: 12px; }
 
-QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 18px; }
-QWidget#FilterCardHeader { background: @SURFACE@; border-top-left-radius: 18px; border-top-right-radius: 18px; }
-QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #222232; border-bottom-left-radius: 18px; border-bottom-right-radius: 18px; }
+/* Command rows: one calm 12px card per row, one value step above the
+   window, "shadowed" by that step plus the light 1px border. The header
+   shares the card surface (no banded strip); the expanded body is an inset
+   tray one value step below the card. */
+QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
+QWidget#FilterCardHeader { background: transparent; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: @SURFACE@; border-bottom-left-radius: 12px; border-bottom-right-radius: 12px; }
+
+/* The command type announces itself like an iOS Settings row: a small
+   rounded-square colour tile leading the row (colour comes inline from the
+   descriptor; the tile shape and caps typography live here). */
 QLabel#FilterTypeBadge {
-    color: white; border-radius: 12px;
-    font-weight: 700; padding: 3px 10px; min-height: 20px;
+    color: white; border-radius: 8px;
+    font-weight: 700; padding: 4px 9px; min-height: 22px;
     font-size: 9pt; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 600; font-size: 10pt; }
+QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 600; font-size: 11pt; }
 QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
 QLabel#FilterCardNumber { color: @MUTED@; background: transparent; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 600; }
+
+/* A commented-out row sleeps: the frame sinks into the window background
+   with a dashed outline (set by the skin's cardFrameStyle) and its header
+   text relaxes to the muted weight. */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardTitle { color: @MUTED@; font-weight: 500; }
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardSummary { color: rgba(167, 174, 194, 0.7); }
+
 QToolButton#FilterCardIconButton {
     background: @SURFACE@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 10px;
-    min-width: 26px; min-height: 26px; padding: 2px 4px; font-weight: 700;
+    border: 1px solid @BORDER@; border-radius: 14px;
+    min-width: 28px; min-height: 28px; padding: 2px 4px; font-weight: 700;
 }
 QToolButton#FilterCardIconButton:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
 QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.30); border-color: @ACCENT@; }
-QLineEdit#FilterCardRawEditor { background: #101018; border: 1px solid @ACCENT@; border-radius: 10px; padding: 8px 12px; }
+QLineEdit#FilterCardRawEditor { background: @SURFACE_SUNKEN@; border: 1px solid @ACCENT@; border-radius: 10px; padding: 8px 12px; }
 QCheckBox#FilterCardEnabled { background: transparent; }
 
 QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
@@ -238,18 +259,41 @@ QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
 QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
 QLabel#PreampCardCaption { color: @MUTED@; font-weight: 600; letter-spacing: 1px; font-size: 9pt; }
 QLabel#EditableValue {
-    background: rgba(255, 255, 255, 0.04); color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 10px;
-    padding: 8px 12px;
+    background: @CARD@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 16px;
+    padding: 8px 14px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
-    background: #101018; border: 1px solid @ACCENT@;
-    border-radius: 10px; padding: 8px 12px;
+    background: @SURFACE_SUNKEN@; border: 1px solid @ACCENT@;
+    border-radius: 16px; padding: 8px 14px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
-QLineEdit#IncludeCardPath { background: #101018; border: 1px solid @BORDER@; border-radius: 10px; padding: 8px 12px; }
-QLabel#IncludeCardStatus { color: @DANGER@; font-size: 9pt; }
+
+/* Include row: the path rides in a rounded breadcrumb chip (a full pill,
+   one value step above the body tray) behind the file glyph. */
+QLineEdit#IncludeCardPath { background: @CARD@; border: 1px solid @BORDER@; border-radius: 16px; padding: 7px 16px; }
+QLineEdit#IncludeCardPath:focus { background: @CARD_HOVER@; border: 1px solid @ACCENT@; }
+QLabel#IncludeCardStatus { color: @DANGER@; font-size: 9pt; padding-left: 6px; }
+
+/* VST row: an app-store-like card. Rounded-square accent "app icon" tile,
+   the plugin name as the large line, the status line beneath it, and an
+   accent pill action button. */
+QLabel#VSTCardGlyph { background: rgba(59, 130, 246, 0.20); border: 1px solid rgba(59, 130, 246, 0.35); border-radius: 10px; padding: 8px; }
+QLineEdit#VSTCardPath { background: transparent; border: 1px solid transparent; border-radius: 10px; padding: 6px 8px; font-size: 11pt; font-weight: 600; }
+QLineEdit#VSTCardPath:hover { background: rgba(255, 255, 255, 0.04); }
+QLineEdit#VSTCardPath:focus { background: @SURFACE_SUNKEN@; border: 1px solid @ACCENT@; }
+QLabel#VSTCardStatus { background: transparent; font-size: 9pt; padding-left: 2px; }
+QPushButton#VSTCardPanelButton {
+    background: rgba(59, 130, 246, 0.18); color: @ACCENT@;
+    border: 0; border-radius: 15px;
+    padding: 6px 18px; min-height: 24px; font-weight: 700;
+}
+QPushButton#VSTCardPanelButton:hover { background: rgba(59, 130, 246, 0.28); }
+QPushButton#VSTCardPanelButton:pressed { background: rgba(59, 130, 246, 0.38); }
+QPushButton#VSTCardPanelButton:disabled { background: @SURFACE@; color: rgba(167, 174, 194, 0.55); }
+QFrame#VSTCardEmbedFrame { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
+QPlainTextEdit#VSTCardWarning { background: rgba(245, 158, 11, 0.10); color: @TEXT@; border: 1px solid rgba(245, 158, 11, 0.40); border-radius: 10px; padding: 6px; }
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -1,8 +1,13 @@
 /* ====================================================================
-   Skin: Soft Light
+   Skin: Soft Light — "The iPhone settings screen"
+   (macOS System Settings: round, roomy, impossible to fear)
+   Corner language: cards/containers 12px, controls 10px, chips and value
+   badges full pills, icon buttons circular. Elevation is faked with two
+   background value steps plus a very light 1px border; hover lifts a
+   surface exactly one value step. Hierarchy by size and whitespace.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 18 / row 44
+           accent @ACCENT@ / borderRadius 12 / row 48
    ==================================================================== */
 
 * {
@@ -24,20 +29,20 @@ QMainWindow::separator { background: @SURFACE@; width: 6px; height: 6px; }
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; padding: 6px 12px; }
 
 QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 6px 8px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 12px; }
+QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 10px; }
 QMenuBar::item:selected, QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 14px; padding: 6px; }
+QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 12px; padding: 6px; }
 QMenu::item { background: transparent; padding: 8px 22px; border-radius: 10px; min-width: 140px; }
 QMenu::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
-QMenu::item:disabled { color: #a0a0b4; }
+QMenu::item:disabled { color: rgba(120, 111, 103, 0.55); }
 QMenu::separator { height: 1px; background: @BORDER@; margin: 6px 8px; }
 QMenu::indicator { width: 14px; height: 14px; margin-left: 4px; }
 QMenu::indicator:checked { background: @ACCENT@; border-radius: 4px; }
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 6px 8px; spacing: 6px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 6px 8px; }
-QToolButton { background: transparent; color: @TEXT@; border: 1px solid transparent; border-radius: 12px; padding: 5px 12px; min-height: 26px; }
+QToolButton { background: transparent; color: @TEXT@; border: 1px solid transparent; border-radius: 10px; padding: 5px 12px; min-height: 26px; }
 QToolButton:hover { background: rgba(0, 0, 0, 0.04); border: 1px solid rgba(0, 0, 0, 0.06); }
 QToolButton:pressed, QToolButton:checked { background: rgba(59, 130, 246, 0.18); border: 1px solid rgba(59, 130, 246, 0.55); }
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
@@ -46,29 +51,29 @@ QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 
 
 QPushButton {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 12px;
+    border: 1px solid @BORDER@; border-radius: 10px;
     padding: 8px 18px; min-height: 24px;
 }
 QPushButton:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
 QPushButton:pressed { background: rgba(59, 130, 246, 0.16); border-color: @ACCENT@; }
 QPushButton:default { border: 1px solid @ACCENT@; }
-QPushButton:disabled { color: #a0a0b4; background: #f4f4f8; border-color: #ececf0; }
+QPushButton:disabled { color: rgba(120, 111, 103, 0.55); background: @SURFACE@; border-color: @BORDER@; }
 
 QLineEdit, QPlainTextEdit, QTextEdit, QAbstractSpinBox {
-    background: #fefefe; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 12px;
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 10px;
     padding: 6px 12px;
     selection-background-color: @ACCENT@; selection-color: @CARD@;
 }
 QLineEdit:focus, QPlainTextEdit:focus, QTextEdit:focus, QAbstractSpinBox:focus { border: 1px solid @ACCENT@; background: @CARD@; }
-QLineEdit:disabled, QAbstractSpinBox:disabled { color: #a0a0b4; background: #f0f0f4; }
+QLineEdit:disabled, QAbstractSpinBox:disabled { color: rgba(120, 111, 103, 0.55); background: @SURFACE@; }
 
 QAbstractSpinBox::up-button, QAbstractSpinBox::down-button {
     subcontrol-origin: border; background: @SURFACE@;
     width: 22px; border-left: 1px solid @BORDER@;
 }
-QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 11px; }
-QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 11px; border-top: 1px solid @BORDER@; }
+QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 9px; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 9px; border-top: 1px solid @BORDER@; }
 QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.16); }
 QAbstractSpinBox::up-arrow {
     image: none; width: 0; height: 0;
@@ -81,7 +86,7 @@ QAbstractSpinBox::down-arrow {
 
 QComboBox {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 12px;
+    border: 1px solid @BORDER@; border-radius: 10px;
     padding: 6px 30px 6px 14px; min-height: 28px;
 }
 QComboBox:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
@@ -95,16 +100,16 @@ QComboBox::down-arrow {
 QComboBox::down-arrow:on { border-top-color: @ACCENT@; }
 QComboBox QAbstractItemView {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 14px;
+    border: 1px solid @BORDER@; border-radius: 12px;
     padding: 6px; outline: 0;
     selection-background-color: rgba(59, 130, 246, 0.18); selection-color: @TEXT@;
 }
 QComboBox QAbstractItemView::item { padding: 8px 12px; border-radius: 10px; min-height: 26px; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 10px; padding: 4px; }
-QCheckBox:disabled, QRadioButton:disabled { color: #a0a0b4; }
+QCheckBox:disabled, QRadioButton:disabled { color: rgba(120, 111, 103, 0.55); }
 QCheckBox::indicator, QRadioButton::indicator {
-    width: 18px; height: 18px; background: @CARD@; border: 1px solid #cfcfde;
+    width: 18px; height: 18px; background: @CARD@; border: 1px solid @BORDER@;
 }
 QCheckBox::indicator { border-radius: 6px; }
 QRadioButton::indicator { border-radius: 9px; }
@@ -112,11 +117,11 @@ QCheckBox::indicator:hover, QRadioButton::indicator:hover { border-color: @ACCEN
 QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
 
 QScrollBar:vertical { background: transparent; width: 14px; margin: 6px 2px; border: 0; }
-QScrollBar::handle:vertical { background: rgba(0, 0, 0, 0.10); min-height: 36px; border-radius: 6px; }
+QScrollBar::handle:vertical { background: rgba(0, 0, 0, 0.10); min-height: 36px; border-radius: 5px; }
 QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
 QScrollBar::handle:vertical:pressed { background: @ACCENT@; }
 QScrollBar:horizontal { background: transparent; height: 14px; margin: 2px 6px; border: 0; }
-QScrollBar::handle:horizontal { background: rgba(0, 0, 0, 0.10); min-width: 36px; border-radius: 6px; }
+QScrollBar::handle:horizontal { background: rgba(0, 0, 0, 0.10); min-width: 36px; border-radius: 5px; }
 QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
 QScrollBar::handle:horizontal:pressed { background: @ACCENT@; }
 QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
@@ -141,7 +146,8 @@ QTabWidget::pane { background: @BG@; border: 0; border-top: 1px solid @BORDER@; 
 QTabBar { background: @BG@; border: 0; qproperty-drawBase: 0; }
 QTabBar::tab {
     background: transparent; color: @MUTED@;
-    padding: 10px 22px; border: 0; border-radius: 0;
+    padding: 10px 22px; border: 0;
+    border-top-left-radius: 10px; border-top-right-radius: 10px;
     min-width: 80px; margin: 0;
 }
 QTabBar::tab:hover { color: @TEXT@; background: rgba(0, 0, 0, 0.04); }
@@ -153,7 +159,7 @@ QTabBar QToolButton { background: @CARD@; border: 1px solid @BORDER@; border-rad
 
 QGroupBox {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 14px;
+    border: 1px solid @BORDER@; border-radius: 12px;
     margin-top: 16px; padding: 16px 14px 12px;
 }
 QGroupBox::title {
@@ -196,12 +202,12 @@ QSplitter::handle:hover { background: @ACCENT@; }
 QStatusBar { background: @SURFACE@; color: @MUTED@; border: 0; border-top: 1px solid @BORDER@; }
 QStatusBar::item { border: 0; }
 
-QProgressBar { background: #fefefe; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; text-align: center; }
+QProgressBar { background: @SURFACE_SUNKEN@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; text-align: center; }
 QProgressBar::chunk { background: @ACCENT@; border-radius: 8px; }
 
 QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0; }
 
-QFrame#analysisControlBar { background: @CARD@; border: 1px solid @BORDER@; border-radius: 18px; }
+QFrame#analysisControlBar { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
 QLabel#AnalysisFormLabel { color: @MUTED@; background: transparent; font-weight: 600; padding: 0 6px; }
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 14px; }
@@ -210,27 +216,42 @@ QLabel#AnalysisStatValue { color: @TEXT@; background: transparent; font-weight: 
 QLabel#AnalysisStatValue[severity="warning"] { color: #d97706; }
 QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
 
-QWidget#ModernAnalysisGraph { background: #fefefe; border: 1px solid @BORDER@; border-radius: 16px; }
+QWidget#ModernAnalysisGraph { background: @SURFACE_SUNKEN@; border: 1px solid @BORDER@; border-radius: 12px; }
 
-QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 18px; }
-QWidget#FilterCardHeader { background: @SURFACE@; border-top-left-radius: 18px; border-top-right-radius: 18px; }
-QWidget#FilterCardBody, QWidget#FilterCardEditor { background: #f2f2f7; border-bottom-left-radius: 18px; border-bottom-right-radius: 18px; }
+/* Command rows: one calm 12px card per row, one value step above the
+   window, "shadowed" by that step plus the light 1px border. The header
+   shares the card surface (no banded strip); the expanded body is an inset
+   tray one value step below the card. */
+QFrame#FilterCardRow { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
+QWidget#FilterCardHeader { background: transparent; }
+QWidget#FilterCardBody, QWidget#FilterCardEditor { background: @BG@; border-bottom-left-radius: 12px; border-bottom-right-radius: 12px; }
+
+/* The command type announces itself like an iOS Settings row: a small
+   rounded-square colour tile leading the row (colour comes inline from the
+   descriptor; the tile shape and caps typography live here). */
 QLabel#FilterTypeBadge {
-    color: white; border-radius: 12px;
-    font-weight: 700; padding: 3px 10px; min-height: 20px;
+    color: white; border-radius: 8px;
+    font-weight: 700; padding: 4px 9px; min-height: 22px;
     font-size: 9pt; letter-spacing: 1px;
 }
-QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 600; font-size: 10pt; }
+QLabel#FilterCardTitle { color: @TEXT@; background: transparent; font-weight: 600; font-size: 11pt; }
 QLabel#FilterCardSummary, QLabel#FilterCardRawText { color: @MUTED@; background: transparent; }
 QLabel#FilterCardNumber { color: @MUTED@; background: transparent; font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 600; }
+
+/* A commented-out row sleeps: the frame sinks into the window background
+   with a dashed outline (set by the skin's cardFrameStyle) and its header
+   text relaxes to the muted weight. */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardTitle { color: @MUTED@; font-weight: 500; }
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardSummary { color: rgba(120, 111, 103, 0.7); }
+
 QToolButton#FilterCardIconButton {
     background: @SURFACE@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 10px;
-    min-width: 26px; min-height: 26px; padding: 2px 4px; font-weight: 700;
+    border: 1px solid @BORDER@; border-radius: 14px;
+    min-width: 28px; min-height: 28px; padding: 2px 4px; font-weight: 700;
 }
 QToolButton#FilterCardIconButton:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.55); }
 QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.22); border-color: @ACCENT@; }
-QLineEdit#FilterCardRawEditor { background: #fefefe; border: 1px solid @ACCENT@; border-radius: 10px; padding: 8px 12px; }
+QLineEdit#FilterCardRawEditor { background: @CARD@; border: 1px solid @ACCENT@; border-radius: 10px; padding: 8px 12px; }
 QCheckBox#FilterCardEnabled { background: transparent; }
 
 QWidget#PreampCardEditor, QWidget#IncludeCardEditor,
@@ -238,18 +259,41 @@ QWidget#PreampCardValueBlock, QLabel#IncludeCardGlyph,
 QLabel#IncludeCardStatus, QLabel#PreampCardCaption { background: transparent; border: 0; }
 QLabel#PreampCardCaption { color: @MUTED@; font-weight: 600; letter-spacing: 1px; font-size: 9pt; }
 QLabel#EditableValue {
-    background: @SURFACE@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 10px;
-    padding: 8px 12px;
+    background: @CARD@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 16px;
+    padding: 8px 14px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
-    background: #fefefe; border: 1px solid @ACCENT@;
-    border-radius: 10px; padding: 8px 12px;
+    background: @CARD@; border: 1px solid @ACCENT@;
+    border-radius: 16px; padding: 8px 14px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
-QLineEdit#IncludeCardPath { background: #fefefe; border: 1px solid @BORDER@; border-radius: 10px; padding: 8px 12px; }
-QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
+
+/* Include row: the path rides in a rounded breadcrumb chip (a full pill,
+   one value step above the body tray) behind the file glyph. */
+QLineEdit#IncludeCardPath { background: @CARD@; border: 1px solid @BORDER@; border-radius: 16px; padding: 7px 16px; }
+QLineEdit#IncludeCardPath:focus { background: @CARD_HOVER@; border: 1px solid @ACCENT@; }
+QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; padding-left: 6px; }
+
+/* VST row: an app-store-like card. Rounded-square accent "app icon" tile,
+   the plugin name as the large line, the status line beneath it, and an
+   accent pill action button. */
+QLabel#VSTCardGlyph { background: rgba(59, 130, 246, 0.12); border: 1px solid rgba(59, 130, 246, 0.30); border-radius: 10px; padding: 8px; }
+QLineEdit#VSTCardPath { background: transparent; border: 1px solid transparent; border-radius: 10px; padding: 6px 8px; font-size: 11pt; font-weight: 600; }
+QLineEdit#VSTCardPath:hover { background: rgba(0, 0, 0, 0.03); }
+QLineEdit#VSTCardPath:focus { background: @CARD@; border: 1px solid @ACCENT@; }
+QLabel#VSTCardStatus { background: transparent; font-size: 9pt; padding-left: 2px; }
+QPushButton#VSTCardPanelButton {
+    background: rgba(59, 130, 246, 0.12); color: @ACCENT@;
+    border: 0; border-radius: 15px;
+    padding: 6px 18px; min-height: 24px; font-weight: 700;
+}
+QPushButton#VSTCardPanelButton:hover { background: rgba(59, 130, 246, 0.20); }
+QPushButton#VSTCardPanelButton:pressed { background: rgba(59, 130, 246, 0.30); }
+QPushButton#VSTCardPanelButton:disabled { background: @SURFACE@; color: rgba(120, 111, 103, 0.55); }
+QFrame#VSTCardEmbedFrame { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
+QPlainTextEdit#VSTCardWarning { background: rgba(217, 119, 6, 0.08); color: @TEXT@; border: 1px solid rgba(217, 119, 6, 0.35); border-radius: 10px; padding: 6px; }
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -1,8 +1,12 @@
 /* ====================================================================
-   Skin: Glassy Dark
+   Skin: Studio Dark - "Glass over the instrument"
+   Deep solid backgrounds; panels are glass: solid colour with alpha plus
+   a single 1px lighter top edge. One glowing accent (#5B8CFF), faked with
+   layered alpha, never effects. Corner radius 8px. Hover brightens,
+   disabled drops opacity. Sans for words, mono for numbers.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 16 / row 40
+           accent @ACCENT@ / borderRadius 8 / row 40
    ==================================================================== */
 
 * {
@@ -33,7 +37,8 @@ QToolTip {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 6px;
     padding: 6px 10px;
 }
 
@@ -48,11 +53,11 @@ QMenuBar {
 QMenuBar::item {
     background: transparent;
     padding: 6px 12px;
-    border-radius: 10px;
+    border-radius: 6px;
 }
 QMenuBar::item:selected,
 QMenuBar::item:pressed {
-    background: rgba(59, 130, 246, 0.22);
+    background: rgba(91, 140, 255, 0.22);
     color: @TEXT@;
 }
 
@@ -60,17 +65,18 @@ QMenu {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
     padding: 6px;
 }
 QMenu::item {
     background: transparent;
     padding: 6px 22px 6px 22px;
-    border-radius: 8px;
+    border-radius: 6px;
     min-width: 140px;
 }
 QMenu::item:selected {
-    background: rgba(59, 130, 246, 0.25);
+    background: rgba(91, 140, 255, 0.25);
     color: @TEXT@;
 }
 QMenu::item:disabled {
@@ -117,18 +123,19 @@ QToolButton {
     background: transparent;
     color: @TEXT@;
     border: 1px solid transparent;
-    border-radius: 10px;
+    border-radius: 8px;
     padding: 4px 8px;
     min-height: 22px;
 }
 QToolButton:hover {
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid rgba(255, 255, 255, 0.08);
+    border-top-color: rgba(255, 255, 255, 0.14);
 }
 QToolButton:pressed,
 QToolButton:checked {
-    background: rgba(59, 130, 246, 0.25);
-    border: 1px solid rgba(59, 130, 246, 0.5);
+    background: rgba(91, 140, 255, 0.25);
+    border: 1px solid rgba(91, 140, 255, 0.5);
 }
 QToolButton::menu-indicator {
     image: none;
@@ -148,16 +155,18 @@ QPushButton {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
     padding: 6px 14px;
     min-height: 22px;
 }
 QPushButton:hover {
     background: @CARD_HOVER@;
-    border-color: rgba(59, 130, 246, 0.45);
+    border-color: rgba(91, 140, 255, 0.45);
+    border-top-color: rgba(255, 255, 255, 0.16);
 }
 QPushButton:pressed {
-    background: rgba(59, 130, 246, 0.3);
+    background: rgba(91, 140, 255, 0.3);
     border-color: @ACCENT@;
 }
 QPushButton:default {
@@ -170,6 +179,8 @@ QPushButton:disabled {
 }
 
 /* ===== Inputs ===== */
+/* Inputs are sunken glass: the darker top edge reads as an inner shadow,
+   the inverse of the raised panels' light top edge. */
 QLineEdit,
 QPlainTextEdit,
 QTextEdit,
@@ -177,10 +188,15 @@ QAbstractSpinBox {
     background: #08080f;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-top-color: rgba(0, 0, 0, 0.55);
+    border-radius: 8px;
     padding: 4px 8px;
     selection-background-color: @ACCENT@;
     selection-color: #f8fafc;
+}
+/* Numbers wear the mono face; words stay sans. */
+QAbstractSpinBox {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QLineEdit:focus,
 QPlainTextEdit:focus,
@@ -204,16 +220,16 @@ QAbstractSpinBox::down-button {
 }
 QAbstractSpinBox::up-button {
     subcontrol-position: top right;
-    border-top-right-radius: 9px;
+    border-top-right-radius: 7px;
 }
 QAbstractSpinBox::down-button {
     subcontrol-position: bottom right;
-    border-bottom-right-radius: 9px;
+    border-bottom-right-radius: 7px;
     border-top: 1px solid @BORDER@;
 }
 QAbstractSpinBox::up-button:hover,
 QAbstractSpinBox::down-button:hover {
-    background: rgba(59, 130, 246, 0.22);
+    background: rgba(91, 140, 255, 0.22);
 }
 QAbstractSpinBox::up-arrow {
     image: none;
@@ -242,12 +258,14 @@ QComboBox {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
     padding: 4px 28px 4px 10px;
     min-height: 28px;
 }
 QComboBox:hover {
-    border-color: rgba(59, 130, 246, 0.45);
+    border-color: rgba(91, 140, 255, 0.45);
+    border-top-color: rgba(255, 255, 255, 0.16);
     background: @CARD_HOVER@;
 }
 QComboBox:focus,
@@ -277,19 +295,20 @@ QComboBox QAbstractItemView {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
     padding: 4px;
     outline: 0;
-    selection-background-color: rgba(59, 130, 246, 0.28);
+    selection-background-color: rgba(91, 140, 255, 0.28);
     selection-color: @TEXT@;
 }
 QComboBox QAbstractItemView::item {
     padding: 6px 10px;
-    border-radius: 8px;
+    border-radius: 6px;
     min-height: 24px;
 }
 QComboBox QAbstractItemView::item:selected {
-    background: rgba(59, 130, 246, 0.28);
+    background: rgba(91, 140, 255, 0.28);
     color: @TEXT@;
 }
 
@@ -342,7 +361,7 @@ QScrollBar::handle:vertical {
     border-radius: 4px;
 }
 QScrollBar::handle:vertical:hover {
-    background: rgba(59, 130, 246, 0.45);
+    background: rgba(91, 140, 255, 0.45);
 }
 QScrollBar::handle:vertical:pressed {
     background: @ACCENT@;
@@ -359,7 +378,7 @@ QScrollBar::handle:horizontal {
     border-radius: 4px;
 }
 QScrollBar::handle:horizontal:hover {
-    background: rgba(59, 130, 246, 0.45);
+    background: rgba(91, 140, 255, 0.45);
 }
 QScrollBar::handle:horizontal:pressed {
     background: @ACCENT@;
@@ -485,7 +504,8 @@ QGroupBox {
     background: @SURFACE@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
     margin-top: 14px;
     padding: 14px 12px 10px 12px;
 }
@@ -524,9 +544,9 @@ QTableView {
     background: @BG@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-radius: 8px;
     alternate-background-color: @SURFACE@;
-    selection-background-color: rgba(59, 130, 246, 0.28);
+    selection-background-color: rgba(91, 140, 255, 0.28);
     selection-color: @TEXT@;
     gridline-color: @BORDER@;
 }
@@ -544,7 +564,7 @@ QTableView::item:hover {
 QTreeView::item:selected,
 QListView::item:selected,
 QTableView::item:selected {
-    background: rgba(59, 130, 246, 0.28);
+    background: rgba(91, 140, 255, 0.28);
     color: @TEXT@;
 }
 QTreeView::branch {
@@ -646,7 +666,8 @@ QFrame[frameShape="5"]  /* VLine */ {
 QFrame#analysisControlBar {
     background: @SURFACE@;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
 }
 QLabel#AnalysisFormLabel {
     color: @MUTED@;
@@ -662,7 +683,8 @@ QComboBox#AnalysisFormCombo {
 QFrame#AnalysisStatChip {
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 10px;
+    border-top-color: rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
 }
 QLabel#AnalysisStatLabel {
     color: @MUTED@;
@@ -684,25 +706,43 @@ QLabel#AnalysisStatValue[severity="critical"] { color: @DANGER@; }
 QWidget#ModernAnalysisGraph {
     background: #08080f;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-top-color: rgba(0, 0, 0, 0.55);
+    border-radius: 8px;
 }
 
-/* ===== Filter Card Components ===== */
+/* ===== Filter Card Components =====
+   The card frame/header chrome is owned by StudioSkin::cardFrameStyle /
+   cardHeaderStyle (glass with a 1px lighter top edge, per-command-type
+   border treatment). These rules are the matching fallback. */
 QFrame#FilterCardRow {
-    background: @CARD@;
+    background: rgba(18, 26, 44, 0.88);
     border: 1px solid @BORDER@;
-    border-radius: 16px;
+    border-top-color: rgba(255, 255, 255, 0.10);
+    border-radius: 8px;
 }
 QWidget#FilterCardHeader {
-    background: rgba(255, 255, 255, 0.03);
-    border-top-left-radius: 16px;
-    border-top-right-radius: 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
 }
+/* The body is one glass panel: a hairline seam under the header and a
+   near-transparent fill, so a shelf filter's three knobs sit on a single
+   pane and read as one unit. */
 QWidget#FilterCardBody,
 QWidget#FilterCardEditor {
     background: rgba(255, 255, 255, 0.02);
-    border-bottom-left-radius: 16px;
-    border-bottom-right-radius: 16px;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+}
+QWidget#FilterCardBody {
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+/* Disabled (commented-out) rows: the light is off - text recedes with the
+   glass instead of staying at full brightness. */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardTitle,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardSummary,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardNumber {
+    color: rgba(145, 160, 186, 0.55);
 }
 QLabel#FilterTypeBadge {
     color: white;
@@ -734,25 +774,27 @@ QToolButton#FilterCardIconButton {
     background: rgba(255, 255, 255, 0.04);
     color: @TEXT@;
     border: 1px solid rgba(255, 255, 255, 0.07);
-    border-radius: 8px;
+    border-top-color: rgba(255, 255, 255, 0.13);
+    border-radius: 6px;
     min-width: 24px;
     min-height: 24px;
     padding: 2px 4px;
     font-weight: 700;
 }
 QToolButton#FilterCardIconButton:hover {
-    background: rgba(59, 130, 246, 0.20);
-    border-color: rgba(59, 130, 246, 0.4);
+    background: rgba(91, 140, 255, 0.20);
+    border-color: rgba(91, 140, 255, 0.4);
 }
 QToolButton#FilterCardIconButton:checked {
-    background: rgba(59, 130, 246, 0.30);
+    background: rgba(91, 140, 255, 0.30);
     border-color: @ACCENT@;
 }
 QLineEdit#FilterCardRawEditor {
     background: #08080f;
     border: 1px solid @ACCENT@;
-    border-radius: 10px;
+    border-radius: 6px;
     padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QCheckBox#FilterCardEnabled {
     background: transparent;
@@ -779,7 +821,8 @@ QLabel#EditableValue {
     background: rgba(255, 255, 255, 0.04);
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-top-color: rgba(255, 255, 255, 0.12);
+    border-radius: 6px;
     padding: 6px 10px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-weight: 700;
@@ -787,20 +830,69 @@ QLabel#EditableValue {
 QLineEdit#EditableValueEditor {
     background: #08080f;
     border: 1px solid @ACCENT@;
-    border-radius: 8px;
+    border-radius: 6px;
     padding: 6px 10px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-weight: 700;
 }
+
+/* ===== Include row: a path chip on a glass card ===== */
+/* The chip is the only pill in the skin: sunken glass, mono path text. */
 QLineEdit#IncludeCardPath {
-    background: #08080f;
+    background: rgba(6, 9, 20, 0.65);
     border: 1px solid @BORDER@;
-    border-radius: 8px;
-    padding: 6px 10px;
+    border-top-color: rgba(0, 0, 0, 0.55);
+    border-radius: 13px;
+    padding: 4px 14px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+}
+QLineEdit#IncludeCardPath:hover {
+    border-color: rgba(91, 140, 255, 0.45);
+}
+QLineEdit#IncludeCardPath:focus {
+    border: 1px solid @ACCENT@;
 }
 QLabel#IncludeCardStatus {
     color: @DANGER@;
     font-size: 9pt;
+}
+QLabel#IncludeCardStatus[severity="warning"] { color: @WARNING@; }
+QLabel#IncludeCardStatus[severity="critical"] { color: @DANGER@; }
+
+/* ===== VST row: a softly glowing module card ===== */
+/* The frame's gradient border and painted halo come from StudioSkin; the
+   panel button is the module's one lit control. */
+QPushButton#VSTCardPanelButton {
+    background: rgba(91, 140, 255, 0.16);
+    color: @TEXT@;
+    border: 1px solid rgba(91, 140, 255, 0.55);
+    border-top-color: rgba(91, 140, 255, 0.80);
+    border-radius: 8px;
+    padding: 5px 14px;
+    font-weight: 600;
+}
+QPushButton#VSTCardPanelButton:hover {
+    background: rgba(91, 140, 255, 0.26);
+    border-color: rgba(91, 140, 255, 0.80);
+}
+QPushButton#VSTCardPanelButton:pressed {
+    background: rgba(91, 140, 255, 0.36);
+    border-color: @ACCENT@;
+}
+QLabel#VSTCardStatus {
+    color: @MUTED@;
+    background: transparent;
+}
+QFrame#VSTCardEmbedFrame {
+    background: #08080f;
+    border: 1px solid @BORDER@;
+    border-radius: 8px;
+}
+QPlainTextEdit#VSTCardWarning {
+    background: rgba(245, 158, 11, 0.08);
+    color: @WARNING@;
+    border: 1px solid rgba(245, 158, 11, 0.40);
+    border-radius: 6px;
 }
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -1,8 +1,12 @@
 /* ====================================================================
-   Skin: Glassy Light
+   Skin: Studio Light - "Glass over the instrument"
+   Calm airy backgrounds; panels are glass: solid colour with alpha plus
+   a single 1px lighter (white) top edge. One glowing accent (#2F6BFF),
+   faked with layered alpha, never effects. Corner radius 8px. Hover
+   brightens, disabled drops opacity. Sans for words, mono for numbers.
    Tokens: bg @BG@ / surface @SURFACE@ / card @CARD@ / cardHover @CARD_HOVER@
            text @TEXT@ / mutedText @MUTED@ / border @BORDER@
-           accent @ACCENT@ / borderRadius 16 / row 40
+           accent @ACCENT@ / borderRadius 8 / row 40
    ==================================================================== */
 
 * {
@@ -33,7 +37,8 @@ QToolTip {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 8px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 6px;
     padding: 6px 10px;
 }
 
@@ -47,11 +52,11 @@ QMenuBar {
 QMenuBar::item {
     background: transparent;
     padding: 6px 12px;
-    border-radius: 10px;
+    border-radius: 6px;
 }
 QMenuBar::item:selected,
 QMenuBar::item:pressed {
-    background: rgba(59, 130, 246, 0.18);
+    background: rgba(47, 107, 255, 0.18);
     color: @TEXT@;
 }
 
@@ -59,17 +64,18 @@ QMenu {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
     padding: 6px;
 }
 QMenu::item {
     background: transparent;
     padding: 6px 22px;
-    border-radius: 8px;
+    border-radius: 6px;
     min-width: 140px;
 }
 QMenu::item:selected {
-    background: rgba(59, 130, 246, 0.18);
+    background: rgba(47, 107, 255, 0.18);
     color: @TEXT@;
 }
 QMenu::item:disabled {
@@ -106,18 +112,19 @@ QToolButton {
     background: transparent;
     color: @TEXT@;
     border: 1px solid transparent;
-    border-radius: 10px;
+    border-radius: 8px;
     padding: 4px 8px;
     min-height: 22px;
 }
 QToolButton:hover {
     background: rgba(0, 0, 0, 0.05);
     border: 1px solid rgba(0, 0, 0, 0.07);
+    border-top-color: rgba(255, 255, 255, 0.85);
 }
 QToolButton:pressed,
 QToolButton:checked {
-    background: rgba(59, 130, 246, 0.18);
-    border: 1px solid rgba(59, 130, 246, 0.5);
+    background: rgba(47, 107, 255, 0.18);
+    border: 1px solid rgba(47, 107, 255, 0.5);
 }
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 
@@ -132,15 +139,18 @@ QPushButton {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
     padding: 6px 14px;
     min-height: 22px;
 }
-QPushButton:hover { background: @CARD_HOVER@; border-color: rgba(59, 130, 246, 0.5); }
-QPushButton:pressed { background: rgba(59, 130, 246, 0.16); border-color: @ACCENT@; }
+QPushButton:hover { background: @CARD_HOVER@; border-color: rgba(47, 107, 255, 0.5); border-top-color: #FFFFFF; }
+QPushButton:pressed { background: rgba(47, 107, 255, 0.16); border-color: @ACCENT@; }
 QPushButton:default { border: 1px solid @ACCENT@; }
 QPushButton:disabled { color: #a0a0b4; background: @CARD_HOVER@; border-color: #e6e8ee; }
 
+/* Inputs are sunken glass: the darker top edge reads as an inner shadow,
+   the inverse of the raised panels' white top edge. */
 QLineEdit,
 QPlainTextEdit,
 QTextEdit,
@@ -148,10 +158,15 @@ QAbstractSpinBox {
     background: @CARD_HOVER@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-top-color: rgba(0, 0, 0, 0.14);
+    border-radius: 8px;
     padding: 4px 8px;
     selection-background-color: @ACCENT@;
     selection-color: @CARD@;
+}
+/* Numbers wear the mono face; words stay sans. */
+QAbstractSpinBox {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QLineEdit:focus,
 QPlainTextEdit:focus,
@@ -170,9 +185,9 @@ QAbstractSpinBox::down-button {
     width: 18px;
     border-left: 1px solid @BORDER@;
 }
-QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 9px; }
-QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 9px; border-top: 1px solid @BORDER@; }
-QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(59, 130, 246, 0.16); }
+QAbstractSpinBox::up-button { subcontrol-position: top right; border-top-right-radius: 7px; }
+QAbstractSpinBox::down-button { subcontrol-position: bottom right; border-bottom-right-radius: 7px; border-top: 1px solid @BORDER@; }
+QAbstractSpinBox::up-button:hover, QAbstractSpinBox::down-button:hover { background: rgba(47, 107, 255, 0.16); }
 QAbstractSpinBox::up-arrow {
     image: none; width: 0; height: 0;
     border-left: 4px solid transparent;
@@ -190,11 +205,12 @@ QComboBox {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 10px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
     padding: 4px 28px 4px 10px;
     min-height: 28px;
 }
-QComboBox:hover { border-color: rgba(59, 130, 246, 0.5); background: @CARD_HOVER@; }
+QComboBox:hover { border-color: rgba(47, 107, 255, 0.5); border-top-color: #FFFFFF; background: @CARD_HOVER@; }
 QComboBox:focus, QComboBox:on { border: 1px solid @ACCENT@; }
 QComboBox::drop-down { subcontrol-origin: padding; subcontrol-position: top right; width: 22px; border: 0; background: transparent; }
 QComboBox::down-arrow {
@@ -209,14 +225,15 @@ QComboBox QAbstractItemView {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
     padding: 4px;
     outline: 0;
-    selection-background-color: rgba(59, 130, 246, 0.18);
+    selection-background-color: rgba(47, 107, 255, 0.18);
     selection-color: @TEXT@;
 }
-QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 8px; min-height: 24px; }
-QComboBox QAbstractItemView::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
+QComboBox QAbstractItemView::item { padding: 6px 10px; border-radius: 6px; min-height: 24px; }
+QComboBox QAbstractItemView::item:selected { background: rgba(47, 107, 255, 0.18); color: @TEXT@; }
 
 QCheckBox, QRadioButton { color: @TEXT@; background: transparent; spacing: 8px; padding: 2px; }
 QCheckBox:disabled, QRadioButton:disabled { color: #a0a0b4; }
@@ -232,11 +249,11 @@ QCheckBox::indicator:checked, QRadioButton::indicator:checked { background: @ACC
 
 QScrollBar:vertical { background: transparent; width: 12px; margin: 4px 2px; border: 0; }
 QScrollBar::handle:vertical { background: rgba(0, 0, 0, 0.12); min-height: 32px; border-radius: 4px; }
-QScrollBar::handle:vertical:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:vertical:hover { background: rgba(47, 107, 255, 0.45); }
 QScrollBar::handle:vertical:pressed { background: @ACCENT@; }
 QScrollBar:horizontal { background: transparent; height: 12px; margin: 2px 4px; border: 0; }
 QScrollBar::handle:horizontal { background: rgba(0, 0, 0, 0.12); min-width: 32px; border-radius: 4px; }
-QScrollBar::handle:horizontal:hover { background: rgba(59, 130, 246, 0.45); }
+QScrollBar::handle:horizontal:hover { background: rgba(47, 107, 255, 0.45); }
 QScrollBar::handle:horizontal:pressed { background: @ACCENT@; }
 QScrollBar::add-line, QScrollBar::sub-line { background: transparent; border: 0; width: 0; height: 0; }
 QScrollBar::add-page, QScrollBar::sub-page { background: transparent; }
@@ -290,7 +307,8 @@ QGroupBox {
     background: @CARD@;
     color: @TEXT@;
     border: 1px solid @BORDER@;
-    border-radius: 12px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
     margin-top: 14px;
     padding: 14px 12px 10px;
 }
@@ -309,15 +327,15 @@ QHeaderView::section {
 }
 QTreeView, QListView, QTableView {
     background: @CARD@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 10px;
+    border: 1px solid @BORDER@; border-radius: 8px;
     alternate-background-color: @CARD_HOVER@;
-    selection-background-color: rgba(59, 130, 246, 0.18);
+    selection-background-color: rgba(47, 107, 255, 0.18);
     selection-color: @TEXT@;
     gridline-color: @BORDER@;
 }
 QTreeView::item, QListView::item, QTableView::item { padding: 4px 6px; border-radius: 6px; }
 QTreeView::item:hover, QListView::item:hover, QTableView::item:hover { background: rgba(0, 0, 0, 0.04); }
-QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
+QTreeView::item:selected, QListView::item:selected, QTableView::item:selected { background: rgba(47, 107, 255, 0.18); color: @TEXT@; }
 QTreeView::branch { background: transparent; }
 
 QSlider::groove:horizontal { background: @BORDER@; height: 4px; border-radius: 2px; margin: 0 6px; }
@@ -356,7 +374,8 @@ QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0
 QFrame#analysisControlBar {
     background: rgba(255, 255, 255, 0.8);
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
 }
 QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
@@ -366,7 +385,8 @@ QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip {
     background: rgba(0, 0, 0, 0.04);
     border: 1px solid rgba(0, 0, 0, 0.06);
-    border-radius: 10px;
+    border-top-color: rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
 }
 QLabel#AnalysisStatLabel {
     color: @MUTED@; background: transparent;
@@ -383,22 +403,40 @@ QLabel#AnalysisStatValue[severity="critical"] { color: #dc2626; }
 QWidget#ModernAnalysisGraph {
     background: @CARD_HOVER@;
     border: 1px solid @BORDER@;
-    border-radius: 14px;
+    border-top-color: rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
 }
 
-/* Filter Cards */
+/* Filter Cards
+   The card frame/header chrome is owned by StudioSkin::cardFrameStyle /
+   cardHeaderStyle (glass with a 1px white top edge, per-command-type
+   border treatment). These rules are the matching fallback. */
 QFrame#FilterCardRow {
-    background: @CARD@;
+    background: rgba(255, 255, 255, 0.88);
     border: 1px solid @BORDER@;
-    border-radius: 16px;
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
 }
 QWidget#FilterCardHeader {
-    background: rgba(255, 255, 255, 0.4);
-    border-top-left-radius: 16px; border-top-right-radius: 16px;
+    background: rgba(255, 255, 255, 0.55);
+    border-top-left-radius: 8px; border-top-right-radius: 8px;
 }
+/* The body is one glass panel: a hairline seam under the header and a
+   near-transparent fill, so a shelf filter's three knobs sit on a single
+   pane and read as one unit. */
 QWidget#FilterCardBody, QWidget#FilterCardEditor {
     background: rgba(255, 255, 255, 0.6);
-    border-bottom-left-radius: 16px; border-bottom-right-radius: 16px;
+    border-bottom-left-radius: 8px; border-bottom-right-radius: 8px;
+}
+QWidget#FilterCardBody {
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+/* Disabled (commented-out) rows: the light is off - text recedes with the
+   glass instead of staying at full brightness. */
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardTitle,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardSummary,
+QFrame#FilterCardRow[filterEnabled="false"] QLabel#FilterCardNumber {
+    color: rgba(102, 114, 138, 0.60);
 }
 QLabel#FilterTypeBadge {
     color: white; border-radius: 10px;
@@ -415,15 +453,17 @@ QToolButton#FilterCardIconButton {
     background: rgba(255, 255, 255, 0.5);
     color: @TEXT@;
     border: 1px solid rgba(0, 0, 0, 0.08);
-    border-radius: 8px;
+    border-top-color: rgba(255, 255, 255, 0.9);
+    border-radius: 6px;
     min-width: 24px; min-height: 24px;
     padding: 2px 4px; font-weight: 700;
 }
-QToolButton#FilterCardIconButton:hover { background: rgba(59, 130, 246, 0.14); border-color: rgba(59, 130, 246, 0.5); }
-QToolButton#FilterCardIconButton:checked { background: rgba(59, 130, 246, 0.22); border-color: @ACCENT@; }
+QToolButton#FilterCardIconButton:hover { background: rgba(47, 107, 255, 0.14); border-color: rgba(47, 107, 255, 0.5); }
+QToolButton#FilterCardIconButton:checked { background: rgba(47, 107, 255, 0.22); border-color: @ACCENT@; }
 QLineEdit#FilterCardRawEditor {
     background: @CARD_HOVER@; border: 1px solid @ACCENT@;
-    border-radius: 10px; padding: 6px 10px;
+    border-radius: 6px; padding: 6px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 QCheckBox#FilterCardEnabled { background: transparent; }
 
@@ -436,20 +476,65 @@ QLabel#PreampCardCaption {
 }
 QLabel#EditableValue {
     background: rgba(0, 0, 0, 0.04); color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 8px;
+    border: 1px solid @BORDER@; border-top-color: rgba(0, 0, 0, 0.10);
+    border-radius: 6px;
     padding: 6px 10px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
 QLineEdit#EditableValueEditor {
     background: @CARD_HOVER@; border: 1px solid @ACCENT@;
-    border-radius: 8px; padding: 6px 10px;
+    border-radius: 6px; padding: 6px 10px;
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace; font-weight: 700;
 }
+
+/* ===== Include row: a path chip on a glass card ===== */
+/* The chip is the only pill in the skin: sunken glass, mono path text. */
 QLineEdit#IncludeCardPath {
-    background: @CARD_HOVER@; border: 1px solid @BORDER@;
-    border-radius: 8px; padding: 6px 10px;
+    background: rgba(232, 238, 248, 0.75);
+    border: 1px solid @BORDER@;
+    border-top-color: rgba(0, 0, 0, 0.12);
+    border-radius: 13px;
+    padding: 4px 14px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
+QLineEdit#IncludeCardPath:hover { border-color: rgba(47, 107, 255, 0.45); }
+QLineEdit#IncludeCardPath:focus { border: 1px solid @ACCENT@; }
 QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
+QLabel#IncludeCardStatus[severity="warning"] { color: #d97706; }
+QLabel#IncludeCardStatus[severity="critical"] { color: #dc2626; }
+
+/* ===== VST row: a softly glowing module card ===== */
+/* The frame's gradient border and painted halo come from StudioSkin; the
+   panel button is the module's one lit control. */
+QPushButton#VSTCardPanelButton {
+    background: rgba(47, 107, 255, 0.10);
+    color: @TEXT@;
+    border: 1px solid rgba(47, 107, 255, 0.50);
+    border-top-color: rgba(255, 255, 255, 0.95);
+    border-radius: 8px;
+    padding: 5px 14px;
+    font-weight: 600;
+}
+QPushButton#VSTCardPanelButton:hover {
+    background: rgba(47, 107, 255, 0.18);
+    border-color: rgba(47, 107, 255, 0.75);
+}
+QPushButton#VSTCardPanelButton:pressed {
+    background: rgba(47, 107, 255, 0.26);
+    border-color: @ACCENT@;
+}
+QLabel#VSTCardStatus { color: @MUTED@; background: transparent; }
+QFrame#VSTCardEmbedFrame {
+    background: @CARD_HOVER@;
+    border: 1px solid @BORDER@;
+    border-radius: 8px;
+}
+QPlainTextEdit#VSTCardWarning {
+    background: rgba(217, 119, 6, 0.07);
+    color: #b45309;
+    border: 1px solid rgba(217, 119, 6, 0.40);
+    border-radius: 6px;
+}
 
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }

--- a/Editor/widgets/CommandRowFrame.cpp
+++ b/Editor/widgets/CommandRowFrame.cpp
@@ -27,5 +27,11 @@ void CommandRowFrame::paintEvent(QPaintEvent* event)
 	QFrame::paintEvent(event);
 
 	QPainter painter(this);
-	SkinManager::instance()->paintCardChrome(painter, rect(), info);
+	// The hover flag is paint-time state, not row state, so it is filled here
+	// instead of by the owning row's refreshStateProperties. Repaints on
+	// enter/leave come for free once the active skin's frame stylesheet
+	// contains a :hover rule (the stylesheet style enables hover tracking).
+	CommandRowInfo paintInfo = info;
+	paintInfo.hovered = underMouse();
+	SkinManager::instance()->paintCardChrome(painter, rect(), paintInfo);
 }

--- a/Editor/widgets/CommandRowFrame.cpp
+++ b/Editor/widgets/CommandRowFrame.cpp
@@ -26,6 +26,13 @@ void CommandRowFrame::paintEvent(QPaintEvent* event)
 	// draws on top (no-op in the neutral default).
 	QFrame::paintEvent(event);
 
+	// The hover flag is sampled at paint time instead of being pushed through
+	// setRowInfo: hover repaints are triggered by the skin's own :hover QSS
+	// rules (or the gallery's WA_UnderMouse equivalent), so the stored info
+	// would always lag one state behind.
+	CommandRowInfo paintInfo = info;
+	paintInfo.hovered = underMouse();
+
 	QPainter painter(this);
-	SkinManager::instance()->paintCardChrome(painter, rect(), info);
+	SkinManager::instance()->paintCardChrome(painter, rect(), paintInfo);
 }

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -420,11 +420,9 @@ void FilterCardRow::rebuildSummary()
 	}
 
 	typeBadge->setText(descriptor.badge);
-	bool outlineBadge = SkinManager::instance()->tokens().badgeStyle == SkinTokens::OutlineOnly || SkinManager::instance()->tokens().badgeStyle == SkinTokens::WireframeBorder;
-	typeBadge->setStyleSheet(QStringLiteral("color:%1; border-color:%2; background-color:%3;")
-		.arg(outlineBadge ? descriptor.color : QStringLiteral("white"),
-			descriptor.color,
-			outlineBadge ? QStringLiteral("transparent") : descriptor.color));
+	// The badge chrome is owned by the active skin (ISkin::typeBadgeStyle); the
+	// default reproduces the previous shared outline/filled treatment.
+	typeBadge->setStyleSheet(SkinManager::instance()->typeBadgeStyle(currentRowInfo(), descriptor.color));
 	titleLabel->setText(descriptor.title);
 	summaryLabel->setText(descriptor.summary);
 	rawPreviewLabel->setText(QStringLiteral("Raw  ") + item->text);

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,9 +12,8 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 
 지금 진행 중인 작업은 다음과 같습니다.
 
-1. Editor의 5개 스킨 전면 개편을 3단계 프로그램(공용 기반 작업, 스킨별 격리 구현 5건, 심사와 통합)으로 진행합니다. 이슈 [#66](https://github.com/115dkk/EqualizerAPO-XT/issues/66), [#67](https://github.com/115dkk/EqualizerAPO-XT/issues/67), [#68](https://github.com/115dkk/EqualizerAPO-XT/issues/68)에서 추적합니다.
-2. 변형별 릴리스 채널을 단일 바이너리 런타임 SIMD dispatch로 대체합니다([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
-3. 격주 자동 코드 감사가 찾아낸 문제를 처리합니다.
+1. 변형별 릴리스 채널을 단일 바이너리 런타임 SIMD dispatch로 대체합니다([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
+2. 격주 자동 코드 감사가 찾아낸 문제를 처리합니다.
 
 ## 주요 기능
 
@@ -22,7 +21,7 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 - Convolution, GraphicEQ, 파라메트릭 EQ, VST2/VST3와 기존 Equalizer APO 필터를 지원합니다.
 - Steinberg VST3 SDK(MIT 라이선스 pluginterfaces)로 VST3를 네이티브 호스팅하며, 플러그인이 지원하면 64비트(double)로 처리합니다.
 - SIMD 커널은 [Google Highway](https://github.com/google/highway)로 한 번만 작성해 변형별로 컴파일합니다. x64는 SSE2, AVX, AVX2, AVX-512, AVX10.1, ARM64는 NEON입니다.
-- Qt Editor를 현대화했습니다. 카드 기반 필터 UI, 스킨별 Copy 라우팅 렌더러를 갖춘 5종 스킨, 내장 폰트, 고해상도(High-DPI) 대응이 들어 있습니다.
+- Qt Editor를 현대화했습니다. 카드 기반 필터 UI와 행 chrome·노브 렌더링·Copy 라우팅 렌더러까지 서로 다른 5종 스킨([docs/skin-integration-report.md](docs/skin-integration-report.md)), 내장 폰트, 고해상도(High-DPI) 대응이 들어 있습니다.
 - Editor가 새 릴리스를 백그라운드에서 내려받아 종료할 때 적용하는 자동 업데이트가 들어 있습니다. 알림만 하는 UpdateChecker 도구도 따로 있습니다.
 - 자동 감지 설치기가 로컬 CPU에 맞는 SIMD 빌드를 골라 내려받고, 실행 전에 릴리스 체크섬으로 검증합니다.
 - 오디오 처리는 AOCL-FFTW, libsndfile, muparserx, TCLAP을 쓰고, GUI 도구는 Qt로 만들었습니다.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ The original fork goals are complete: the convolution tail bug is fixed, the eng
 
 Current work areas:
 
-1. A five-skin visual overhaul of the Editor, run as a three-phase program (shared groundwork, five isolated skin implementations, judging and integration) — tracked in issues [#66](https://github.com/115dkk/EqualizerAPO-XT/issues/66), [#67](https://github.com/115dkk/EqualizerAPO-XT/issues/67), and [#68](https://github.com/115dkk/EqualizerAPO-XT/issues/68).
-2. Runtime SIMD dispatch in a single binary, replacing the per-variant release channels ([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
-3. Acting on findings from the biweekly automated code audit.
+1. Runtime SIMD dispatch in a single binary, replacing the per-variant release channels ([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
+2. Acting on findings from the biweekly automated code audit.
 
 ## Features
 
@@ -22,7 +21,7 @@ Current work areas:
 - Convolution, GraphicEQ, parametric EQ, VST2/VST3, and standard Equalizer APO filter support.
 - Native VST3 hosting through the Steinberg VST3 SDK (MIT-licensed pluginterfaces), with 64-bit (double) processing where the plug-in supports it.
 - Portable SIMD kernels written once with [Google Highway](https://github.com/google/highway) and compiled per variant: SSE2, AVX, AVX2, AVX-512, and AVX10.1 on x64, NEON on ARM64.
-- Modernized Qt Editor: card-based filter UI, five visual skins with per-skin Copy routing renderers, embedded fonts, and high-DPI scaling.
+- Modernized Qt Editor: card-based filter UI and five fully differentiated visual skins — each with its own row chrome, knob rendering, and Copy routing renderer ([docs/skin-integration-report.md](docs/skin-integration-report.md)) — plus embedded fonts and high-DPI scaling.
 - Automatic updates: the Editor downloads new releases in the background and applies them on exit. A standalone UpdateChecker tool provides notify-only checks.
 - Auto-detect installer that picks the matching SIMD build for the local CPU and verifies the download against the release checksums before running it.
 - AOCL-FFTW, libsndfile, muparserx, TCLAP, and Qt-based GUI tools.

--- a/docs/skin-integration-report.md
+++ b/docs/skin-integration-report.md
@@ -1,0 +1,121 @@
+# Skin program — Phase 2 integration report
+
+Closes the three-phase skin program (issues #66 → #67 → #68). Five isolated
+agents each implemented one skin on `skin/<id>` branches (Phase 1); this
+report records the judging and the integration of those branches into one
+tree (Phase 2).
+
+## Branches integrated
+
+Merged into `integrate/skins` cheapest-first, exactly in this order:
+
+| order | branch | head | scope (files outside `Editor/skins/` + own QSS) |
+|---|---|---|---|
+| 1 | `skin/minimal` | 5921455 | none |
+| 2 | `skin/matrix` | 0e5e6fd | `SkinManager.{h,cpp}`, `widgets/CommandRowFrame.cpp`, `widgets/FilterCardRow.cpp` (new `typeBadgeStyle` hook + `hovered` flag) |
+| 3 | `skin/studio` | d75a104 | `widgets/CommandRowFrame.cpp` (`hovered` flag) |
+| 4 | `skin/soft` | b1dad2d | none |
+| 5 | `skin/rack` | 8415116 | `Editor.pro` (registers `skins/RackChrome.{h,cpp}`) |
+
+Merge conflicts were limited to `Skins.cpp` include unions and helper-block
+ordering, plus one genuinely interesting collision: **studio and matrix both
+added the same `CommandRowInfo.hovered` paint-time flag independently**
+(isolation working as designed); the merge kept a single copy. No branch
+touched `filters/` (command codecs), `AudioKnob` input handling, or any other
+forbidden area.
+
+## Differentiation gate (the core check)
+
+Rule: an item FAILS if any two skins differ only by palette. Judged from the
+contact sheets (below) and the implementations. **All seven items pass for
+all five skins.** Condensed answers:
+
+| # | item | studio | minimal | soft | rack | matrix |
+|---|---|---|---|---|---|---|
+| 1 | type announcement | border treatment (solid/dashed/gradient) + painted signal lamp/halo | leading ASCII glyph (`~`, `>>`, `[]`) + bare mono token | rounded-square colour tile + per-type body shape | per-type plate finish + jacks/nameplate + engraved ear designation | square mono type-code cell + per-type body layout |
+| 2 | hover | glass brightens, glow intensifies (painted) | one background step | card lifts one elevation step | faceplate sheen + amber hardware edges | row band + coordinate-column band (crosspoint) |
+| 3 | disabled | glass with the light off (alpha drop, reflection/lamp gone) | `#` marker glyph + one step below rest | sleeping slot (dashed silhouette, sunk flush) | powered-down unit (LED dark, dim film, hardware stays) | cancelled departure (dashed border, amber hollow lamp, strikethrough) |
+| 4 | Include row | path chip (pill) on dashed glass card | one text line, payload brighter than command | rounded breadcrumb chip on body tray | patchbay insert unit with painted jacks | `> source: <path>` mono board line |
+| 5 | VST row | softly glowing module (gradient border + halo) | same single-line grammar as Include | app-store card (icon tile + vendor caption) | rack unit with riveted brass nameplate | external-device entry with IN/OUT port strip |
+| 6 | corner/edge | 8px glass, lighter top edge / darker sunken edge | radius 0, 1px hairlines, no header plate | 12px cards, pills, faked two-step shadows | 3px machined corners, bezels, grooves, four screws | radius 0, 1px rules, 3px status rail, 24px grid texture |
+| 7 | hierarchy lead | luminance backed by weight | text brightness, one mono size | size and whitespace (48px headers) | physical depth (raised/flat/recessed) | grid position, uniform type |
+
+The closest structural pair is studio/soft (both keep the stock card
+silhouette); they still separate by radius language, elevation strategy
+(alpha-glass with top-edge reflection vs two-step elevation), knob vocabulary
+(thin glowing arc vs largest soft-bodied knob) and the raw-preview strip
+(studio keeps it, soft removes it). Verdict: pass, worth rechecking whenever
+either skin is revised.
+
+Knob vocabularies (Annex K) are five distinct instruments: glowing arc
+(studio), number-first flat circle (minimal), large pastel handle (soft),
+pointer knob over panel-printed scale (rack), LED segment ring + boxed numeric
+cell (matrix). Bipolar gain knobs anchor mid-scale distinctly in each.
+
+## Technical review per branch
+
+All five branches: build passed, gallery rendered (24 PNGs each), scope
+clean, serialization untouched, cppcheck 2.21.0 gate zero findings (verified
+again on the integrated tree, including the new 500-line `RackChrome`
+painter). Shared-hook additions (`hovered`, `typeBadgeStyle`) follow the
+neutral-default rule; neutrality was proven empirically, not assumed — see
+below.
+
+## Interference verification (per merge step)
+
+After every merge the full 120-PNG gallery was rendered and SHA-256-compared:
+skins not yet integrated had to stay pixel-identical to the v1.18.0 main
+baseline, and integrated skins had to stay pixel-identical to their own
+branch gallery. Result at every one of the five steps: **0 mismatches** (600
+comparisons total). The hook extensions changed nothing for skins that do not
+override them.
+
+Default skin: `studio` (unchanged; `SkinManager` and the startup settings
+default both verified). QSS identity headers: all ten sheets carry their
+constitution names (the `minimal` skin intentionally keeps its historical
+`precision_*.qss` file names).
+
+Skin-switch performance: switching still recreates rows via the existing
+`FilterTable::updateGuis()` path; no skin added per-switch work beyond
+construction-time painting, and full-tree QSS re-polish behavior is
+unchanged. The offscreen gallery (which performs five full skin switches per
+run) completes in seconds, same as before the program.
+
+## Judging material
+
+Contact sheets (the same row across all five skins, normal and disabled,
+dark and light) are hosted on the `gallery-phase2` branch (never merge it):
+
+`https://raw.githubusercontent.com/115dkk/EqualizerAPO-XT/gallery-phase2/sheets/sheet_<dark|light>_<filter|shelf|include|vst>_<normal|disabled>.png`
+
+Per-skin Phase 1 galleries are browsable in issue #72 (hosted on
+`gallery-phase1`). To regenerate any of it:
+`Editor --skin-gallery <outDir> [--skin-gallery-skins id,...]` (see
+`docs/skin-hooks.md`).
+
+## Interaction-layer wishes (follow-up candidates)
+
+Collected from the five agents, deduplicated; none implemented in this
+program (presentation-only rule):
+
+1. **`KnobState` label/unit fields** — rack (engraved label under the knob),
+   matrix (unit-suffixed numeric cell), minimal (engineering-value readout)
+   all hit the same missing API; the host would fill it from the `.ui`
+   captions/spin boxes.
+2. **Legacy `.ui` dials pass no `valueText`** — blocks studio's fade-in
+   readout and soft's per-knob captions on shelf rows; same root as (1).
+3. **VST status label colours via `QPalette` `Qt::red`/`Qt::black`** — should
+   route through `SkinTokens` (`danger`/`text`); unreadable on dark cards.
+4. **Gallery harness artifacts** — the offscreen synthetic cursor at (0,0)
+   gives row 1's frame hover chrome in its `normal` shot, and
+   `FilterTable::setLines` focuses row 1 so its focus ring is visible. Worth
+   clearing `WA_UnderMouse`/focus before the normal grab.
+5. **Raw-preview strip styling is hardcoded in `FilterCardRow`** — a skin
+   hook would let rack render it as a serial-number label (rack disables it
+   via `showRawPreview` for now).
+6. **FilterTable-level hover hook** — matrix's crosspoint column band can
+   only paint inside the hovered card; a table-level band would cross the
+   whole board.
+7. Smaller: single-line Include/VST body layout (minimal), VST vendor
+   metadata plumbing (soft), no condensed font in the repo (rack approximates
+   with letter-spaced DM Sans).


### PR DESCRIPTION
## Summary

Integrates the five Phase 1 skin branches (issue #67) and closes the skin program (closes #68). Each skin now answers the seven-item differentiation questionnaire with shape, texture, typography and layout — not palette:

- **studio** — glass over the instrument: alpha-glass cards with a 1px top reflection, painted signal lamps/halos per command type, and "the arc IS the value" glow knobs.
- **minimal** — the bank teller's terminal: radius 0, hairline boxes, leading ASCII type glyphs, one mono size, number-first knobs.
- **soft** — the settings screen: 12px cards, breadcrumb chips, app-store VST cards, the largest knobs of the five, hierarchy by size and whitespace.
- **rack** — the amplifier faceplate: painted bezels, corner screws, engraved ear designations, insert jacks, brass VST nameplates, pointer knobs over panel-printed scales (new `RackChrome` painter).
- **matrix** — the departure board: grid texture, coordinate cells, traffic-light status rail, crosspoint hover bands, LED-ring encoder knobs with boxed numeric cells.

Merged cheapest-first (`minimal` -> `matrix` -> `studio` -> `soft` -> `rack`) into this single integration PR. Two small shared-hook extensions rode along with neutral defaults: a paint-time `CommandRowInfo.hovered` flag (added independently by studio AND matrix — isolation working; merged to one copy) and an `ISkin::typeBadgeStyle` hook (default is the previous `FilterCardRow` inline string verbatim).

Full judging record: [docs/skin-integration-report.md](https://github.com/115dkk/EqualizerAPO-XT/blob/integrate/skins/docs/skin-integration-report.md) (differentiation table, per-branch findings, contact-sheet URLs on the `gallery-phase2` branch, consolidated follow-up wishes).

## Verification

- **Interference gate:** after every one of the five merges, the full 120-PNG gallery was re-rendered and SHA-256-compared — not-yet-integrated skins identical to the v1.18.0 baseline, integrated skins identical to their Phase 1 branch galleries. 0 mismatches across 600 comparisons.
- Forbidden-area check per branch: `filters/` (command codecs) and `AudioKnob` input handling untouched everywhere.
- `EditorLogicTests` (102 checks) and `HybridConvTests` (all suites) pass; local cppcheck 2.21.0 with the CI gate flags: zero findings on the integrated tree including the new `RackChrome`.
- Default skin stays `studio`; all ten QSS identity headers carry their constitution names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)