### PR TITLE
feat(editor): per-skin dropdown filter pickers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1038,9 +1038,9 @@ jobs:
         }
         $pngs = @(Get-ChildItem $outDir -Filter *.png)
         Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # 5 skins x 2 modes x 4 rows x 3 states
-        if ($pngs.Count -ne 120) {
-          Write-Error "Expected 120 gallery PNGs, got $($pngs.Count)"
+        # 5 skins x 2 modes x (4 rows x 3 states + 1 filter picker)
+        if ($pngs.Count -ne 130) {
+          Write-Error "Expected 130 gallery PNGs, got $($pngs.Count)"
           exit 1
         }
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,16 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- 필터 추가 픽커가 모든 템플릿을 한꺼번에 쏟아내는 평면 목록에서, 추가
+  버튼에 붙는 콤팩트한 드롭다운으로 바뀌었습니다. 카탈로그 표현은 스킨마다
+  다릅니다. Studio Glass는 프로스트 글래스 패널, Precision Minimal은 숫자
+  점프가 되는 번호식 터미널 인덱스, Soft Lab은 둥근 설정 메뉴, Hardware
+  Rack은 LCD 검색창이 달린 1U 모듈 프리셋 브라우저, Signal Matrix는 2축
+  크로스포인트 계기판입니다. 스킨은 새 `ISkin::createFilterPicker` 훅으로
+  자기 픽커를 제공하며, 오프스크린 갤러리가 모든 픽커를 캡처합니다. ([#81])
+
 ## v1.21.0 (2026-06-12)
 
 - 게인 노브(Preamp 카드 노브, biquad 게인 다이얼)가 설정 가능한 ±범위를
@@ -334,3 +344,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#75]: https://github.com/115dkk/EqualizerAPO-XT/issues/75
 [#76]: https://github.com/115dkk/EqualizerAPO-XT/pull/76
 [#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78
+[#81]: https://github.com/115dkk/EqualizerAPO-XT/pull/81

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- The "add filter" picker is no longer one flat list of every template: it is
+  a compact dropdown anchored at the add button, and each skin presents the
+  catalog in its own design language — a frosted-glass panel (Studio Glass),
+  a numbered terminal index with digit-jump (Precision Minimal), a rounded
+  settings menu (Soft Lab), a 1U module preset browser with an LCD search
+  strip (Hardware Rack), and a two-axis crosspoint instrument (Signal
+  Matrix). Skins contribute their picker through the new
+  `ISkin::createFilterPicker` hook; the offscreen gallery captures every
+  picker. ([#81])
+
 ## v1.21.0 — 2026-06-12
 
 - Gain knobs (the Preamp card knob and the biquad gain dial) now turn across
@@ -351,3 +363,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#75]: https://github.com/115dkk/EqualizerAPO-XT/issues/75
 [#76]: https://github.com/115dkk/EqualizerAPO-XT/pull/76
 [#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78
+[#81]: https://github.com/115dkk/EqualizerAPO-XT/pull/81

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -182,6 +182,7 @@ SOURCES += main.cpp\
 	skins/ISkin.cpp \
 	skins/RackChrome.cpp \
 	skins/Skins.cpp \
+	skins/pickers/RackFilterPicker.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
 	widgets/SkinComboBox.cpp \
@@ -357,6 +358,7 @@ HEADERS  += \
 	skins/ISkin.h \
 	skins/RackChrome.h \
 	skins/Skins.h \
+	skins/pickers/RackFilterPicker.h \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \
 	widgets/SkinComboBox.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -196,6 +196,7 @@ SOURCES += main.cpp\
 	widgets/EqGraphView.cpp \
 	widgets/FilterCardModel.cpp \
 	widgets/FilterCardRow.cpp \
+	widgets/FilterPickerView.cpp \
 	widgets/routing/CopyRoutingAdapter.cpp \
 	widgets/routing/CrosspointMatrixRoutingRenderer.cpp \
 	widgets/routing/StepListRoutingRenderer.cpp \
@@ -370,6 +371,7 @@ HEADERS  += \
 	widgets/EqGraphView.h \
 	widgets/FilterCardModel.h \
 	widgets/FilterCardRow.h \
+	widgets/FilterPickerView.h \
 	widgets/routing/CopyRoutingAdapter.h \
 	widgets/routing/IRoutingRenderer.h \
 	widgets/routing/CrosspointMatrixRoutingRenderer.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -182,6 +182,7 @@ SOURCES += main.cpp\
 	skins/ISkin.cpp \
 	skins/RackChrome.cpp \
 	skins/Skins.cpp \
+	skins/pickers/MinimalFilterPicker.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
 	widgets/SkinComboBox.cpp \
@@ -357,6 +358,7 @@ HEADERS  += \
 	skins/ISkin.h \
 	skins/RackChrome.h \
 	skins/Skins.h \
+	skins/pickers/MinimalFilterPicker.h \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \
 	widgets/SkinComboBox.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -180,6 +180,7 @@ SOURCES += main.cpp\
 	SkinGallery.cpp \
 	SkinManager.cpp \
 	skins/ISkin.cpp \
+	skins/pickers/MatrixFilterPicker.cpp \
 	skins/RackChrome.cpp \
 	skins/Skins.cpp \
 	widgets/AudioKnob.cpp \
@@ -355,6 +356,7 @@ HEADERS  += \
 	SkinTokens.h \
 	SkinManager.h \
 	skins/ISkin.h \
+	skins/pickers/MatrixFilterPicker.h \
 	skins/RackChrome.h \
 	skins/Skins.h \
 	widgets/AudioKnob.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -182,6 +182,7 @@ SOURCES += main.cpp\
 	skins/ISkin.cpp \
 	skins/RackChrome.cpp \
 	skins/Skins.cpp \
+	skins/pickers/StudioFilterPicker.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
 	widgets/SkinComboBox.cpp \
@@ -357,6 +358,7 @@ HEADERS  += \
 	skins/ISkin.h \
 	skins/RackChrome.h \
 	skins/Skins.h \
+	skins/pickers/StudioFilterPicker.h \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \
 	widgets/SkinComboBox.h \

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -182,6 +182,7 @@ SOURCES += main.cpp\
 	skins/ISkin.cpp \
 	skins/RackChrome.cpp \
 	skins/Skins.cpp \
+	skins/pickers/SoftFilterPicker.cpp \
 	widgets/AudioKnob.cpp \
 	widgets/CommandRowFrame.cpp \
 	widgets/SkinComboBox.cpp \
@@ -357,6 +358,7 @@ HEADERS  += \
 	skins/ISkin.h \
 	skins/RackChrome.h \
 	skins/Skins.h \
+	skins/pickers/SoftFilterPicker.h \
 	widgets/AudioKnob.h \
 	widgets/CommandRowFrame.h \
 	widgets/SkinComboBox.h \

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -29,6 +29,7 @@
 #include <QJsonObject>
 
 #include "Editor/helpers/DisableWheelFilter.h"
+#include "Editor/widgets/FilterPickerView.h"
 #include "DeviceAPOInfo.h"
 #include "FilterTemplate.h"
 #include "IFilterGUI.h"
@@ -93,6 +94,9 @@ public:
 	Item* addLine(const QString& line, Item* before = nullptr);
 	void removeItem(Item* item);
 	QMenu* createAddPopupMenu();
+	// Every insertable template flattened from the factories, in factory order.
+	// Feeds the skinnable picker and the offscreen skin gallery.
+	QList<FilterPickerEntry> filterPickerEntries() const;
 	bool chooseFilterTemplate(FilterTemplate* selectedTemplate, const QPoint& globalPos = QPoint());
 	void cut();
 	void copy();

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -11,18 +11,23 @@
 #include <QToolBar>
 #include <QComboBox>
 #include <QAbstractSpinBox>
+#include <QCursor>
 #include <QDial>
-#include <QDialog>
-#include <QDialogButtonBox>
+#include <QEventLoop>
+#include <QGuiApplication>
 #include <QJsonDocument>
 #include <QLabel>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QRegularExpression>
+#include <QScreen>
 #include <QSettings>
 #include <QVBoxLayout>
 
+#include <functional>
+
 #include "MainWindow.h"
+#include "SkinManager.h"
 #include "FilterTableRow.h"
 #include "FilterTableMimeData.h"
 #include "guis/ExpressionFilterGUIFactory.h"
@@ -232,96 +237,94 @@ QMenu* FilterTable::createAddPopupMenu()
 	return rootMenu;
 }
 
+QList<FilterPickerEntry> FilterTable::filterPickerEntries() const
+{
+	QList<FilterPickerEntry> entries;
+	for (IFilterGUIFactory* factory : factories)
+	{
+		const QList<FilterTemplate> templates = factory->createFilterTemplates();
+		for (const FilterTemplate& filterTemplate : templates)
+			entries.append({ filterTemplate.getPath(), filterTemplate.getName(), filterTemplate.getLine() });
+	}
+	return entries;
+}
+
+namespace
+{
+// Dropdown-style host for the skin's picker view: a frameless Qt::Popup that
+// closes on outside clicks and Esc like any combo box popup. hideEvent is the
+// single funnel for "the popup went away", whatever the reason.
+class FilterPickerPopup : public QWidget
+{
+public:
+	explicit FilterPickerPopup(QWidget* parent)
+		: QWidget(parent, Qt::Popup | Qt::FramelessWindowHint)
+	{
+	}
+
+	std::function<void()> onHide;
+
+protected:
+	void hideEvent(QHideEvent* event) override
+	{
+		QWidget::hideEvent(event);
+		if (onHide)
+			onHide();
+	}
+};
+}
+
 bool FilterTable::chooseFilterTemplate(FilterTemplate* selectedTemplate, const QPoint& globalPos)
 {
 	if (selectedTemplate == nullptr)
 		return false;
 
-	struct PaletteEntry
-	{
-		FilterTemplate filterTemplate;
-		QString searchText;
-	};
-
-	QList<PaletteEntry> entries;
+	QList<FilterTemplate> templates;
 	for (IFilterGUIFactory* factory : factories)
-	{
-		const QList<FilterTemplate> templates = factory->createFilterTemplates();
-		for (const FilterTemplate& filterTemplate : templates)
-		{
-			QString path = filterTemplate.getPath().join(QStringLiteral(" / "));
-			QString label = path.isEmpty() ? filterTemplate.getName() : path + QStringLiteral(" / ") + filterTemplate.getName();
-			entries.append({ filterTemplate, label + QStringLiteral(" ") + filterTemplate.getLine() });
-		}
-	}
+		templates.append(factory->createFilterTemplates());
+	if (templates.isEmpty())
+		return false;
 
-	QDialog dialog(this);
-	dialog.setWindowTitle(tr("Add filter"));
-	dialog.setMinimumWidth(520);
-	if (!globalPos.isNull())
-		dialog.move(globalPos);
+	// The picker itself comes from the active skin so the control matches the
+	// skin's design language; this host only provides dropdown behaviour.
+	FilterPickerPopup popup(this);
+	popup.setObjectName(QStringLiteral("FilterPickerPopup"));
+	popup.setAttribute(Qt::WA_StyledBackground, true);
+	QVBoxLayout* layout = new QVBoxLayout(&popup);
+	layout->setContentsMargins(0, 0, 0, 0);
+	FilterPickerView* view = SkinManager::instance()->createFilterPicker(&popup);
+	view->setEntries(filterPickerEntries());
+	layout->addWidget(view);
 
-	QVBoxLayout* layout = new QVBoxLayout(&dialog);
-	QLabel* title = new QLabel(tr("Add filter"), &dialog);
-	title->setObjectName(QStringLiteral("FilterPaletteTitle"));
-	layout->addWidget(title);
-
-	QLineEdit* searchEdit = new QLineEdit(&dialog);
-	searchEdit->setObjectName(QStringLiteral("FilterPaletteSearch"));
-	searchEdit->setPlaceholderText(tr("Search filter or configuration line"));
-	layout->addWidget(searchEdit);
-
-	QListWidget* resultList = new QListWidget(&dialog);
-	resultList->setObjectName(QStringLiteral("FilterPaletteResults"));
-	layout->addWidget(resultList, 1);
-
-	auto refreshResults = [&]() {
-		resultList->clear();
-		QStringList terms = searchEdit->text().split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
-		for (int i = 0; i < entries.size(); i++)
-		{
-			bool matches = true;
-			for (const QString& term : terms)
-			{
-				if (!entries[i].searchText.contains(term, Qt::CaseInsensitive))
-				{
-					matches = false;
-					break;
-				}
-			}
-			if (!matches)
-				continue;
-
-			QString path = entries[i].filterTemplate.getPath().join(QStringLiteral(" / "));
-			QString label = path.isEmpty() ? entries[i].filterTemplate.getName() : path + QStringLiteral(" / ") + entries[i].filterTemplate.getName();
-			QListWidgetItem* item = new QListWidgetItem(label + QStringLiteral("\n") + entries[i].filterTemplate.getLine(), resultList);
-			item->setData(Qt::UserRole, i);
-		}
-		if (resultList->count() > 0)
-			resultList->setCurrentRow(0);
+	int chosenIndex = -1;
+	QEventLoop loop;
+	connect(view, &FilterPickerView::entryChosen, &loop, [&](int index) {
+		chosenIndex = index;
+		loop.quit();
+	});
+	connect(view, &FilterPickerView::dismissed, &loop, &QEventLoop::quit);
+	popup.onHide = [&loop]() {
+		loop.quit();
 	};
 
-	connect(searchEdit, &QLineEdit::textChanged, &dialog, refreshResults);
-	connect(resultList, &QListWidget::itemDoubleClicked, &dialog, [&](QListWidgetItem*) {
-		dialog.accept();
-	});
+	popup.adjustSize();
+	QPoint position = globalPos.isNull() ? QCursor::pos() : globalPos;
+	if (QScreen* screen = QGuiApplication::screenAt(position))
+	{
+		const QRect available = screen->availableGeometry();
+		position.setX(qBound(available.left(), position.x(), available.right() - popup.width() + 1));
+		position.setY(qBound(available.top(), position.y(), available.bottom() - popup.height() + 1));
+	}
+	popup.move(position);
+	popup.show();
+	view->setFocus();
+	loop.exec();
+	popup.onHide = nullptr;
 
-	QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
-	buttons->button(QDialogButtonBox::Ok)->setText(tr("Insert"));
-	connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-	connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-	layout->addWidget(buttons);
-
-	refreshResults();
-	searchEdit->setFocus();
-	if (dialog.exec() != QDialog::Accepted || resultList->currentItem() == nullptr)
+	if (chosenIndex < 0 || chosenIndex >= templates.size())
 		return false;
 
-	int entryIndex = resultList->currentItem()->data(Qt::UserRole).toInt();
-	if (entryIndex < 0 || entryIndex >= entries.size())
-		return false;
-
-	*selectedTemplate = entries[entryIndex].filterTemplate;
+	*selectedTemplate = templates[chosenIndex];
 	return true;
 }
 

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -12,6 +12,7 @@
 #include "Editor/skins/ISkin.h"
 #include "Editor/skins/Skins.h"
 #include "Editor/widgets/FilterCardRow.h"
+#include "Editor/widgets/FilterPickerView.h"
 
 namespace
 {
@@ -149,6 +150,23 @@ int renderSkin(const QDir& outDir, const QString& skinId, bool dark)
 	int failures = 0;
 	failures += renderStates(outDir, skinId, mode, galleryRows(), false);
 	failures += renderStates(outDir, skinId, mode, galleryRows(), true);
+
+	// The skin's "add filter" picker with the real template set, captured the
+	// same way the rows are. A throwaway FilterTable supplies the entries; its
+	// factories are the same ones chooseFilterTemplate consults at runtime.
+	{
+		QScrollArea scrollArea;
+		scrollArea.resize(960, 720);
+		buildRows(scrollArea, { QStringLiteral("Preamp: -6 dB") });
+		FilterTable* table = qobject_cast<FilterTable*>(scrollArea.widget());
+		FilterPickerView* picker = SkinManager::instance()->createFilterPicker(nullptr);
+		picker->setEntries(table != nullptr ? table->filterPickerEntries() : QList<FilterPickerEntry>());
+		picker->adjustSize();
+		picker->show();
+		QApplication::processEvents();
+		failures += saveGrab(picker, outDir, skinId, mode, QStringLiteral("picker"), QStringLiteral("normal")) ? 0 : 1;
+		delete picker;
+	}
 	return failures;
 }
 }

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -6,6 +6,7 @@
 
 #include "helpers/LogHelper.h"
 #include "Editor/helpers/CrashHandler.h"
+#include "Editor/widgets/FilterPickerView.h"
 #include "skins/ISkin.h"
 #include "skins/Skins.h"
 
@@ -149,4 +150,11 @@ void SkinManager::paintCardChrome(QPainter& painter, const QRect& rect, const Co
 {
 	if (activeSkin != nullptr)
 		activeSkin->paintCardChrome(painter, rect, info, currentTokens);
+}
+
+FilterPickerView* SkinManager::createFilterPicker(QWidget* parent) const
+{
+	if (activeSkin != nullptr)
+		return activeSkin->createFilterPicker(parent);
+	return new DefaultFilterPickerView(parent);
 }

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -5,6 +5,7 @@
 
 #include "SkinTokens.h"
 
+class FilterPickerView;
 class IRoutingRenderer;
 class ISkin;
 class QPainter;
@@ -43,6 +44,9 @@ public:
 	QString typeBadgeStyle(const CommandRowInfo& info, const QString& typeColor) const;
 	void prepareCommandRow(const CommandRowInfo& info, QWidget* card, QWidget* header, QWidget* body) const;
 	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info) const;
+
+	// The "add filter" picker view for the active skin (ISkin::createFilterPicker).
+	FilterPickerView* createFilterPicker(QWidget* parent) const;
 
 signals:
 	void skinChanged(const SkinTokens& tokens);

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -12,6 +12,8 @@
 #include <QPainter>
 #include <QtMath>
 
+#include "Editor/widgets/FilterPickerView.h"
+
 namespace
 {
 QPointF pointOnArc(const QRectF& rect, double degrees)
@@ -122,4 +124,10 @@ void ISkin::prepareCommandRow(const CommandRowInfo&, QWidget*, QWidget*, QWidget
 void ISkin::paintCardChrome(QPainter&, const QRect&, const CommandRowInfo&, const SkinTokens&) const
 {
 	// Neutral default: no painted decoration on top of the QSS chrome.
+}
+
+FilterPickerView* ISkin::createFilterPicker(QWidget* parent) const
+{
+	// Neutral default: the shared search-over-sections dropdown.
+	return new DefaultFilterPickerView(parent);
 }

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -16,6 +16,7 @@
 
 #include "Editor/SkinTokens.h"
 
+class FilterPickerView;
 class IRoutingRenderer;
 class QPainter;
 class QWidget;
@@ -119,4 +120,13 @@ public:
 	// per-type markers). Runs after the frame's stylesheet background and
 	// before child widgets paint. Default: no-op.
 	virtual void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens) const;
+
+	// The "add filter" picker that matches this skin's philosophy. The caller
+	// (FilterTable::chooseFilterTemplate) hosts the returned view in a
+	// dropdown-style Qt::Popup container anchored at the add button, feeds it
+	// the template entries and waits for entryChosen()/dismissed(). The
+	// default (ISkin.cpp) is the neutral DefaultFilterPickerView: a search
+	// field over one sectioned list. Ownership passes to the caller via the
+	// usual QWidget parent mechanism.
+	virtual FilterPickerView* createFilterPicker(QWidget* parent) const;
 };

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -16,6 +16,7 @@
 #include <QtMath>
 
 #include "Editor/skins/RackChrome.h"
+#include "Editor/skins/pickers/StudioFilterPicker.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -95,6 +96,14 @@ public:
 	{
 		static CurvedNodeRoutingRenderer renderer;
 		return &renderer;
+	}
+
+	// The "add filter" picker as a floating frosted-glass panel: painted
+	// stage + glow, a prominent sunken-glass search field and a sectioned
+	// list whose hover pools light under the cursor (StudioFilterPicker.cpp).
+	FilterPickerView* createFilterPicker(QWidget* parent) const override
+	{
+		return new StudioFilterPickerView(parent);
 	}
 
 	// "The arc IS the value": no knob body, only a thin track circle, a

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -16,6 +16,7 @@
 #include <QtMath>
 
 #include "Editor/skins/RackChrome.h"
+#include "Editor/skins/pickers/MatrixFilterPicker.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -1007,6 +1008,13 @@ public:
 	{
 		static CrosspointMatrixRoutingRenderer renderer;
 		return &renderer;
+	}
+	// The "add filter" picker as a two-axis selection instrument: a bus rail
+	// of categories and a column of coordinate-labelled entry cells, engaged
+	// like a crosspoint (MatrixFilterPicker.cpp).
+	FilterPickerView* createFilterPicker(QWidget* parent) const override
+	{
+		return new MatrixFilterPickerView(parent);
 	}
 	SkinTokens tokens(bool dark) const override
 	{

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -16,6 +16,7 @@
 #include <QtMath>
 
 #include "Editor/skins/RackChrome.h"
+#include "Editor/skins/pickers/SoftFilterPicker.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -630,6 +631,15 @@ public:
 		static BlockChipRoutingRenderer renderer;
 		return &renderer;
 	}
+
+	// The picker is this skin's consumer-settings moment: a rounded menu card
+	// with a pill search field, pastel category tiles and stadium row
+	// highlights (skins/pickers/SoftFilterPicker.cpp).
+	FilterPickerView* createFilterPicker(QWidget* parent) const override
+	{
+		return new SoftFilterPickerView(parent);
+	}
+
 	SkinTokens tokens(bool dark) const override
 	{
 		SkinTokens t;

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -16,6 +16,7 @@
 #include <QtMath>
 
 #include "Editor/skins/RackChrome.h"
+#include "Editor/skins/pickers/MinimalFilterPicker.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -514,6 +515,12 @@ public:
 	{
 		static StepListRoutingRenderer renderer;
 		return &renderer;
+	}
+	FilterPickerView* createFilterPicker(QWidget* parent) const override
+	{
+		// The add-filter dropdown as a numbered terminal index; see
+		// MinimalFilterPicker.h for the design.
+		return new MinimalFilterPickerView(parent);
 	}
 	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
 	{

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -16,6 +16,7 @@
 #include <QtMath>
 
 #include "Editor/skins/RackChrome.h"
+#include "Editor/skins/pickers/RackFilterPicker.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
@@ -913,6 +914,13 @@ public:
 	void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo& info, const SkinTokens& tokens) const override
 	{
 		RackChrome::paintCardChrome(painter, rect, info, tokens);
+	}
+
+	FilterPickerView* createFilterPicker(QWidget* parent) const override
+	{
+		// The module library browser: a brushed 1U faceplate with engraved
+		// section plates, LED-lit slots and an LCD search strip.
+		return new RackFilterPickerView(parent);
 	}
 
 	SkinTokens tokens(bool dark) const override

--- a/Editor/skins/pickers/MatrixFilterPicker.cpp
+++ b/Editor/skins/pickers/MatrixFilterPicker.cpp
@@ -1,0 +1,713 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "MatrixFilterPicker.h"
+
+#include <QFontMetrics>
+#include <QHash>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QRegularExpression>
+
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+
+namespace
+{
+// Unscaled metric constants; everything is multiplied by GUIHelper::scale so
+// the board keeps its 1px-rule density on high-DPI screens.
+namespace Metrics
+{
+constexpr double headerHeight = 32.0;
+constexpr double footerHeight = 22.0;
+constexpr double cellHeight = 30.0;
+// The faint column grid behind the entry cells; same pitch as the card
+// chrome's graph paper (MatrixMetrics::gridPitch).
+constexpr double gridPitch = 24.0;
+constexpr double railMinWidth = 132.0;
+constexpr double railMaxWidth = 204.0;
+constexpr double entryMinWidth = 240.0;
+// Keeps the whole instrument inside the host's ~300-460px width window.
+constexpr double panelMaxWidth = 458.0;
+constexpr double panelMaxHeight = 478.0;
+}
+
+int s(double pixel)
+{
+	return GUIHelper::scale(pixel);
+}
+
+QColor withAlpha(QColor color, int alpha)
+{
+	color.setAlpha(alpha);
+	return color;
+}
+}
+
+MatrixFilterPickerView::MatrixFilterPickerView(QWidget* parent)
+	: FilterPickerView(parent)
+{
+	setObjectName(QStringLiteral("MatrixFilterPicker"));
+	setFocusPolicy(Qt::StrongFocus);
+	setMouseTracking(true);
+}
+
+void MatrixFilterPickerView::setEntries(const QList<FilterPickerEntry>& entries)
+{
+	query.clear();
+	rebuildBuses(entries);
+	applyQuery();
+	computeMetrics();
+	setFixedSize(computedSize);
+	updateGeometry();
+	update();
+}
+
+QSize MatrixFilterPickerView::sizeHint() const
+{
+	return computedSize.isValid() ? computedSize : QSize(s(360.0), s(220.0));
+}
+
+void MatrixFilterPickerView::rebuildBuses(const QList<FilterPickerEntry>& entries)
+{
+	buses.clear();
+
+	QHash<QString, int> busOf;
+	int generalBus = -1;
+	for (int i = 0; i < entries.size(); i++)
+	{
+		const FilterPickerEntry& entry = entries[i];
+		const bool general = entry.path.isEmpty();
+		const QString key = general ? QString() : entry.path.join(QStringLiteral(" / "));
+		int busIndex = busOf.value(key, -1);
+		if (busIndex < 0)
+		{
+			Bus bus;
+			bus.label = (general ? tr("General") : key).toUpper();
+			buses.append(bus);
+			busIndex = buses.size() - 1;
+			busOf.insert(key, busIndex);
+			if (general)
+				generalBus = busIndex;
+		}
+		Cell cell;
+		cell.entryIndex = i;
+		cell.name = entry.name;
+		cell.line = entry.line;
+		buses[busIndex].cells.append(cell);
+	}
+
+	// The catch-all bus parks at the bottom of the rail; real categories keep
+	// their first-appearance order.
+	if (generalBus >= 0 && generalBus != buses.size() - 1)
+		buses.append(buses.takeAt(generalBus));
+
+	// Stable board coordinates: bus letter + 1-based cell number. They never
+	// renumber while scanning, like channel numbers on a desk.
+	for (int b = 0; b < buses.size(); b++)
+	{
+		buses[b].letter = QString(QChar('A' + (b % 26)));
+		for (int c = 0; c < buses[b].cells.size(); c++)
+			buses[b].cells[c].coordinate = buses[b].letter + QString::number(c + 1);
+	}
+
+	// The board opens on the densest bus (the parametric filters in practice)
+	// so the instrument never opens onto a near-empty column.
+	activeBus = -1;
+	int bestCount = -1;
+	for (int b = 0; b < buses.size(); b++)
+	{
+		if (buses[b].cells.size() > bestCount)
+		{
+			bestCount = buses[b].cells.size();
+			activeBus = b;
+		}
+	}
+	cursorRow = buses.isEmpty() ? -1 : 0;
+	hoverBus = -1;
+	hoverRow = -1;
+}
+
+void MatrixFilterPickerView::computeMetrics()
+{
+	headerH = s(Metrics::headerHeight);
+	footerH = s(Metrics::footerHeight);
+	cellH = s(Metrics::cellHeight);
+
+	const QFontMetrics busMetrics(monoFont(7.5, true, 0.5));
+	const QFontMetrics nameMetrics(monoFont(8.5, false));
+	const QFontMetrics coordMetrics(monoFont(7.0, true));
+
+	int maxLabel = 0;
+	int maxName = 0;
+	int maxCells = 0;
+	QString widestCoordinate = QStringLiteral("A1");
+	for (const Bus& bus : buses)
+	{
+		maxLabel = qMax(maxLabel, busMetrics.horizontalAdvance(bus.label));
+		maxCells = qMax(maxCells, bus.cells.size());
+		for (const Cell& cell : bus.cells)
+		{
+			maxName = qMax(maxName, nameMetrics.horizontalAdvance(cell.name));
+			if (cell.coordinate.size() > widestCoordinate.size())
+				widestCoordinate = cell.coordinate;
+		}
+	}
+	coordW = qMax(s(22.0), coordMetrics.horizontalAdvance(widestCoordinate) + s(8.0));
+
+	const int countW = coordMetrics.horizontalAdvance(QStringLiteral("88"));
+	railW = qBound(s(Metrics::railMinWidth),
+			s(8.0) + s(16.0) + s(6.0) + maxLabel + s(6.0) + countW + s(8.0),
+			s(Metrics::railMaxWidth));
+	entryW = qBound(s(Metrics::entryMinWidth),
+			s(8.0) + coordW + s(8.0) + maxName + s(10.0),
+			qMax(s(Metrics::entryMinWidth), s(Metrics::panelMaxWidth) - railW - 3));
+
+	// Both columns share one fixed body height so switching buses never
+	// resizes the popup; the grid simply has dark cells where a bus is short.
+	bodyRows = qMax(buses.size(), maxCells);
+	if (bodyRows < 1)
+		bodyRows = 1;
+	if (headerH + bodyRows * cellH + footerH + 2 > s(Metrics::panelMaxHeight))
+		cellH = qMax(s(20.0), (s(Metrics::panelMaxHeight) - headerH - footerH - 2) / bodyRows);
+
+	computedSize = QSize(railW + entryW + 3, headerH + bodyRows * cellH + footerH + 2);
+}
+
+void MatrixFilterPickerView::applyQuery()
+{
+	const QStringList terms = query.split(
+		QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+
+	for (Bus& bus : buses)
+	{
+		for (Cell& cell : bus.cells)
+		{
+			const QString haystack = bus.label + QLatin1Char(' ') + cell.name + QLatin1Char(' ') + cell.line;
+			cell.matches = true;
+			for (const QString& term : terms)
+			{
+				if (!haystack.contains(term, Qt::CaseInsensitive))
+				{
+					cell.matches = false;
+					break;
+				}
+			}
+		}
+	}
+
+	// Keep the operator's bus when it still answers; otherwise jump to the
+	// first bus that does.
+	if (activeBus < 0 || !busHasMatches(activeBus))
+		activeBus = firstBusWithMatches();
+	const int visibleCount = activeBus >= 0 ? visibleRows(activeBus).size() : 0;
+	if (visibleCount == 0)
+		cursorRow = -1;
+	else
+		cursorRow = qBound(0, cursorRow, visibleCount - 1);
+}
+
+QVector<int> MatrixFilterPickerView::visibleRows(int busIndex) const
+{
+	QVector<int> rows;
+	if (busIndex < 0 || busIndex >= buses.size())
+		return rows;
+	for (int c = 0; c < buses[busIndex].cells.size(); c++)
+	{
+		if (buses[busIndex].cells[c].matches)
+			rows.append(c);
+	}
+	return rows;
+}
+
+bool MatrixFilterPickerView::busHasMatches(int busIndex) const
+{
+	if (busIndex < 0 || busIndex >= buses.size())
+		return false;
+	for (const Cell& cell : buses[busIndex].cells)
+	{
+		if (cell.matches)
+			return true;
+	}
+	return false;
+}
+
+int MatrixFilterPickerView::firstBusWithMatches() const
+{
+	for (int b = 0; b < buses.size(); b++)
+	{
+		if (busHasMatches(b))
+			return b;
+	}
+	return -1;
+}
+
+const MatrixFilterPickerView::Cell* MatrixFilterPickerView::cursorCell() const
+{
+	if (activeBus < 0 || cursorRow < 0)
+		return nullptr;
+	const QVector<int> rows = visibleRows(activeBus);
+	if (cursorRow >= rows.size())
+		return nullptr;
+	return &buses[activeBus].cells[rows[cursorRow]];
+}
+
+void MatrixFilterPickerView::chooseCursor()
+{
+	const Cell* cell = cursorCell();
+	if (cell != nullptr)
+		emit entryChosen(cell->entryIndex);
+}
+
+void MatrixFilterPickerView::moveCursor(int delta)
+{
+	if (buses.isEmpty())
+		return;
+	if (activeBus < 0)
+	{
+		activeBus = firstBusWithMatches();
+		cursorRow = activeBus >= 0 ? 0 : -1;
+		update();
+		return;
+	}
+	const int count = visibleRows(activeBus).size();
+	const int next = cursorRow + delta;
+	if (next >= 0 && next < count)
+	{
+		cursorRow = next;
+		update();
+		return;
+	}
+	// Walking off either end of a bus continues onto the adjacent bus, so
+	// Up/Down alone traverses the whole catalog.
+	int b = activeBus;
+	for (int step = 0; step < buses.size(); step++)
+	{
+		b = (b + (delta > 0 ? 1 : -1) + buses.size()) % buses.size();
+		const int n = visibleRows(b).size();
+		if (n > 0)
+		{
+			activeBus = b;
+			cursorRow = delta > 0 ? 0 : n - 1;
+			update();
+			return;
+		}
+	}
+}
+
+void MatrixFilterPickerView::switchBus(int delta)
+{
+	if (buses.isEmpty())
+		return;
+	int b = activeBus < 0 ? firstBusWithMatches() : activeBus;
+	if (b < 0)
+		return;
+	for (int step = 0; step < buses.size(); step++)
+	{
+		b = (b + (delta > 0 ? 1 : -1) + buses.size()) % buses.size();
+		if (busHasMatches(b))
+		{
+			activeBus = b;
+			cursorRow = 0;
+			update();
+			return;
+		}
+	}
+}
+
+QRect MatrixFilterPickerView::headerRect() const
+{
+	return QRect(1, 1, width() - 2, headerH);
+}
+
+QRect MatrixFilterPickerView::bodyRect() const
+{
+	return QRect(1, 1 + headerH, width() - 2, height() - 2 - headerH - footerH);
+}
+
+QRect MatrixFilterPickerView::railRect() const
+{
+	const QRect body = bodyRect();
+	return QRect(body.left(), body.top(), railW, body.height());
+}
+
+QRect MatrixFilterPickerView::entriesRect() const
+{
+	const QRect body = bodyRect();
+	return QRect(body.left() + railW + 1, body.top(), body.width() - railW - 1, body.height());
+}
+
+QRect MatrixFilterPickerView::footerRect() const
+{
+	return QRect(1, height() - 1 - footerH, width() - 2, footerH);
+}
+
+QRect MatrixFilterPickerView::busCellRect(int busIndex) const
+{
+	const QRect rail = railRect();
+	return QRect(rail.left(), rail.top() + busIndex * cellH, rail.width(), cellH);
+}
+
+QRect MatrixFilterPickerView::entryCellRect(int visibleRow) const
+{
+	const QRect entries = entriesRect();
+	return QRect(entries.left(), entries.top() + visibleRow * cellH, entries.width(), cellH);
+}
+
+QFont MatrixFilterPickerView::monoFont(double pointSize, bool bold, double letterSpacing) const
+{
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	QFont font(tokens.monoFontFamily);
+	font.setFamilies(QStringList()
+		<< tokens.monoFontFamily
+		<< QStringLiteral("Consolas")
+		<< QStringLiteral("Malgun Gothic"));
+	font.setPointSizeF(pointSize);
+	font.setBold(bold);
+	if (letterSpacing > 0.0)
+		font.setLetterSpacing(QFont::AbsoluteSpacing, letterSpacing);
+	return font;
+}
+
+void MatrixFilterPickerView::paintEvent(QPaintEvent* event)
+{
+	Q_UNUSED(event);
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const QColor border(tokens.border);
+	const QColor accent(tokens.accent);
+	const QColor textColor(tokens.text);
+	const QColor muted(tokens.mutedText);
+	const QColor dimmed = withAlpha(muted, 110);
+	const QColor sunken(tokens.surfaceSunken);
+
+	QPainter painter(this);
+	painter.setRenderHint(QPainter::Antialiasing, false);
+
+	painter.fillRect(rect(), QColor(tokens.surface));
+
+	// ---- Header: panel designation + scan readout strip ----
+	const QRect header = headerRect();
+	painter.fillRect(header, QColor(tokens.cardHover));
+
+	const int pad = s(10.0);
+	const QRect lamp(header.left() + pad, header.center().y() - s(2.0), s(5.0), s(5.0));
+	painter.fillRect(lamp, accent);
+	painter.setFont(monoFont(7.5, true, 2.0));
+	painter.setPen(muted);
+	painter.drawText(QRect(lamp.right() + s(8.0), header.top(), header.width() / 2, header.height()),
+		Qt::AlignVCenter | Qt::AlignLeft, QStringLiteral("INSERT"));
+
+	// Scan readout: a sunken status cell, not a search box. Typing anywhere
+	// in the panel writes into it.
+	const int boxW = qMin(s(160.0), header.width() / 2);
+	const QRect box(header.right() - pad - boxW,
+		header.top() + (header.height() - s(18.0)) / 2, boxW, s(18.0));
+	painter.fillRect(box, sunken);
+	painter.setPen(QPen(query.isEmpty() ? border : accent, 1));
+	painter.drawRect(box.adjusted(0, 0, -1, -1));
+	const QFont scanFont = monoFont(8.0, false);
+	const QFontMetrics scanMetrics(scanFont);
+	painter.setFont(scanFont);
+	int textX = box.left() + s(6.0);
+	painter.setPen(accent);
+	painter.drawText(QRect(textX, box.top(), box.width(), box.height()),
+		Qt::AlignVCenter | Qt::AlignLeft, QStringLiteral(">"));
+	textX += scanMetrics.horizontalAdvance(QStringLiteral("> "));
+	const int caretWidth = s(6.0);
+	const int queryAvail = box.right() - s(6.0) - caretWidth - textX;
+	const QString shownQuery = scanMetrics.elidedText(query, Qt::ElideLeft, qMax(0, queryAvail));
+	painter.setPen(textColor);
+	painter.drawText(QRect(textX, box.top(), qMax(0, queryAvail), box.height()),
+		Qt::AlignVCenter | Qt::AlignLeft, shownQuery);
+	textX += scanMetrics.horizontalAdvance(shownQuery) + 1;
+	painter.fillRect(QRect(textX, box.top() + s(4.0), caretWidth, box.height() - s(8.0)), accent);
+	if (query.isEmpty())
+	{
+		painter.setPen(dimmed);
+		painter.drawText(box.adjusted(0, 0, -s(6.0), 0),
+			Qt::AlignVCenter | Qt::AlignRight, QStringLiteral("SCAN"));
+	}
+
+	painter.setPen(QPen(border, 1));
+	painter.drawLine(header.left(), header.bottom(), header.right(), header.bottom());
+
+	// ---- Bus rail (left column of category selects) ----
+	const QRect rail = railRect();
+	const QFont busFont = monoFont(7.5, true, 0.5);
+	const QFont coordFont = monoFont(7.0, true);
+	const QFontMetrics coordMetrics(coordFont);
+	const int countW = coordMetrics.horizontalAdvance(QStringLiteral("88"));
+	for (int b = 0; b < buses.size(); b++)
+	{
+		const QRect cell = busCellRect(b);
+		const bool active = b == activeBus;
+		const bool answering = busHasMatches(b);
+		const bool hovered = b == hoverBus && answering && !active;
+
+		if (active)
+		{
+			painter.fillRect(cell, withAlpha(accent, 26));
+			painter.fillRect(QRect(cell.left(), cell.top(), s(3.0), cell.height()), accent);
+		}
+		else if (hovered)
+		{
+			painter.fillRect(cell, withAlpha(accent, 10));
+		}
+		painter.setPen(QPen(border, 1));
+		painter.drawLine(cell.left(), cell.bottom(), cell.right(), cell.bottom());
+
+		// Bus designation cell.
+		const QRect letterBox(cell.left() + s(8.0), cell.center().y() - s(8.0), s(16.0), s(16.0));
+		painter.fillRect(letterBox, sunken);
+		painter.setPen(QPen(active ? accent : border, 1));
+		painter.drawRect(letterBox.adjusted(0, 0, -1, -1));
+		painter.setFont(coordFont);
+		painter.setPen(!answering ? dimmed : (active ? accent : muted));
+		painter.drawText(letterBox, Qt::AlignCenter, buses[b].letter);
+
+		// Channel count: how many cells of this bus answer the scan.
+		const int visibleCount = visibleRows(b).size();
+		painter.setPen(!answering ? dimmed : muted);
+		painter.drawText(QRect(cell.right() - s(8.0) - countW, cell.top(), countW, cell.height()),
+			Qt::AlignVCenter | Qt::AlignRight, QString::number(visibleCount));
+
+		// Bus caption.
+		painter.setFont(busFont);
+		const QFontMetrics busMetrics(busFont);
+		const int labelX = letterBox.right() + s(6.0);
+		const int labelAvail = cell.right() - s(8.0) - countW - s(4.0) - labelX;
+		painter.setPen(!answering ? dimmed : (active ? textColor : muted));
+		painter.drawText(QRect(labelX, cell.top(), qMax(0, labelAvail), cell.height()),
+			Qt::AlignVCenter | Qt::AlignLeft,
+			busMetrics.elidedText(buses[b].label, Qt::ElideRight, qMax(0, labelAvail)));
+	}
+
+	// ---- Entry column (the active bus's cells) ----
+	const QRect entries = entriesRect();
+	painter.fillRect(entries, QColor(tokens.card));
+
+	// Faint column grid: the graph paper the cells sit on.
+	painter.setPen(QPen(withAlpha(border, 50), 1));
+	for (int x = entries.left() + s(Metrics::gridPitch); x < entries.right(); x += s(Metrics::gridPitch))
+		painter.drawLine(x, entries.top(), x, entries.bottom());
+
+	const QVector<int> rows = visibleRows(activeBus);
+	const QFont nameFont = monoFont(8.5, false);
+	const QFontMetrics nameMetrics(nameFont);
+	for (int r = 0; r < rows.size(); r++)
+	{
+		const Cell& cell = buses[activeBus].cells[rows[r]];
+		const QRect cellRect = entryCellRect(r);
+		const bool engaged = r == cursorRow;
+		const bool hovered = r == hoverRow && !engaged;
+
+		if (engaged)
+			painter.fillRect(cellRect, withAlpha(accent, 30));
+		else if (hovered)
+			painter.fillRect(cellRect, withAlpha(accent, 12));
+		painter.setPen(QPen(border, 1));
+		painter.drawLine(cellRect.left(), cellRect.bottom(), cellRect.right(), cellRect.bottom());
+		if (engaged)
+		{
+			painter.setPen(QPen(accent, 1));
+			painter.drawRect(cellRect.adjusted(0, 0, -1, -1));
+		}
+
+		// Coordinate cell.
+		const QRect coordBox(cellRect.left() + s(8.0), cellRect.center().y() - s(8.0), coordW, s(16.0));
+		painter.fillRect(coordBox, sunken);
+		painter.setPen(QPen(engaged ? accent : border, 1));
+		painter.drawRect(coordBox.adjusted(0, 0, -1, -1));
+		painter.setFont(coordFont);
+		painter.setPen(engaged ? accent : muted);
+		painter.drawText(coordBox, Qt::AlignCenter, cell.coordinate);
+
+		// Template name in board mono.
+		painter.setFont(nameFont);
+		painter.setPen(textColor);
+		const int nameX = coordBox.right() + s(8.0);
+		const int nameAvail = cellRect.right() - s(8.0) - nameX;
+		painter.drawText(QRect(nameX, cellRect.top(), qMax(0, nameAvail), cellRect.height()),
+			Qt::AlignVCenter | Qt::AlignLeft,
+			nameMetrics.elidedText(cell.name, Qt::ElideRight, qMax(0, nameAvail)));
+	}
+
+	// Divider rule between rail and entry column.
+	const int dividerX = rail.right() + 1;
+	painter.setPen(QPen(border, 1));
+	painter.drawLine(dividerX, bodyRect().top(), dividerX, bodyRect().bottom());
+
+	// Patch trace: the engaged crosspoint is wired from its bus cell to the
+	// cursor cell across the divider.
+	if (activeBus >= 0 && cursorRow >= 0 && cursorRow < rows.size())
+	{
+		const int busY = busCellRect(activeBus).center().y();
+		const int cursorY = entryCellRect(cursorRow).center().y();
+		painter.fillRect(QRect(dividerX - s(6.0), busY, s(6.0), 2), accent);
+		painter.fillRect(QRect(dividerX, qMin(busY, cursorY), 2, qAbs(cursorY - busY) + 2), accent);
+		painter.fillRect(QRect(dividerX + 2, cursorY, s(6.0), 2), accent);
+	}
+
+	// ---- Footer: readout of the line the engaged coordinate inserts ----
+	const QRect footer = footerRect();
+	painter.fillRect(footer, sunken);
+	painter.setPen(QPen(border, 1));
+	painter.drawLine(footer.left(), footer.top(), footer.right(), footer.top());
+	const QFont footFont = monoFont(7.5, false);
+	const QFontMetrics footMetrics(footFont);
+	painter.setFont(footFont);
+	const Cell* engagedCell = cursorCell();
+	const QString coordText = engagedCell != nullptr ? engagedCell->coordinate : QStringLiteral("--");
+	const int coordTextW = footMetrics.horizontalAdvance(coordText);
+	painter.setPen(engagedCell != nullptr ? accent : dimmed);
+	painter.drawText(QRect(footer.right() - pad - coordTextW, footer.top(), coordTextW, footer.height()),
+		Qt::AlignVCenter | Qt::AlignRight, coordText);
+	const QString lineText = engagedCell != nullptr
+		? QStringLiteral("> ") + engagedCell->line
+		: QStringLiteral("> NO MATCH");
+	const int lineAvail = footer.width() - 2 * pad - coordTextW - s(12.0);
+	painter.setPen(muted);
+	painter.drawText(QRect(footer.left() + pad, footer.top(), qMax(0, lineAvail), footer.height()),
+		Qt::AlignVCenter | Qt::AlignLeft,
+		footMetrics.elidedText(lineText, Qt::ElideRight, qMax(0, lineAvail)));
+
+	// Outer 1px rule, square corners: the panel's own cell boundary.
+	painter.setPen(QPen(border, 1));
+	painter.drawRect(rect().adjusted(0, 0, -1, -1));
+}
+
+void MatrixFilterPickerView::keyPressEvent(QKeyEvent* event)
+{
+	switch (event->key())
+	{
+	case Qt::Key_Down:
+		moveCursor(1);
+		return;
+	case Qt::Key_Up:
+		moveCursor(-1);
+		return;
+	case Qt::Key_Right:
+	case Qt::Key_PageDown:
+		switchBus(1);
+		return;
+	case Qt::Key_Left:
+	case Qt::Key_PageUp:
+		switchBus(-1);
+		return;
+	case Qt::Key_Home:
+		if (!visibleRows(activeBus).isEmpty())
+		{
+			cursorRow = 0;
+			update();
+		}
+		return;
+	case Qt::Key_End:
+	{
+		const int count = visibleRows(activeBus).size();
+		if (count > 0)
+		{
+			cursorRow = count - 1;
+			update();
+		}
+		return;
+	}
+	case Qt::Key_Return:
+	case Qt::Key_Enter:
+		chooseCursor();
+		return;
+	case Qt::Key_Backspace:
+		if (!query.isEmpty())
+		{
+			query.chop(1);
+			applyQuery();
+			update();
+		}
+		return;
+	default:
+		break;
+	}
+
+	// Printable input writes into the scan readout. Esc is deliberately not
+	// handled: the popup host owns dismissal.
+	const QString input = event->text();
+	if (!input.isEmpty() && input.at(0).isPrint()
+		&& !(event->modifiers() & (Qt::ControlModifier | Qt::AltModifier)))
+	{
+		query += input;
+		applyQuery();
+		update();
+		return;
+	}
+	FilterPickerView::keyPressEvent(event);
+}
+
+void MatrixFilterPickerView::mouseMoveEvent(QMouseEvent* event)
+{
+	const QPoint pos = event->pos();
+	int newHoverBus = -1;
+	int newHoverRow = -1;
+	if (railRect().contains(pos))
+	{
+		const int b = (pos.y() - railRect().top()) / qMax(1, cellH);
+		if (b >= 0 && b < buses.size())
+			newHoverBus = b;
+	}
+	else if (entriesRect().contains(pos))
+	{
+		const int r = (pos.y() - entriesRect().top()) / qMax(1, cellH);
+		if (r >= 0 && r < visibleRows(activeBus).size())
+			newHoverRow = r;
+	}
+	if (newHoverBus != hoverBus || newHoverRow != hoverRow)
+	{
+		hoverBus = newHoverBus;
+		hoverRow = newHoverRow;
+		update();
+	}
+	FilterPickerView::mouseMoveEvent(event);
+}
+
+void MatrixFilterPickerView::mousePressEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton)
+	{
+		const QPoint pos = event->pos();
+		if (railRect().contains(pos))
+		{
+			const int b = (pos.y() - railRect().top()) / qMax(1, cellH);
+			if (b >= 0 && b < buses.size() && busHasMatches(b) && b != activeBus)
+			{
+				activeBus = b;
+				cursorRow = 0;
+				update();
+			}
+			return;
+		}
+		if (entriesRect().contains(pos))
+		{
+			const int r = (pos.y() - entriesRect().top()) / qMax(1, cellH);
+			const QVector<int> rows = visibleRows(activeBus);
+			if (r >= 0 && r < rows.size())
+			{
+				// Dropdown semantics: engaging a crosspoint inserts.
+				cursorRow = r;
+				emit entryChosen(buses[activeBus].cells[rows[r]].entryIndex);
+			}
+			return;
+		}
+	}
+	FilterPickerView::mousePressEvent(event);
+}
+
+void MatrixFilterPickerView::leaveEvent(QEvent* event)
+{
+	if (hoverBus != -1 || hoverRow != -1)
+	{
+		hoverBus = -1;
+		hoverRow = -1;
+		update();
+	}
+	FilterPickerView::leaveEvent(event);
+}

--- a/Editor/skins/pickers/MatrixFilterPicker.h
+++ b/Editor/skins/pickers/MatrixFilterPicker.h
@@ -1,0 +1,96 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Signal Matrix "add filter" picker: a two-axis selection instrument, not a
+	menu. The left rail is a column of bus-select cells (one per template
+	category); the right column shows that bus's templates as rectangular
+	grid cells with stable mono coordinates (A1..G8). Selecting an entry
+	reads as engaging a crosspoint: the active bus is lit, a patch trace runs
+	from the bus cell to the cursor cell, and the footer readout shows the
+	config line that the engaged coordinate would insert. Typing scans the
+	board through a status readout in the panel header (no rounded search
+	box). The catalog itself stays monochrome; the accent is reserved for the
+	engaged/selected state, traffic-light colours are not used at all.
+*/
+
+#pragma once
+
+#include <QVector>
+
+#include "Editor/widgets/FilterPickerView.h"
+
+class MatrixFilterPickerView : public FilterPickerView
+{
+	Q_OBJECT
+
+public:
+	explicit MatrixFilterPickerView(QWidget* parent = nullptr);
+
+	void setEntries(const QList<FilterPickerEntry>& entries) override;
+
+	QSize sizeHint() const override;
+
+protected:
+	void paintEvent(QPaintEvent* event) override;
+	void keyPressEvent(QKeyEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
+	void mousePressEvent(QMouseEvent* event) override;
+	void leaveEvent(QEvent* event) override;
+
+private:
+	// One insertable template, parked at a fixed coordinate of the board.
+	struct Cell
+	{
+		int entryIndex = -1; // original index into the setEntries() list
+		QString coordinate;  // stable board coordinate, e.g. "C4"
+		QString name;
+		QString line;
+		bool matches = true; // current scan-query verdict
+	};
+
+	// One category: a selectable bus on the left rail.
+	struct Bus
+	{
+		QString label;  // upper-cased category caption
+		QString letter; // bus designation, "A".."Z"
+		QVector<Cell> cells;
+	};
+
+	void rebuildBuses(const QList<FilterPickerEntry>& entries);
+	void computeMetrics();
+	void applyQuery();
+	QVector<int> visibleRows(int busIndex) const;
+	bool busHasMatches(int busIndex) const;
+	int firstBusWithMatches() const;
+	const Cell* cursorCell() const;
+	void chooseCursor();
+	void moveCursor(int delta);
+	void switchBus(int delta);
+
+	QRect headerRect() const;
+	QRect bodyRect() const;
+	QRect railRect() const;
+	QRect entriesRect() const;
+	QRect footerRect() const;
+	QRect busCellRect(int busIndex) const;
+	QRect entryCellRect(int visibleRow) const;
+
+	QFont monoFont(double pointSize, bool bold, double letterSpacing = 0.0) const;
+
+	QVector<Bus> buses;
+	QString query;
+	int activeBus = -1;
+	int cursorRow = -1; // index into visibleRows(activeBus)
+	int hoverBus = -1;  // bus cell under the mouse, -1 when none
+	int hoverRow = -1;  // visible entry row under the mouse, -1 when none
+
+	// Scaled metrics, computed per entry set.
+	int headerH = 0;
+	int footerH = 0;
+	int cellH = 0;
+	int railW = 0;
+	int entryW = 0;
+	int coordW = 0;
+	int bodyRows = 0;
+	QSize computedSize;
+};

--- a/Editor/skins/pickers/MinimalFilterPicker.cpp
+++ b/Editor/skins/pickers/MinimalFilterPicker.cpp
@@ -1,0 +1,459 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "MinimalFilterPicker.h"
+
+#include <QHash>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QRegularExpression>
+#include <QScrollArea>
+#include <QVBoxLayout>
+
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+
+namespace
+{
+// Dense terminal metrics: a 20px entry line at 9pt mono, captions slightly
+// taller so the hairline underline gets one clear pixel row of its own.
+int entryRowHeight()
+{
+	return GUIHelper::scale(20.0);
+}
+
+int sectionRowHeight()
+{
+	return GUIHelper::scale(26.0);
+}
+
+int sidePadding()
+{
+	return GUIHelper::scale(10.0);
+}
+
+QFont pickerMonoFont(double pointSize, bool bold = false)
+{
+	QFont font(SkinManager::instance()->tokens().monoFontFamily);
+	font.setPointSizeF(pointSize);
+	font.setBold(bold);
+	return font;
+}
+}
+
+// ── MinimalPickerIndexList ───────────────────────────────────────────────────
+
+MinimalPickerIndexList::MinimalPickerIndexList(QWidget* parent)
+	: QWidget(parent)
+{
+	setMouseTracking(true);
+}
+
+void MinimalPickerIndexList::setRows(const QList<Row>& rows)
+{
+	rowList = rows;
+	rowTops.clear();
+	rowTops.reserve(rowList.size());
+	int y = GUIHelper::scale(2.0);
+	for (const Row& row : rowList)
+	{
+		rowTops.append(y);
+		y += row.entryIndex < 0 ? sectionRowHeight() : entryRowHeight();
+	}
+	contentHeight = y + GUIHelper::scale(4.0);
+	// Inside a widgetResizable scroll area the minimum height is what makes
+	// the viewport scroll instead of squashing the rows.
+	setMinimumHeight(contentHeight);
+	hoverRow = -1;
+	updateGeometry();
+	update();
+}
+
+void MinimalPickerIndexList::setSelectedEntry(int entryIndex)
+{
+	if (selectedEntryIndex == entryIndex)
+		return;
+	selectedEntryIndex = entryIndex;
+	update();
+}
+
+int MinimalPickerIndexList::rowOfEntry(int entryIndex) const
+{
+	if (entryIndex < 0)
+		return -1;
+	for (int i = 0; i < rowList.size(); i++)
+	{
+		if (rowList[i].entryIndex == entryIndex)
+			return i;
+	}
+	return -1;
+}
+
+QRect MinimalPickerIndexList::rowRect(int row) const
+{
+	if (row < 0 || row >= rowList.size())
+		return QRect();
+	const int rowHeight = rowList[row].entryIndex < 0 ? sectionRowHeight() : entryRowHeight();
+	return QRect(0, rowTops[row], width(), rowHeight);
+}
+
+QSize MinimalPickerIndexList::sizeHint() const
+{
+	return QSize(GUIHelper::scale(380.0), contentHeight);
+}
+
+int MinimalPickerIndexList::rowAt(const QPoint& pos) const
+{
+	for (int i = 0; i < rowList.size(); i++)
+	{
+		if (rowRect(i).contains(pos))
+			return i;
+	}
+	return -1;
+}
+
+void MinimalPickerIndexList::paintEvent(QPaintEvent* event)
+{
+	QPainter painter(this);
+	const SkinTokens& t = SkinManager::instance()->tokens();
+	painter.fillRect(rect(), QColor(t.background));
+
+	QFont entryFont = pickerMonoFont(9.0);
+	QFont captionFont = pickerMonoFont(7.5, true);
+	captionFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.5);
+	const QFontMetrics entryMetrics(entryFont);
+
+	const int pad = sidePadding();
+	const int numberGap = GUIHelper::scale(8.0);
+
+	for (int i = 0; i < rowList.size(); i++)
+	{
+		const Row& row = rowList[i];
+		const QRect r = rowRect(i);
+		if (!r.intersects(event->rect()))
+			continue;
+
+		if (row.entryIndex < 0)
+		{
+			// Section caption: uppercase letter-spaced mono over a full-width
+			// hairline rule. The rule is the only "decoration" the index has,
+			// and it is really a separator, i.e. information.
+			painter.setFont(captionFont);
+			painter.setPen(QColor(t.mutedText));
+			painter.drawText(r.adjusted(pad, GUIHelper::scale(5.0), -pad, -GUIHelper::scale(3.0)),
+				Qt::AlignVCenter | Qt::AlignLeft, row.text);
+			painter.fillRect(QRect(r.left(), r.bottom(), r.width(), 1), QColor(t.border));
+		}
+		else
+		{
+			const bool selected = row.entryIndex == selectedEntryIndex;
+			if (selected)
+			{
+				// Inverted block: the line trades foreground for background,
+				// the bluntest possible cursor a text instrument can have.
+				painter.fillRect(r, QColor(t.text));
+			}
+			else if (i == hoverRow)
+			{
+				painter.fillRect(r, QColor(t.cardHover));
+			}
+
+			painter.setFont(entryFont);
+			QColor numberColor = selected ? QColor(t.background) : QColor(t.mutedText);
+			if (selected)
+				numberColor.setAlpha(170);
+			painter.setPen(numberColor);
+			const int numberWidth = entryMetrics.horizontalAdvance(row.number);
+			painter.drawText(QRect(r.left() + pad, r.top(), numberWidth, r.height()),
+				Qt::AlignVCenter | Qt::AlignLeft, row.number);
+
+			painter.setPen(selected ? QColor(t.background) : QColor(t.text));
+			const int nameLeft = r.left() + pad + numberWidth + numberGap;
+			const int nameWidth = r.right() - pad - nameLeft;
+			painter.drawText(QRect(nameLeft, r.top(), nameWidth, r.height()),
+				Qt::AlignVCenter | Qt::AlignLeft,
+				entryMetrics.elidedText(row.text, Qt::ElideRight, nameWidth));
+		}
+	}
+}
+
+void MinimalPickerIndexList::mousePressEvent(QMouseEvent* event)
+{
+	if (event->button() != Qt::LeftButton)
+		return;
+	const int row = rowAt(event->pos());
+	if (row < 0 || rowList[row].entryIndex < 0)
+		return;
+	selectedEntryIndex = rowList[row].entryIndex;
+	update();
+	if (onEntryActivated)
+		onEntryActivated(rowList[row].entryIndex);
+}
+
+void MinimalPickerIndexList::mouseMoveEvent(QMouseEvent* event)
+{
+	int row = rowAt(event->pos());
+	if (row >= 0 && rowList[row].entryIndex < 0)
+		row = -1;
+	if (row != hoverRow)
+	{
+		hoverRow = row;
+		update();
+	}
+}
+
+void MinimalPickerIndexList::leaveEvent(QEvent* event)
+{
+	Q_UNUSED(event);
+	if (hoverRow != -1)
+	{
+		hoverRow = -1;
+		update();
+	}
+}
+
+// ── MinimalFilterPickerView ──────────────────────────────────────────────────
+
+MinimalFilterPickerView::MinimalFilterPickerView(QWidget* parent)
+	: FilterPickerView(parent)
+{
+	setObjectName(QStringLiteral("MinimalFilterPicker"));
+
+	QVBoxLayout* layout = new QVBoxLayout(this);
+	// 1px margins keep the children inside the hairline frame painted by
+	// paintEvent (the popup container itself is chromeless).
+	layout->setContentsMargins(1, 1, 1, 1);
+	layout->setSpacing(0);
+
+	// Query line: a bare ">" prompt, a frameless line edit and a match
+	// counter; the hairline under the row comes from the skin QSS.
+	QWidget* header = new QWidget(this);
+	header->setObjectName(QStringLiteral("MinimalPickerHeader"));
+	header->setAttribute(Qt::WA_StyledBackground, true);
+	QHBoxLayout* headerLayout = new QHBoxLayout(header);
+	headerLayout->setContentsMargins(sidePadding(), GUIHelper::scale(6.0), sidePadding(), GUIHelper::scale(6.0));
+	headerLayout->setSpacing(GUIHelper::scale(8.0));
+
+	QLabel* prompt = new QLabel(QStringLiteral(">"), header);
+	prompt->setObjectName(QStringLiteral("MinimalPickerPrompt"));
+	headerLayout->addWidget(prompt);
+
+	queryEdit = new QLineEdit(header);
+	queryEdit->setObjectName(QStringLiteral("MinimalPickerQuery"));
+	queryEdit->setFrame(false);
+	queryEdit->installEventFilter(this);
+	connect(queryEdit, &QLineEdit::textChanged, this, &MinimalFilterPickerView::rebuildIndex);
+	headerLayout->addWidget(queryEdit, 1);
+
+	countLabel = new QLabel(header);
+	countLabel->setObjectName(QStringLiteral("MinimalPickerCount"));
+	headerLayout->addWidget(countLabel);
+
+	layout->addWidget(header);
+
+	scrollArea = new QScrollArea(this);
+	scrollArea->setObjectName(QStringLiteral("MinimalPickerScroll"));
+	scrollArea->setFrameShape(QFrame::NoFrame);
+	scrollArea->setWidgetResizable(true);
+	scrollArea->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+	scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	indexList = new MinimalPickerIndexList(scrollArea);
+	indexList->onEntryActivated = [this](int entryIndex)
+	{
+		emit entryChosen(entryIndex);
+	};
+	scrollArea->setWidget(indexList);
+	layout->addWidget(scrollArea, 1);
+
+	// Key legend, the BIOS-menu signature. Plain text, hairline above (QSS);
+	// the arrows are built from code points so the source stays pure ASCII.
+	const QString dot = QStringLiteral(" %1 ").arg(QChar(0x00B7));
+	QLabel* legend = new QLabel(
+		QString(QChar(0x2191)) + QChar(0x2193) + QStringLiteral(" MOVE") + dot
+		+ QStringLiteral("NN JUMP") + dot + QStringLiteral("RET INSERT"), this);
+	legend->setObjectName(QStringLiteral("MinimalPickerLegend"));
+	layout->addWidget(legend);
+
+	// The host calls view->setFocus(); typing must land in the query line.
+	setFocusProxy(queryEdit);
+	setMinimumWidth(GUIHelper::scale(360.0));
+	setMaximumHeight(GUIHelper::scale(460.0));
+}
+
+void MinimalFilterPickerView::setEntries(const QList<FilterPickerEntry>& entries)
+{
+	allEntries = entries;
+	rebuildIndex();
+	queryEdit->setFocus();
+}
+
+QSize MinimalFilterPickerView::sizeHint() const
+{
+	// The layout-driven hint grows with the full index; cap it here so the
+	// host's adjustSize() yields a dropdown, not a tower.
+	QSize hint = FilterPickerView::sizeHint();
+	hint.setWidth(GUIHelper::scale(380.0));
+	hint.setHeight(qMin(hint.height(), GUIHelper::scale(460.0)));
+	return hint;
+}
+
+void MinimalFilterPickerView::rebuildIndex()
+{
+	const QString query = queryEdit->text().trimmed();
+
+	// Pure digits = index jump (the numbers are the menu); anything else is a
+	// plain substring filter over section, name and config line.
+	bool jumpMode = !query.isEmpty();
+	for (const QChar& c : query)
+	{
+		if (!c.isDigit())
+		{
+			jumpMode = false;
+			break;
+		}
+	}
+	const QStringList terms = jumpMode
+		? QStringList()
+		: query.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+
+	// Coalesce by path (first-appearance order): one caption per category,
+	// each entry keeping its stable original number. Factories may revisit a
+	// category, and a repeated caption would read as corruption in an index.
+	QStringList sectionOrder;
+	QHash<QString, QList<int>> sectionEntries;
+	for (int i = 0; i < allEntries.size(); i++)
+	{
+		const FilterPickerEntry& entry = allEntries[i];
+		const QString section = entry.path.isEmpty()
+			? tr("General") : entry.path.join(QStringLiteral(" / "));
+
+		bool matches = true;
+		const QString haystack = section + QLatin1Char(' ') + entry.name + QLatin1Char(' ') + entry.line;
+		for (const QString& term : terms)
+		{
+			if (!haystack.contains(term, Qt::CaseInsensitive))
+			{
+				matches = false;
+				break;
+			}
+		}
+		if (!matches)
+			continue;
+
+		if (!sectionEntries.contains(section))
+			sectionOrder.append(section);
+		sectionEntries[section].append(i);
+	}
+
+	const int digits = qMax(2, QString::number(allEntries.size()).size());
+	QList<MinimalPickerIndexList::Row> rows;
+	int firstVisible = -1;
+	int visibleCount = 0;
+	for (const QString& section : sectionOrder)
+	{
+		rows.append({ QString(), section.toUpper(), -1 });
+		for (int i : sectionEntries.value(section))
+		{
+			rows.append({ QStringLiteral("%1").arg(i + 1, digits, 10, QLatin1Char('0')), allEntries[i].name, i });
+			if (firstVisible < 0)
+				firstVisible = i;
+			visibleCount++;
+		}
+	}
+	indexList->setRows(rows);
+
+	int target = firstVisible;
+	if (jumpMode && !allEntries.isEmpty())
+	{
+		// 1-based, clamped: "0" stays on the first entry, overshoot stops at
+		// the last. The index is original and stable, never the filtered row.
+		target = qBound(0, query.toInt() - 1, allEntries.size() - 1);
+	}
+	indexList->setSelectedEntry(target);
+	ensureSelectionVisible();
+
+	countLabel->setText(QStringLiteral("%1/%2").arg(visibleCount).arg(allEntries.size()));
+}
+
+void MinimalFilterPickerView::moveSelection(int delta)
+{
+	const QList<MinimalPickerIndexList::Row>& rows = indexList->rows();
+	QVector<int> entryOrder;
+	entryOrder.reserve(rows.size());
+	for (const MinimalPickerIndexList::Row& row : rows)
+	{
+		if (row.entryIndex >= 0)
+			entryOrder.append(row.entryIndex);
+	}
+	if (entryOrder.isEmpty())
+		return;
+	int pos = entryOrder.indexOf(indexList->selectedEntry());
+	pos = pos < 0 ? 0 : qBound(0, pos + delta, entryOrder.size() - 1);
+	indexList->setSelectedEntry(entryOrder[pos]);
+	ensureSelectionVisible();
+}
+
+void MinimalFilterPickerView::chooseCurrent()
+{
+	const int index = indexList->selectedEntry();
+	if (index >= 0 && indexList->rowOfEntry(index) >= 0)
+		emit entryChosen(index);
+}
+
+void MinimalFilterPickerView::ensureSelectionVisible()
+{
+	const int row = indexList->rowOfEntry(indexList->selectedEntry());
+	if (row < 0)
+		return;
+	const QRect r = indexList->rowRect(row);
+	// Two calls cover both scroll directions; the margin keeps the adjacent
+	// line (or the section caption above) in view as context.
+	scrollArea->ensureVisible(0, r.top(), 0, r.height() + 2);
+	scrollArea->ensureVisible(0, r.bottom(), 0, r.height() + 2);
+}
+
+void MinimalFilterPickerView::paintEvent(QPaintEvent* event)
+{
+	Q_UNUSED(event);
+	// The whole control sits in one square hairline frame; no other chrome.
+	QPainter painter(this);
+	const SkinTokens& t = SkinManager::instance()->tokens();
+	painter.fillRect(rect(), QColor(t.background));
+	painter.setPen(QColor(t.border));
+	painter.drawRect(rect().adjusted(0, 0, -1, -1));
+}
+
+bool MinimalFilterPickerView::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == queryEdit && event->type() == QEvent::KeyPress)
+	{
+		QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+		switch (keyEvent->key())
+		{
+		case Qt::Key_Down:
+			moveSelection(1);
+			return true;
+		case Qt::Key_Up:
+			moveSelection(-1);
+			return true;
+		case Qt::Key_PageDown:
+			moveSelection(10);
+			return true;
+		case Qt::Key_PageUp:
+			moveSelection(-10);
+			return true;
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			chooseCurrent();
+			return true;
+		default:
+			break;
+		}
+	}
+	return FilterPickerView::eventFilter(watched, event);
+}

--- a/Editor/skins/pickers/MinimalFilterPicker.h
+++ b/Editor/skins/pickers/MinimalFilterPicker.h
@@ -1,0 +1,101 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	"Add filter" picker for the minimal skin (Precision Minimal): a terminal
+	index. The control is all type, hairlines and alignment - a man page /
+	BIOS menu rather than a dialog. One bare ">"-prefixed query line on top,
+	a numbered mono index below (uppercase section captions with full-width
+	hairline underlines, entries as single "NN  Name" lines) and a key legend
+	at the bottom. Zero radius, no decoration; selection is an inverted text
+	block, hover is exactly one background-value step.
+
+	Keyboard is the soul: typing letters filters the index, typing digits
+	jumps straight to that entry number (the numbers are stable original
+	indices, so "07" always means the same template even while filtered),
+	Up/Down move, Return inserts. Esc belongs to the popup host.
+*/
+
+#pragma once
+
+#include <functional>
+
+#include <QList>
+#include <QVector>
+
+#include "Editor/widgets/FilterPickerView.h"
+
+class QLabel;
+class QLineEdit;
+class QScrollArea;
+
+// The painted index body. It only paints rows and hit-tests clicks; all
+// keyboard logic and filtering live in MinimalFilterPickerView. Painting by
+// hand (instead of a QListWidget) keeps the mono number column, the caption
+// underlines and the inverted selection block on exact 1px terms.
+class MinimalPickerIndexList : public QWidget
+{
+public:
+	struct Row
+	{
+		QString number;       // zero-padded 1-based original index; empty for captions
+		QString text;         // entry name, or the uppercase caption text
+		int entryIndex = -1;  // original index into the entries list; -1 = caption
+	};
+
+	explicit MinimalPickerIndexList(QWidget* parent = nullptr);
+
+	void setRows(const QList<Row>& rows);
+	const QList<Row>& rows() const { return rowList; }
+
+	void setSelectedEntry(int entryIndex);
+	int selectedEntry() const { return selectedEntryIndex; }
+	int rowOfEntry(int entryIndex) const;
+	QRect rowRect(int row) const;
+
+	// One click inserts (dropdown semantics, same as the neutral picker).
+	std::function<void(int entryIndex)> onEntryActivated;
+
+	QSize sizeHint() const override;
+
+protected:
+	void paintEvent(QPaintEvent* event) override;
+	void mousePressEvent(QMouseEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
+	void leaveEvent(QEvent* event) override;
+
+private:
+	int rowAt(const QPoint& pos) const;
+
+	QList<Row> rowList;
+	QVector<int> rowTops;
+	int contentHeight = 0;
+	int selectedEntryIndex = -1;
+	int hoverRow = -1;
+};
+
+class MinimalFilterPickerView : public FilterPickerView
+{
+	Q_OBJECT
+
+public:
+	explicit MinimalFilterPickerView(QWidget* parent = nullptr);
+
+	void setEntries(const QList<FilterPickerEntry>& entries) override;
+	QSize sizeHint() const override;
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override;
+	void paintEvent(QPaintEvent* event) override;
+
+private:
+	void rebuildIndex();
+	void moveSelection(int delta);
+	void chooseCurrent();
+	void ensureSelectionVisible();
+
+	QList<FilterPickerEntry> allEntries;
+	QLineEdit* queryEdit = nullptr;
+	QLabel* countLabel = nullptr;
+	QScrollArea* scrollArea = nullptr;
+	MinimalPickerIndexList* indexList = nullptr;
+};

--- a/Editor/skins/pickers/RackFilterPicker.cpp
+++ b/Editor/skins/pickers/RackFilterPicker.cpp
@@ -1,0 +1,508 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	See RackFilterPicker.h. The small screw/LED painters are deliberately
+	local re-creations of RackChrome's idiom (that file's helpers are
+	private to it); they stay visually consistent with the card chrome.
+*/
+
+#include "RackFilterPicker.h"
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPainter>
+#include <QRegularExpression>
+#include <QStyledItemDelegate>
+#include <QVBoxLayout>
+#include <QtMath>
+
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+
+namespace
+{
+enum
+{
+	// Original index into the entries list handed to setEntries.
+	OriginalIndexRole = Qt::UserRole,
+	// Row kind: section plate or labeled slot.
+	KindRole = Qt::UserRole + 1
+};
+
+enum RowKind
+{
+	EntryRow = 0,
+	SectionRow = 1
+};
+
+bool isDarkPanel(const SkinTokens& tokens)
+{
+	return QColor(tokens.background).lightness() < 128;
+}
+
+QColor withAlpha(const QColor& color, int alpha)
+{
+	QColor result = color;
+	result.setAlpha(alpha);
+	return result;
+}
+
+// Engraved faceplate printing: a contrast pass offset one pixel down (the
+// recess edge catching the light), then the body color on top.
+void engraveText(QPainter& painter, const QRectF& rect, int flags, const QString& text, const QColor& body, bool dark)
+{
+	painter.setPen(dark ? QColor(0, 0, 0, 170) : QColor(255, 255, 255, 200));
+	painter.drawText(rect.translated(0, 1), flags, text);
+	painter.setPen(body);
+	painter.drawText(rect, flags, text);
+}
+
+// A slotted machine screw, same construction as the card faceplates'.
+void paintScrew(QPainter& painter, const QPointF& center, qreal radius, qreal slotDegrees, bool dark)
+{
+	QRadialGradient body(center - QPointF(radius * 0.35, radius * 0.35), radius * 2.1);
+	if (dark)
+	{
+		body.setColorAt(0.0, QColor(0x9A, 0xA4, 0xAC));
+		body.setColorAt(0.55, QColor(0x4E, 0x57, 0x5E));
+		body.setColorAt(1.0, QColor(0x23, 0x28, 0x2C));
+	}
+	else
+	{
+		body.setColorAt(0.0, QColor(0xFF, 0xFF, 0xFC));
+		body.setColorAt(0.55, QColor(0xC4, 0xBD, 0xAE));
+		body.setColorAt(1.0, QColor(0x8E, 0x86, 0x76));
+	}
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 200) : QColor(0x6B, 0x62, 0x52), 1));
+	painter.setBrush(body);
+	painter.drawEllipse(center, radius, radius);
+
+	const qreal rad = qDegreesToRadians(slotDegrees);
+	const QPointF dir(qCos(rad), qSin(rad));
+	const QPointF a = center - dir * (radius - 1.2);
+	const QPointF b = center + dir * (radius - 1.2);
+	painter.setPen(QPen(dark ? QColor(10, 12, 14, 230) : QColor(60, 54, 44, 220), 1.4, Qt::SolidLine, Qt::RoundCap));
+	painter.drawLine(a, b);
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 60 : 170), 0.8, Qt::SolidLine, Qt::RoundCap));
+	painter.drawLine(a + QPointF(0, 1), b + QPointF(0, 1));
+}
+
+// A panel LED in a bezel ring; glow scales 0..1 so the hover lamp can sit
+// between fully dark and fully lit.
+void paintLed(QPainter& painter, const QPointF& center, qreal radius, const QColor& litColor, qreal glow, bool dark)
+{
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 190) : QColor(70, 62, 50, 190), 1));
+	painter.setBrush(Qt::NoBrush);
+	painter.drawEllipse(center, radius + 1.2, radius + 1.2);
+
+	if (glow > 0.0)
+	{
+		QRadialGradient halo(center, radius * 3.2);
+		halo.setColorAt(0.0, withAlpha(litColor, int(110 * glow)));
+		halo.setColorAt(1.0, withAlpha(litColor, 0));
+		painter.setPen(Qt::NoPen);
+		painter.setBrush(halo);
+		painter.drawEllipse(center, radius * 3.2, radius * 3.2);
+	}
+
+	QRadialGradient dome(center - QPointF(radius * 0.3, radius * 0.3), radius * 1.6);
+	const QColor off = litColor.darker(330);
+	const QColor hot = litColor.lighter(150);
+	auto mix = [glow](const QColor& a, const QColor& b) {
+		return QColor(
+			qRound(a.red() + (b.red() - a.red()) * glow),
+			qRound(a.green() + (b.green() - a.green()) * glow),
+			qRound(a.blue() + (b.blue() - a.blue()) * glow));
+	};
+	dome.setColorAt(0.0, mix(off.lighter(140), hot));
+	dome.setColorAt(1.0, mix(off, litColor.darker(125)));
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(dome);
+	painter.drawEllipse(center, radius, radius);
+	painter.setBrush(QColor(255, 255, 255, int((dark ? 28 : 60) + (170 - (dark ? 28 : 60)) * glow)));
+	painter.drawEllipse(center - QPointF(radius * 0.35, radius * 0.35), radius * 0.3, radius * 0.3);
+}
+
+// Paints section plates and labeled slots; the panel behind them belongs to
+// RackFilterPickerView::paintEvent.
+class RackFilterPickerDelegate : public QStyledItemDelegate
+{
+public:
+	explicit RackFilterPickerDelegate(QObject* parent = nullptr)
+		: QStyledItemDelegate(parent)
+	{
+	}
+
+	QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
+	{
+		Q_UNUSED(option);
+		const bool section = index.data(KindRole).toInt() == SectionRow;
+		return QSize(0, GUIHelper::scale(section ? 24.0 : 26.0));
+	}
+
+	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+	{
+		const SkinTokens& tokens = SkinManager::instance()->tokens();
+		const bool dark = isDarkPanel(tokens);
+
+		painter->save();
+		painter->setRenderHint(QPainter::Antialiasing);
+
+		if (index.data(KindRole).toInt() == SectionRow)
+			paintSection(painter, option, index, tokens, dark);
+		else
+			paintEntry(painter, option, index, tokens, dark);
+
+		painter->restore();
+	}
+
+private:
+	// An engraved section plate riveted onto the panel: a slightly recessed
+	// band, two rivets, uppercase letter-spaced printing.
+	void paintSection(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index, const SkinTokens& tokens, bool dark) const
+	{
+		const QRectF plate = QRectF(option.rect).adjusted(2, 5, -2, -3);
+
+		painter->setPen(QPen(QColor(0, 0, 0, dark ? 150 : 70), 1));
+		painter->setBrush(QColor(0, 0, 0, dark ? 52 : 16));
+		painter->drawRoundedRect(plate, 2, 2);
+		// The lower plate edge catches the work light.
+		painter->setPen(QPen(QColor(255, 255, 255, dark ? 26 : 140), 1));
+		painter->drawLine(QPointF(plate.left() + 2, plate.bottom() + 1), QPointF(plate.right() - 2, plate.bottom() + 1));
+
+		// Rivets at both plate ends, like the VST brass nameplate's.
+		painter->setPen(QPen(dark ? QColor(0, 0, 0, 180) : QColor(0x6B, 0x62, 0x52), 0.8));
+		painter->setBrush(dark ? QColor(0x6A, 0x74, 0x7C) : QColor(0xD8, 0xCF, 0xBC));
+		painter->drawEllipse(QPointF(plate.left() + 7, plate.center().y()), 1.6, 1.6);
+		painter->drawEllipse(QPointF(plate.right() - 7, plate.center().y()), 1.6, 1.6);
+
+		QFont plateFont(tokens.fontFamily);
+		plateFont.setPixelSize(9);
+		plateFont.setBold(true);
+		plateFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.6);
+		painter->setFont(plateFont);
+		const QRectF textRect = plate.adjusted(14, 0, -14, 0);
+		engraveText(*painter, textRect, Qt::AlignVCenter | Qt::AlignLeft,
+			index.data(Qt::DisplayRole).toString().toUpper(),
+			withAlpha(QColor(tokens.mutedText), 220), dark);
+	}
+
+	// A labeled slot: panel LED left of the printed label. Selection lights
+	// the LED amber and backlights the slot; hover is a faint lamp glow.
+	void paintEntry(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index, const SkinTokens& tokens, bool dark) const
+	{
+		const bool selected = option.state & QStyle::State_Selected;
+		const bool hovered = option.state & QStyle::State_MouseOver;
+		const QRectF slot = QRectF(option.rect).adjusted(2, 1, -2, -1);
+		const QColor accent(tokens.accent);
+
+		if (selected)
+		{
+			// Backlit slot: the lamp sits behind the LED end, so the light
+			// falls off toward the right.
+			QLinearGradient backlight(slot.topLeft(), slot.topRight());
+			backlight.setColorAt(0.0, withAlpha(accent, dark ? 64 : 70));
+			backlight.setColorAt(1.0, withAlpha(accent, dark ? 12 : 16));
+			painter->setPen(QPen(withAlpha(accent, 130), 1));
+			painter->setBrush(backlight);
+			painter->drawRoundedRect(slot, 2, 2);
+		}
+		else if (hovered)
+		{
+			QLinearGradient lamp(slot.topLeft(), slot.topRight());
+			lamp.setColorAt(0.0, withAlpha(accent, dark ? 26 : 30));
+			lamp.setColorAt(1.0, withAlpha(accent, 0));
+			painter->setPen(Qt::NoPen);
+			painter->setBrush(lamp);
+			painter->drawRoundedRect(slot, 2, 2);
+		}
+
+		const QPointF led(slot.left() + 11.0, slot.center().y());
+		paintLed(*painter, led, 2.8, accent, selected ? 1.0 : (hovered ? 0.4 : 0.0), dark);
+
+		QFont labelFont(tokens.fontFamily);
+		labelFont.setPixelSize(12);
+		painter->setFont(labelFont);
+		const QRectF textRect = slot.adjusted(24, 0, -8, 0);
+		const QString label = QFontMetrics(labelFont).elidedText(
+			index.data(Qt::DisplayRole).toString(), Qt::ElideRight, int(textRect.width()));
+		painter->setPen(withAlpha(QColor(tokens.text), selected ? 255 : 225));
+		painter->drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, label);
+	}
+};
+}
+
+RackFilterPickerView::RackFilterPickerView(QWidget* parent)
+	: FilterPickerView(parent)
+{
+	setObjectName(QStringLiteral("RackFilterPicker"));
+
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const bool dark = isDarkPanel(tokens);
+
+	QVBoxLayout* layout = new QVBoxLayout(this);
+	layout->setContentsMargins(GUIHelper::scale(12.0), GUIHelper::scale(38.0), GUIHelper::scale(12.0), GUIHelper::scale(20.0));
+	layout->setSpacing(GUIHelper::scale(8.0));
+
+	// The search strip is an LCD character display set into the faceplate:
+	// a dark well with green segments in both modes (hardware displays do
+	// not follow the panel finish).
+	searchEdit = new QLineEdit(this);
+	searchEdit->setObjectName(QStringLiteral("RackFilterPickerSearch"));
+	searchEdit->setPlaceholderText(tr("SEARCH"));
+	searchEdit->installEventFilter(this);
+	connect(searchEdit, &QLineEdit::textChanged, this, &RackFilterPickerView::rebuildList);
+	const QColor lcdInk = dark ? QColor(0x86, 0xF2, 0xBA) : QColor(0x3E, 0xD6, 0x8E);
+	QFont lcdFont(tokens.monoFontFamily);
+	lcdFont.setPointSizeF(9.0);
+	lcdFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.0);
+	searchEdit->setFont(lcdFont);
+	searchEdit->setStyleSheet(QStringLiteral(
+		"QLineEdit#RackFilterPickerSearch {"
+		" background: #0A0E0C; color: %1;"
+		" border: 1px solid #050706; border-bottom-color: %2;"
+		" border-radius: 2px; padding: 4px 8px;"
+		" selection-background-color: %1; selection-color: #0A0E0C; }"
+		"QLineEdit#RackFilterPickerSearch:focus { border: 1px solid %3; }")
+		.arg(lcdInk.name(), dark ? QStringLiteral("#39424A") : QStringLiteral("#FFFFFF"), tokens.accent));
+	QPalette lcdPalette = searchEdit->palette();
+	lcdPalette.setColor(QPalette::PlaceholderText, withAlpha(lcdInk, 110));
+	searchEdit->setPalette(lcdPalette);
+	layout->addWidget(searchEdit);
+
+	listWidget = new QListWidget(this);
+	listWidget->setObjectName(QStringLiteral("RackFilterPickerList"));
+	listWidget->setFrameShape(QFrame::NoFrame);
+	listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	listWidget->setUniformItemSizes(false);
+	// The delegate paints slots straight onto the brushed panel; the global
+	// item-view styling (well background, hover bands) must not interfere.
+	listWidget->setStyleSheet(QStringLiteral(
+		"QListWidget#RackFilterPickerList { background: transparent; border: 0; }"
+		"QListWidget#RackFilterPickerList::item { background: transparent; padding: 0; border: 0; }"));
+	listWidget->viewport()->setMouseTracking(true);
+	listWidget->setItemDelegate(new RackFilterPickerDelegate(listWidget));
+	// Dropdown semantics: one click inserts.
+	connect(listWidget, &QListWidget::itemClicked, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(OriginalIndexRole).toInt());
+	});
+	connect(listWidget, &QListWidget::itemActivated, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(OriginalIndexRole).toInt());
+	});
+	layout->addWidget(listWidget, 1);
+
+	// The host gives focus to the view; the LCD is where typing belongs.
+	setFocusProxy(searchEdit);
+	setMinimumWidth(GUIHelper::scale(360.0));
+	setMaximumHeight(GUIHelper::scale(480.0));
+}
+
+void RackFilterPickerView::setEntries(const QList<FilterPickerEntry>& entries)
+{
+	allEntries = entries;
+	rebuildList();
+	searchEdit->setFocus();
+}
+
+QSize RackFilterPickerView::sizeHint() const
+{
+	// As tall as the module's slots require, up to the rack height limit;
+	// past that the slot column scrolls behind the faceplate.
+	const QMargins margins = layout()->contentsMargins();
+	const int height = margins.top() + searchEdit->sizeHint().height()
+		+ layout()->spacing() + listContentHeight + margins.bottom();
+	return QSize(GUIHelper::scale(366.0), qMin(height, GUIHelper::scale(470.0)));
+}
+
+void RackFilterPickerView::rebuildList()
+{
+	listWidget->clear();
+
+	const QStringList terms = searchEdit->text().split(
+		QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+
+	int sectionCount = 0;
+	int entryCount = 0;
+	QString currentSection;
+	bool sectionStarted = false;
+	for (int i = 0; i < allEntries.size(); i++)
+	{
+		const FilterPickerEntry& entry = allEntries[i];
+		const QString section = entry.path.isEmpty() ? tr("General") : entry.path.join(QStringLiteral(" / "));
+
+		bool matches = true;
+		const QString haystack = section + QLatin1Char(' ') + entry.name + QLatin1Char(' ') + entry.line;
+		for (const QString& term : terms)
+		{
+			if (!haystack.contains(term, Qt::CaseInsensitive))
+			{
+				matches = false;
+				break;
+			}
+		}
+		if (!matches)
+			continue;
+
+		if (!sectionStarted || section != currentSection)
+		{
+			sectionStarted = true;
+			currentSection = section;
+			QListWidgetItem* plate = new QListWidgetItem(section, listWidget);
+			plate->setFlags(Qt::NoItemFlags);
+			plate->setData(KindRole, int(SectionRow));
+			sectionCount++;
+		}
+
+		QListWidgetItem* item = new QListWidgetItem(entry.name, listWidget);
+		item->setData(OriginalIndexRole, i);
+		item->setData(KindRole, int(EntryRow));
+		item->setToolTip(entry.line);
+		entryCount++;
+	}
+
+	listContentHeight = sectionCount * GUIHelper::scale(24.0)
+		+ entryCount * GUIHelper::scale(26.0) + GUIHelper::scale(4.0);
+	updateGeometry();
+
+	// Preselect the first real slot so Return inserts immediately.
+	for (int row = 0; row < listWidget->count(); row++)
+	{
+		if (listWidget->item(row)->flags() & Qt::ItemIsSelectable)
+		{
+			listWidget->setCurrentRow(row);
+			break;
+		}
+	}
+}
+
+void RackFilterPickerView::chooseCurrent()
+{
+	QListWidgetItem* item = listWidget->currentItem();
+	if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+		emit entryChosen(item->data(OriginalIndexRole).toInt());
+}
+
+bool RackFilterPickerView::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == searchEdit && event->type() == QEvent::KeyPress)
+	{
+		QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+		switch (keyEvent->key())
+		{
+		case Qt::Key_Down:
+		case Qt::Key_Up:
+		case Qt::Key_PageDown:
+		case Qt::Key_PageUp:
+			QApplication::sendEvent(listWidget, event);
+			return true;
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			chooseCurrent();
+			return true;
+		default:
+			break;
+		}
+	}
+	return FilterPickerView::eventFilter(watched, event);
+}
+
+void RackFilterPickerView::paintEvent(QPaintEvent* event)
+{
+	Q_UNUSED(event);
+
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const bool dark = isDarkPanel(tokens);
+
+	QPainter painter(this);
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	const QRectF r = QRectF(rect()).adjusted(0.5, 0.5, -0.5, -0.5);
+	const qreal radius = tokens.borderRadius;
+
+	// Brushed faceplate: the card metal with a rolled top edge falling into
+	// shadow, exactly the card chrome's sheen direction.
+	const QColor plateColor(tokens.card);
+	QLinearGradient sheen(r.topLeft(), r.bottomLeft());
+	if (dark)
+	{
+		sheen.setColorAt(0.0, plateColor.lighter(138));
+		sheen.setColorAt(0.12, plateColor.lighter(112));
+		sheen.setColorAt(0.55, plateColor);
+		sheen.setColorAt(1.0, plateColor.darker(130));
+	}
+	else
+	{
+		sheen.setColorAt(0.0, plateColor.lighter(104));
+		sheen.setColorAt(0.5, plateColor);
+		sheen.setColorAt(1.0, plateColor.darker(108));
+	}
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(sheen);
+	painter.drawRoundedRect(r, radius, radius);
+
+	// Horizontal brushing texture.
+	painter.setPen(QPen(dark ? QColor(255, 255, 255, 7) : QColor(96, 84, 64, 8), 1));
+	for (qreal y = r.top() + 3; y < r.bottom() - 1; y += 3)
+		painter.drawLine(QPointF(r.left() + 2, y), QPointF(r.right() - 2, y));
+
+	// Machined plate edge: dark outline, lit top bezel, shadowed bottom.
+	painter.setBrush(Qt::NoBrush);
+	painter.setPen(QPen(dark ? QColor(0, 0, 0, 210) : QColor(0x8A, 0x80, 0x6C), 1));
+	painter.drawRoundedRect(r, radius, radius);
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 36 : 150), 1));
+	painter.drawLine(QPointF(r.left() + radius, r.top() + 1), QPointF(r.right() - radius, r.top() + 1));
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 140 : 60), 1));
+	painter.drawLine(QPointF(r.left() + radius, r.bottom() - 1), QPointF(r.right() - radius, r.bottom() - 1));
+
+	// Four corner screws; fixed slot angles so the faceplate looks hand-set,
+	// not stamped.
+	paintScrew(painter, QPointF(r.left() + 11, r.top() + 11), 3.6, 23.0, dark);
+	paintScrew(painter, QPointF(r.right() - 11, r.top() + 11), 3.6, 117.0, dark);
+	paintScrew(painter, QPointF(r.left() + 11, r.bottom() - 11), 3.6, 64.0, dark);
+	paintScrew(painter, QPointF(r.right() - 11, r.bottom() - 11), 3.6, 158.0, dark);
+
+	// Engraved header: the unit designation, with the power LED on the right.
+	QFont titleFont(tokens.fontFamily);
+	titleFont.setPixelSize(10);
+	titleFont.setBold(true);
+	titleFont.setLetterSpacing(QFont::AbsoluteSpacing, 2.0);
+	painter.setFont(titleFont);
+	const QRectF titleRect(r.left() + 26, r.top() + 6, r.width() - 80, 22);
+	engraveText(painter, titleRect, Qt::AlignVCenter | Qt::AlignLeft,
+		QStringLiteral("MODULE SELECT"), withAlpha(QColor(tokens.mutedText), 230), dark);
+	paintLed(painter, QPointF(r.right() - 28, r.top() + 17), 3.0, QColor(tokens.accent2), 1.0, dark);
+
+	// Machined groove separating the header from the controls.
+	const qreal grooveY = r.top() + 31;
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 120 : 60), 1));
+	painter.drawLine(QPointF(r.left() + 8, grooveY), QPointF(r.right() - 8, grooveY));
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 26 : 130), 1));
+	painter.drawLine(QPointF(r.left() + 8, grooveY + 1), QPointF(r.right() - 8, grooveY + 1));
+
+	// A filtered-out catalog leaves dead slots: the panel says so the way
+	// hardware would.
+	if (listWidget != nullptr && listWidget->count() == 0)
+	{
+		QFont emptyFont(tokens.fontFamily);
+		emptyFont.setPixelSize(10);
+		emptyFont.setBold(true);
+		emptyFont.setLetterSpacing(QFont::AbsoluteSpacing, 2.0);
+		painter.setFont(emptyFont);
+		engraveText(painter, QRectF(listWidget->geometry()), Qt::AlignCenter,
+			QStringLiteral("NO SIGNAL"), withAlpha(QColor(tokens.mutedText), 170), dark);
+	}
+
+	// Tiny model engraving on the bottom rail, between the screws.
+	QFont modelFont(tokens.fontFamily);
+	modelFont.setPixelSize(8);
+	modelFont.setBold(true);
+	modelFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.2);
+	painter.setFont(modelFont);
+	engraveText(painter, QRectF(r.left() + 26, r.bottom() - 16, r.width() - 52, 12),
+		Qt::AlignVCenter | Qt::AlignHCenter, QStringLiteral("EAPO-XT SERIES"),
+		withAlpha(QColor(tokens.mutedText), 140), dark);
+}

--- a/Editor/skins/pickers/RackFilterPicker.h
+++ b/Editor/skins/pickers/RackFilterPicker.h
@@ -1,0 +1,48 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	The "add filter" picker of the rack skin: a hardware module's preset
+	browser. A brushed 1U faceplate with corner screws and an engraved
+	MODULE SELECT header, a recessed LCD character display as the search
+	strip, categories as engraved section plates and every insertable
+	template as a labeled slot with its own panel LED (lit = selected,
+	faint lamp glow = hovered). All painting follows RackChrome's
+	tiebreaker: only what a hardware faceplate would carry.
+*/
+
+#pragma once
+
+#include <QList>
+
+#include "Editor/widgets/FilterPickerView.h"
+
+class QLineEdit;
+class QListWidget;
+
+class RackFilterPickerView : public FilterPickerView
+{
+	Q_OBJECT
+
+public:
+	explicit RackFilterPickerView(QWidget* parent = nullptr);
+
+	void setEntries(const QList<FilterPickerEntry>& entries) override;
+
+	QSize sizeHint() const override;
+
+protected:
+	void paintEvent(QPaintEvent* event) override;
+	bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+	void rebuildList();
+	void chooseCurrent();
+
+	QList<FilterPickerEntry> allEntries;
+	QLineEdit* searchEdit = nullptr;
+	QListWidget* listWidget = nullptr;
+	// Natural (uncapped) pixel height of the current list content, kept by
+	// rebuildList so sizeHint can size the popup like a real 1U module:
+	// exactly as tall as its slots, up to the rack's height limit.
+	int listContentHeight = 0;
+};

--- a/Editor/skins/pickers/SoftFilterPicker.cpp
+++ b/Editor/skins/pickers/SoftFilterPicker.cpp
@@ -1,0 +1,423 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "SoftFilterPicker.h"
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPainter>
+#include <QRegularExpression>
+#include <QStyledItemDelegate>
+#include <QVBoxLayout>
+
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+
+namespace
+{
+enum SoftPickerRole
+{
+	// Original index into the entries list; -1 for sections / the empty state.
+	EntryIndexRole = Qt::UserRole,
+	// Entry name or section label.
+	TitleRole,
+	// The template's config line (entries only).
+	CaptionRole,
+	// The category pastel (QColor).
+	TintRole,
+	// SoftPickerItemKind.
+	KindRole
+};
+
+enum SoftPickerItemKind
+{
+	EntryItem = 0,
+	SectionItem,
+	EmptyStateItem
+};
+
+// Linear blend between two colours, the skin's stand-in for shadows and tints
+// (Soft fakes all elevation by mixing token colours; see Skins.cpp).
+QColor mixColor(const QColor& a, const QColor& b, double t)
+{
+	return QColor(
+		qRound(a.red() + (b.red() - a.red()) * t),
+		qRound(a.green() + (b.green() - a.green()) * t),
+		qRound(a.blue() + (b.blue() - a.blue()) * t));
+}
+
+QColor withAlpha(QColor color, int alpha)
+{
+	color.setAlpha(alpha);
+	return color;
+}
+
+// Friendly pastel hues handed out to categories in catalog order, the way a
+// consumer settings app gives every group its own icon colour.
+QColor sectionPastel(int sectionIndex, bool dark)
+{
+	static const int hues[] = { 216, 150, 26, 268, 336, 190, 48, 0, 286, 120 };
+	const int hue = hues[sectionIndex % int(sizeof(hues) / sizeof(hues[0]))];
+	return QColor::fromHslF(hue / 360.0, dark ? 0.52 : 0.58, dark ? 0.64 : 0.56);
+}
+
+// Paints the menu rows: stadium highlights, rounded-square colour tiles and
+// pill section headers, all from the live skin tokens so both modes stay calm.
+class SoftPickerDelegate : public QStyledItemDelegate
+{
+public:
+	using QStyledItemDelegate::QStyledItemDelegate;
+
+	QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
+	{
+		Q_UNUSED(option);
+		switch (index.data(KindRole).toInt())
+		{
+		case SectionItem:
+			// Whitespace is the hierarchy device: every section after the
+			// first carries its breathing room above the pill.
+			return QSize(GUIHelper::scale(100.0), GUIHelper::scale(index.row() == 0 ? 26.0 : 38.0));
+		case EmptyStateItem:
+			return QSize(GUIHelper::scale(100.0), GUIHelper::scale(64.0));
+		default:
+			return QSize(GUIHelper::scale(100.0), GUIHelper::scale(48.0));
+		}
+	}
+
+	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+	{
+		const SkinTokens& t = SkinManager::instance()->tokens();
+		const bool dark = SkinManager::instance()->isDark();
+		const QString title = index.data(TitleRole).toString();
+
+		painter->save();
+		painter->setRenderHint(QPainter::Antialiasing);
+
+		switch (index.data(KindRole).toInt())
+		{
+		case SectionItem:
+			paintSection(painter, option, index, t, dark, title);
+			break;
+		case EmptyStateItem:
+			painter->setPen(QColor(t.mutedText));
+			painter->drawText(option.rect, Qt::AlignCenter, title);
+			break;
+		default:
+			paintEntry(painter, option, index, t, dark, title);
+			break;
+		}
+
+		painter->restore();
+	}
+
+private:
+	static void paintSection(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
+		const SkinTokens& t, bool dark, const QString& title)
+	{
+		const QColor tint = index.data(TintRole).value<QColor>();
+		QFont pillFont = option.font;
+		pillFont.setWeight(QFont::DemiBold);
+		pillFont.setPointSizeF(option.font.pointSizeF() * 0.84);
+		pillFont.setLetterSpacing(QFont::AbsoluteSpacing, 0.8);
+		const QString label = title.toUpper();
+		const QFontMetricsF metrics(pillFont);
+
+		const qreal pillHeight = GUIHelper::scale(22.0);
+		const qreal pillWidth = qMin<qreal>(option.rect.width() - GUIHelper::scale(12.0),
+			metrics.horizontalAdvance(label) + GUIHelper::scale(24.0));
+		const QRectF pill(option.rect.left() + GUIHelper::scale(6.0),
+			option.rect.bottom() - pillHeight - GUIHelper::scale(1.0), pillWidth, pillHeight);
+
+		painter->setPen(Qt::NoPen);
+		painter->setBrush(withAlpha(tint, dark ? 46 : 40));
+		painter->drawRoundedRect(pill, pillHeight / 2.0, pillHeight / 2.0);
+		painter->setFont(pillFont);
+		painter->setPen(mixColor(tint, QColor(t.text), dark ? 0.42 : 0.40));
+		painter->drawText(pill, Qt::AlignCenter, metrics.elidedText(label, Qt::ElideRight, pillWidth - GUIHelper::scale(16.0)));
+	}
+
+	static void paintEntry(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
+		const SkinTokens& t, bool dark, const QString& title)
+	{
+		QRectF row(option.rect);
+		row.adjust(0, GUIHelper::scale(2.0), 0, -GUIHelper::scale(2.0));
+
+		// The hovered row lifts one value step; the current row gets the
+		// fully rounded stadium in the selection tint, the same silhouette as
+		// the skin's chips. Calm: no fill change beyond one step, no glow.
+		const bool selected = option.state.testFlag(QStyle::State_Selected);
+		const bool hovered = option.state.testFlag(QStyle::State_MouseOver);
+		if (selected || hovered)
+		{
+			const qreal radius = row.height() / 2.0;
+			if (selected)
+			{
+				painter->setPen(QPen(withAlpha(QColor(t.accent), dark ? 120 : 110), 1));
+				painter->setBrush(QColor(t.cardSelected));
+			}
+			else
+			{
+				painter->setPen(Qt::NoPen);
+				painter->setBrush(QColor(t.cardHover));
+			}
+			painter->drawRoundedRect(row.adjusted(0.5, 0.5, -0.5, -0.5), radius, radius);
+		}
+
+		// The category announces itself like an iOS Settings row: a rounded
+		// square colour tile carrying the entry's initial.
+		const QColor tint = index.data(TintRole).value<QColor>();
+		const qreal tileSide = GUIHelper::scale(28.0);
+		const QRectF tile(row.left() + GUIHelper::scale(10.0), row.center().y() - tileSide / 2.0, tileSide, tileSide);
+		painter->setPen(Qt::NoPen);
+		painter->setBrush(tint);
+		painter->drawRoundedRect(tile, tileSide * 0.32, tileSide * 0.32);
+		QFont glyphFont = option.font;
+		glyphFont.setWeight(QFont::DemiBold);
+		glyphFont.setPointSizeF(option.font.pointSizeF() * 1.1);
+		painter->setFont(glyphFont);
+		painter->setPen(QColor(QStringLiteral("#FAFAFC")));
+		painter->drawText(tile, Qt::AlignCenter, title.left(1).toUpper());
+
+		// Name over the config line as a friendly muted caption (regular
+		// face, not monospace: here it is a description, not an editor).
+		const QString caption = index.data(CaptionRole).toString();
+		const qreal textLeft = tile.right() + GUIHelper::scale(12.0);
+		const qreal textWidth = row.right() - GUIHelper::scale(16.0) - textLeft;
+
+		QFont nameFont = option.font;
+		nameFont.setWeight(QFont::DemiBold);
+		const QFontMetricsF nameMetrics(nameFont);
+		QFont captionFont = option.font;
+		captionFont.setPointSizeF(option.font.pointSizeF() * 0.82);
+		const QFontMetricsF captionMetrics(captionFont);
+
+		const qreal gap = caption.isEmpty() ? 0.0 : GUIHelper::scale(1.0);
+		const qreal textHeight = nameMetrics.height() + gap + (caption.isEmpty() ? 0.0 : captionMetrics.height());
+		const qreal textTop = row.center().y() - textHeight / 2.0;
+
+		painter->setFont(nameFont);
+		painter->setPen(QColor(t.text));
+		painter->drawText(QRectF(textLeft, textTop, textWidth, nameMetrics.height()),
+			Qt::AlignLeft | Qt::AlignVCenter, nameMetrics.elidedText(title, Qt::ElideRight, textWidth));
+
+		if (!caption.isEmpty())
+		{
+			painter->setFont(captionFont);
+			painter->setPen(QColor(t.mutedText));
+			painter->drawText(QRectF(textLeft, textTop + nameMetrics.height() + gap, textWidth, captionMetrics.height()),
+				Qt::AlignLeft | Qt::AlignVCenter, captionMetrics.elidedText(caption, Qt::ElideRight, textWidth));
+		}
+	}
+};
+}
+
+SoftFilterPickerView::SoftFilterPickerView(QWidget* parent)
+	: FilterPickerView(parent)
+{
+	setObjectName(QStringLiteral("SoftFilterPicker"));
+
+	QVBoxLayout* layout = new QVBoxLayout(this);
+	const int pad = GUIHelper::scale(14.0);
+	// The extra bottom margin keeps the list clear of the faked drop step
+	// painted along the card's bottom edge (paintEvent).
+	layout->setContentsMargins(pad, pad, pad, pad + GUIHelper::scale(2.0));
+	layout->setSpacing(GUIHelper::scale(10.0));
+
+	searchEdit = new QLineEdit(this);
+	searchEdit->setObjectName(QStringLiteral("SoftPickerSearch"));
+	searchEdit->setPlaceholderText(tr("Search filters"));
+	searchEdit->setClearButtonEnabled(true);
+	// Arrow keys and Return typed in the pill drive the list below, so
+	// keyboard users never have to leave the field.
+	searchEdit->installEventFilter(this);
+	connect(searchEdit, &QLineEdit::textChanged, this, &SoftFilterPickerView::rebuildList);
+	layout->addWidget(searchEdit);
+
+	listWidget = new QListWidget(this);
+	listWidget->setObjectName(QStringLiteral("SoftPickerList"));
+	listWidget->setFrameShape(QFrame::NoFrame);
+	listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	listWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	listWidget->setUniformItemSizes(false);
+	listWidget->setItemDelegate(new SoftPickerDelegate(listWidget));
+	// Dropdown semantics: one click inserts.
+	connect(listWidget, &QListWidget::itemClicked, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(EntryIndexRole).toInt());
+	});
+	connect(listWidget, &QListWidget::itemActivated, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(EntryIndexRole).toInt());
+	});
+	layout->addWidget(listWidget, 1);
+
+	// Roomy and approachable: the widest, tallest-rowed picker of the five.
+	setFixedWidth(GUIHelper::scale(380.0));
+	setMaximumHeight(GUIHelper::scale(470.0));
+}
+
+void SoftFilterPickerView::setEntries(const QList<FilterPickerEntry>& entries)
+{
+	allEntries = entries;
+	sectionColors.clear();
+	const bool dark = SkinManager::instance()->isDark();
+	for (const FilterPickerEntry& entry : entries)
+	{
+		const QString section = entry.path.isEmpty() ? tr("General") : entry.path.join(QStringLiteral(" / "));
+		if (!sectionColors.contains(section))
+			sectionColors.insert(section, sectionPastel(sectionColors.size(), dark));
+	}
+	rebuildList();
+	searchEdit->setFocus();
+}
+
+void SoftFilterPickerView::rebuildList()
+{
+	listWidget->clear();
+
+	const QStringList terms = searchEdit->text().split(
+		QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+
+	QString currentSection;
+	bool sectionStarted = false;
+	for (int i = 0; i < allEntries.size(); i++)
+	{
+		const FilterPickerEntry& entry = allEntries[i];
+		const QString section = entry.path.isEmpty() ? tr("General") : entry.path.join(QStringLiteral(" / "));
+
+		bool matches = true;
+		const QString haystack = section + QLatin1Char(' ') + entry.name + QLatin1Char(' ') + entry.line;
+		for (const QString& term : terms)
+		{
+			if (!haystack.contains(term, Qt::CaseInsensitive))
+			{
+				matches = false;
+				break;
+			}
+		}
+		if (!matches)
+			continue;
+
+		const QColor tint = sectionColors.value(section,
+			sectionPastel(0, SkinManager::instance()->isDark()));
+		if (!sectionStarted || section != currentSection)
+		{
+			sectionStarted = true;
+			currentSection = section;
+			QListWidgetItem* caption = new QListWidgetItem(listWidget);
+			caption->setFlags(Qt::NoItemFlags);
+			caption->setData(EntryIndexRole, -1);
+			caption->setData(TitleRole, section);
+			caption->setData(TintRole, tint);
+			caption->setData(KindRole, SectionItem);
+		}
+
+		QListWidgetItem* item = new QListWidgetItem(listWidget);
+		item->setData(EntryIndexRole, i);
+		item->setData(TitleRole, entry.name);
+		item->setData(CaptionRole, entry.line);
+		item->setData(TintRole, tint);
+		item->setData(KindRole, EntryItem);
+		item->setToolTip(entry.line);
+	}
+
+	// A friendly, quiet empty state instead of a bare void.
+	if (listWidget->count() == 0)
+	{
+		QListWidgetItem* empty = new QListWidgetItem(listWidget);
+		empty->setFlags(Qt::NoItemFlags);
+		empty->setData(EntryIndexRole, -1);
+		empty->setData(TitleRole, tr("Nothing matches your search"));
+		empty->setData(KindRole, EmptyStateItem);
+	}
+
+	// Preselect the first real entry so Return inserts immediately.
+	for (int row = 0; row < listWidget->count(); row++)
+	{
+		if (listWidget->item(row)->flags() & Qt::ItemIsSelectable)
+		{
+			listWidget->setCurrentRow(row);
+			break;
+		}
+	}
+
+	listContentHeight = 0;
+	for (int row = 0; row < listWidget->count(); row++)
+		listContentHeight += listWidget->sizeHintForRow(row);
+	updateGeometry();
+}
+
+QSize SoftFilterPickerView::sizeHint() const
+{
+	const QMargins margins = layout()->contentsMargins();
+	int height = margins.top() + margins.bottom() + layout()->spacing()
+		+ searchEdit->sizeHint().height() + listContentHeight + GUIHelper::scale(4.0);
+	height = qMin(height, maximumHeight());
+	return QSize(GUIHelper::scale(380.0), height);
+}
+
+void SoftFilterPickerView::chooseCurrent()
+{
+	QListWidgetItem* item = listWidget->currentItem();
+	if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+		emit entryChosen(item->data(EntryIndexRole).toInt());
+}
+
+bool SoftFilterPickerView::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == searchEdit && event->type() == QEvent::KeyPress)
+	{
+		QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+		switch (keyEvent->key())
+		{
+		case Qt::Key_Down:
+		case Qt::Key_Up:
+		case Qt::Key_PageDown:
+		case Qt::Key_PageUp:
+			QApplication::sendEvent(listWidget, event);
+			return true;
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			chooseCurrent();
+			return true;
+		default:
+			break;
+		}
+	}
+	return FilterPickerView::eventFilter(watched, event);
+}
+
+void SoftFilterPickerView::paintEvent(QPaintEvent* event)
+{
+	Q_UNUSED(event);
+	const SkinTokens& t = SkinManager::instance()->tokens();
+	const bool dark = SkinManager::instance()->isDark();
+
+	QPainter painter(this);
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	// Backing for the rounded corners: the window background, which is also
+	// what the popup floats over.
+	painter.fillRect(rect(), QColor(t.background));
+
+	// Faked elevation, per the constitution: one background value step nudged
+	// down under the card; never a real shadow effect.
+	const qreal radius = 12.0;
+	QRectF card(rect());
+	card.adjust(0.5, 0.5, -0.5, -2.5);
+	const QColor stepColor = dark
+		? mixColor(QColor(t.background), QColor(Qt::black), 0.45)
+		: mixColor(QColor(t.background), QColor(t.border), 0.7);
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(stepColor);
+	painter.drawRoundedRect(card.translated(0, 2.0), radius, radius);
+
+	// The menu card itself: rounded, one value step above the window, with
+	// the very light 1px border.
+	painter.setPen(QPen(QColor(t.border), 1));
+	painter.setBrush(QColor(t.card));
+	painter.drawRoundedRect(card, radius, radius);
+}

--- a/Editor/skins/pickers/SoftFilterPicker.h
+++ b/Editor/skins/pickers/SoftFilterPicker.h
@@ -1,0 +1,50 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Soft Lab's "add filter" picker: a rounded menu card in the language of a
+	consumer settings app. A pill search field sits over comfortable two-line
+	rows (template name plus its config line as a muted caption), each led by
+	an iOS-Settings-style rounded-square colour tile in its category's pastel;
+	category headers are tinted pills of the same hue. The hovered row lifts
+	one value step and the current row gets a fully rounded stadium highlight,
+	echoing the skin's chip grammar. Elevation is faked with one background
+	value step under the card plus the usual very light 1px border.
+*/
+
+#pragma once
+
+#include <QColor>
+#include <QHash>
+
+#include "Editor/widgets/FilterPickerView.h"
+
+class QLineEdit;
+class QListWidget;
+
+class SoftFilterPickerView : public FilterPickerView
+{
+	Q_OBJECT
+
+public:
+	explicit SoftFilterPickerView(QWidget* parent = nullptr);
+
+	void setEntries(const QList<FilterPickerEntry>& entries) override;
+
+	QSize sizeHint() const override;
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override;
+	void paintEvent(QPaintEvent* event) override;
+
+private:
+	void rebuildList();
+	void chooseCurrent();
+
+	QList<FilterPickerEntry> allEntries;
+	// Category -> pastel tile colour, assigned in catalog order so a category
+	// keeps its hue however the search narrows the list.
+	QHash<QString, QColor> sectionColors;
+	QLineEdit* searchEdit = nullptr;
+	QListWidget* listWidget = nullptr;
+	int listContentHeight = 0;
+};

--- a/Editor/skins/pickers/StudioFilterPicker.cpp
+++ b/Editor/skins/pickers/StudioFilterPicker.cpp
@@ -1,0 +1,549 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "StudioFilterPicker.h"
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPainter>
+#include <QPainterPath>
+#include <QRegularExpression>
+#include <QStyledItemDelegate>
+#include <QVBoxLayout>
+
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+
+namespace
+{
+// Studio's glow rule: light is faked with layered strokes and gradients,
+// never effects. These helpers mirror the alpha/mix vocabulary Skins.cpp
+// uses for the card chrome so the picker speaks the exact same dialect.
+QColor withAlpha(const QString& hex, int alpha)
+{
+	QColor color(hex);
+	color.setAlpha(alpha);
+	return color;
+}
+
+QColor mixColor(const QColor& a, const QColor& b, double t)
+{
+	return QColor(
+		qRound(a.red() + (b.red() - a.red()) * t),
+		qRound(a.green() + (b.green() - a.green()) * t),
+		qRound(a.blue() + (b.blue() - a.blue()) * t));
+}
+
+// Item data roles. EntryIndexRole carries the ORIGINAL index into the
+// entries list handed to setEntries; captions and notes carry -1.
+constexpr int EntryIndexRole = Qt::UserRole;
+constexpr int CaptionRole = Qt::UserRole + 1;
+constexpr int FirstCaptionRole = Qt::UserRole + 2;
+constexpr int EmptyNoteRole = Qt::UserRole + 3;
+
+// A small magnifier glyph for the search field, drawn in token colours so
+// both modes stay intentional without shipping an icon asset.
+QPixmap makeSearchGlyph(const QColor& color)
+{
+	const int side = GUIHelper::scale(16.0);
+	QPixmap pixmap(side, side);
+	pixmap.fill(Qt::transparent);
+	QPainter painter(&pixmap);
+	painter.setRenderHint(QPainter::Antialiasing);
+	QPen pen(color, qMax(1.4, side / 10.0));
+	pen.setCapStyle(Qt::RoundCap);
+	painter.setPen(pen);
+	const double radius = side * 0.28;
+	const QPointF center(side * 0.42, side * 0.42);
+	painter.drawEllipse(center, radius, radius);
+	painter.drawLine(
+		QPointF(center.x() + radius * 0.72, center.y() + radius * 0.72),
+		QPointF(side * 0.82, side * 0.82));
+	return pixmap;
+}
+
+// Paints captions as understated luminous dividers and entries as glass
+// strips: hover pools light under the cursor (radial accent wash), the
+// selected entry glows from within and carries the skin's signal lamp.
+class StudioPickerDelegate : public QStyledItemDelegate
+{
+public:
+	StudioPickerDelegate(const SkinTokens& tokens, bool dark, QObject* parent)
+		: QStyledItemDelegate(parent), t(tokens), dark(dark)
+	{
+	}
+
+	QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
+	{
+		Q_UNUSED(option);
+		if (index.data(CaptionRole).toBool())
+			return QSize(0, GUIHelper::scale(index.data(FirstCaptionRole).toBool() ? 22.0 : 31.0));
+		if (index.data(EmptyNoteRole).toBool())
+			return QSize(0, GUIHelper::scale(44.0));
+		return QSize(0, GUIHelper::scale(30.0));
+	}
+
+	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+	{
+		painter->save();
+		painter->setRenderHint(QPainter::Antialiasing);
+
+		if (index.data(CaptionRole).toBool())
+			paintCaption(painter, option, index);
+		else if (index.data(EmptyNoteRole).toBool())
+			paintEmptyNote(painter, option, index);
+		else
+			paintEntry(painter, option, index);
+
+		painter->restore();
+	}
+
+private:
+	void paintCaption(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+	{
+		const int pad = GUIHelper::scale(10.0);
+		// The extra height above non-first captions is the section gap; the
+		// caption text itself sits in the lower band.
+		QRectF rect = QRectF(option.rect).adjusted(pad, 0, -pad, 0);
+		rect.setTop(rect.bottom() - GUIHelper::scale(20.0));
+
+		QFont font(t.fontFamily);
+		font.setPointSizeF(7.6);
+		font.setWeight(QFont::DemiBold);
+		font.setLetterSpacing(QFont::AbsoluteSpacing, 1.1);
+		painter->setFont(font);
+		painter->setPen(withAlpha(t.mutedText, dark ? 215 : 235));
+
+		const QString text = index.data(Qt::DisplayRole).toString().toUpper();
+		painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, text);
+
+		// Slightly luminous divider: a hairline that picks up the accent near
+		// the caption and dissolves toward the right edge.
+		const double textWidth = QFontMetricsF(font).horizontalAdvance(text);
+		const double y = rect.center().y() + 0.5;
+		const double x0 = rect.left() + textWidth + GUIHelper::scale(8.0);
+		if (x0 < rect.right() - GUIHelper::scale(12.0))
+		{
+			QLinearGradient line(x0, y, rect.right(), y);
+			line.setColorAt(0.0, withAlpha(t.accent, dark ? 110 : 130));
+			line.setColorAt(0.55, withAlpha(t.accent2, dark ? 45 : 60));
+			line.setColorAt(1.0, withAlpha(t.accent2, 0));
+			painter->setPen(QPen(QBrush(line), 1.0));
+			painter->drawLine(QPointF(x0, y), QPointF(rect.right(), y));
+		}
+	}
+
+	void paintEmptyNote(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+	{
+		QFont font(t.fontFamily);
+		font.setPointSizeF(9.0);
+		font.setItalic(true);
+		painter->setFont(font);
+		painter->setPen(withAlpha(t.mutedText, 200));
+		painter->drawText(option.rect, Qt::AlignCenter, index.data(Qt::DisplayRole).toString());
+	}
+
+	void paintEntry(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+	{
+		const bool selected = option.state.testFlag(QStyle::State_Selected);
+		const bool hovered = option.state.testFlag(QStyle::State_MouseOver);
+		const QRectF rect = QRectF(option.rect).adjusted(2.0, 1.0, -2.0, -1.0);
+		const double radius = 8.0;
+
+		QPainterPath path;
+		path.addRoundedRect(rect, radius, radius);
+
+		if (selected)
+		{
+			// Glass selection lit from within: gradient fill, a wide soft
+			// inner stroke as the pooled light, a crisp 1px edge, and the
+			// skin's signal lamp on the left rim.
+			QLinearGradient fill(rect.topLeft(), rect.bottomLeft());
+			fill.setColorAt(0.0, withAlpha(t.accent, dark ? 70 : 52));
+			fill.setColorAt(1.0, withAlpha(t.accent, dark ? 32 : 24));
+			painter->fillPath(path, fill);
+
+			painter->setBrush(Qt::NoBrush);
+			painter->setPen(QPen(withAlpha(t.accent, dark ? 52 : 40), 4.0));
+			painter->drawRoundedRect(rect.adjusted(2.0, 2.0, -2.0, -2.0), radius - 2.0, radius - 2.0);
+			painter->setPen(QPen(withAlpha(t.accent, dark ? 200 : 180), 1.0));
+			painter->drawRoundedRect(rect.adjusted(0.5, 0.5, -0.5, -0.5), radius, radius);
+
+			// Signal lamp: the same vertical fade-in/out segment the studio
+			// cards wear, with its bloom.
+			const double segment = qMin(16.0, rect.height() - 8.0);
+			const double y0 = rect.center().y() - segment / 2.0;
+			QLinearGradient bloom(0, y0 - 3.0, 0, y0 + segment + 3.0);
+			bloom.setColorAt(0.0, withAlpha(t.accent, 0));
+			bloom.setColorAt(0.5, withAlpha(t.accent, 80));
+			bloom.setColorAt(1.0, withAlpha(t.accent, 0));
+			QLinearGradient lamp(0, y0, 0, y0 + segment);
+			lamp.setColorAt(0.0, withAlpha(t.accent, 0));
+			lamp.setColorAt(0.5, withAlpha(t.accent, 245));
+			lamp.setColorAt(1.0, withAlpha(t.accent, 0));
+			painter->save();
+			painter->setClipPath(path);
+			painter->fillRect(QRectF(rect.left(), y0 - 3.0, 4.0, segment + 6.0), bloom);
+			painter->fillRect(QRectF(rect.left() + 1.0, y0, 2.0, segment), lamp);
+			painter->restore();
+		}
+		else if (hovered)
+		{
+			// Light pooling under the cursor: a faint sheen plus a radial
+			// accent wash that brightens the middle of the strip.
+			painter->fillPath(path, QColor(255, 255, 255, dark ? 8 : 90));
+			QRadialGradient pool(rect.center(), rect.width() * 0.46);
+			pool.setColorAt(0.0, withAlpha(t.accent, dark ? 40 : 30));
+			pool.setColorAt(1.0, withAlpha(t.accent, 0));
+			painter->fillPath(path, pool);
+		}
+
+		QFont font(t.fontFamily);
+		font.setPointSizeF(9.4);
+		if (selected)
+			font.setWeight(QFont::DemiBold);
+		painter->setFont(font);
+		QColor textColor(t.text);
+		if (!selected && !hovered)
+			textColor = mixColor(QColor(t.text), QColor(t.mutedText), 0.18);
+		painter->setPen(textColor);
+		painter->drawText(rect.adjusted(GUIHelper::scale(12.0), 0, -GUIHelper::scale(8.0), 0),
+			Qt::AlignLeft | Qt::AlignVCenter,
+			painter->fontMetrics().elidedText(
+				index.data(Qt::DisplayRole).toString(), Qt::ElideRight,
+				qRound(rect.width() - GUIHelper::scale(20.0))));
+	}
+
+	SkinTokens t;
+	bool dark;
+};
+}
+
+StudioFilterPickerView::StudioFilterPickerView(QWidget* parent)
+	: FilterPickerView(parent)
+{
+	setObjectName(QStringLiteral("StudioFilterPicker"));
+	skinTokens = SkinManager::instance()->tokens();
+	// The hooks convention: studio's dark background is near-black, so
+	// luminance is an unambiguous mode proxy (see Skins.cpp).
+	dark = QColor(skinTokens.background).lightness() < 128;
+
+	const int glow = GUIHelper::scale(13.0);
+	const int pad = GUIHelper::scale(12.0);
+	QVBoxLayout* layout = new QVBoxLayout(this);
+	layout->setContentsMargins(glow + pad, glow + pad, glow + pad, glow + pad);
+	layout->setSpacing(GUIHelper::scale(10.0));
+
+	// Prominent sunken-glass search field: the inverse of the raised panel,
+	// with a darker top edge as the inner shadow (the skin's input rule).
+	searchEdit = new QLineEdit(this);
+	searchEdit->setObjectName(QStringLiteral("StudioPickerSearch"));
+	searchEdit->setPlaceholderText(tr("Search filters"));
+	searchEdit->setClearButtonEnabled(true);
+	searchEdit->addAction(QIcon(makeSearchGlyph(QColor(skinTokens.mutedText))), QLineEdit::LeadingPosition);
+	const QString sunken = dark ? skinTokens.surfaceSunken : skinTokens.graph;
+	const QString focusBackground = dark ? skinTokens.surface : skinTokens.card;
+	const QString innerShadow = dark
+		? QStringLiteral("rgba(0, 0, 0, 0.55)") : QStringLiteral("rgba(24, 32, 51, 0.16)");
+	searchEdit->setStyleSheet(QStringLiteral(
+		"QLineEdit#StudioPickerSearch {"
+		" background: %1; color: %2;"
+		" border: 1px solid %3; border-top-color: %4;"
+		" border-radius: 9px; padding: 6px 10px 6px 4px;"
+		" selection-background-color: %5; selection-color: #f8fafc;"
+		" font-family: \"%6\"; font-size: 10pt; }"
+		"QLineEdit#StudioPickerSearch:focus {"
+		" border: 1px solid %5; background: %7; }")
+		.arg(sunken, skinTokens.text, skinTokens.border, innerShadow,
+			skinTokens.accent, skinTokens.fontFamily, focusBackground));
+	// Arrow keys and Return typed in the search field drive the list below,
+	// so keyboard users never have to leave the field.
+	searchEdit->installEventFilter(this);
+	connect(searchEdit, &QLineEdit::textChanged, this, &StudioFilterPickerView::rebuildList);
+	layout->addWidget(searchEdit);
+	setFocusProxy(searchEdit);
+
+	listWidget = new QListWidget(this);
+	listWidget->setObjectName(QStringLiteral("StudioPickerList"));
+	listWidget->setFrameShape(QFrame::NoFrame);
+	listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	listWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	listWidget->setMouseTracking(true);
+	listWidget->setItemDelegate(new StudioPickerDelegate(skinTokens, dark, listWidget));
+	// The scroll bar gap is filled with the global QAbstractScrollArea
+	// background (the deep stage colour), which would cut a hard stripe into
+	// the glass. Restyle it as an intentional sunken-glass channel whose
+	// opaque track sits on the panel's own colour family.
+	const QColor track = mixColor(QColor(skinTokens.card), QColor(skinTokens.background), dark ? 0.45 : 0.40);
+	const QString handleColor = dark
+		? QStringLiteral("rgba(255, 255, 255, 0.16)") : QStringLiteral("rgba(24, 32, 51, 0.22)");
+	listWidget->setStyleSheet(QStringLiteral(
+		"QListWidget#StudioPickerList { background: transparent; border: 0; outline: 0; }"
+		"QListWidget#StudioPickerList::item { border: 0; padding: 0; }"
+		"QListWidget#StudioPickerList QScrollBar:vertical {"
+		" background: %1; width: 8px; margin: 0; border: 0; border-radius: 4px; }"
+		"QListWidget#StudioPickerList QScrollBar::handle:vertical {"
+		" background: %2; min-height: 32px; border-radius: 4px; }"
+		"QListWidget#StudioPickerList QScrollBar::handle:vertical:hover {"
+		" background: %3; }"
+		"QListWidget#StudioPickerList QScrollBar::handle:vertical:pressed {"
+		" background: %4; }"
+		"QListWidget#StudioPickerList QScrollBar::add-line:vertical,"
+		"QListWidget#StudioPickerList QScrollBar::sub-line:vertical {"
+		" background: transparent; border: 0; width: 0; height: 0; }"
+		"QListWidget#StudioPickerList QScrollBar::add-page:vertical,"
+		"QListWidget#StudioPickerList QScrollBar::sub-page:vertical {"
+		" background: transparent; }")
+		.arg(QStringLiteral("rgb(%1, %2, %3)").arg(track.red()).arg(track.green()).arg(track.blue()),
+			handleColor,
+			QStringLiteral("rgba(%1, %2, %3, 0.55)")
+			.arg(QColor(skinTokens.accent).red()).arg(QColor(skinTokens.accent).green()).arg(QColor(skinTokens.accent).blue()),
+			skinTokens.accent));
+	listWidget->setMinimumHeight(GUIHelper::scale(330.0));
+	// Dropdown semantics: one click inserts.
+	connect(listWidget, &QListWidget::itemClicked, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(EntryIndexRole).toInt());
+	});
+	connect(listWidget, &QListWidget::itemActivated, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(EntryIndexRole).toInt());
+	});
+	layout->addWidget(listWidget, 1);
+
+	setMinimumWidth(GUIHelper::scale(388.0));
+	setMaximumWidth(GUIHelper::scale(440.0));
+	setMaximumHeight(GUIHelper::scale(470.0));
+}
+
+void StudioFilterPickerView::setEntries(const QList<FilterPickerEntry>& entries)
+{
+	allEntries = entries;
+	rebuildList();
+	searchEdit->setFocus();
+}
+
+void StudioFilterPickerView::rebuildList()
+{
+	listWidget->clear();
+
+	const QStringList terms = searchEdit->text().split(
+		QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+
+	QString currentSection;
+	bool sectionStarted = false;
+	for (int i = 0; i < allEntries.size(); i++)
+	{
+		const FilterPickerEntry& entry = allEntries[i];
+		const QString section = entry.path.isEmpty() ? tr("General") : entry.path.join(QStringLiteral(" / "));
+
+		bool matches = true;
+		const QString haystack = section + QLatin1Char(' ') + entry.name + QLatin1Char(' ') + entry.line;
+		for (const QString& term : terms)
+		{
+			if (!haystack.contains(term, Qt::CaseInsensitive))
+			{
+				matches = false;
+				break;
+			}
+		}
+		if (!matches)
+			continue;
+
+		if (!sectionStarted || section != currentSection)
+		{
+			QListWidgetItem* caption = new QListWidgetItem(section, listWidget);
+			caption->setFlags(Qt::NoItemFlags);
+			caption->setData(EntryIndexRole, -1);
+			caption->setData(CaptionRole, true);
+			caption->setData(FirstCaptionRole, !sectionStarted);
+			sectionStarted = true;
+			currentSection = section;
+		}
+
+		QListWidgetItem* item = new QListWidgetItem(entry.name, listWidget);
+		item->setData(EntryIndexRole, i);
+		item->setToolTip(entry.line);
+	}
+
+	if (listWidget->count() == 0)
+	{
+		QListWidgetItem* note = new QListWidgetItem(tr("No matching filters"), listWidget);
+		note->setFlags(Qt::NoItemFlags);
+		note->setData(EntryIndexRole, -1);
+		note->setData(EmptyNoteRole, true);
+	}
+
+	// Preselect the first real entry so Return inserts immediately.
+	for (int row = 0; row < listWidget->count(); row++)
+	{
+		if (listWidget->item(row)->flags() & Qt::ItemIsSelectable)
+		{
+			listWidget->setCurrentRow(row);
+			break;
+		}
+	}
+}
+
+void StudioFilterPickerView::chooseCurrent()
+{
+	QListWidgetItem* item = listWidget->currentItem();
+	if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+		emit entryChosen(item->data(EntryIndexRole).toInt());
+}
+
+bool StudioFilterPickerView::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == searchEdit && event->type() == QEvent::KeyPress)
+	{
+		QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+		switch (keyEvent->key())
+		{
+		case Qt::Key_Down:
+		case Qt::Key_Up:
+		case Qt::Key_PageDown:
+		case Qt::Key_PageUp:
+			QApplication::sendEvent(listWidget, event);
+			return true;
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			chooseCurrent();
+			return true;
+		default:
+			break;
+		}
+	}
+	return FilterPickerView::eventFilter(watched, event);
+}
+
+void StudioFilterPickerView::paintEvent(QPaintEvent* event)
+{
+	Q_UNUSED(event);
+	QPainter painter(this);
+	painter.setRenderHint(QPainter::Antialiasing);
+
+	// The stage: an opaque strip of the deep studio background around the
+	// panel. The popup host is a plain opaque window, so the glass effect is
+	// staged here; over the editor (whose background is this same token) the
+	// margin melts away and only the lit panel appears to float.
+	const QColor background(skinTokens.background);
+	painter.fillRect(rect(), background);
+
+	const double glow = GUIHelper::scale(13.0);
+	const QRectF panel = QRectF(rect()).adjusted(glow, glow, -glow, -glow);
+	const double radius = GUIHelper::scale(14.0);
+	const QColor accent(skinTokens.accent);
+	const QColor card(skinTokens.card);
+
+	// Soft elevation shadow: stacked translucent rounded rects drifting
+	// downward (no effects, per the skin's glow rule).
+	painter.setPen(Qt::NoPen);
+	for (int i = 4; i >= 1; i--)
+	{
+		painter.setBrush(QColor(0, 0, 0, dark ? 26 - i * 4 : 24 - i * 4));
+		painter.drawRoundedRect(panel.translated(0, i + 1).adjusted(-i, -i, i, i), radius + i, radius + i);
+	}
+
+	// Light behind the glass: the accent glow hugging the border, painted as
+	// progressively tighter, brighter strokes.
+	painter.setBrush(Qt::NoBrush);
+	const struct { double width; int alpha; } glowLayers[] = {
+		{ 11.0, dark ? 14 : 16 },
+		{ 7.0, dark ? 26 : 30 },
+		{ 4.0, dark ? 44 : 48 },
+		{ 2.0, dark ? 66 : 70 }
+	};
+	for (const auto& layer : glowLayers)
+	{
+		QColor stroke = accent;
+		stroke.setAlpha(layer.alpha);
+		painter.setPen(QPen(stroke, layer.width));
+		painter.drawRoundedRect(panel, radius, radius);
+	}
+
+	// The glass itself: a vertical gradient slab over the deep background.
+	QPainterPath panelPath;
+	panelPath.addRoundedRect(panel, radius, radius);
+	QLinearGradient glass(panel.topLeft(), panel.bottomLeft());
+	if (dark)
+	{
+		glass.setColorAt(0.0, mixColor(card, QColor(255, 255, 255), 0.05));
+		glass.setColorAt(1.0, mixColor(card, background, 0.30));
+	}
+	else
+	{
+		glass.setColorAt(0.0, card);
+		glass.setColorAt(1.0, mixColor(card, background, 0.35));
+	}
+	painter.setPen(Qt::NoPen);
+	painter.fillPath(panelPath, glass);
+
+	// The light sources behind the glass: a key light shining through near
+	// the search field and a violet rim light low in the opposite corner.
+	// They tint the panel from within, which is what makes it read as lit
+	// glass rather than a flat card.
+	QRadialGradient keyLight(
+		QPointF(panel.center().x() - panel.width() * 0.16, panel.top() + panel.height() * 0.08),
+		panel.width() * 0.62);
+	keyLight.setColorAt(0.0, withAlpha(skinTokens.accent, dark ? 38 : 30));
+	keyLight.setColorAt(1.0, withAlpha(skinTokens.accent, 0));
+	painter.fillPath(panelPath, keyLight);
+	QRadialGradient rimLight(
+		QPointF(panel.right() - panel.width() * 0.10, panel.bottom() - panel.height() * 0.06),
+		panel.width() * 0.55);
+	rimLight.setColorAt(0.0, withAlpha(skinTokens.accent2, dark ? 30 : 22));
+	rimLight.setColorAt(1.0, withAlpha(skinTokens.accent2, 0));
+	painter.fillPath(panelPath, rimLight);
+
+	// Frost sheen across the upper region: the light caught in the glass.
+	QLinearGradient sheen(panel.topLeft(), QPointF(panel.left(), panel.top() + panel.height() * 0.42));
+	sheen.setColorAt(0.0, QColor(255, 255, 255, dark ? 20 : 150));
+	sheen.setColorAt(1.0, QColor(255, 255, 255, 0));
+	painter.fillPath(panelPath, sheen);
+
+	// 1px border: an icy reflection at the top dissolving into accent light
+	// toward the bottom.
+	QLinearGradient edge(panel.topLeft(), panel.bottomLeft());
+	if (dark)
+	{
+		edge.setColorAt(0.0, QColor(255, 255, 255, 56));
+		edge.setColorAt(0.45, withAlpha(skinTokens.border, 230));
+		edge.setColorAt(1.0, withAlpha(skinTokens.accent, 90));
+	}
+	else
+	{
+		edge.setColorAt(0.0, QColor(255, 255, 255, 240));
+		edge.setColorAt(0.45, withAlpha(skinTokens.border, 255));
+		edge.setColorAt(1.0, withAlpha(skinTokens.accent, 110));
+	}
+	painter.setBrush(Qt::NoBrush);
+	painter.setPen(QPen(QBrush(edge), 1.0));
+	painter.drawRoundedRect(panel.adjusted(0.5, 0.5, -0.5, -0.5), radius, radius);
+
+	// The luminous arc: an accent-to-violet light caught on the top edge,
+	// echoing the skin's glowing knob arcs. Bloom first, then the core.
+	const double arcSpan = panel.width() * 0.58;
+	const double arcX0 = panel.center().x() - arcSpan / 2.0;
+	const double arcY = panel.top();
+	QLinearGradient arc(arcX0, arcY, arcX0 + arcSpan, arcY);
+	arc.setColorAt(0.0, withAlpha(skinTokens.accent, 0));
+	arc.setColorAt(0.35, withAlpha(skinTokens.accent, dark ? 255 : 235));
+	arc.setColorAt(0.7, withAlpha(skinTokens.accent2, dark ? 220 : 195));
+	arc.setColorAt(1.0, withAlpha(skinTokens.accent2, 0));
+	QLinearGradient arcBloom(arcX0, arcY, arcX0 + arcSpan, arcY);
+	arcBloom.setColorAt(0.0, withAlpha(skinTokens.accent, 0));
+	arcBloom.setColorAt(0.35, withAlpha(skinTokens.accent, dark ? 95 : 75));
+	arcBloom.setColorAt(0.7, withAlpha(skinTokens.accent2, dark ? 75 : 58));
+	arcBloom.setColorAt(1.0, withAlpha(skinTokens.accent2, 0));
+	QPen bloomPen(QBrush(arcBloom), 5.0);
+	bloomPen.setCapStyle(Qt::RoundCap);
+	painter.setPen(bloomPen);
+	painter.drawLine(QPointF(arcX0, arcY), QPointF(arcX0 + arcSpan, arcY));
+	QPen arcPen(QBrush(arc), 2.0);
+	arcPen.setCapStyle(Qt::RoundCap);
+	painter.setPen(arcPen);
+	painter.drawLine(QPointF(arcX0, arcY), QPointF(arcX0 + arcSpan, arcY));
+}

--- a/Editor/skins/pickers/StudioFilterPicker.h
+++ b/Editor/skins/pickers/StudioFilterPicker.h
@@ -1,0 +1,44 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Studio Glass "add filter" picker: a floating frosted-glass panel. The
+	widget paints its own stage (the deep studio background), a soft
+	elevation shadow, an accent glow behind the panel and a luminous top
+	edge; inside sit a prominent sunken-glass search field and one airy
+	sectioned list whose hovered entry pools light under the cursor and
+	whose selected entry carries the skin's signal lamp.
+*/
+
+#pragma once
+
+#include <QList>
+
+#include "Editor/SkinTokens.h"
+#include "Editor/widgets/FilterPickerView.h"
+
+class QLineEdit;
+class QListWidget;
+
+class StudioFilterPickerView : public FilterPickerView
+{
+	Q_OBJECT
+
+public:
+	explicit StudioFilterPickerView(QWidget* parent = nullptr);
+
+	void setEntries(const QList<FilterPickerEntry>& entries) override;
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override;
+	void paintEvent(QPaintEvent* event) override;
+
+private:
+	void rebuildList();
+	void chooseCurrent();
+
+	QList<FilterPickerEntry> allEntries;
+	SkinTokens skinTokens;
+	bool dark = true;
+	QLineEdit* searchEdit = nullptr;
+	QListWidget* listWidget = nullptr;
+};

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -353,6 +353,21 @@ QLineEdit#IncludeCardPath {
 }
 QLabel#IncludeCardStatus { color: @DANGER@; font-size: 9pt; }
 
+/* Add-filter picker: a terminal index (man page / BIOS menu). The frame,
+   the section rules and the inverted selection block are painted by
+   MinimalFilterPickerView; QSS only dresses the query line and the legend. */
+QWidget#MinimalPickerHeader { background: @BG@; border: 0; border-bottom: 1px solid @BORDER@; }
+QLabel#MinimalPickerPrompt { color: @ACCENT@; background: transparent; font-weight: 700; padding: 0; }
+QLineEdit#MinimalPickerQuery, QLineEdit#MinimalPickerQuery:focus {
+    background: transparent; border: 0; border-radius: 0; padding: 0; color: @TEXT@;
+}
+QLabel#MinimalPickerCount { color: @MUTED@; background: transparent; font-size: 8pt; font-weight: 700; }
+QLabel#MinimalPickerLegend {
+    color: @MUTED@; background: @BG@; border: 0; border-top: 1px solid @BORDER@;
+    padding: 4px 10px; font-size: 7pt; font-weight: 700; letter-spacing: 1px;
+}
+QScrollArea#MinimalPickerScroll, QScrollArea#MinimalPickerScroll > QWidget > QWidget { background: @BG@; border: 0; }
+
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -292,6 +292,21 @@ QLineEdit#EditableValueEditor {
 QLineEdit#IncludeCardPath { background: #ffffff; border: 1px solid @BORDER@; border-radius: 0; padding: 4px 8px; }
 QLabel#IncludeCardStatus { color: #dc2626; font-size: 9pt; }
 
+/* Add-filter picker: a terminal index (man page / BIOS menu). The frame,
+   the section rules and the inverted selection block are painted by
+   MinimalFilterPickerView; QSS only dresses the query line and the legend. */
+QWidget#MinimalPickerHeader { background: @BG@; border: 0; border-bottom: 1px solid @BORDER@; }
+QLabel#MinimalPickerPrompt { color: @ACCENT@; background: transparent; font-weight: 700; padding: 0; }
+QLineEdit#MinimalPickerQuery, QLineEdit#MinimalPickerQuery:focus {
+    background: transparent; border: 0; border-radius: 0; padding: 0; color: @TEXT@;
+}
+QLabel#MinimalPickerCount { color: @MUTED@; background: transparent; font-size: 8pt; font-weight: 700; }
+QLabel#MinimalPickerLegend {
+    color: @MUTED@; background: @BG@; border: 0; border-top: 1px solid @BORDER@;
+    padding: 4px 10px; font-size: 7pt; font-weight: 700; letter-spacing: 1px;
+}
+QScrollArea#MinimalPickerScroll, QScrollArea#MinimalPickerScroll > QWidget > QWidget { background: @BG@; border: 0; }
+
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -295,6 +295,17 @@ QPushButton#VSTCardPanelButton:disabled { background: @SURFACE@; color: rgba(167
 QFrame#VSTCardEmbedFrame { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
 QPlainTextEdit#VSTCardWarning { background: rgba(245, 158, 11, 0.10); color: @TEXT@; border: 1px solid rgba(245, 158, 11, 0.40); border-radius: 10px; padding: 6px; }
 
+/* Add-filter picker (SoftFilterPickerView): a rounded menu card. The card
+   frame, its faked drop step and the rows (pastel tiles, stadium highlights,
+   pill section headers) are painted from tokens by the view and its delegate;
+   here live the pill search field and the transparent list body. */
+QLineEdit#SoftPickerSearch {
+    background: @SURFACE_SUNKEN@; border: 1px solid @BORDER@;
+    border-radius: 17px; padding: 8px 16px; min-height: 18px;
+}
+QLineEdit#SoftPickerSearch:focus { border: 1px solid @ACCENT@; background: @SURFACE_SUNKEN@; }
+QListWidget#SoftPickerList { background: transparent; border: 0; }
+
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -295,6 +295,17 @@ QPushButton#VSTCardPanelButton:disabled { background: @SURFACE@; color: rgba(120
 QFrame#VSTCardEmbedFrame { background: @CARD@; border: 1px solid @BORDER@; border-radius: 12px; }
 QPlainTextEdit#VSTCardWarning { background: rgba(217, 119, 6, 0.08); color: @TEXT@; border: 1px solid rgba(217, 119, 6, 0.35); border-radius: 10px; padding: 6px; }
 
+/* Add-filter picker (SoftFilterPickerView): a rounded menu card. The card
+   frame, its faked drop step and the rows (pastel tiles, stadium highlights,
+   pill section headers) are painted from tokens by the view and its delegate;
+   here live the pill search field and the transparent list body. */
+QLineEdit#SoftPickerSearch {
+    background: @SURFACE_SUNKEN@; border: 1px solid @BORDER@;
+    border-radius: 17px; padding: 8px 16px; min-height: 18px;
+}
+QLineEdit#SoftPickerSearch:focus { border: 1px solid @ACCENT@; background: @SURFACE_SUNKEN@; }
+QListWidget#SoftPickerList { background: transparent; border: 0; }
+
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }

--- a/Editor/widgets/FilterPickerView.cpp
+++ b/Editor/widgets/FilterPickerView.cpp
@@ -1,0 +1,152 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "FilterPickerView.h"
+
+#include <QApplication>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QRegularExpression>
+#include <QVBoxLayout>
+
+#include "Editor/helpers/GUIHelper.h"
+
+FilterPickerView::FilterPickerView(QWidget* parent)
+	: QWidget(parent)
+{
+}
+
+DefaultFilterPickerView::DefaultFilterPickerView(QWidget* parent)
+	: FilterPickerView(parent)
+{
+	setObjectName(QStringLiteral("FilterPicker"));
+	setAttribute(Qt::WA_StyledBackground, true);
+
+	QVBoxLayout* layout = new QVBoxLayout(this);
+	layout->setContentsMargins(8, 8, 8, 8);
+	layout->setSpacing(6);
+
+	searchEdit = new QLineEdit(this);
+	searchEdit->setObjectName(QStringLiteral("FilterPickerSearch"));
+	searchEdit->setPlaceholderText(tr("Search filters"));
+	searchEdit->setClearButtonEnabled(true);
+	// Arrow keys and Return typed in the search field drive the list below, so
+	// keyboard users never have to leave the field.
+	searchEdit->installEventFilter(this);
+	connect(searchEdit, &QLineEdit::textChanged, this, &DefaultFilterPickerView::rebuildList);
+	layout->addWidget(searchEdit);
+
+	listWidget = new QListWidget(this);
+	listWidget->setObjectName(QStringLiteral("FilterPickerList"));
+	listWidget->setFrameShape(QFrame::NoFrame);
+	listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+	listWidget->setUniformItemSizes(false);
+	// Dropdown semantics: one click inserts.
+	connect(listWidget, &QListWidget::itemClicked, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(Qt::UserRole).toInt());
+	});
+	connect(listWidget, &QListWidget::itemActivated, this, [this](QListWidgetItem* item) {
+		if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+			emit entryChosen(item->data(Qt::UserRole).toInt());
+	});
+	layout->addWidget(listWidget, 1);
+
+	setMinimumWidth(GUIHelper::scale(300.0));
+	setMaximumHeight(GUIHelper::scale(420.0));
+}
+
+void DefaultFilterPickerView::setEntries(const QList<FilterPickerEntry>& entries)
+{
+	allEntries = entries;
+	rebuildList();
+	searchEdit->setFocus();
+}
+
+void DefaultFilterPickerView::rebuildList()
+{
+	listWidget->clear();
+
+	const QStringList terms = searchEdit->text().split(
+		QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+
+	QString currentSection;
+	bool sectionStarted = false;
+	for (int i = 0; i < allEntries.size(); i++)
+	{
+		const FilterPickerEntry& entry = allEntries[i];
+		const QString section = entry.path.isEmpty() ? tr("General") : entry.path.join(QStringLiteral(" / "));
+
+		bool matches = true;
+		const QString haystack = section + QLatin1Char(' ') + entry.name + QLatin1Char(' ') + entry.line;
+		for (const QString& term : terms)
+		{
+			if (!haystack.contains(term, Qt::CaseInsensitive))
+			{
+				matches = false;
+				break;
+			}
+		}
+		if (!matches)
+			continue;
+
+		if (!sectionStarted || section != currentSection)
+		{
+			sectionStarted = true;
+			currentSection = section;
+			QListWidgetItem* caption = new QListWidgetItem(section, listWidget);
+			caption->setFlags(Qt::NoItemFlags);
+			QFont captionFont = caption->font();
+			captionFont.setBold(true);
+			captionFont.setPointSizeF(captionFont.pointSizeF() * 0.9);
+			caption->setFont(captionFont);
+		}
+
+		QListWidgetItem* item = new QListWidgetItem(entry.name, listWidget);
+		item->setData(Qt::UserRole, i);
+		item->setToolTip(entry.line);
+	}
+
+	// Preselect the first real entry so Return inserts immediately.
+	for (int row = 0; row < listWidget->count(); row++)
+	{
+		if (listWidget->item(row)->flags() & Qt::ItemIsSelectable)
+		{
+			listWidget->setCurrentRow(row);
+			break;
+		}
+	}
+}
+
+void DefaultFilterPickerView::chooseCurrent()
+{
+	QListWidgetItem* item = listWidget->currentItem();
+	if (item != nullptr && (item->flags() & Qt::ItemIsSelectable))
+		emit entryChosen(item->data(Qt::UserRole).toInt());
+}
+
+bool DefaultFilterPickerView::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == searchEdit && event->type() == QEvent::KeyPress)
+	{
+		QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+		switch (keyEvent->key())
+		{
+		case Qt::Key_Down:
+		case Qt::Key_Up:
+		case Qt::Key_PageDown:
+		case Qt::Key_PageUp:
+			QApplication::sendEvent(listWidget, event);
+			return true;
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			chooseCurrent();
+			return true;
+		default:
+			break;
+		}
+	}
+	return FilterPickerView::eventFilter(watched, event);
+}

--- a/Editor/widgets/FilterPickerView.h
+++ b/Editor/widgets/FilterPickerView.h
@@ -1,0 +1,70 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	The skinnable "add filter" picker. FilterTable::chooseFilterTemplate used
+	to open one flat search palette that listed every template at once, which
+	read as noise. The picker is now a compact, dropdown-like popup anchored at
+	the add button, and each skin can contribute its own FilterPickerView so
+	the control matches the skin's design language (ISkin::createFilterPicker).
+*/
+
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <QStringList>
+#include <QWidget>
+
+class QLineEdit;
+class QListWidget;
+
+// One insertable template, flattened from the filter GUI factories.
+struct FilterPickerEntry
+{
+	QStringList path; // category path, e.g. ["Parametric filters"]
+	QString name;     // display name, e.g. "Peaking filter"
+	QString line;     // the config line the template inserts
+};
+
+// Base class for the skin-specific picker widget. The host embeds it in a
+// frameless Qt::Popup container, calls setEntries() once, and runs a local
+// event loop until entryChosen(index into that entries list) or dismissed().
+// The container already closes on outside clicks and Esc; the view only has
+// to present the entries and report a choice.
+class FilterPickerView : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit FilterPickerView(QWidget* parent = nullptr);
+
+	virtual void setEntries(const QList<FilterPickerEntry>& entries) = 0;
+
+signals:
+	void entryChosen(int index);
+	void dismissed();
+};
+
+// Neutral default, used by skins without a picker of their own: a search
+// field over one sectioned column (category captions with that category's
+// templates beneath), like a long structured dropdown.
+class DefaultFilterPickerView : public FilterPickerView
+{
+	Q_OBJECT
+
+public:
+	explicit DefaultFilterPickerView(QWidget* parent = nullptr);
+
+	void setEntries(const QList<FilterPickerEntry>& entries) override;
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+	void rebuildList();
+	void chooseCurrent();
+
+	QList<FilterPickerEntry> allEntries;
+	QLineEdit* searchEdit = nullptr;
+	QListWidget* listWidget = nullptr;
+};


### PR DESCRIPTION
The "add filter" palette listed every template at once in one flat search dialog, which read as noise. This PR replaces it with a compact, dropdown-like popup anchored at the add button, and gives every skin its own picker in its established design language.

## Architecture

- `FilterPickerView` (new): the picker contract — `setEntries(QList<FilterPickerEntry>)`, signals `entryChosen(index)` / `dismissed()` — plus the neutral `DefaultFilterPickerView` (search field over one sectioned column, keyboard-first).
- `ISkin::createFilterPicker(QWidget*)` (new hook): skins return their own view; the default returns the neutral one.
- `FilterTable::chooseFilterTemplate` now hosts the skin view in a frameless `Qt::Popup` (closes on outside click / Esc) with a local event loop, keeping the synchronous contract for both call sites. `FilterTable::filterPickerEntries()` exposes the flattened template list.
- The offscreen gallery captures `<skin>_<mode>_picker_normal.png` with the real template set; CI now expects 130 PNGs.

## Per-skin pickers (5 isolated agents, one worktree each; record on `picker/<skin>` branches)

- **studio** — frosted-glass floating panel: layered border glow, luminous top arc, radial key/rim lights behind the glass, sunken search field, hover pools light under the cursor.
- **minimal** — numbered terminal index: `>` prompt with live match counter, uppercase hairline section captions, zero-padded stable entry numbers (typing digits jumps BIOS-style), inverted-block selection, key-legend footer.
- **soft** — rounded settings menu: stadium search pill, 48px two-line rows (name + muted config line), per-category pastel letter tiles and pill headers, stadium selection highlight.
- **rack** — 1U module preset browser: brushed faceplate with corner screws, engraved `MODULE SELECT` header with power LED, recessed LCD search strip, riveted section plates, LED-lit slots with lamp-gradient backlight.
- **matrix** — two-axis crosspoint instrument: bus-select rail (A..G with counts) wired to a coordinate column (C1..C8) by a painted patch trace, scan readout search strip, footer showing the exact config line the engaged coordinate inserts.

## Verification

- Differentiation gate: the five pickers are identifiable by philosophy alone in both modes (gallery PNGs attached as the `skin-gallery` artifact).
- Interference check: after sequential integration, all **120 row PNGs are byte-identical** to the pre-integration baseline — the pickers changed nothing outside themselves.
- Integrated gallery renders 130/130 PNGs; 10s offscreen MainWindow smoke run with no crash dump; cppcheck 2.21.0 clean on all new files; local x64 Editor build clean.

Changelog entries will be added once the v1.21.0 changelog-move PR (#80) lands, to avoid a section conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)