### PR TITLE
docs: move the Unreleased changelog entries to v1.20.0

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v1.20.0 (2026-06-12)
 
 - Editor가 예기치 않게 죽을 때 흔적 없이 사라지는 대신, 크래시 미니덤프와
   요약 리포트(버전, 예외 주소, 마지막으로 전환한 스킨)를

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v1.20.0 — 2026-06-12
 
 - The Editor now writes a crash minidump and a small text report (version,
   exception address, the last skin switched to) to


### PR DESCRIPTION
v1.20.0 (crash minidumps + CI debug symbols, #76) was released, so the Unreleased section of both changelogs becomes the dated v1.20.0 section. No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)