### PR TITLE
docs: move the Unreleased changelog entries to v1.19.0

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v1.19.0 (2026-06-12)
 
 - Editor의 5개 스킨이 색만 다른 변형이 아니라 서로 다른 시각 정체성이
   됐습니다. 명령 종류 표시, 호버, 비활성 상태, Include/VST 표현, 모서리

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v1.19.0 — 2026-06-12
 
 - The five Editor skins are now fully differentiated visual identities
   instead of palette variations. Each answers command-type marking, hover,


### PR DESCRIPTION
v1.19.0 was released from PR #73; both changelogs now carry the dated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)