### PR TITLE
feat(editor): knob gain range setting, compact analysis panel, explicit graph position, refillable Copy routing

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,23 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- 게인 노브(Preamp 카드 노브, biquad 게인 다이얼)가 설정 가능한 ±범위를
+  돌도록 바뀌었습니다. 기본값은 ±20dB이고 View > Interface > Knob gain
+  range에서 바꿀 수 있습니다. 직접 입력하는 값은 기존 전체 범위를 그대로
+  받고 노브만 끝에 걸립니다. 기존에는 Preamp 노브가 ±100dB 고정이라 조금만
+  돌려도 수십 dB씩 튀었습니다. ([#78])
+- 분석 패널의 기본 높이를 줄였고, 원본 Equalizer APO처럼 아래쪽이 기본
+  위치가 됐으며, 위치는 Ctrl+Alt+G 순환 대신 패널 컨트롤 바의 Pos
+  드롭다운(위/아래/오른쪽)에서 직접 고릅니다. ([#78])
+- Copy 명령을 일부러 비워도 모든 스킨에서 GUI로 다시 채울 수 있습니다.
+  크로스포인트 격자(Signal Matrix)와 패치베이(Hardware Rack)는 장치 채널
+  전체를 항상 표시하고, 스텝 목록(Precision Minimal)과 수식 블록(Soft Lab)은
+  장치 채널마다 행을 만들고 행별 [+] 메뉴로 소스를 추가할 수 있으며, 계수를
+  지우면 해당 소스가 빠집니다. 비어 있는 행은 설정 줄에 아무것도 쓰지
+  않습니다. ([#78])
+
 ## v1.20.0 (2026-06-12)
 
 - Editor가 예기치 않게 죽을 때 흔적 없이 사라지는 대신, 크래시 미니덤프와
@@ -316,3 +333,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#73]: https://github.com/115dkk/EqualizerAPO-XT/pull/73
 [#75]: https://github.com/115dkk/EqualizerAPO-XT/issues/75
 [#76]: https://github.com/115dkk/EqualizerAPO-XT/pull/76
+[#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- Gain knobs (the Preamp card knob and the biquad gain dial) now turn across
+  a configurable ±range, default ±20 dB, set via View > Interface > Knob gain
+  range. Typed values still accept each command's full range and simply peg
+  the knob; the previous fixed ±100 dB preamp span made small turns jump by
+  tens of dB. ([#78])
+- The analysis panel starts at a more modest height, docks at the bottom by
+  default like the original Equalizer APO, and its position is picked from a
+  Pos dropdown (Top / Bottom / Right) in the panel's control bar instead of
+  the implicit Ctrl+Alt+G cycling. ([#78])
+- A deliberately emptied Copy command can be refilled from the GUI in every
+  skin. The crosspoint grid (Signal Matrix) and patch-bay (Hardware Rack)
+  always offer the full device channel surface; the step list (Precision
+  Minimal) and equation blocks (Soft Lab) seed a row per device channel and
+  gained a per-row [+] menu for adding sources, and clearing a factor removes
+  that source. Seeded empty rows write nothing to the config line. ([#78])
+
 ## v1.20.0 — 2026-06-12
 
 - The Editor now writes a crash minidump and a small text report (version,
@@ -332,3 +350,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#73]: https://github.com/115dkk/EqualizerAPO-XT/pull/73
 [#75]: https://github.com/115dkk/EqualizerAPO-XT/issues/75
 [#76]: https://github.com/115dkk/EqualizerAPO-XT/pull/76
+[#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -96,7 +96,8 @@ private slots:
 	void interfaceModeSelected(QAction* action);
 	void skinSelected(QAction* action);
 	void darkThemeToggled(bool checked);
-	void cycleGraphPosition();
+	void knobRangeSelected(QAction* action);
+	void on_graphPositionComboBox_currentIndexChanged(int index);
 	void toggleGraphFullscreen();
 	void on_actionResetAllGlobalPreferences_triggered();
 	void on_actionResetAllFileSpecificPreferences_triggered();
@@ -112,6 +113,7 @@ private:
 	void updateRecentFiles();
 	void setupRedesignActions();
 	void applyRedesignPreferences();
+	void syncKnobRangeActions();
 	void setCurrentRenderMode(FilterTable::RenderMode mode);
 	FilterTable* filterTableForTab(int tabIndex) const;
 	FilterTable* currentFilterTable() const;
@@ -140,11 +142,13 @@ private:
 	QString skinId = QStringLiteral("studio");
 	bool skinDark = true;
 	bool graphFullscreen = false;
-	int graphDockPosition = 0;
+	// 0 = top, 1 = bottom (default, matching the original Equalizer APO), 2 = right.
+	int graphDockPosition = 1;
 	FilterTable::RenderMode currentRenderMode = FilterTable::ModernCards;
 	QActionGroup* interfaceModeActionGroup = nullptr;
 	QActionGroup* skinActionGroup = nullptr;
 	QAction* darkThemeAction = nullptr;
+	QActionGroup* knobRangeActionGroup = nullptr;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<AbstractAPOInfo>)

--- a/Editor/MainWindow.ui
+++ b/Editor/MainWindow.ui
@@ -218,6 +218,32 @@
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="graphPositionLabel">
+          <property name="text">
+           <string>Pos</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="graphPositionComboBox">
+          <item>
+           <property name="text">
+            <string>Top</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Bottom</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Right</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
          <spacer name="analysisControlSpacer">
           <property name="orientation">
            <enum>Qt::Orientation::Horizontal</enum>

--- a/Editor/MainWindowParts/MainWindow.Preferences.cpp
+++ b/Editor/MainWindowParts/MainWindow.Preferences.cpp
@@ -46,7 +46,8 @@ void MainWindow::loadPreferences()
 	skinId = settings.value("interface/skin", "studio").toString();
 	skinDark = settings.value("interface/dark", GUIHelper::isDarkMode()).toBool();
 	currentRenderMode = settings.value("interface/legacyRows", false).toBool() ? FilterTable::LegacyRows : FilterTable::ModernCards;
-	graphDockPosition = settings.value("interface/graphDockPosition", 0).toInt();
+	// Default to the bottom, like the original Equalizer APO's analysis panel.
+	graphDockPosition = qBound(0, settings.value("interface/graphDockPosition", 1).toInt(), 2);
 	applyRedesignPreferences();
 
 	QVariant geometryValue = settings.value("geometry");
@@ -244,13 +245,61 @@ void MainWindow::setupRedesignActions()
 	connect(darkThemeAction, SIGNAL(toggled(bool)), this, SLOT(darkThemeToggled(bool)));
 
 	interfaceMenu->addSeparator();
-	QAction* cycleGraphAction = interfaceMenu->addAction(tr("Cycle graph position"));
-	cycleGraphAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Alt+G")));
-	connect(cycleGraphAction, SIGNAL(triggered()), this, SLOT(cycleGraphPosition()));
 
+	// The gain knobs (Preamp card, biquad gain dial) span a configurable ±range;
+	// typed values keep the full command range. Data: the range in dB, 0.0 marks
+	// the "Custom..." entry which asks for a number.
+	QMenu* knobRangeMenu = interfaceMenu->addMenu(tr("Knob gain range"));
+	knobRangeActionGroup = new QActionGroup(this);
+	knobRangeActionGroup->setExclusive(true);
+	for (double range : { 6.0, 12.0, 20.0, 40.0, 100.0 })
+	{
+		QAction* action = knobRangeMenu->addAction(tr("±%1 dB").arg(range));
+		action->setCheckable(true);
+		action->setData(range);
+		knobRangeActionGroup->addAction(action);
+	}
+	QAction* customRangeAction = knobRangeMenu->addAction(tr("Custom..."));
+	customRangeAction->setCheckable(true);
+	customRangeAction->setData(0.0);
+	knobRangeActionGroup->addAction(customRangeAction);
+	connect(knobRangeActionGroup, SIGNAL(triggered(QAction*)), this, SLOT(knobRangeSelected(QAction*)));
+
+	// The graph position is chosen explicitly via the dropdown in the analysis
+	// panel's control bar (graphPositionComboBox); the old implicit
+	// "cycle graph position" action is gone.
 	QAction* fullscreenGraphAction = interfaceMenu->addAction(tr("Fullscreen graph"));
 	fullscreenGraphAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Alt+F")));
 	connect(fullscreenGraphAction, SIGNAL(triggered()), this, SLOT(toggleGraphFullscreen()));
+}
+
+void MainWindow::syncKnobRangeActions()
+{
+	if (knobRangeActionGroup == nullptr)
+		return;
+
+	const double knobRange = GUIHelper::knobGainRange();
+	QAction* customAction = nullptr;
+	bool presetMatched = false;
+	for (QAction* action : knobRangeActionGroup->actions())
+	{
+		const double value = action->data().toDouble();
+		if (value == 0.0)
+		{
+			customAction = action;
+			continue;
+		}
+		const bool matches = value == knobRange;
+		action->setChecked(matches);
+		presetMatched = presetMatched || matches;
+	}
+	if (customAction != nullptr)
+	{
+		customAction->setChecked(!presetMatched);
+		customAction->setText(presetMatched
+			? tr("Custom...")
+			: tr("Custom (±%1 dB)...").arg(knobRange));
+	}
 }
 
 void MainWindow::applyRedesignPreferences()
@@ -274,6 +323,11 @@ void MainWindow::applyRedesignPreferences()
 		darkThemeAction->setChecked(skinDark);
 		darkThemeAction->blockSignals(false);
 	}
+	syncKnobRangeActions();
+
+	ui->graphPositionComboBox->blockSignals(true);
+	ui->graphPositionComboBox->setCurrentIndex(graphDockPosition);
+	ui->graphPositionComboBox->blockSignals(false);
 
 	ui->analysisDockWidget->setWindowTitle(tr("Graph"));
 	bool graphWasShown = !ui->analysisDockWidget->isHidden();

--- a/Editor/MainWindowParts/MainWindow.ViewActions.cpp
+++ b/Editor/MainWindowParts/MainWindow.ViewActions.cpp
@@ -9,6 +9,7 @@
 #include <QScrollArea>
 #include <QFileInfo>
 #include <QFileDialog>
+#include <QInputDialog>
 #include <QMessageBox>
 #include <QProcess>
 #include <QSettings>
@@ -124,10 +125,44 @@ void MainWindow::darkThemeToggled(bool checked)
 	}
 }
 
-void MainWindow::cycleGraphPosition()
+void MainWindow::on_graphPositionComboBox_currentIndexChanged(int index)
 {
-	graphDockPosition = (graphDockPosition + 1) % 3;
+	if (index < 0 || index > 2 || index == graphDockPosition)
+		return;
+
+	graphDockPosition = index;
 	applyRedesignPreferences();
+}
+
+void MainWindow::knobRangeSelected(QAction* action)
+{
+	if (action == nullptr)
+		return;
+
+	double range = action->data().toDouble();
+	if (range == 0.0)
+	{
+		// The "Custom..." entry asks for a number instead of carrying one.
+		bool ok = false;
+		range = QInputDialog::getDouble(this, tr("Knob gain range"),
+			tr("Gain knobs will cover ± this many dB:"),
+			GUIHelper::knobGainRange(), 1.0, 100.0, 1, &ok);
+		if (!ok)
+		{
+			syncKnobRangeActions();
+			return;
+		}
+	}
+
+	GUIHelper::setKnobGainRange(range);
+	syncKnobRangeActions();
+	// Rebuild the open rows so existing Preamp / Filter knobs pick up the new span.
+	for (int i = 0; i < ui->tabWidget->count(); i++)
+	{
+		FilterTable* filterTable = filterTableForTab(i);
+		if (filterTable != nullptr)
+			filterTable->updateGuis();
+	}
 }
 
 void MainWindow::toggleGraphFullscreen()

--- a/Editor/guis/BiQuadFilterGUI.cpp
+++ b/Editor/guis/BiQuadFilterGUI.cpp
@@ -44,6 +44,11 @@ BiQuadFilterGUI::BiQuadFilterGUI(const BiQuadCommand& command)
 	// The flag reaches the skin through KnobState so bipolar knobs can read
 	// differently from unipolar ones.
 	ui->gainDial->setBipolar(true);
+	// The dial spans the user-configured comfort range (default ±20 dB) in
+	// 0.1 dB steps; the spin box still accepts the full command range and a
+	// larger typed gain just pegs the dial at its end.
+	const double knobRange = GUIHelper::knobGainRange();
+	ui->gainDial->setRange(qRound(-knobRange * 10.0), qRound(knobRange * 10.0));
 
 	ui->typeComboBox->addItem(tr("Peaking filter"), BiQuad::PEAKING);
 	ui->typeComboBox->addItem(tr("Low-pass filter"), BiQuad::LOW_PASS);

--- a/Editor/helpers/GUIHelper.cpp
+++ b/Editor/helpers/GUIHelper.cpp
@@ -26,8 +26,10 @@
 #include <QPalette>
 #include <QPixmap>
 #include <QScreen>
+#include <QSettings>
 #include <QStyleHints>
 
+#include "Editor/MainWindow.h"
 #include "Editor/SkinManager.h"
 
 QSize GUIHelper::scale(QSize size)
@@ -129,4 +131,17 @@ void GUIHelper::applySkinPalette()
 	palette.setColor(QPalette::Link, accent);
 	palette.setColor(QPalette::LinkVisited, accent.darker(110));
 	qApp->setPalette(palette);
+}
+
+double GUIHelper::knobGainRange()
+{
+	QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+	const double range = settings.value("interface/knobGainRange", 20.0).toDouble();
+	return qBound(1.0, range, 100.0);
+}
+
+void GUIHelper::setKnobGainRange(double range)
+{
+	QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+	settings.setValue("interface/knobGainRange", qBound(1.0, range, 100.0));
 }

--- a/Editor/helpers/GUIHelper.h
+++ b/Editor/helpers/GUIHelper.h
@@ -43,4 +43,10 @@ public:
 	// palette must follow the skin. Called at startup and by the offscreen
 	// skin gallery whenever it switches skins.
 	static void applySkinPalette();
+	// User-configurable span for dB gain knobs (Preamp card, biquad gain dial):
+	// a knob covers ±knobGainRange() dB, while direct text entry keeps each
+	// command's full range and merely pegs the knob at its end. Stored under
+	// interface/knobGainRange; clamped to [1, 100], default ±20 dB.
+	static double knobGainRange();
+	static void setKnobGainRange(double range);
 };

--- a/Editor/widgets/EqGraphView.cpp
+++ b/Editor/widgets/EqGraphView.cpp
@@ -32,7 +32,7 @@ double dbToY(const QRectF& graphRect, double db, double minDb, double maxDb)
 EqGraphView::EqGraphView(QWidget* parent)
 	: QWidget(parent)
 {
-	setMinimumHeight(180);
+	setMinimumHeight(130);
 	setObjectName(QStringLiteral("EqGraphView"));
 	connect(SkinManager::instance(), &SkinManager::skinChanged, this, [this](const SkinTokens&) {
 		update();
@@ -68,7 +68,9 @@ const QString& EqGraphView::channel() const
 
 QSize EqGraphView::sizeHint() const
 {
-	return QSize(960, 280);
+	// Keeps the analysis dock's default height modest; the graph auto-fits its
+	// data, so users who want a taller view can simply drag the dock splitter.
+	return QSize(960, 190);
 }
 
 void EqGraphView::paintEvent(QPaintEvent*)

--- a/Editor/widgets/cards/PreampCardEditor.cpp
+++ b/Editor/widgets/cards/PreampCardEditor.cpp
@@ -7,11 +7,15 @@
 #include <QLocale>
 #include <QRegularExpression>
 
+#include "Editor/helpers/GUIHelper.h"
 #include "Editor/widgets/AudioKnob.h"
 #include "Editor/widgets/EditableValue.h"
 
 namespace
 {
+// Bounds for directly typed values; the knob itself only spans the
+// user-configured GUIHelper::knobGainRange() so a small turn stays a small
+// change.
 constexpr double MinimumGain = -100.0;
 constexpr double MaximumGain = 100.0;
 constexpr double GainStep = 0.1;
@@ -40,7 +44,10 @@ PreampCardEditor::PreampCardEditor(double dbGain, QWidget* parent)
 	knob = new AudioKnob(this);
 	knob->setObjectName(QStringLiteral("PreampCardKnob"));
 	knob->setBipolar(true);
-	knob->setRange(gainToKnobValue(MinimumGain), gainToKnobValue(MaximumGain));
+	// A gain outside the knob span (typed directly) pegs the knob at its end
+	// while the editable value keeps showing the real number.
+	const double knobRange = GUIHelper::knobGainRange();
+	knob->setRange(gainToKnobValue(-knobRange), gainToKnobValue(knobRange));
 	knob->setSingleStep(1);
 	knob->setPageStep(10);
 	connect(knob, SIGNAL(valueChanged(int)), this, SLOT(knobChanged(int)));

--- a/Editor/widgets/routing/BlockChipRoutingRenderer.cpp
+++ b/Editor/widgets/routing/BlockChipRoutingRenderer.cpp
@@ -237,7 +237,7 @@ void BlockChipView::showAddMenu(int row, const QPoint& globalPos)
 	QMenu menu(this);
 	for (const QString& channel : candidates)
 		menu.addAction(channel);
-	QAction* chosen = menu.exec(globalPos);
+	const QAction* chosen = menu.exec(globalPos);
 	if (chosen == nullptr)
 		return;
 

--- a/Editor/widgets/routing/BlockChipRoutingRenderer.cpp
+++ b/Editor/widgets/routing/BlockChipRoutingRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "BlockChipRoutingRenderer.h"
 
+#include <QMenu>
 #include <QPainter>
 #include <QPainterPath>
 #include <QMouseEvent>
@@ -14,8 +15,14 @@
 
 using std::vector;
 
-BlockChipView::BlockChipView(const vector<Assignment>& assignments, QWidget* parent)
-	: RoutingView(parent), workingAssignments(assignments)
+BlockChipView::BlockChipView(const vector<Assignment>& assignments,
+	const vector<std::wstring>& channelNames, QWidget* parent)
+	: RoutingView(parent),
+	// Seed every device channel as an equation block so an emptied Copy can be
+	// refilled from the GUI; blocks whose source sum stays empty are skipped by
+	// the serializer and never reach the config line.
+	workingAssignments(CopyRoutingAdapter::seedTargets(assignments, channelNames)),
+	deviceChannels(channelNames)
 {
 	setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 	setMinimumSize(0, 0);
@@ -39,7 +46,7 @@ QSize BlockChipView::sizeHint() const
 	int maxW = 240;
 	for (const Assignment& a : workingAssignments)
 	{
-		int w = 24 + fm.horizontalAdvance(QString::fromStdWString(a.targetChannel)) + 24 + 24;
+		int w = 24 + fm.horizontalAdvance(QString::fromStdWString(a.targetChannel)) + 24 + 24 + 44; // + add chip
 		for (const Assignment::Summand& s : a.sourceSum)
 			w += fm.horizontalAdvance(QString::fromStdWString(s.channel)) + 90;
 		maxW = qMax(maxW, w);
@@ -66,6 +73,7 @@ void BlockChipView::paintEvent(QPaintEvent*)
 	const QColor ok(t.success), warn(t.warning), accent(t.accent);
 
 	hits.clear();
+	addHits.clear();
 
 	for (int r = 0; r < (int)workingAssignments.size(); ++r)
 	{
@@ -168,7 +176,79 @@ void BlockChipView::paintEvent(QPaintEvent*)
 
 			x += chipW + 8;
 		}
+
+		// Soft [+] chip per block: adds a source channel to this equation. This
+		// is what makes an emptied Copy refillable from the GUI.
+		const QRect addChip(x, y + (blockH - 26) / 2, 32, 26);
+		p.setPen(QPen(alpha(accent, 140), 1, Qt::DashLine));
+		p.setBrush(alpha(accent, 24));
+		p.drawRoundedRect(addChip, 13, 13);
+		p.setPen(alpha(accent, 220));
+		p.drawText(addChip, Qt::AlignCenter, QStringLiteral("+"));
+		addHits.append({ r, addChip });
 	}
+}
+
+void BlockChipView::mousePressEvent(QMouseEvent* event)
+{
+	for (const AddHit& h : addHits)
+	{
+		if (h.rect.contains(event->pos()))
+		{
+			showAddMenu(h.row, mapToGlobal(h.rect.bottomLeft()));
+			return;
+		}
+	}
+	RoutingView::mousePressEvent(event);
+}
+
+void BlockChipView::showAddMenu(int row, const QPoint& globalPos)
+{
+	if (row < 0 || row >= (int)workingAssignments.size())
+		return;
+
+	auto inSum = [this, row](const QString& channel) {
+		for (const Assignment::Summand& s : workingAssignments[row].sourceSum)
+			if (QString::fromStdWString(s.channel).compare(channel, Qt::CaseInsensitive) == 0)
+				return true;
+		return false;
+	};
+
+	QStringList candidates;
+	auto addCandidate = [&](const QString& channel) {
+		if (channel.isEmpty() || channel == QLatin1String(" ")
+			|| inSum(channel) || candidates.contains(channel, Qt::CaseInsensitive))
+			return;
+		candidates.append(channel);
+	};
+	for (const std::wstring& name : deviceChannels)
+		addCandidate(QString::fromStdWString(name));
+	// Channels the command references elsewhere (e.g. virtual channels) stay
+	// available even when the device layout is unknown.
+	for (const Assignment& other : workingAssignments)
+	{
+		addCandidate(QString::fromStdWString(other.targetChannel));
+		for (const Assignment::Summand& s : other.sourceSum)
+			addCandidate(QString::fromStdWString(s.channel));
+	}
+	if (candidates.isEmpty())
+		return;
+
+	QMenu menu(this);
+	for (const QString& channel : candidates)
+		menu.addAction(channel);
+	QAction* chosen = menu.exec(globalPos);
+	if (chosen == nullptr)
+		return;
+
+	Assignment::Summand s;
+	s.factor = 1.0;
+	s.isDecibel = false;
+	s.channel = chosen->text().toStdWString();
+	workingAssignments[row].sourceSum.push_back(s);
+	updateGeometry();
+	update();
+	emit routingChanged();
 }
 
 void BlockChipView::mouseDoubleClickEvent(QMouseEvent* event)
@@ -215,6 +295,18 @@ void BlockChipView::commitEditor()
 	if (row >= (int)workingAssignments.size() || si >= (int)workingAssignments[row].sourceSum.size())
 		return;
 
+	if (raw.isEmpty())
+	{
+		// Clearing the factor removes the source chip, mirroring the
+		// crosspoint / patch-bay grids.
+		Assignment& a = workingAssignments[row];
+		a.sourceSum.erase(a.sourceSum.begin() + si);
+		updateGeometry();
+		update();
+		emit routingChanged();
+		return;
+	}
+
 	Assignment::Summand& s = workingAssignments[row].sourceSum[si];
 	if (raw.compare(QLatin1String("INV"), Qt::CaseInsensitive) == 0)
 	{
@@ -244,7 +336,7 @@ void BlockChipView::commitEditor()
 }
 
 RoutingView* BlockChipRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& /*channelNames*/, QWidget* parent)
+	const vector<std::wstring>& channelNames, QWidget* parent)
 {
-	return new BlockChipView(assignments, parent);
+	return new BlockChipView(assignments, channelNames, parent);
 }

--- a/Editor/widgets/routing/BlockChipRoutingRenderer.h
+++ b/Editor/widgets/routing/BlockChipRoutingRenderer.h
@@ -19,7 +19,8 @@ class BlockChipView : public RoutingView
 	Q_OBJECT
 
 public:
-	BlockChipView(const std::vector<Assignment>& assignments, QWidget* parent);
+	BlockChipView(const std::vector<Assignment>& assignments,
+		const std::vector<std::wstring>& channelNames, QWidget* parent);
 
 	std::vector<Assignment> assignments() const override;
 	QSize sizeHint() const override;
@@ -27,14 +28,20 @@ public:
 
 protected:
 	void paintEvent(QPaintEvent*) override;
+	void mousePressEvent(QMouseEvent* event) override;
 	void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
 	struct Hit { int row = 0; int summand = 0; QRect rect; };
+	struct AddHit { int row = 0; QRect rect; };
 	void commitEditor();
+	void showAddMenu(int row, const QPoint& globalPos);
 
 	std::vector<Assignment> workingAssignments;
+	// Device channel layout, offered by the per-block [+] chip menu.
+	std::vector<std::wstring> deviceChannels;
 	QVector<Hit> hits;
+	QVector<AddHit> addHits;
 	QLineEdit* editor = nullptr;
 	int editRow = -1;
 	int editSummand = -1;

--- a/Editor/widgets/routing/CopyRoutingAdapter.cpp
+++ b/Editor/widgets/routing/CopyRoutingAdapter.cpp
@@ -79,6 +79,12 @@ CopyRoutingAdapter::Cell CopyRoutingAdapter::Matrix::cell(int outRow, int inCol)
 
 CopyRoutingAdapter::Matrix CopyRoutingAdapter::buildMatrix(const std::vector<Assignment>& assignments)
 {
+	return buildMatrix(assignments, {});
+}
+
+CopyRoutingAdapter::Matrix CopyRoutingAdapter::buildMatrix(const std::vector<Assignment>& assignments,
+	const std::vector<std::wstring>& channelNames)
+{
 	Matrix matrix;
 
 	// Inputs in first-seen order across all summands.
@@ -102,6 +108,18 @@ CopyRoutingAdapter::Matrix CopyRoutingAdapter::buildMatrix(const std::vector<Ass
 		}
 	}
 
+	// Offer every device channel as an input column, after the channels the
+	// command already references. This must happen before the cells are keyed
+	// because indexOf() depends on the final column count.
+	for (const std::wstring& name : channelNames)
+	{
+		const QString channel = QString::fromStdWString(name);
+		if (channel.isEmpty() || seenInputs.contains(channel))
+			continue;
+		seenInputs.insert(channel);
+		matrix.inputs.append(channel);
+	}
+
 	for (int outRow = 0; outRow < matrix.outputs.size(); ++outRow)
 	{
 		const Assignment& assignment = assignments[outRow];
@@ -120,4 +138,27 @@ CopyRoutingAdapter::Matrix CopyRoutingAdapter::buildMatrix(const std::vector<Ass
 	}
 
 	return matrix;
+}
+
+std::vector<Assignment> CopyRoutingAdapter::seedTargets(const std::vector<Assignment>& assignments,
+	const std::vector<std::wstring>& channelNames)
+{
+	vector<Assignment> seeded = assignments;
+
+	QSet<QString> targets;
+	for (const Assignment& assignment : assignments)
+		targets.insert(QString::fromStdWString(assignment.targetChannel).toUpper());
+
+	for (const wstring& name : channelNames)
+	{
+		const QString channel = QString::fromStdWString(name);
+		if (channel.isEmpty() || targets.contains(channel.toUpper()))
+			continue;
+		targets.insert(channel.toUpper());
+		Assignment assignment;
+		assignment.targetChannel = name;
+		seeded.push_back(assignment);
+	}
+
+	return seeded;
 }

--- a/Editor/widgets/routing/CopyRoutingAdapter.h
+++ b/Editor/widgets/routing/CopyRoutingAdapter.h
@@ -63,4 +63,25 @@ public:
 	};
 
 	static Matrix buildMatrix(const std::vector<Assignment>& assignments);
+
+	// ── Device channel seeding ─────────────────────────────────────────────
+	// The views derive their rows/columns from the assignments alone, so an
+	// emptied Copy used to leave nothing to click and could never be refilled
+	// from the GUI. These helpers blend the device channel layout in: every
+	// device channel becomes available as an output row / input column even
+	// when the command line does not (yet) reference it. Rows whose source sum
+	// stays empty are skipped by the serializer, so seeding never changes the
+	// written config line.
+
+	// Returns assignments extended with an empty assignment per device channel
+	// that is not already a target (original order preserved, seeds appended).
+	static std::vector<Assignment> seedTargets(const std::vector<Assignment>& assignments,
+		const std::vector<std::wstring>& channelNames);
+
+	// buildMatrix variant that additionally offers every device channel as an
+	// input column. The extra columns must be known before the cells are keyed
+	// (indexOf depends on the final column count), hence an overload rather
+	// than a post-hoc extension.
+	static Matrix buildMatrix(const std::vector<Assignment>& assignments,
+		const std::vector<std::wstring>& channelNames);
 };

--- a/Editor/widgets/routing/CrosspointMatrixRoutingRenderer.cpp
+++ b/Editor/widgets/routing/CrosspointMatrixRoutingRenderer.cpp
@@ -12,8 +12,15 @@
 
 using std::vector;
 
-CrosspointMatrixView::CrosspointMatrixView(const vector<Assignment>& assignments, QWidget* parent)
-	: RoutingView(parent), workingAssignments(assignments)
+CrosspointMatrixView::CrosspointMatrixView(const vector<Assignment>& assignments,
+	const vector<std::wstring>& channelNames, QWidget* parent)
+	: RoutingView(parent),
+	// Seeding every device channel as a row/column keeps the grid editable even
+	// when the command references few (or no) channels; without it an emptied
+	// Copy could never be refilled from the GUI. Empty rows are skipped by the
+	// serializer, so the config line is unaffected.
+	workingAssignments(CopyRoutingAdapter::seedTargets(assignments, channelNames)),
+	deviceChannels(channelNames)
 {
 	setMouseTracking(true);
 	// Match the stable painted-routing-view size contract (StepList / BlockChip):
@@ -27,7 +34,7 @@ CrosspointMatrixView::CrosspointMatrixView(const vector<Assignment>& assignments
 
 void CrosspointMatrixView::rebuildMatrix()
 {
-	matrix = CopyRoutingAdapter::buildMatrix(workingAssignments);
+	matrix = CopyRoutingAdapter::buildMatrix(workingAssignments, deviceChannels);
 	updateGeometry();
 	update();
 }
@@ -311,7 +318,7 @@ void CrosspointMatrixView::commitEditor()
 }
 
 RoutingView* CrosspointMatrixRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& /*channelNames*/, QWidget* parent)
+	const vector<std::wstring>& channelNames, QWidget* parent)
 {
-	return new CrosspointMatrixView(assignments, parent);
+	return new CrosspointMatrixView(assignments, channelNames, parent);
 }

--- a/Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h
+++ b/Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h
@@ -20,7 +20,8 @@ class CrosspointMatrixView : public RoutingView
 	Q_OBJECT
 
 public:
-	CrosspointMatrixView(const std::vector<Assignment>& assignments, QWidget* parent);
+	CrosspointMatrixView(const std::vector<Assignment>& assignments,
+		const std::vector<std::wstring>& channelNames, QWidget* parent);
 
 	std::vector<Assignment> assignments() const override;
 	QSize sizeHint() const override;
@@ -39,6 +40,9 @@ private:
 	void commitEditor();
 
 	std::vector<Assignment> workingAssignments;
+	// Device channel layout; keeps the full routing surface clickable even when
+	// the command references few (or no) channels.
+	std::vector<std::wstring> deviceChannels;
 	CopyRoutingAdapter::Matrix matrix;
 
 	QLineEdit* editor = nullptr;

--- a/Editor/widgets/routing/HardwarePatchbayRoutingRenderer.cpp
+++ b/Editor/widgets/routing/HardwarePatchbayRoutingRenderer.cpp
@@ -13,8 +13,13 @@
 
 using std::vector;
 
-HardwarePatchbayView::HardwarePatchbayView(const vector<Assignment>& assignments, QWidget* parent)
-	: RoutingView(parent), workingAssignments(assignments)
+HardwarePatchbayView::HardwarePatchbayView(const vector<Assignment>& assignments,
+	const vector<std::wstring>& channelNames, QWidget* parent)
+	: RoutingView(parent),
+	// Seed every device channel as a row/column so an emptied Copy can be
+	// refilled from the GUI; empty rows are skipped by the serializer.
+	workingAssignments(CopyRoutingAdapter::seedTargets(assignments, channelNames)),
+	deviceChannels(channelNames)
 {
 	// Match the stable painted-routing-view size contract (StepList / BlockChip).
 	setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
@@ -24,7 +29,7 @@ HardwarePatchbayView::HardwarePatchbayView(const vector<Assignment>& assignments
 
 void HardwarePatchbayView::rebuildMatrix()
 {
-	matrix = CopyRoutingAdapter::buildMatrix(workingAssignments);
+	matrix = CopyRoutingAdapter::buildMatrix(workingAssignments, deviceChannels);
 	updateGeometry();
 	update();
 }
@@ -270,7 +275,7 @@ void HardwarePatchbayView::commitEditor()
 }
 
 RoutingView* HardwarePatchbayRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& /*channelNames*/, QWidget* parent)
+	const vector<std::wstring>& channelNames, QWidget* parent)
 {
-	return new HardwarePatchbayView(assignments, parent);
+	return new HardwarePatchbayView(assignments, channelNames, parent);
 }

--- a/Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h
+++ b/Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h
@@ -19,7 +19,8 @@ class HardwarePatchbayView : public RoutingView
 	Q_OBJECT
 
 public:
-	HardwarePatchbayView(const std::vector<Assignment>& assignments, QWidget* parent);
+	HardwarePatchbayView(const std::vector<Assignment>& assignments,
+		const std::vector<std::wstring>& channelNames, QWidget* parent);
 
 	std::vector<Assignment> assignments() const override;
 	QSize sizeHint() const override;
@@ -38,6 +39,9 @@ private:
 	void commitEditor();
 
 	std::vector<Assignment> workingAssignments;
+	// Device channel layout; keeps the full patch-bay clickable even when the
+	// command references few (or no) channels.
+	std::vector<std::wstring> deviceChannels;
 	CopyRoutingAdapter::Matrix matrix;
 
 	QLineEdit* editor = nullptr;

--- a/Editor/widgets/routing/StepListRoutingRenderer.cpp
+++ b/Editor/widgets/routing/StepListRoutingRenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "StepListRoutingRenderer.h"
 
+#include <QMenu>
 #include <QPainter>
 #include <QMouseEvent>
 #include <QFontMetrics>
@@ -13,8 +14,14 @@
 
 using std::vector;
 
-StepListView::StepListView(const vector<Assignment>& assignments, QWidget* parent)
-	: RoutingView(parent), workingAssignments(assignments)
+StepListView::StepListView(const vector<Assignment>& assignments,
+	const vector<std::wstring>& channelNames, QWidget* parent)
+	: RoutingView(parent),
+	// Seed every device channel as a step so an emptied Copy can be refilled
+	// from the GUI; steps whose source sum stays empty are skipped by the
+	// serializer and never reach the config line.
+	workingAssignments(CopyRoutingAdapter::seedTargets(assignments, channelNames)),
+	deviceChannels(channelNames)
 {
 	setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 	setMinimumSize(0, 0);
@@ -38,7 +45,7 @@ QSize StepListView::sizeHint() const
 	int maxWidth = 220;
 	for (const Assignment& a : workingAssignments)
 	{
-		int w = 36 + 52 + 28; // number + dest + arrow
+		int w = 36 + 52 + 28 + 26; // number + dest + arrow + [+] target
 		for (const Assignment::Summand& s : a.sourceSum)
 		{
 			const QString ch = QString::fromStdWString(s.channel);
@@ -69,6 +76,7 @@ void StepListView::paintEvent(QPaintEvent*)
 	const QColor ok(t.success), warn(t.warning);
 
 	hits.clear();
+	addHits.clear();
 
 	// Header
 	p.setPen(muted);
@@ -134,7 +142,11 @@ void StepListView::paintEvent(QPaintEvent*)
 				x += 14;
 			}
 
-			x += drawChannelPill(ch, x, y, 18) + 4;
+			const int pillW = drawChannelPill(ch, x, y, 18);
+			// The pill itself is an edit target so unity summands (which show no
+			// gain label) can still be edited or removed via the factor editor.
+			hits.append({ r, si, QRect(x, y + (rowH - 18) / 2, pillW, 18) });
+			x += pillW + 4;
 
 			if (showGain)
 			{
@@ -161,7 +173,79 @@ void StepListView::paintEvent(QPaintEvent*)
 				x += 10;
 			}
 		}
+
+		// Bracketed [+] target per step: adds a source channel to this sum. This
+		// is what makes an emptied Copy refillable from the GUI.
+		const QRect addRect(x, y + (rowH - 18) / 2, 18, 18);
+		p.setPen(QPen(withAlpha(border, 160), 1));
+		p.setBrush(withAlpha(border, 26));
+		p.drawRect(addRect);
+		p.setPen(muted);
+		p.drawText(addRect, Qt::AlignCenter, QStringLiteral("+"));
+		addHits.append({ r, addRect });
 	}
+}
+
+void StepListView::mousePressEvent(QMouseEvent* event)
+{
+	for (const AddHit& h : addHits)
+	{
+		if (h.rect.contains(event->pos()))
+		{
+			showAddMenu(h.row, mapToGlobal(h.rect.bottomLeft()));
+			return;
+		}
+	}
+	RoutingView::mousePressEvent(event);
+}
+
+void StepListView::showAddMenu(int row, const QPoint& globalPos)
+{
+	if (row < 0 || row >= (int)workingAssignments.size())
+		return;
+
+	auto inSum = [this, row](const QString& channel) {
+		for (const Assignment::Summand& s : workingAssignments[row].sourceSum)
+			if (QString::fromStdWString(s.channel).compare(channel, Qt::CaseInsensitive) == 0)
+				return true;
+		return false;
+	};
+
+	QStringList candidates;
+	auto addCandidate = [&](const QString& channel) {
+		if (channel.isEmpty() || channel == QLatin1String(" ")
+			|| inSum(channel) || candidates.contains(channel, Qt::CaseInsensitive))
+			return;
+		candidates.append(channel);
+	};
+	for (const std::wstring& name : deviceChannels)
+		addCandidate(QString::fromStdWString(name));
+	// Channels the command references elsewhere (e.g. virtual channels) stay
+	// available even when the device layout is unknown.
+	for (const Assignment& other : workingAssignments)
+	{
+		addCandidate(QString::fromStdWString(other.targetChannel));
+		for (const Assignment::Summand& s : other.sourceSum)
+			addCandidate(QString::fromStdWString(s.channel));
+	}
+	if (candidates.isEmpty())
+		return;
+
+	QMenu menu(this);
+	for (const QString& channel : candidates)
+		menu.addAction(channel);
+	QAction* chosen = menu.exec(globalPos);
+	if (chosen == nullptr)
+		return;
+
+	Assignment::Summand s;
+	s.factor = 1.0;
+	s.isDecibel = false;
+	s.channel = chosen->text().toStdWString();
+	workingAssignments[row].sourceSum.push_back(s);
+	updateGeometry();
+	update();
+	emit routingChanged();
 }
 
 void StepListView::mouseDoubleClickEvent(QMouseEvent* event)
@@ -215,6 +299,18 @@ void StepListView::commitEditor()
 	if (row >= (int)workingAssignments.size() || si >= (int)workingAssignments[row].sourceSum.size())
 		return;
 
+	if (raw.isEmpty())
+	{
+		// Clearing the factor removes the source from the sum, mirroring the
+		// crosspoint / patch-bay grids.
+		Assignment& a = workingAssignments[row];
+		a.sourceSum.erase(a.sourceSum.begin() + si);
+		updateGeometry();
+		update();
+		emit routingChanged();
+		return;
+	}
+
 	Assignment::Summand& s = workingAssignments[row].sourceSum[si];
 	if (raw.compare(QLatin1String("INV"), Qt::CaseInsensitive) == 0)
 	{
@@ -244,7 +340,7 @@ void StepListView::commitEditor()
 }
 
 RoutingView* StepListRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& /*channelNames*/, QWidget* parent)
+	const vector<std::wstring>& channelNames, QWidget* parent)
 {
-	return new StepListView(assignments, parent);
+	return new StepListView(assignments, channelNames, parent);
 }

--- a/Editor/widgets/routing/StepListRoutingRenderer.cpp
+++ b/Editor/widgets/routing/StepListRoutingRenderer.cpp
@@ -234,7 +234,7 @@ void StepListView::showAddMenu(int row, const QPoint& globalPos)
 	QMenu menu(this);
 	for (const QString& channel : candidates)
 		menu.addAction(channel);
-	QAction* chosen = menu.exec(globalPos);
+	const QAction* chosen = menu.exec(globalPos);
 	if (chosen == nullptr)
 		return;
 

--- a/Editor/widgets/routing/StepListRoutingRenderer.h
+++ b/Editor/widgets/routing/StepListRoutingRenderer.h
@@ -21,7 +21,8 @@ class StepListView : public RoutingView
 	Q_OBJECT
 
 public:
-	StepListView(const std::vector<Assignment>& assignments, QWidget* parent);
+	StepListView(const std::vector<Assignment>& assignments,
+		const std::vector<std::wstring>& channelNames, QWidget* parent);
 
 	std::vector<Assignment> assignments() const override;
 	QSize sizeHint() const override;
@@ -29,15 +30,21 @@ public:
 
 protected:
 	void paintEvent(QPaintEvent*) override;
+	void mousePressEvent(QMouseEvent* event) override;
 	void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
 	struct Hit { int row = 0; int summand = 0; QRect rect; };
+	struct AddHit { int row = 0; QRect rect; };
 
 	void commitEditor();
+	void showAddMenu(int row, const QPoint& globalPos);
 
 	std::vector<Assignment> workingAssignments;
-	QVector<Hit> hits;       // factor chip hit-rects, rebuilt each paint
+	// Device channel layout, offered by the per-row [+] source menu.
+	std::vector<std::wstring> deviceChannels;
+	QVector<Hit> hits;       // factor / channel chip hit-rects, rebuilt each paint
+	QVector<AddHit> addHits; // per-row [+] hit-rects, rebuilt each paint
 	QLineEdit* editor = nullptr;
 	int editRow = -1;
 	int editSummand = -1;

--- a/Tests/HybridConvTests/CopyCommandTests.cpp
+++ b/Tests/HybridConvTests/CopyCommandTests.cpp
@@ -174,6 +174,24 @@ void testSerializeRoundTrip()
 	harness.expectTrue(reparsed[0].targetChannel == L"SL", "round-trip target");
 	expectSummand(reparsed, 0, 0, L"L", 0.7, false, "round-trip summand");
 }
+
+void testEmptySumAssignmentsSerializeToNothing()
+{
+	// The Editor's routing views seed one empty assignment per device channel
+	// so an emptied Copy stays editable in the GUI; those seeded rows must
+	// vanish when the line is written back.
+	vector<Assignment> assignments = parseCopyAssignments(L"L=R");
+	Assignment seeded;
+	seeded.targetChannel = L"C";
+	assignments.push_back(seeded);
+	harness.expectTrue(serializeCopyAssignments(assignments) == L"L=R",
+		"an assignment with an empty source sum serializes to nothing");
+
+	vector<Assignment> onlySeeded;
+	onlySeeded.push_back(seeded);
+	harness.expectTrue(serializeCopyAssignments(onlySeeded) == L"",
+		"a lone empty-sum assignment serializes to an empty string");
+}
 }
 
 void runCopyCommandTests()
@@ -185,5 +203,6 @@ void runCopyCommandTests()
 	testConstantValue();
 	testMalformedChunkDropped();
 	testSerializeRoundTrip();
+	testEmptySumAssignmentsSerializeToNothing();
 	harness.report();
 }


### PR DESCRIPTION
Four UX fixes from field feedback:

1. **Configurable knob gain range (default ±20 dB).** The Preamp card knob spanned the full ±100 dB, so a small turn jumped tens of dB. Gain knobs (Preamp card, biquad gain dial) now cover a user-configurable ±range via *View > Interface > Knob gain range* (±6/±12/±20/±40/±100 presets or a custom value, stored in `interface/knobGainRange`). Direct text entry keeps each command's full range and just pegs the knob at its end — the same contract the biquad spin box always had.

2. **Compact analysis panel.** The graph's default height was overwhelming; its size hint drops 280 → 190 px (minimum 180 → 130). Dragging the dock edge still gives any height.

3. **Explicit graph position.** The dock position is now chosen from a *Pos* dropdown (Top / Bottom / Right) in the analysis control bar instead of the implicit Ctrl+Alt+G cycling, and the default follows the original Equalizer APO: bottom.

4. **Refillable Copy routing in every skin.** Emptying a Copy in the non-studio skins left nothing to click (the views derived their rows/columns from the command line alone), so the routing could never be rebuilt from the GUI. All renderers now seed the device channel layout: the crosspoint grid (matrix) and patch-bay (rack) always show the full device routing surface; the step list (minimal) and equation blocks (soft) seed a row per device channel, get a per-row **[+]** menu to add sources, make channel chips edit targets even at unity gain, and treat a cleared factor as removal. Seeded empty rows serialize to nothing — a new `CopyCommandTests` check pins that invariant — so config lines are unchanged until the user actually routes something.

Verification: local x64 Editor build; `HybridConvTests` green (CopyCommandTests 90 checks incl. the new empty-sum invariant); skin gallery renders 120/120 PNGs; 10s offscreen MainWindow smoke run with no crash dump and no `connectSlotsByName` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)