### PR TITLE
feat(editor): per-skin main toolbar chrome with modern icons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1038,9 +1038,9 @@ jobs:
         }
         $pngs = @(Get-ChildItem $outDir -Filter *.png)
         Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # 5 skins x 2 modes x (4 rows x 3 states + 1 filter picker)
-        if ($pngs.Count -ne 130) {
-          Write-Error "Expected 130 gallery PNGs, got $($pngs.Count)"
+        # 5 skins x 2 modes x (4 rows x 3 states + 1 filter picker + 1 toolbar)
+        if ($pngs.Count -ne 140) {
+          Write-Error "Expected 140 gallery PNGs, got $($pngs.Count)"
           exit 1
         }
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,18 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- 메인 툴바가 윈도우 기본 모습과 2005년풍 아이콘에서 벗어났습니다. 새
+  `ISkin::styleMainToolbar` 훅으로 스킨마다 다르게 입습니다. Studio Glass는
+  테두리 없는 버튼 아래 빛이 고이는 유리 윗변, Precision Minimal은
+  NEW/OPEN/SAVE를 모노 텍스트 명령으로 쓰는 터미널 명령줄, Soft Lab은 파스텔
+  타일과 진짜 스타디움 토글의 차분한 헤더 밴드, Hardware Rack은 트랜스포트
+  버튼·나사·LCD 저장 상태 창이 달린 브러시드 마스터 레일, Signal Matrix는
+  상태 램프가 붙은 정사각 기능 셀의 보드 헤더입니다. 저장 상태 배지는 이제
+  하드코딩된 알약 대신 각 스킨이 직접 스타일하며, 오프스크린 갤러리가 모든
+  툴바를 캡처합니다. ([#85])
+
 ## v1.22.0 (2026-06-12)
 
 - 필터 추가 픽커가 모든 템플릿을 한꺼번에 쏟아내는 평면 목록에서, 추가
@@ -345,3 +357,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#76]: https://github.com/115dkk/EqualizerAPO-XT/pull/76
 [#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78
 [#81]: https://github.com/115dkk/EqualizerAPO-XT/pull/81
+[#85]: https://github.com/115dkk/EqualizerAPO-XT/pull/85

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- The main toolbar lost its stock Windows look and 2005-era icons. A new
+  `ISkin::styleMainToolbar` hook dresses it per skin: the top edge of the
+  glass with light pooling under unboxed buttons (Studio Glass), a terminal
+  command line with NEW/OPEN/SAVE as mono text commands (Precision Minimal),
+  a calm header band with pastel tiles and a real stadium toggle (Soft Lab),
+  a brushed master rail with transport buttons, screws and an LCD save-state
+  well (Hardware Rack), and a board header of square function cells with a
+  status lamp (Signal Matrix). The save-state badge is now styled by each
+  skin (the old hardcoded pill is gone), and the offscreen gallery captures
+  every toolbar. ([#85])
+
 ## v1.22.0 — 2026-06-12
 
 - The "add filter" picker is no longer one flat list of every template: it is
@@ -364,3 +377,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#76]: https://github.com/115dkk/EqualizerAPO-XT/pull/76
 [#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78
 [#81]: https://github.com/115dkk/EqualizerAPO-XT/pull/81
+[#85]: https://github.com/115dkk/EqualizerAPO-XT/pull/85

--- a/Editor/Editor.qrc
+++ b/Editor/Editor.qrc
@@ -40,6 +40,8 @@
         <file>icons/modern/file-new.svg</file>
         <file>icons/modern/save.svg</file>
         <file>icons/modern/save-as.svg</file>
+        <file>icons/modern/soft-toggle-knob-off.svg</file>
+        <file>icons/modern/soft-toggle-knob-on.svg</file>
         <file>translations/Editor_zh_CN.qm</file>
         <file>translations/qtbase_zh_CN.qm</file>
         <file>translations/Editor_fr.qm</file>

--- a/Editor/Editor.qrc
+++ b/Editor/Editor.qrc
@@ -37,6 +37,9 @@
         <file>icons/modern/import.svg</file>
         <file>icons/modern/file-include.svg</file>
         <file>icons/modern/plugin.svg</file>
+        <file>icons/modern/file-new.svg</file>
+        <file>icons/modern/save.svg</file>
+        <file>icons/modern/save-as.svg</file>
         <file>translations/Editor_zh_CN.qm</file>
         <file>translations/qtbase_zh_CN.qm</file>
         <file>translations/Editor_fr.qm</file>

--- a/Editor/MainWindowParts/MainWindow.Edit.cpp
+++ b/Editor/MainWindowParts/MainWindow.Edit.cpp
@@ -114,12 +114,13 @@ void MainWindow::updateDirtyStatus()
 	const int index = ui->tabWidget->currentIndex();
 	const bool dirty = index >= 0 && ui->tabWidget->tabText(index).endsWith('*');
 	dirtyStatusLabel->setText(dirty ? tr("Unsaved changes") : tr("Saved"));
+	// The badge's look is owned by the skins: every sheet styles
+	// QLabel#DirtyStatusBadge and its [dirty="true"] variant in its own
+	// grammar (amber glass lamp, brighter mono ink, warm pill, LCD segments,
+	// status lamp cell). The inline stylesheet that used to be set here
+	// overrode all of that with one hardcoded pill on the first save-state
+	// change; only the dynamic property + repolish remain.
 	dirtyStatusLabel->setProperty("dirty", dirty);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
-	dirtyStatusLabel->setStyleSheet(QStringLiteral("QLabel#DirtyStatusBadge { background: %1; color: %2; border: 1px solid %3; border-radius: 10px; padding: 4px 10px; font-weight: 700; }")
-		.arg(dirty ? tokens.warning : tokens.surfaceRaised,
-			dirty ? QStringLiteral("#111111") : tokens.text,
-			dirty ? tokens.warning : tokens.border));
 	dirtyStatusLabel->style()->unpolish(dirtyStatusLabel);
 	dirtyStatusLabel->style()->polish(dirtyStatusLabel);
 	dirtyStatusLabel->update();

--- a/Editor/MainWindowParts/MainWindow.Preferences.cpp
+++ b/Editor/MainWindowParts/MainWindow.Preferences.cpp
@@ -307,6 +307,14 @@ void MainWindow::applyRedesignPreferences()
 	SkinManager::instance()->applySkin(skinId, skinDark);
 	skinId = SkinManager::instance()->currentSkinId();
 
+	// The toolbar is dressed by the active skin (icons + chrome); re-run on
+	// every skin/dark switch so the tinted icons follow the new ink. The
+	// menu-only Save As action gets the matching neutral icon here - it is
+	// not on the toolbar, so the skin hook never sees it.
+	SkinManager::instance()->styleMainToolbar(ui->mainToolBar);
+	ui->actionSaveAs->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/save-as.svg"),
+		QColor(SkinManager::instance()->tokens().text), 18));
+
 	if (interfaceModeActionGroup != nullptr)
 	{
 		for (QAction* action : interfaceModeActionGroup->actions())

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -1,10 +1,13 @@
 #include "SkinGallery.h"
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QDir>
+#include <QLabel>
 #include <QPixmap>
 #include <QScrollArea>
 #include <QString>
+#include <QToolBar>
 
 #include "Editor/FilterTable.h"
 #include "Editor/SkinManager.h"
@@ -13,6 +16,7 @@
 #include "Editor/skins/Skins.h"
 #include "Editor/widgets/FilterCardRow.h"
 #include "Editor/widgets/FilterPickerView.h"
+#include "Editor/widgets/SkinComboBox.h"
 
 namespace
 {
@@ -34,6 +38,69 @@ QList<GalleryRow> galleryRows()
 		{ QStringLiteral("include"), QStringLiteral("Include: example.txt") },
 		{ QStringLiteral("vst"), QStringLiteral("VSTPlugin: Library example.dll") }
 	};
+}
+
+// Faithful chrome replica of MainWindow's toolbar: same object names, same
+// widget train, dummy data where the real one reads devices. The gallery
+// judges chrome, not data, and constructing the real toolbar would drag in
+// device enumeration (flaky on machines without audio endpoints).
+QToolBar* buildToolbarReplica(QWidget* parent)
+{
+	QToolBar* toolBar = new QToolBar(parent);
+	toolBar->setObjectName(QStringLiteral("MainToolBar"));
+	toolBar->setMovable(false);
+
+	QAction* actionNew = toolBar->addAction(QStringLiteral("New"));
+	actionNew->setObjectName(QStringLiteral("actionNew"));
+	QAction* actionOpen = toolBar->addAction(QStringLiteral("Open"));
+	actionOpen->setObjectName(QStringLiteral("actionOpen"));
+	QAction* actionSave = toolBar->addAction(QStringLiteral("Save"));
+	actionSave->setObjectName(QStringLiteral("actionSave"));
+
+	QWidget* spacer = new QWidget;
+	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
+	spacer->setFixedWidth(10);
+	toolBar->addWidget(spacer);
+
+	QCheckBox* instantMode = new QCheckBox(QStringLiteral("Instant mode"));
+	instantMode->setObjectName(QStringLiteral("InstantModeCheckBox"));
+	instantMode->setChecked(true);
+	toolBar->addWidget(instantMode);
+
+	QLabel* dirtyBadge = new QLabel(QStringLiteral("Saved"));
+	dirtyBadge->setObjectName(QStringLiteral("DirtyStatusBadge"));
+	toolBar->addWidget(dirtyBadge);
+
+	spacer = new QWidget;
+	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
+	spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	toolBar->addWidget(spacer);
+
+	QLabel* deviceLabel = new QLabel(QStringLiteral("Device"));
+	deviceLabel->setObjectName(QStringLiteral("ToolBarLabel"));
+	toolBar->addWidget(deviceLabel);
+
+	SkinComboBox* deviceCombo = new SkinComboBox;
+	deviceCombo->setObjectName(QStringLiteral("ToolBarComboBox"));
+	deviceCombo->addItem(QStringLiteral("Default (Speakers - Example Audio)"));
+	toolBar->addWidget(deviceCombo);
+
+	spacer = new QWidget;
+	spacer->setObjectName(QStringLiteral("ToolBarSpacer"));
+	spacer->setFixedWidth(10);
+	toolBar->addWidget(spacer);
+
+	QLabel* channelLabel = new QLabel(QStringLiteral("Channels"));
+	channelLabel->setObjectName(QStringLiteral("ToolBarLabel"));
+	toolBar->addWidget(channelLabel);
+
+	SkinComboBox* channelCombo = new SkinComboBox;
+	channelCombo->setObjectName(QStringLiteral("ToolBarComboBox"));
+	channelCombo->addItem(QStringLiteral("7.1 surround"));
+	toolBar->addWidget(channelCombo);
+
+	SkinManager::instance()->styleMainToolbar(toolBar);
+	return toolBar;
 }
 
 // QSS :hover matches widgets whose Qt::WA_UnderMouse attribute is set, and
@@ -166,6 +233,17 @@ int renderSkin(const QDir& outDir, const QString& skinId, bool dark)
 		QApplication::processEvents();
 		failures += saveGrab(picker, outDir, skinId, mode, QStringLiteral("picker"), QStringLiteral("normal")) ? 0 : 1;
 		delete picker;
+	}
+
+	// The skin's main-toolbar chrome on a faithful replica (same object names
+	// and widget train as MainWindow, dummy device data).
+	{
+		QToolBar* toolBar = buildToolbarReplica(nullptr);
+		toolBar->resize(960, toolBar->sizeHint().height());
+		toolBar->show();
+		QApplication::processEvents();
+		failures += saveGrab(toolBar, outDir, skinId, mode, QStringLiteral("toolbar"), QStringLiteral("normal")) ? 0 : 1;
+		delete toolBar;
 	}
 	return failures;
 }

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -161,6 +161,11 @@ FilterPickerView* SkinManager::createFilterPicker(QWidget* parent) const
 
 void SkinManager::styleMainToolbar(QToolBar* toolBar) const
 {
-	if (activeSkin != nullptr)
-		activeSkin->styleMainToolbar(toolBar, currentTokens);
+	if (toolBar == nullptr || activeSkin == nullptr)
+		return;
+	// Reset the shared mutable toolbar state before delegating so one skin's
+	// choices cannot leak across a live skin switch (minimal sets
+	// Qt::ToolButtonTextOnly; everyone else expects icon-only).
+	toolBar->setToolButtonStyle(Qt::ToolButtonIconOnly);
+	activeSkin->styleMainToolbar(toolBar, currentTokens);
 }

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -158,3 +158,9 @@ FilterPickerView* SkinManager::createFilterPicker(QWidget* parent) const
 		return activeSkin->createFilterPicker(parent);
 	return new DefaultFilterPickerView(parent);
 }
+
+void SkinManager::styleMainToolbar(QToolBar* toolBar) const
+{
+	if (activeSkin != nullptr)
+		activeSkin->styleMainToolbar(toolBar, currentTokens);
+}

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -10,6 +10,7 @@ class IRoutingRenderer;
 class ISkin;
 class QPainter;
 class QRect;
+class QToolBar;
 class QWidget;
 struct CommandRowInfo;
 struct KnobState;
@@ -47,6 +48,9 @@ public:
 
 	// The "add filter" picker view for the active skin (ISkin::createFilterPicker).
 	FilterPickerView* createFilterPicker(QWidget* parent) const;
+
+	// Main toolbar icons/chrome for the active skin (ISkin::styleMainToolbar).
+	void styleMainToolbar(QToolBar* toolBar) const;
 
 signals:
 	void skinChanged(const SkinTokens& tokens);

--- a/Editor/icons/modern/file-new.svg
+++ b/Editor/icons/modern/file-new.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.5 3.5H7A1.5 1.5 0 0 0 5.5 5v14A1.5 1.5 0 0 0 7 20.5h10a1.5 1.5 0 0 0 1.5-1.5V8.5l-5-5z"/>
+  <path d="M13.5 3.5V8.5h5"/>
+  <path d="M12 11.5v5"/>
+  <path d="M9.5 14h5"/>
+</svg>

--- a/Editor/icons/modern/save-as.svg
+++ b/Editor/icons/modern/save-as.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 4.5h11l3.5 3.5V11"/>
+  <path d="M4.5 6A1.5 1.5 0 0 1 6 4.5"/>
+  <path d="M4.5 6v13A1.5 1.5 0 0 0 6 20.5h5"/>
+  <path d="M8 4.5V9h7V4.5"/>
+  <path d="M19.3 13.6a1.3 1.3 0 0 1 1.9 1.9l-5.5 5.5-2.6.7.7-2.6 5.5-5.5z"/>
+</svg>

--- a/Editor/icons/modern/save.svg
+++ b/Editor/icons/modern/save.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 4.5h11l3.5 3.5V19a1.5 1.5 0 0 1-1.5 1.5H6A1.5 1.5 0 0 1 4.5 19V6A1.5 1.5 0 0 1 5 4.5z"/>
+  <path d="M8 4.5V9h7V4.5"/>
+  <path d="M7.5 20.5v-6A1 1 0 0 1 8.5 13.5h7a1 1 0 0 1 1 1v6"/>
+</svg>

--- a/Editor/icons/modern/soft-toggle-knob-off.svg
+++ b/Editor/icons/modern/soft-toggle-knob-off.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="20" viewBox="0 0 36 20" fill="none">
+  <circle cx="10" cy="10" r="7" fill="#FAFAFC"/>
+</svg>

--- a/Editor/icons/modern/soft-toggle-knob-on.svg
+++ b/Editor/icons/modern/soft-toggle-knob-on.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="20" viewBox="0 0 36 20" fill="none">
+  <circle cx="26" cy="10" r="7" fill="#FAFAFC"/>
+</svg>

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -9,9 +9,12 @@
 
 #include "ISkin.h"
 
+#include <QAction>
 #include <QPainter>
+#include <QToolBar>
 #include <QtMath>
 
+#include "Editor/helpers/GUIHelper.h"
 #include "Editor/widgets/FilterPickerView.h"
 
 namespace
@@ -130,4 +133,26 @@ FilterPickerView* ISkin::createFilterPicker(QWidget* parent) const
 {
 	// Neutral default: the shared search-over-sections dropdown.
 	return new DefaultFilterPickerView(parent);
+}
+
+void ISkin::styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const
+{
+	if (toolBar == nullptr)
+		return;
+
+	// Neutral default: the shared modern stroke icons, tinted with the text
+	// token so they follow every skin's dark/light ink. This replaces the
+	// legacy .ico set the .ui file still references (kept there so a skin
+	// could deliberately return to it).
+	const QColor ink(tokens.text);
+	toolBar->setIconSize(GUIHelper::scale(QSize(18, 18)));
+	for (QAction* action : toolBar->actions())
+	{
+		if (action->objectName() == QStringLiteral("actionNew"))
+			action->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/file-new.svg"), ink, 18));
+		else if (action->objectName() == QStringLiteral("actionOpen"))
+			action->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/folder-open.svg"), ink, 18));
+		else if (action->objectName() == QStringLiteral("actionSave"))
+			action->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/save.svg"), ink, 18));
+	}
 }

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -19,6 +19,7 @@
 class FilterPickerView;
 class IRoutingRenderer;
 class QPainter;
+class QToolBar;
 class QWidget;
 
 // Identifies a command row for per-command-type chrome decisions.
@@ -129,4 +130,15 @@ public:
 	// field over one sectioned list. Ownership passes to the caller via the
 	// usual QWidget parent mechanism.
 	virtual FilterPickerView* createFilterPicker(QWidget* parent) const;
+
+	// Dress the main toolbar in this skin's language. Called from
+	// applyRedesignPreferences at startup and again on every skin/dark
+	// switch, so implementations must be idempotent. The default replaces the
+	// legacy .ico action icons (the 2005-era document set) with the shared
+	// modern stroke icons tinted by the text token and sets a scaled icon
+	// size; skins override to re-tint, swap the icon language, set dynamic
+	// properties their QSS targets, or attach painted chrome. The file
+	// actions are identified by their .ui object names (actionNew,
+	// actionOpen, actionSave).
+	virtual void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const;
 };

--- a/Editor/skins/RackChrome.cpp
+++ b/Editor/skins/RackChrome.cpp
@@ -10,12 +10,17 @@
 
 #include "RackChrome.h"
 
+#include <QAction>
+#include <QCheckBox>
+#include <QEvent>
 #include <QFontMetricsF>
 #include <QHash>
 #include <QPainter>
 #include <QPainterPath>
+#include <QToolBar>
 #include <QtMath>
 
+#include "Editor/SkinManager.h"
 #include "ISkin.h"
 
 namespace
@@ -166,6 +171,200 @@ QString unitLabel(const CommandRowInfo& info)
 		if (info.type == QLatin1String(entry.type))
 			return QLatin1String(entry.label);
 	return info.command.toUpper().left(8);
+}
+
+// ── Master-rail toolbar chrome ──────────────────────────────────────────────
+
+const char* const kToolbarPlateName = "RackToolbarPlate";
+const char* const kToolbarEarSpacerName = "RackToolbarEarSpacer";
+// Width of the rail-ear zone at both toolbar ends. QToolBar ignores
+// stylesheet padding and QToolBarLayout cannot carry asymmetric margins, so
+// the zones are reserved by two fixed-width spacer widgets at the ends of
+// the action train; the painter reads their live geometry back, so an ear
+// that no longer fits (toolbar overflow) simply is not painted.
+const int kRailEarWidth = 24;
+
+// Painted master-rail decoration: everything the QSS base rail cannot
+// express. Drawn by the RackToolbarPlate overlay between the toolbar's
+// stylesheet background and its controls, in the same faceplate grammar as
+// the card chrome so the rail reads as the rack's master section.
+void paintToolbarRail(QPainter& painter, const QRect& rect, const QToolBar* toolBar, const SkinTokens& tokens)
+{
+	const bool dark = isDarkPanel(tokens);
+	painter.setRenderHint(QPainter::Antialiasing);
+	const QRectF r(rect);
+
+	// Brushed-metal sheen: the rolled top edge falling into shadow.
+	QLinearGradient sheen(r.topLeft(), r.bottomLeft());
+	if (dark)
+	{
+		sheen.setColorAt(0.0, QColor(255, 255, 255, 26));
+		sheen.setColorAt(0.14, QColor(255, 255, 255, 10));
+		sheen.setColorAt(0.55, QColor(255, 255, 255, 0));
+		sheen.setColorAt(1.0, QColor(0, 0, 0, 52));
+	}
+	else
+	{
+		sheen.setColorAt(0.0, QColor(255, 255, 255, 120));
+		sheen.setColorAt(0.5, QColor(255, 255, 255, 0));
+		sheen.setColorAt(1.0, QColor(0, 0, 0, 30));
+	}
+	painter.fillRect(r, sheen);
+
+	// Horizontal brushing texture.
+	painter.setPen(QPen(dark ? QColor(255, 255, 255, 5) : QColor(96, 84, 64, 8), 1));
+	for (qreal y = r.top() + 3; y < r.bottom() - 2; y += 3)
+		painter.drawLine(QPointF(r.left() + 2, y), QPointF(r.right() - 2, y));
+
+	// Machined edges: lit top chamfer, shadowed groove above the QSS border,
+	// so the strip reads as a milled rail rather than a flat band.
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 36 : 150), 1));
+	painter.drawLine(QPointF(r.left(), r.top() + 0.5), QPointF(r.right(), r.top() + 0.5));
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 150 : 70), 1));
+	painter.drawLine(QPointF(r.left(), r.bottom() - 0.5), QPointF(r.right(), r.bottom() - 0.5));
+
+	// Rail ears with one mounting screw each, painted at the live geometry of
+	// the ear spacers (an ear pushed out by toolbar overflow is not painted,
+	// so the screw never sits under a control). The slot angles differ -
+	// hand-tightened, like the card corners.
+	const uint seed = uint(qHash(QStringLiteral("master-rail")));
+	const QColor earFill(0, 0, 0, dark ? 52 : 20);
+	for (const QWidget* spacer : toolBar->findChildren<QWidget*>(QLatin1String(kToolbarEarSpacerName), Qt::FindDirectChildrenOnly))
+	{
+		if (!spacer->isVisible() || spacer->width() < kRailEarWidth - 4)
+			continue;
+		const QRectF g(spacer->geometry());
+		const bool leftSide = g.center().x() < r.center().x();
+		// The ear runs from the rail edge to the machined groove that
+		// separates it from the panel.
+		const QRectF ear = leftSide
+			? QRectF(r.left(), r.top(), g.right() - r.left(), r.height())
+			: QRectF(g.left(), r.top(), r.right() - g.left(), r.height());
+		const qreal grooveX = leftSide ? ear.right() : ear.left();
+		painter.fillRect(ear, earFill);
+		painter.setPen(QPen(QColor(0, 0, 0, dark ? 120 : 60), 1));
+		painter.drawLine(QPointF(grooveX, r.top()), QPointF(grooveX, r.bottom()));
+		painter.setPen(QPen(QColor(255, 255, 255, dark ? 26 : 120), 1));
+		painter.drawLine(QPointF(grooveX + (leftSide ? 1 : -1), r.top()), QPointF(grooveX + (leftSide ? 1 : -1), r.bottom()));
+		paintScrew(painter, QPointF(ear.center().x(), r.center().y()), 4.0,
+			qreal((seed + (leftSide ? 0u : 73u)) % 180u), dark);
+	}
+
+	// Engraved section designation on the blank panel between the save-state
+	// readout and the device selectors (the expanding spacer), drawn only
+	// when the blank leaves room. Hardware printing, not a UI string -
+	// never translated.
+	const QString marking = QStringLiteral("MASTER");
+	QFont markFont(tokens.fontFamily);
+	markFont.setPixelSize(8);
+	markFont.setBold(true);
+	markFont.setLetterSpacing(QFont::AbsoluteSpacing, 2.0);
+	const QFontMetricsF metrics(markFont);
+	const QWidget* blank = nullptr;
+	for (const QWidget* spacer : toolBar->findChildren<QWidget*>(QStringLiteral("ToolBarSpacer"), Qt::FindDirectChildrenOnly))
+		if (blank == nullptr || spacer->width() > blank->width())
+			blank = spacer;
+	if (blank != nullptr && blank->width() >= metrics.horizontalAdvance(marking) + 16)
+	{
+		painter.setFont(markFont);
+		QColor ink(tokens.mutedText);
+		ink.setAlpha(dark ? 150 : 190);
+		engraveText(painter, QRectF(blank->geometry()), Qt::AlignCenter, marking, ink, dark);
+	}
+
+	// The instant-mode power LED, mounted in the well the checkbox's QSS
+	// padding reserves (its indicator is collapsed): lit green while the
+	// mode is engaged, a dark dome when it is off.
+	if (const QCheckBox* box = toolBar->findChild<QCheckBox*>(QStringLiteral("InstantModeCheckBox"), Qt::FindDirectChildrenOnly))
+	{
+		const QRectF g(box->geometry());
+		paintLed(painter, QPointF(g.left() + 10.0, g.center().y()), 3.2, QColor(tokens.accent2),
+			box->isChecked() && box->isEnabled(), dark);
+	}
+}
+
+// The transparent overlay carrying the painted rail chrome. It sits as the
+// bottom-most child of the toolbar (above the QSS background, below the
+// controls), tracks the toolbar's size, repaints when the instant-mode
+// switch toggles and hides itself when another skin's stylesheet takes over
+// (every skin switch delivers StyleChange to the toolbar). No Q_OBJECT: it
+// is found again by object name and only connects to existing signals.
+class RackToolbarPlate : public QWidget
+{
+public:
+	explicit RackToolbarPlate(QToolBar* parentToolBar)
+		: QWidget(parentToolBar)
+		, toolBar(parentToolBar)
+	{
+		setObjectName(QLatin1String(kToolbarPlateName));
+		setAttribute(Qt::WA_TransparentForMouseEvents);
+		toolBar->installEventFilter(this);
+		setGeometry(toolBar->rect());
+		if (QCheckBox* box = toolBar->findChild<QCheckBox*>(QStringLiteral("InstantModeCheckBox"), Qt::FindDirectChildrenOnly))
+			connect(box, &QCheckBox::toggled, this, QOverload<>::of(&QWidget::update));
+	}
+
+	void setTokens(const SkinTokens& newTokens)
+	{
+		tokens = newTokens;
+	}
+
+	// The actions wrapping the two ear spacers; their visibility follows the
+	// plate's, so the reserved zones vanish with the chrome when another
+	// skin takes over.
+	void setEarActions(QAction* left, QAction* right)
+	{
+		leftEarAction = left;
+		rightEarAction = right;
+	}
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override
+	{
+		if (watched == toolBar)
+		{
+			if (event->type() == QEvent::Resize)
+			{
+				setGeometry(toolBar->rect());
+			}
+			else if (event->type() == QEvent::StyleChange)
+			{
+				// Every skin switch restyles the application; only the rack
+				// stylesheet may keep the rail chrome and the ear zones.
+				const bool rackActive = SkinManager::instance()->currentSkinId() == QLatin1String("rack");
+				setVisible(rackActive);
+				if (leftEarAction != nullptr)
+					leftEarAction->setVisible(rackActive);
+				if (rightEarAction != nullptr)
+					rightEarAction->setVisible(rackActive);
+			}
+		}
+		return QWidget::eventFilter(watched, event);
+	}
+
+	void paintEvent(QPaintEvent*) override
+	{
+		QPainter painter(this);
+		paintToolbarRail(painter, rect(), toolBar, tokens);
+	}
+
+private:
+	QToolBar* toolBar = nullptr;
+	QAction* leftEarAction = nullptr;
+	QAction* rightEarAction = nullptr;
+	SkinTokens tokens;
+};
+
+// A fixed-width blank widget reserving one rail-ear zone in the toolbar's
+// action train. The plate paints the ear and its screw at this widget's
+// live geometry.
+QWidget* makeEarSpacer(QWidget* parent)
+{
+	QWidget* spacer = new QWidget(parent);
+	spacer->setObjectName(QLatin1String(kToolbarEarSpacerName));
+	spacer->setFixedWidth(kRailEarWidth);
+	spacer->setAttribute(Qt::WA_TransparentForMouseEvents);
+	return spacer;
 }
 }
 
@@ -499,5 +698,39 @@ void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, con
 		painter.setPen(ledInk);
 		painter.drawText(window, Qt::AlignCenter, state.valueText);
 	}
+}
+
+void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens)
+{
+	if (toolBar == nullptr)
+		return;
+
+	// Hook runs at startup and on every skin/dark switch: reuse the plate if
+	// it is already mounted. Only this file ever creates a child with that
+	// object name, so the static_cast is safe (the class has no Q_OBJECT, so
+	// findChild on the concrete type would match any QWidget).
+	QWidget* existing = toolBar->findChild<QWidget*>(QLatin1String(kToolbarPlateName), Qt::FindDirectChildrenOnly);
+	RackToolbarPlate* plate;
+	if (existing != nullptr)
+	{
+		plate = static_cast<RackToolbarPlate*>(existing);
+	}
+	else
+	{
+		plate = new RackToolbarPlate(toolBar);
+		// Reserve the rail-ear zones once, at both ends of the action train.
+		// The plate toggles these actions with its own visibility, so the
+		// zones leave with the chrome on a skin switch and return with it.
+		const QList<QAction*> actions = toolBar->actions();
+		QAction* leftEar = actions.isEmpty()
+			? toolBar->addWidget(makeEarSpacer(toolBar))
+			: toolBar->insertWidget(actions.first(), makeEarSpacer(toolBar));
+		QAction* rightEar = toolBar->addWidget(makeEarSpacer(toolBar));
+		plate->setEarActions(leftEar, rightEar);
+	}
+	plate->setTokens(tokens);
+	plate->lower();
+	plate->show();
+	plate->update();
 }
 }

--- a/Editor/skins/RackChrome.h
+++ b/Editor/skins/RackChrome.h
@@ -19,6 +19,7 @@ struct CommandRowInfo;
 struct KnobState;
 struct SkinTokens;
 class QPainter;
+class QToolBar;
 
 namespace RackChrome
 {
@@ -35,4 +36,12 @@ void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo&
 
 // Skeuomorphic pointer knob with a panel-printed scale.
 void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens);
+
+// Mount (or refresh) the master-rail chrome on the main toolbar: a painted
+// overlay widget (brushed strip, machined edges, end screws, engraved series
+// marking and the instant-mode power LED) kept below the toolbar's controls.
+// Idempotent - re-running only refreshes the tokens. The overlay hides
+// itself when another skin's stylesheet takes over, so no chrome leaks
+// across skin switches.
+void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens);
 }

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -11,6 +11,7 @@
 #include <QLayout>
 #include <QPainter>
 #include <QPixmap>
+#include <QToolBar>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
@@ -533,6 +534,21 @@ public:
 		// The add-filter dropdown as a numbered terminal index; see
 		// MinimalFilterPicker.h for the design.
 		return new MinimalFilterPickerView(parent);
+	}
+	// The toolbar is the terminal's command line: all type and one hairline.
+	// The neutral default keeps the shared stroke icons on the actions so the
+	// File menu (which shares the QActions) stays modern; the toolbar buttons
+	// themselves drop the pictures and show the command words instead -
+	// precision_*.qss uppercases and letter-spaces them and walks their states
+	// up the value ladder (hover = one background step, pressed = the
+	// inverted block from the picker's cursor grammar). Both calls set
+	// absolute state, so re-running on every skin/dark switch is idempotent.
+	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override
+	{
+		if (toolBar == nullptr)
+			return;
+		ISkin::styleMainToolbar(toolBar, tokens);
+		toolBar->setToolButtonStyle(Qt::ToolButtonTextOnly);
 	}
 	void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens) const override
 	{

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -961,7 +961,8 @@ private:
 	static QIcon softTileIcon(const QString& resource, const QColor& tile)
 	{
 		QIcon icon;
-		for (const int logical : { 16, 18, 20, 22, 24, 32 })
+		// 44/64 keep the tile crisp on 2x displays (22/32 logical at DPR 2).
+		for (const int logical : { 16, 18, 20, 22, 24, 32, 44, 64 })
 		{
 			const int side = GUIHelper::scale(double(logical));
 			QPixmap pixmap(side, side);
@@ -974,7 +975,13 @@ private:
 			const int glyphSide = qMax(10, qRound(logical * 0.66));
 			const QPixmap glyph = GUIHelper::tintedIcon(resource, QColor(QStringLiteral("#FAFAFC")), glyphSide)
 				.pixmap(GUIHelper::scale(QSize(glyphSide, glyphSide)));
-			painter.drawPixmap(QPointF((side - glyph.width()) / 2.0, (side - glyph.height()) / 2.0), glyph);
+			// Centre by the glyph's LOGICAL size: on high-DPR displays
+			// QIcon::pixmap returns a pixmap whose width() is physical pixels
+			// (dpr baked in), and drawPixmap honors the dpr - centring by
+			// width() shoved the glyph toward the top-left at 200% scale.
+			const QSizeF glyphLogical = glyph.deviceIndependentSize();
+			painter.drawPixmap(QPointF((side - glyphLogical.width()) / 2.0,
+				(side - glyphLogical.height()) / 2.0), glyph);
 			painter.end();
 			icon.addPixmap(pixmap);
 		}

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,7 @@
 
 #include "Skins.h"
 
+#include <QEvent>
 #include <QFontMetrics>
 #include <QFontMetricsF>
 #include <QHBoxLayout>
@@ -11,10 +12,12 @@
 #include <QLayout>
 #include <QPainter>
 #include <QPixmap>
+#include <QToolBar>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
 
+#include "Editor/SkinManager.h"
 #include "Editor/skins/RackChrome.h"
 #include "Editor/skins/pickers/StudioFilterPicker.h"
 #include "Editor/skins/pickers/MinimalFilterPicker.h"
@@ -1028,6 +1031,143 @@ QPointF matrixRadialPoint(const QPointF& center, double radius, double fraction)
 	const double radians = qDegreesToRadians(-(135.0 + 270.0 * fraction));
 	return QPointF(center.x() + qCos(radians) * radius, center.y() - qSin(radians) * radius);
 }
+
+// Painted chrome layers for the main toolbar (the board's header strip).
+// QSS cannot draw the 24px column grid or the status lamp, so the matrix
+// toolbar hook parents two transparent, mouse-transparent widgets to the
+// toolbar: UnderCells (lowered below every cell) paints the column grid,
+// the doubled header rule and the sunken fill of the status readout cell;
+// OverCells (raised above the cells) paints the DirtyStatusBadge lamp on
+// top of that readout. Instances are found again by object name on every
+// hook run (this file has no moc, so findChild by class is unavailable),
+// and painting self-suspends while another skin is active because the real
+// MainWindow toolbar keeps its children across runtime skin switches.
+class MatrixToolbarBoard : public QWidget
+{
+public:
+	enum Layer { UnderCells, OverCells };
+
+	MatrixToolbarBoard(QToolBar* toolBar, Layer boardLayer)
+		: QWidget(toolBar), layer(boardLayer)
+	{
+		setObjectName(layer == UnderCells
+			? QStringLiteral("MatrixToolbarBoardUnder")
+			: QStringLiteral("MatrixToolbarBoardOver"));
+		setAttribute(Qt::WA_TransparentForMouseEvents);
+		toolBar->installEventFilter(this);
+		if (layer == OverCells)
+		{
+			// The lamp must follow the badge's dirty-state restyles and the
+			// layout moving the cell around.
+			if (QWidget* badge = toolBar->findChild<QWidget*>(QStringLiteral("DirtyStatusBadge")))
+				badge->installEventFilter(this);
+		}
+		setGeometry(toolBar->rect());
+		if (layer == UnderCells)
+			lower();
+		else
+			raise();
+		show();
+	}
+
+	void setBoardTokens(const SkinTokens& tokens)
+	{
+		ruleColor = QColor(tokens.border);
+		sunkenColor = QColor(tokens.surfaceSunken);
+		savedColor = QColor(tokens.success);
+		modifiedColor = QColor(tokens.warning);
+		// The hook carries no mode flag; infer it from the strip's surface
+		// (the studioIsDark pattern). The light border ink needs more alpha
+		// than the dark one to stay visible as graph paper on white.
+		gridAlpha = QColor(tokens.surface).lightness() < 128 ? 55 : 90;
+		update();
+	}
+
+	bool eventFilter(QObject* watched, QEvent* event) override
+	{
+		if (watched == parentWidget())
+		{
+			if (event->type() == QEvent::Resize)
+				setGeometry(parentWidget()->rect());
+		}
+		else if (event->type() == QEvent::Paint || event->type() == QEvent::Move
+			|| event->type() == QEvent::Resize || event->type() == QEvent::Show
+			|| event->type() == QEvent::Hide)
+		{
+			update();
+		}
+		return QWidget::eventFilter(watched, event);
+	}
+
+protected:
+	void paintEvent(QPaintEvent*) override
+	{
+		// The layers stay parented to the shared toolbar after a runtime
+		// skin switch; they must never leak matrix chrome into another skin.
+		if (SkinManager::instance()->currentSkinId() != QStringLiteral("matrix"))
+			return;
+
+		QPainter painter(this);
+		painter.setRenderHint(QPainter::Antialiasing, false);
+		if (layer == UnderCells)
+			paintBoard(painter);
+		else
+			paintLamp(painter);
+	}
+
+private:
+	// The badge is only board chrome while the skin owns its appearance.
+	// MainWindow::updateDirtyStatus replaces it with an inline-styled pill
+	// at runtime; painting a lamp under that pill would garble its text.
+	QWidget* ownedBadge() const
+	{
+		QWidget* badge = parentWidget()->findChild<QWidget*>(QStringLiteral("DirtyStatusBadge"));
+		if (badge == nullptr || !badge->isVisible() || !badge->styleSheet().isEmpty())
+			return nullptr;
+		return badge;
+	}
+
+	void paintBoard(QPainter& painter)
+	{
+		// The faint 24px column grid: the graph paper the whole board sits
+		// on, same pitch and ink as the card grid texture.
+		QColor grid(ruleColor);
+		grid.setAlpha(gridAlpha);
+		painter.setPen(QPen(grid, 1));
+		for (int x = MatrixMetrics::gridPitch; x < width(); x += MatrixMetrics::gridPitch)
+			painter.drawLine(x, 0, x, height());
+
+		// Doubled header rule above the QSS bottom border: the strip closes
+		// like a board's title rule, not a plain window edge.
+		painter.setPen(QPen(ruleColor, 1));
+		painter.drawLine(0, height() - 4, width(), height() - 4);
+
+		// Sunken fill behind the status readout cell (the badge's own QSS
+		// background stays transparent so this fill and the lamp show).
+		if (QWidget* badge = ownedBadge())
+			painter.fillRect(badge->geometry().adjusted(1, 1, -1, -1), sunkenColor);
+	}
+
+	void paintLamp(QPainter& painter)
+	{
+		QWidget* badge = ownedBadge();
+		if (badge == nullptr)
+			return;
+		// Solid square lamp in traffic-light semantics: green = saved,
+		// amber = modified. This is exactly what colour rationing reserves
+		// colour for - the one truthful lamp on the header strip.
+		const QRect cell = badge->geometry();
+		const QRect lampRect(cell.left() + 8, cell.center().y() - 4, 8, 8);
+		painter.fillRect(lampRect, badge->property("dirty").toBool() ? modifiedColor : savedColor);
+	}
+
+	Layer layer;
+	QColor ruleColor;
+	QColor sunkenColor;
+	QColor savedColor;
+	QColor modifiedColor;
+	int gridAlpha = 55;
+};
 }
 
 class MatrixSkin : public ISkin
@@ -1369,6 +1509,37 @@ public:
 			painter.setBrush(Qt::NoBrush);
 			painter.drawRect(lampRect.adjusted(0, 0, -1, -1));
 		}
+	}
+
+	// The board's header strip. The neutral stroke icons stay, tinted in
+	// plain ink (the catalog is monochrome - colour belongs to the status
+	// lamp); the QSS dresses every toolbar item as a square 1px cell, and
+	// two painted layers add what QSS cannot express: the 24px column grid
+	// behind the cells and the solid square status lamp inside the
+	// DirtyStatusBadge readout. Runs at startup and on every skin/dark
+	// switch, so the layers are looked up again and re-tinted, never
+	// created twice.
+	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override
+	{
+		if (toolBar == nullptr)
+			return;
+
+		// Shared modern stroke icons, tinted with the text token.
+		ISkin::styleMainToolbar(toolBar, tokens);
+		toolBar->setToolButtonStyle(Qt::ToolButtonIconOnly);
+
+		// Painted board layers: created once per toolbar, re-tinted on every
+		// call (dark/light switches reuse the same instances).
+		auto boardLayer = [toolBar](const QString& name, MatrixToolbarBoard::Layer layer)
+		{
+			QWidget* existing = toolBar->findChild<QWidget*>(name, Qt::FindDirectChildrenOnly);
+			MatrixToolbarBoard* board = existing != nullptr
+				? static_cast<MatrixToolbarBoard*>(existing)
+				: new MatrixToolbarBoard(toolBar, layer);
+			return board;
+		};
+		boardLayer(QStringLiteral("MatrixToolbarBoardUnder"), MatrixToolbarBoard::UnderCells)->setBoardTokens(tokens);
+		boardLayer(QStringLiteral("MatrixToolbarBoardOver"), MatrixToolbarBoard::OverCells)->setBoardTokens(tokens);
 	}
 };
 

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -950,6 +950,18 @@ public:
 		return new RackFilterPickerView(parent);
 	}
 
+	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override
+	{
+		// The shared stroke icons first (tinted with the panel's warm ink),
+		// then the master-rail chrome: RackChrome mounts a painted overlay
+		// (brushed strip, machined edges, end screws, engraved series
+		// marking, instant-mode power LED) under the toolbar's controls. The
+		// QSS dresses the controls themselves as transport buttons and an
+		// LCD save-state well.
+		ISkin::styleMainToolbar(toolBar, tokens);
+		RackChrome::styleMainToolbar(toolBar, tokens);
+	}
+
 	SkinTokens tokens(bool dark) const override
 	{
 		SkinTokens t;

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,16 +4,21 @@
 
 #include "Skins.h"
 
+#include <QAction>
 #include <QFontMetrics>
 #include <QFontMetricsF>
 #include <QHBoxLayout>
+#include <QIcon>
 #include <QLabel>
 #include <QLayout>
 #include <QPainter>
 #include <QPixmap>
+#include <QToolBar>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
+
+#include "Editor/helpers/GUIHelper.h"
 
 #include "Editor/skins/RackChrome.h"
 #include "Editor/skins/pickers/StudioFilterPicker.h"
@@ -874,6 +879,60 @@ public:
 			painter.setPen(state.enabled ? QColor(tokens.text) : muted);
 			painter.drawText(badgeRect, Qt::AlignCenter, state.valueText);
 		}
+	}
+
+	// The toolbar is this skin's calm header band; the QSS sheets carry the
+	// band, the toggle, the pills and the stadium combos. The hook's share is
+	// the one thing QSS cannot express: the three file actions wear
+	// iOS-Settings-style rounded-square colour tiles - pastels mixed from
+	// existing tokens (accent blue for New, warning amber for the folder,
+	// success green for Save) under the shared stroke glyph, the same tile
+	// recipe as the picker's category tiles. Re-running the hook only calls
+	// setters, so skin/dark switches stay idempotent.
+	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override
+	{
+		if (toolBar == nullptr)
+			return;
+
+		toolBar->setIconSize(GUIHelper::scale(QSize(22, 22)));
+		const QColor card(tokens.card);
+		for (QAction* action : toolBar->actions())
+		{
+			if (action->objectName() == QStringLiteral("actionNew"))
+				action->setIcon(softTileIcon(QStringLiteral(":/icons/modern/file-new.svg"), softMix(QColor(tokens.accent), card, 0.15)));
+			else if (action->objectName() == QStringLiteral("actionOpen"))
+				action->setIcon(softTileIcon(QStringLiteral(":/icons/modern/folder-open.svg"), softMix(QColor(tokens.warning), card, 0.15)));
+			else if (action->objectName() == QStringLiteral("actionSave"))
+				action->setIcon(softTileIcon(QStringLiteral(":/icons/modern/save.svg"), softMix(QColor(tokens.success), card, 0.15)));
+		}
+	}
+
+private:
+	// One icon, several pre-rendered sizes (16px for the File menu rows up to
+	// the 22px toolbar size and beyond), so Qt never stretches a tile. The
+	// tile matches SoftFilterPicker's category tiles: a rounded square at 32%
+	// corner radius with the glyph inked in the picker's near-white literal.
+	static QIcon softTileIcon(const QString& resource, const QColor& tile)
+	{
+		QIcon icon;
+		for (const int logical : { 16, 18, 20, 22, 24, 32 })
+		{
+			const int side = GUIHelper::scale(double(logical));
+			QPixmap pixmap(side, side);
+			pixmap.fill(Qt::transparent);
+			QPainter painter(&pixmap);
+			painter.setRenderHint(QPainter::Antialiasing);
+			painter.setPen(Qt::NoPen);
+			painter.setBrush(tile);
+			painter.drawRoundedRect(QRectF(0, 0, side, side), side * 0.32, side * 0.32);
+			const int glyphSide = qMax(10, qRound(logical * 0.66));
+			const QPixmap glyph = GUIHelper::tintedIcon(resource, QColor(QStringLiteral("#FAFAFC")), glyphSide)
+				.pixmap(GUIHelper::scale(QSize(glyphSide, glyphSide)));
+			painter.drawPixmap(QPointF((side - glyph.width()) / 2.0, (side - glyph.height()) / 2.0), glyph);
+			painter.end();
+			icon.addPixmap(pixmap);
+		}
+		return icon;
 	}
 };
 

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -4,6 +4,7 @@
 
 #include "Skins.h"
 
+#include <QAction>
 #include <QFontMetrics>
 #include <QFontMetricsF>
 #include <QHBoxLayout>
@@ -11,10 +12,12 @@
 #include <QLayout>
 #include <QPainter>
 #include <QPixmap>
+#include <QToolBar>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
 
+#include "Editor/helpers/GUIHelper.h"
 #include "Editor/skins/RackChrome.h"
 #include "Editor/skins/pickers/StudioFilterPicker.h"
 #include "Editor/skins/pickers/MinimalFilterPicker.h"
@@ -108,6 +111,36 @@ public:
 	FilterPickerView* createFilterPicker(QWidget* parent) const override
 	{
 		return new StudioFilterPickerView(parent);
+	}
+
+	// The toolbar is the top edge of the window's glass. The QSS sheets own
+	// the strip itself (deep background, a 1px reflection along the bottom
+	// edge, accent light pooling under hovered buttons, the Instant mode
+	// lamp, sunken mono readouts); code only re-inks the file actions as
+	// quiet ink - the muted colour lifted halfway toward the text ink - so
+	// the icons rest behind the data until interaction lights the glass
+	// under them, yet stay legible at menu size. Idempotent: re-tinting and
+	// re-sizing converge on every skin/dark switch.
+	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override
+	{
+		if (toolBar == nullptr)
+			return;
+
+		const QColor text(tokens.text);
+		const QColor muted(tokens.mutedText);
+		const QColor ink((muted.red() + text.red()) / 2,
+			(muted.green() + text.green()) / 2,
+			(muted.blue() + text.blue()) / 2);
+		toolBar->setIconSize(GUIHelper::scale(QSize(18, 18)));
+		for (QAction* action : toolBar->actions())
+		{
+			if (action->objectName() == QStringLiteral("actionNew"))
+				action->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/file-new.svg"), ink, 18));
+			else if (action->objectName() == QStringLiteral("actionOpen"))
+				action->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/folder-open.svg"), ink, 18));
+			else if (action->objectName() == QStringLiteral("actionSave"))
+				action->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/save.svg"), ink, 18));
+		}
 	}
 
 	// "The arc IS the value": no knob body, only a thin track circle, a

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -150,6 +150,145 @@ QLabel#ToolBarLabel {
     font-size: 9pt;
 }
 
+/* ===== Main toolbar: the board's header strip =====
+   A row of square 24px-tall cells with 1px rules, sitting on the 24px
+   column grid that MatrixToolbarBoard paints behind them (it also paints
+   the doubled header rule and the status lamp). The rules never change
+   state - only the light inside the cells does. QToolBar's own padding/
+   spacing are style metrics Qt does not read from QSS, so the geometry
+   discipline lives entirely in the cells. */
+QToolBar#MainToolBar {
+    background: @SURFACE@;
+    border: 0;
+    border-bottom: 1px solid @BORDER@;
+}
+/* Function cells: monochrome ink glyphs in transparent cells, so the
+   column grid runs through them. Hover = dim cell pre-light, pressed/
+   checked = engaged crosspoint (accent fill + accent rule). */
+QToolBar#MainToolBar QToolButton {
+    background: transparent;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 13px;
+    min-height: 24px;
+    max-height: 24px;
+}
+QToolBar#MainToolBar QToolButton:hover {
+    background: rgba(34, 211, 238, 0.10);
+}
+QToolBar#MainToolBar QToolButton:pressed,
+QToolBar#MainToolBar QToolButton:checked {
+    background: rgba(34, 211, 238, 0.28);
+    border-color: @ACCENT@;
+}
+QToolBar#MainToolBar QToolButton:disabled {
+    border-style: dashed;
+}
+/* Engage cell: monochrome caption at rest, the square indicator is the
+   crosspoint LED - accent-lit only while engaged. */
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox {
+    background: transparent;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px;
+    spacing: 6px;
+    min-height: 24px;
+    max-height: 24px;
+    font-weight: 600;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator {
+    width: 10px;
+    height: 10px;
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+}
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:hover {
+    border-color: @ACCENT@;
+}
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:checked {
+    background: @ACCENT@;
+    border-color: @ACCENT@;
+}
+/* Status readout cell: mono code on the sunken fill painted by the board
+   layer, headed by the solid square lamp (green = saved, amber = modified
+   - the colours rationing reserves for status). */
+QToolBar#MainToolBar QLabel#DirtyStatusBadge {
+    background: transparent;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px 2px 20px;
+    min-height: 24px;
+    max-height: 24px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 500;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QToolBar#MainToolBar QLabel#DirtyStatusBadge[dirty="true"] {
+    color: @WARNING@;
+}
+/* Caption cells: uppercase board captions ahead of their readout. */
+QToolBar#MainToolBar QLabel#ToolBarLabel {
+    background: transparent;
+    color: @MUTED@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 6px;
+    min-height: 24px;
+    max-height: 24px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+}
+/* Destination readouts: square sunken cells (device names are names, not
+   values, so they keep the board's sans type). */
+QToolBar#MainToolBar QComboBox#ToolBarComboBox {
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 6px 2px 8px;
+    min-height: 24px;
+    max-height: 24px;
+    font-size: 9pt;
+}
+QToolBar#MainToolBar QComboBox#ToolBarComboBox:hover {
+    border-color: @ACCENT@;
+}
+QToolBar#MainToolBar QComboBox#ToolBarComboBox:focus,
+QToolBar#MainToolBar QComboBox#ToolBarComboBox:on {
+    border-color: @ACCENT@;
+}
+/* Format readout: a mono value cell; amber ink + rule only when the
+   stream is not processed natively (severity is status, never
+   decoration). */
+QToolBar#MainToolBar QLabel#DeviceFormatBadge {
+    background: @GRAPH@;
+    color: @MUTED@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px;
+    min-height: 24px;
+    max-height: 24px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+}
+QToolBar#MainToolBar QLabel#DeviceFormatBadge[severity="warning"] {
+    color: @WARNING@;
+    border-color: @WARNING@;
+}
+QWidget#MatrixToolbarBoardUnder,
+QWidget#MatrixToolbarBoardOver {
+    background: transparent;
+}
+
 /* ===== Push Buttons ===== */
 QPushButton {
     background: @CARD@;

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -150,6 +150,145 @@ QLabel#ToolBarLabel {
     font-size: 9pt;
 }
 
+/* ===== Main toolbar: the board's header strip =====
+   A row of square 24px-tall cells with 1px rules, sitting on the 24px
+   column grid that MatrixToolbarBoard paints behind them (it also paints
+   the doubled header rule and the status lamp). The rules never change
+   state - only the light inside the cells does. QToolBar's own padding/
+   spacing are style metrics Qt does not read from QSS, so the geometry
+   discipline lives entirely in the cells. */
+QToolBar#MainToolBar {
+    background: @SURFACE@;
+    border: 0;
+    border-bottom: 1px solid @BORDER@;
+}
+/* Function cells: monochrome ink glyphs in transparent cells, so the
+   column grid runs through them. Hover = dim cell pre-light, pressed/
+   checked = engaged crosspoint (accent fill + accent rule). */
+QToolBar#MainToolBar QToolButton {
+    background: transparent;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 13px;
+    min-height: 24px;
+    max-height: 24px;
+}
+QToolBar#MainToolBar QToolButton:hover {
+    background: rgba(0, 142, 170, 0.08);
+}
+QToolBar#MainToolBar QToolButton:pressed,
+QToolBar#MainToolBar QToolButton:checked {
+    background: rgba(0, 142, 170, 0.18);
+    border-color: @ACCENT@;
+}
+QToolBar#MainToolBar QToolButton:disabled {
+    border-style: dashed;
+}
+/* Engage cell: monochrome caption at rest, the square indicator is the
+   crosspoint LED - accent-lit only while engaged. */
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox {
+    background: transparent;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px;
+    spacing: 6px;
+    min-height: 24px;
+    max-height: 24px;
+    font-weight: 600;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator {
+    width: 10px;
+    height: 10px;
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+}
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:hover {
+    border-color: @ACCENT@;
+}
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:checked {
+    background: @ACCENT@;
+    border-color: @ACCENT@;
+}
+/* Status readout cell: mono code on the sunken fill painted by the board
+   layer, headed by the solid square lamp (green = saved, amber = modified
+   - the colours rationing reserves for status). */
+QToolBar#MainToolBar QLabel#DirtyStatusBadge {
+    background: transparent;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px 2px 20px;
+    min-height: 24px;
+    max-height: 24px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 500;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QToolBar#MainToolBar QLabel#DirtyStatusBadge[dirty="true"] {
+    color: @WARNING@;
+}
+/* Caption cells: uppercase board captions ahead of their readout. */
+QToolBar#MainToolBar QLabel#ToolBarLabel {
+    background: transparent;
+    color: @MUTED@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 6px;
+    min-height: 24px;
+    max-height: 24px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+}
+/* Destination readouts: square sunken cells (device names are names, not
+   values, so they keep the board's sans type). */
+QToolBar#MainToolBar QComboBox#ToolBarComboBox {
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 6px 2px 8px;
+    min-height: 24px;
+    max-height: 24px;
+    font-size: 9pt;
+}
+QToolBar#MainToolBar QComboBox#ToolBarComboBox:hover {
+    border-color: @ACCENT@;
+}
+QToolBar#MainToolBar QComboBox#ToolBarComboBox:focus,
+QToolBar#MainToolBar QComboBox#ToolBarComboBox:on {
+    border-color: @ACCENT@;
+}
+/* Format readout: a mono value cell; amber ink + rule only when the
+   stream is not processed natively (severity is status, never
+   decoration). */
+QToolBar#MainToolBar QLabel#DeviceFormatBadge {
+    background: @GRAPH@;
+    color: @MUTED@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px;
+    min-height: 24px;
+    max-height: 24px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+}
+QToolBar#MainToolBar QLabel#DeviceFormatBadge[severity="warning"] {
+    color: @WARNING@;
+    border-color: @WARNING@;
+}
+QWidget#MatrixToolbarBoardUnder,
+QWidget#MatrixToolbarBoardOver {
+    background: transparent;
+}
+
 /* ===== Push Buttons ===== */
 QPushButton {
     background: @CARD@;

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -67,6 +67,46 @@ QLabel#ToolBarLabel {
     font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
 }
 
+/* Main toolbar: the terminal's command line - all type and one hairline
+   (the strip's bottom rule comes from QToolBar above). MinimalSkin's
+   styleMainToolbar drops the action icons, so the commands are uppercase
+   mono words. State keeps to the value ladder: rest is bare type on the
+   strip, hover is exactly one background step, pressed is the inverted
+   block (foreground/background swap - the picker's cursor grammar). */
+QToolBar#MainToolBar QToolButton {
+    background: transparent; color: @TEXT@;
+    border: 0; border-radius: 0;
+    padding: 3px 7px; min-height: 22px;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+QToolBar#MainToolBar QToolButton:hover { background: @CARD@; border: 0; }
+QToolBar#MainToolBar QToolButton:pressed { background: @TEXT@; color: @SURFACE@; border: 0; }
+/* Instant mode is an armed flag: off rests muted, on is full ink (the
+   checked indicator's accent block is the active-state tag). */
+QToolBar#MainToolBar QCheckBox { color: @MUTED@; }
+QToolBar#MainToolBar QCheckBox:checked { color: @TEXT@; }
+/* Save-state readout: a status field, never an alarm. "Saved" rests muted;
+   unsaved changes are simply brighter ink. */
+QToolBar#MainToolBar QLabel#DirtyStatusBadge {
+    color: @MUTED@; background: transparent; border: 0;
+    padding: 0 8px; font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QToolBar#MainToolBar QLabel#DirtyStatusBadge[dirty="true"] { color: @TEXT@; }
+/* Stream-format readout: the same field grammar; severity is an ink tag
+   (like the analysis chips), never a fill or a box. */
+QToolBar#MainToolBar QLabel#DeviceFormatBadge {
+    color: @MUTED@; background: transparent; border: 0;
+    padding: 0 6px; font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QToolBar#MainToolBar QLabel#DeviceFormatBadge[severity="warning"] { color: @WARNING@; }
+/* Device/channel fields: hairline boxes on the strip; hover is one value
+   step, the accent border only while the field is active (open/focused). */
+QToolBar#MainToolBar QComboBox { background: @CARD@; border: 1px solid @BORDER@; padding: 2px 22px 2px 8px; min-height: 24px; }
+QToolBar#MainToolBar QComboBox:hover { background: @CARD_HOVER@; border: 1px solid @BORDER@; }
+QToolBar#MainToolBar QComboBox:focus, QToolBar#MainToolBar QComboBox:on { border: 1px solid @ACCENT@; }
+
 QPushButton {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 0;

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -47,6 +47,46 @@ QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 
 QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
 
+/* Main toolbar: the terminal's command line - all type and one hairline
+   (the strip's bottom rule comes from QToolBar above). MinimalSkin's
+   styleMainToolbar drops the action icons, so the commands are uppercase
+   mono words. State keeps to the value ladder: rest is bare type on the
+   strip, hover is exactly one background step (one step darker on paper),
+   pressed is the inverted block (the printed cursor). */
+QToolBar#MainToolBar QToolButton {
+    background: transparent; color: @TEXT@;
+    border: 0; border-radius: 0;
+    padding: 3px 7px; min-height: 22px;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+QToolBar#MainToolBar QToolButton:hover { background: @CARD_HOVER@; border: 0; }
+QToolBar#MainToolBar QToolButton:pressed { background: @TEXT@; color: @SURFACE@; border: 0; }
+/* Instant mode is an armed flag: off rests muted, on is full ink (the
+   checked indicator's accent block is the active-state tag). */
+QToolBar#MainToolBar QCheckBox { color: @MUTED@; }
+QToolBar#MainToolBar QCheckBox:checked { color: @TEXT@; }
+/* Save-state readout: a status field, never an alarm. "Saved" rests muted;
+   unsaved changes are simply brighter ink. */
+QToolBar#MainToolBar QLabel#DirtyStatusBadge {
+    color: @MUTED@; background: transparent; border: 0;
+    padding: 0 8px; font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QToolBar#MainToolBar QLabel#DirtyStatusBadge[dirty="true"] { color: @TEXT@; }
+/* Stream-format readout: the same field grammar; severity is an ink tag
+   (like the analysis chips), never a fill or a box. */
+QToolBar#MainToolBar QLabel#DeviceFormatBadge {
+    color: @MUTED@; background: transparent; border: 0;
+    padding: 0 6px; font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QToolBar#MainToolBar QLabel#DeviceFormatBadge[severity="warning"] { color: @WARNING@; }
+/* Device/channel fields: hairline boxes on the strip; hover is one value
+   step, the accent border only while the field is active (open/focused). */
+QToolBar#MainToolBar QComboBox { background: @CARD@; border: 1px solid @BORDER@; padding: 2px 22px 2px 8px; min-height: 24px; }
+QToolBar#MainToolBar QComboBox:hover { background: @CARD_HOVER@; border: 1px solid @BORDER@; }
+QToolBar#MainToolBar QComboBox:focus, QToolBar#MainToolBar QComboBox:on { border: 1px solid @ACCENT@; }
+
 QPushButton {
     background: @CARD@; color: @TEXT@;
     border: 1px solid @BORDER@; border-radius: 0;

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -57,7 +57,67 @@ QToolButton:pressed, QToolButton:checked {
 }
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 
-QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+/* ── Main toolbar: the rack's master rail ────────────────────────────────
+   RackChrome mounts a painted overlay (RackToolbarPlate: brushed strip,
+   machined edges, end screws, engraved series marking, instant-mode power
+   LED); QSS supplies the base rail and dresses the controls as hardware.
+   The rail-ear zones for the screws are reserved as layout margins by
+   RackChrome::styleMainToolbar (QToolBar ignores stylesheet padding). */
+QToolBar#MainToolBar {
+    background: @SURFACE@;
+    border: 0; border-bottom: 1px solid #060809;
+    spacing: 6px;
+}
+/* The painted overlay and the ear spacers stay transparent: the chrome is
+   drawn by RackChrome at their geometry. */
+QWidget#RackToolbarPlate, QWidget#RackToolbarEarSpacer { background: transparent; }
+/* The file actions are transport buttons: raised square caps with a lit top
+   bevel; pressing recesses the cap into the rail. */
+QToolBar#MainToolBar QToolButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    color: @TEXT@;
+    border: 1px solid #11161A; border-top-color: #3E474F;
+    border-radius: 2px;
+    min-width: 22px; min-height: 22px; padding: 3px 5px; margin: 0 1px;
+}
+QToolBar#MainToolBar QToolButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #343C44, stop:1 #20272D);
+    border-color: @ACCENT@; border-top-color: #3E474F;
+}
+QToolBar#MainToolBar QToolButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #14181C, stop:1 #232A30);
+    border-color: @ACCENT@; border-top-color: #0C1013;
+}
+/* Instant mode is a panel switch read by its lamp: the stock indicator
+   collapses and RackChrome paints a real LED in the padding-reserved well. */
+QCheckBox#InstantModeCheckBox {
+    color: @TEXT@; background: transparent;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+    padding: 2px 4px 2px 22px; spacing: 0;
+}
+QCheckBox#InstantModeCheckBox::indicator { width: 0; height: 0; background: transparent; border: 0; image: none; }
+/* The save-state readout is a dark LCD well in both modes - displays do not
+   follow the panel finish. Modified state burns amber segments. */
+QLabel#DirtyStatusBadge {
+    background: #0B0F0C; color: #86F2BA;
+    border: 1px solid #050807; border-bottom-color: #39424A;
+    border-radius: 2px; padding: 4px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QLabel#DirtyStatusBadge[dirty="true"] { color: #F2C063; }
+/* Device-format status: engraved wireframe, amber when the unit bypasses. */
+QLabel#DeviceFormatBadge {
+    background: transparent; color: @MUTED@;
+    border: 1px solid @MUTED@; border-radius: 1px;
+    padding: 2px 6px; font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QLabel#DeviceFormatBadge[severity="warning"] { color: @WARNING@; border-color: @WARNING@; }
+
+QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; font-size: 8pt; text-transform: uppercase; letter-spacing: 2px; }
 
 /* Push buttons are raised switch caps: lit top edge, shadowed base; pressing
    inverts the gradient (the cap goes in). */

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -57,7 +57,68 @@ QToolButton:pressed, QToolButton:checked {
 }
 QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 
-QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; }
+/* ── Main toolbar: the rack's master rail ────────────────────────────────
+   RackChrome mounts a painted overlay (RackToolbarPlate: brushed strip,
+   machined edges, end screws, engraved series marking, instant-mode power
+   LED); QSS supplies the base rail and dresses the controls as hardware.
+   The rail-ear zones for the screws are reserved as layout margins by
+   RackChrome::styleMainToolbar (QToolBar ignores stylesheet padding). */
+QToolBar#MainToolBar {
+    background: @SURFACE@;
+    border: 0; border-bottom: 1px solid #AFA288;
+    spacing: 6px;
+}
+/* The painted overlay and the ear spacers stay transparent: the chrome is
+   drawn by RackChrome at their geometry. */
+QWidget#RackToolbarPlate, QWidget#RackToolbarEarSpacer { background: transparent; }
+/* The file actions are transport buttons: raised square caps with a lit top
+   bevel; pressing recesses the cap into the rail. */
+QToolBar#MainToolBar QToolButton {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    color: @TEXT@;
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
+    border-radius: 2px;
+    min-width: 22px; min-height: 22px; padding: 3px 5px; margin: 0 1px;
+}
+QToolBar#MainToolBar QToolButton:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #F0E8D6);
+    border-color: @ACCENT@; border-top-color: #FFFFFF;
+}
+QToolBar#MainToolBar QToolButton:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #D8CFBB, stop:1 #EFE8D8);
+    border-color: @ACCENT@; border-top-color: #B8AC92;
+}
+/* Instant mode is a panel switch read by its lamp: the stock indicator
+   collapses and RackChrome paints a real LED in the padding-reserved well. */
+QCheckBox#InstantModeCheckBox {
+    color: @TEXT@; background: transparent;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+    padding: 2px 4px 2px 22px; spacing: 0;
+}
+QCheckBox#InstantModeCheckBox::indicator { width: 0; height: 0; background: transparent; border: 0; image: none; }
+/* The save-state readout is a dark LCD well in both modes - displays do not
+   follow the panel finish (a cream panel still carries a dark glass
+   window). Modified state burns amber segments. */
+QLabel#DirtyStatusBadge {
+    background: #11150F; color: #3ED68E;
+    border: 1px solid #4A4438; border-bottom-color: #6B6354;
+    border-radius: 2px; padding: 4px 10px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QLabel#DirtyStatusBadge[dirty="true"] { color: #F2C063; }
+/* Device-format status: engraved wireframe, amber when the unit bypasses. */
+QLabel#DeviceFormatBadge {
+    background: transparent; color: @MUTED@;
+    border: 1px solid @MUTED@; border-radius: 1px;
+    padding: 2px 6px; font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QLabel#DeviceFormatBadge[severity="warning"] { color: @WARNING@; border-color: @WARNING@; }
+
+QLabel#ToolBarLabel { color: @MUTED@; background: transparent; padding: 0 4px 0 8px; font-weight: 700; font-size: 8pt; text-transform: uppercase; letter-spacing: 2px; }
 
 /* Push buttons are raised switch caps: lit top edge, shadowed base; pressing
    inverts the gradient (the cap goes in). */

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -309,3 +309,77 @@ QListWidget#SoftPickerList { background: transparent; border: 0; }
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ====================================================================
+   Main toolbar: the calm header band of a consumer settings app.
+   The band rests one value step above the window with NO hard separator
+   (whitespace does the separating). File actions are invisible at rest;
+   the cursor lifts them one value step on a fully rounded highlight,
+   pressing adds one more. Instant mode is a real stadium toggle, the save
+   state and device format ride in pastel stadium pills, and the combos
+   breathe inside full pills one value step above the band.
+   ==================================================================== */
+QToolBar#MainToolBar { background: @SURFACE@; border: 0; padding: 10px 14px; spacing: 8px; }
+QToolBar#MainToolBar::separator { background: transparent; width: 12px; margin: 0; }
+
+QToolBar#MainToolBar QToolButton {
+    background: transparent; color: @TEXT@;
+    border: 1px solid transparent; border-radius: 17px;
+    padding: 6px; min-width: 22px; min-height: 22px;
+}
+QToolBar#MainToolBar QToolButton:hover { background: @CARD@; border: 1px solid @BORDER@; }
+QToolBar#MainToolBar QToolButton:pressed,
+QToolBar#MainToolBar QToolButton:checked { background: @CARD_HOVER@; border: 1px solid @BORDER@; }
+
+QToolBar#MainToolBar QLabel#ToolBarLabel { color: @MUTED@; padding: 0 6px 0 14px; font-weight: 600; }
+
+/* Instant mode as a friendly toggle: stadium track, knob baked into the
+   state SVGs, calm accent when on. The off track is the muted token at low
+   alpha so the near-white knob reads in both modes. */
+QCheckBox#InstantModeCheckBox { color: @TEXT@; font-weight: 600; spacing: 10px; padding: 4px 6px; }
+QCheckBox#InstantModeCheckBox::indicator {
+    width: 36px; height: 20px; border-radius: 10px; border: 0;
+    background: rgba(167, 174, 194, 0.38);
+    image: url(:/icons/modern/soft-toggle-knob-off.svg);
+}
+QCheckBox#InstantModeCheckBox::indicator:hover { background: rgba(167, 174, 194, 0.50); }
+QCheckBox#InstantModeCheckBox::indicator:checked {
+    background: @ACCENT@;
+    image: url(:/icons/modern/soft-toggle-knob-on.svg);
+}
+QCheckBox#InstantModeCheckBox::indicator:checked:hover { background: rgba(59, 130, 246, 0.85); }
+
+/* The save state is a status pill: "Saved" rests in a muted success
+   pastel; unsaved warms up one tint - warmer, never an alarm. */
+QLabel#DirtyStatusBadge {
+    background: rgba(34, 197, 94, 0.15); color: #8ADDAC;
+    border: 1px solid rgba(34, 197, 94, 0.30);
+    border-radius: 13px; padding: 5px 14px;
+    font-weight: 600; font-size: 9pt;
+}
+QLabel#DirtyStatusBadge[dirty="true"] {
+    background: rgba(245, 158, 11, 0.15); color: #F4C577;
+    border: 1px solid rgba(245, 158, 11, 0.32);
+}
+
+/* Device format pill: calm accent pastel normally, the same warm (not
+   alarmed) tint when the stream is only forwarded. */
+QLabel#DeviceFormatBadge {
+    background: rgba(59, 130, 246, 0.15); color: #8DB5F8;
+    border: 1px solid rgba(59, 130, 246, 0.30);
+    border-radius: 13px; padding: 5px 12px;
+    font-weight: 600; font-size: 9pt;
+}
+QLabel#DeviceFormatBadge[severity="warning"] {
+    background: rgba(245, 158, 11, 0.15); color: #F4C577;
+    border: 1px solid rgba(245, 158, 11, 0.32);
+}
+
+/* The combos breathe in full stadium pills one value step above the band;
+   hover lifts exactly one more step. */
+QComboBox#ToolBarComboBox {
+    background: @CARD@; border: 1px solid @BORDER@;
+    border-radius: 16px; padding: 6px 32px 6px 16px; min-height: 20px;
+}
+QComboBox#ToolBarComboBox:hover { background: @CARD_HOVER@; border-color: @BORDER@; }
+QComboBox#ToolBarComboBox:focus, QComboBox#ToolBarComboBox:on { border: 1px solid @ACCENT@; }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -309,3 +309,77 @@ QListWidget#SoftPickerList { background: transparent; border: 0; }
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ====================================================================
+   Main toolbar: the calm header band of a consumer settings app.
+   The band rests one value step above the window with NO hard separator
+   (whitespace does the separating). File actions are invisible at rest;
+   the cursor lifts them one value step on a fully rounded highlight,
+   pressing adds one more. Instant mode is a real stadium toggle, the save
+   state and device format ride in pastel stadium pills, and the combos
+   breathe inside full pills one value step above the band.
+   ==================================================================== */
+QToolBar#MainToolBar { background: @SURFACE@; border: 0; padding: 10px 14px; spacing: 8px; }
+QToolBar#MainToolBar::separator { background: transparent; width: 12px; margin: 0; }
+
+QToolBar#MainToolBar QToolButton {
+    background: transparent; color: @TEXT@;
+    border: 1px solid transparent; border-radius: 17px;
+    padding: 6px; min-width: 22px; min-height: 22px;
+}
+QToolBar#MainToolBar QToolButton:hover { background: @CARD@; border: 1px solid @BORDER@; }
+QToolBar#MainToolBar QToolButton:pressed,
+QToolBar#MainToolBar QToolButton:checked { background: @CARD_HOVER@; border: 1px solid @BORDER@; }
+
+QToolBar#MainToolBar QLabel#ToolBarLabel { color: @MUTED@; padding: 0 6px 0 14px; font-weight: 600; }
+
+/* Instant mode as a friendly toggle: stadium track, knob baked into the
+   state SVGs, calm accent when on. The off track is the muted token at low
+   alpha so the near-white knob reads in both modes. */
+QCheckBox#InstantModeCheckBox { color: @TEXT@; font-weight: 600; spacing: 10px; padding: 4px 6px; }
+QCheckBox#InstantModeCheckBox::indicator {
+    width: 36px; height: 20px; border-radius: 10px; border: 0;
+    background: rgba(120, 111, 103, 0.35);
+    image: url(:/icons/modern/soft-toggle-knob-off.svg);
+}
+QCheckBox#InstantModeCheckBox::indicator:hover { background: rgba(120, 111, 103, 0.45); }
+QCheckBox#InstantModeCheckBox::indicator:checked {
+    background: @ACCENT@;
+    image: url(:/icons/modern/soft-toggle-knob-on.svg);
+}
+QCheckBox#InstantModeCheckBox::indicator:checked:hover { background: rgba(59, 130, 246, 0.85); }
+
+/* The save state is a status pill: "Saved" rests in a muted success
+   pastel; unsaved warms up one tint - warmer, never an alarm. */
+QLabel#DirtyStatusBadge {
+    background: rgba(34, 197, 94, 0.13); color: #257C42;
+    border: 1px solid rgba(34, 197, 94, 0.30);
+    border-radius: 13px; padding: 5px 14px;
+    font-weight: 600; font-size: 9pt;
+}
+QLabel#DirtyStatusBadge[dirty="true"] {
+    background: rgba(245, 158, 11, 0.14); color: #996714;
+    border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+/* Device format pill: calm accent pastel normally, the same warm (not
+   alarmed) tint when the stream is only forwarded. */
+QLabel#DeviceFormatBadge {
+    background: rgba(59, 130, 246, 0.12); color: #32538B;
+    border: 1px solid rgba(59, 130, 246, 0.32);
+    border-radius: 13px; padding: 5px 12px;
+    font-weight: 600; font-size: 9pt;
+}
+QLabel#DeviceFormatBadge[severity="warning"] {
+    background: rgba(245, 158, 11, 0.14); color: #996714;
+    border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+/* The combos breathe in full stadium pills one value step above the band;
+   hover lifts exactly one more step. */
+QComboBox#ToolBarComboBox {
+    background: @CARD@; border: 1px solid @BORDER@;
+    border-radius: 16px; padding: 6px 32px 6px 16px; min-height: 20px;
+}
+QComboBox#ToolBarComboBox:hover { background: @CARD_HOVER@; border-color: @BORDER@; }
+QComboBox#ToolBarComboBox:focus, QComboBox#ToolBarComboBox:on { border: 1px solid @ACCENT@; }

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -218,7 +218,8 @@ QCheckBox#InstantModeCheckBox::indicator:checked:disabled {
 }
 
 /* Save-state readout: a value, so it reads like one - sunken glass window,
-   mono face, muted until it matters. */
+   mono face, muted until it matters. Unsaved changes light an amber lamp
+   behind the glass, the same grammar as the format warning below. */
 QLabel#DirtyStatusBadge {
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-size: 9pt;
@@ -228,6 +229,11 @@ QLabel#DirtyStatusBadge {
     border-top-color: rgba(0, 0, 0, 0.55);
     border-radius: 8px;
     padding: 3px 10px;
+}
+QLabel#DirtyStatusBadge[dirty="true"] {
+    color: @TEXT@;
+    background: rgba(245, 158, 11, 0.16);
+    border-color: rgba(245, 158, 11, 0.60);
 }
 
 /* Device format readout: same meter window; a warning is an amber lamp

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -146,8 +146,106 @@ QToolButton::menu-indicator {
 QLabel#ToolBarLabel {
     color: @MUTED@;
     background: transparent;
-    padding: 0 4px 0 8px;
-    font-weight: 600;
+    padding: 0 6px 0 10px;
+    font-size: 9pt;
+    font-weight: 500;
+}
+
+/* ===== Main toolbar: the top edge of the glass =====
+   The strip is not a separate bar. It stays the window's deep background
+   and only a 1px reflection along its bottom edge marks where the glass
+   begins. Buttons are unboxed quiet ink at rest; hovering pools accent
+   light under the button (radial wash - glow faked with gradients, never
+   effects) and pressing turns the light up. The Instant mode indicator is
+   the cards' signal lamp recast as a switch; the dirty and format badges
+   are sunken mono readouts (meter windows, not panels). */
+QToolBar#MainToolBar {
+    background: @BG@;
+    border: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    padding: 6px 10px;
+    spacing: 8px;
+}
+QToolBar#MainToolBar QToolButton {
+    background: transparent;
+    border: 0;
+    border-radius: 8px;
+    padding: 5px 9px;
+    min-height: 22px;
+}
+QToolBar#MainToolBar QToolButton:hover {
+    background: qradialgradient(cx: 0.5, cy: 1.05, radius: 0.85, fx: 0.5, fy: 1.05,
+        stop: 0 rgba(91, 140, 255, 0.42), stop: 0.4 rgba(91, 140, 255, 0.16), stop: 1 rgba(91, 140, 255, 0));
+}
+QToolBar#MainToolBar QToolButton:pressed {
+    background: qradialgradient(cx: 0.5, cy: 1.05, radius: 0.9, fx: 0.5, fy: 1.05,
+        stop: 0 rgba(91, 140, 255, 0.62), stop: 0.4 rgba(91, 140, 255, 0.28), stop: 1 rgba(91, 140, 255, 0.02));
+}
+
+/* Instant mode is a light switch: a round signal lamp that is dark sunken
+   glass while off and glows from its core when on. The label is lit with
+   the lamp. */
+QCheckBox#InstantModeCheckBox {
+    color: @MUTED@;
+    background: transparent;
+    spacing: 8px;
+    padding: 2px 4px;
+}
+QCheckBox#InstantModeCheckBox:checked {
+    color: @TEXT@;
+}
+QCheckBox#InstantModeCheckBox:disabled {
+    color: #5a5a72;
+}
+QCheckBox#InstantModeCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    background: #08080f;
+    border: 1px solid @BORDER@;
+}
+QCheckBox#InstantModeCheckBox::indicator:hover {
+    border-color: rgba(91, 140, 255, 0.65);
+}
+QCheckBox#InstantModeCheckBox::indicator:checked {
+    background: qradialgradient(cx: 0.5, cy: 0.42, radius: 0.75, fx: 0.5, fy: 0.36,
+        stop: 0 #E2EBFF, stop: 0.35 @ACCENT@, stop: 1 rgba(91, 140, 255, 0.16));
+    border: 1px solid rgba(91, 140, 255, 0.8);
+}
+QCheckBox#InstantModeCheckBox::indicator:checked:disabled {
+    background: @BORDER@;
+    border-color: @BORDER@;
+}
+
+/* Save-state readout: a value, so it reads like one - sunken glass window,
+   mono face, muted until it matters. */
+QLabel#DirtyStatusBadge {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+    color: @MUTED@;
+    background: #08080f;
+    border: 1px solid @BORDER@;
+    border-top-color: rgba(0, 0, 0, 0.55);
+    border-radius: 8px;
+    padding: 3px 10px;
+}
+
+/* Device format readout: same meter window; a warning is an amber lamp
+   lighting the glass from behind, not a recoloured label. */
+QLabel#DeviceFormatBadge {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+    color: @MUTED@;
+    background: #08080f;
+    border: 1px solid @BORDER@;
+    border-top-color: rgba(0, 0, 0, 0.55);
+    border-radius: 8px;
+    padding: 3px 10px;
+}
+QLabel#DeviceFormatBadge[severity="warning"] {
+    color: @TEXT@;
+    background: rgba(245, 158, 11, 0.16);
+    border-color: rgba(245, 158, 11, 0.60);
 }
 
 /* ===== Push Buttons ===== */

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -131,8 +131,96 @@ QToolButton::menu-indicator { image: none; width: 0; height: 0; }
 QLabel#ToolBarLabel {
     color: @MUTED@;
     background: transparent;
-    padding: 0 4px 0 8px;
-    font-weight: 600;
+    padding: 0 6px 0 10px;
+    font-size: 9pt;
+    font-weight: 500;
+}
+
+/* ===== Main toolbar: the top edge of the glass =====
+   Same grammar as the dark sheet: the strip stays the window background,
+   a 1px white reflection marks its bottom edge, hover pools accent light
+   under the unboxed buttons, the Instant mode lamp glows when on and the
+   badges are sunken mono readouts. */
+QToolBar#MainToolBar {
+    background: @BG@;
+    border: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.95);
+    padding: 6px 10px;
+    spacing: 8px;
+}
+QToolBar#MainToolBar QToolButton {
+    background: transparent;
+    border: 0;
+    border-radius: 8px;
+    padding: 5px 9px;
+    min-height: 22px;
+}
+QToolBar#MainToolBar QToolButton:hover {
+    background: qradialgradient(cx: 0.5, cy: 1.05, radius: 0.85, fx: 0.5, fy: 1.05,
+        stop: 0 rgba(47, 107, 255, 0.30), stop: 0.4 rgba(47, 107, 255, 0.11), stop: 1 rgba(47, 107, 255, 0));
+}
+QToolBar#MainToolBar QToolButton:pressed {
+    background: qradialgradient(cx: 0.5, cy: 1.05, radius: 0.9, fx: 0.5, fy: 1.05,
+        stop: 0 rgba(47, 107, 255, 0.46), stop: 0.4 rgba(47, 107, 255, 0.20), stop: 1 rgba(47, 107, 255, 0.02));
+}
+
+QCheckBox#InstantModeCheckBox {
+    color: @MUTED@;
+    background: transparent;
+    spacing: 8px;
+    padding: 2px 4px;
+}
+QCheckBox#InstantModeCheckBox:checked {
+    color: @TEXT@;
+}
+QCheckBox#InstantModeCheckBox:disabled {
+    color: #a0a0b4;
+}
+QCheckBox#InstantModeCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    background: @CARD_HOVER@;
+    border: 1px solid @BORDER@;
+}
+QCheckBox#InstantModeCheckBox::indicator:hover {
+    border-color: rgba(47, 107, 255, 0.65);
+}
+QCheckBox#InstantModeCheckBox::indicator:checked {
+    background: qradialgradient(cx: 0.5, cy: 0.42, radius: 0.75, fx: 0.5, fy: 0.36,
+        stop: 0 #FFFFFF, stop: 0.35 @ACCENT@, stop: 1 rgba(47, 107, 255, 0.18));
+    border: 1px solid rgba(47, 107, 255, 0.8);
+}
+QCheckBox#InstantModeCheckBox::indicator:checked:disabled {
+    background: @BORDER@;
+    border-color: @BORDER@;
+}
+
+QLabel#DirtyStatusBadge {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+    color: @MUTED@;
+    background: @CARD_HOVER@;
+    border: 1px solid @BORDER@;
+    border-top-color: rgba(0, 0, 0, 0.14);
+    border-radius: 8px;
+    padding: 3px 10px;
+}
+
+QLabel#DeviceFormatBadge {
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+    color: @MUTED@;
+    background: @CARD_HOVER@;
+    border: 1px solid @BORDER@;
+    border-top-color: rgba(0, 0, 0, 0.14);
+    border-radius: 8px;
+    padding: 3px 10px;
+}
+QLabel#DeviceFormatBadge[severity="warning"] {
+    color: @TEXT@;
+    background: rgba(245, 158, 11, 0.18);
+    border-color: rgba(245, 158, 11, 0.60);
 }
 
 QPushButton {

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -206,6 +206,13 @@ QLabel#DirtyStatusBadge {
     border-radius: 8px;
     padding: 3px 10px;
 }
+/* Unsaved changes: the amber lamp lights the glass from behind, matching the
+   format-warning grammar below. */
+QLabel#DirtyStatusBadge[dirty="true"] {
+    color: @TEXT@;
+    background: rgba(245, 158, 11, 0.18);
+    border-color: rgba(245, 158, 11, 0.60);
+}
 
 QLabel#DeviceFormatBadge {
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;


### PR DESCRIPTION
The main toolbar still wore stock Windows chrome and the 2005-era `.ico` document icons — the same set already evicted from the Include/VST cards. This dresses it per skin.

## Phase 0 (neutral baseline)

- Three new modern stroke SVGs (`file-new`, `save`, `save-as`; `folder-open` reused) in the shared icon language (24x24, 1.8px stroke, tint via alpha mask).
- New `ISkin::styleMainToolbar(QToolBar*, tokens)` hook, called at startup and on every skin/dark switch; the neutral default replaces the legacy action icons with the modern set tinted by the text token. The File menu''s Save As gets the matching icon.
- The offscreen gallery captures a faithful toolbar replica per skin/mode (same object names and widget train as MainWindow, dummy device data); CI now expects **140 PNGs**.

## Per-skin toolbars (5 isolated agents; record on `toolbar/<skin>` branches)

- **studio** — the top edge of the glass: unboxed quiet-ink buttons, hover pools accent light underneath, Instant mode as the signal lamp recast as a switch, save-state as a sunken mono meter window.
- **minimal** — the terminal''s command line: `NEW / OPEN / SAVE` as uppercase letter-spaced mono commands (text-only buttons), one hairline rule, hover = one value step, pressed = inverted block, status as muted uppercase fields.
- **soft** — a calm header band: iOS-Settings pastel tiles for the three actions, a real stadium toggle for Instant mode, save state in a muted pastel pill that warms (never alarms) when dirty.
- **rack** — the master rail: brushed faceplate with rail ears and hand-tightened screws (painted overlay), transport-style raised buttons that recess when pressed, a bezel-and-dome LED on the engage toggle, save state as a dark LCD well with green segments in both modes.
- **matrix** — the board''s header strip: square function cells on the 24px grid texture, engaged-crosspoint press grammar, Instant mode as an engage cell with a square LED, save state as a painted status lamp (green saved / amber modified) heading a sunken mono readout.

## Integrator glue (cross-cutting items the agents flagged)

- `MainWindow::updateDirtyStatus` no longer installs an inline stylesheet on the badge — every skin now owns `QLabel#DirtyStatusBadge` and its `[dirty="true"]` variant (studio gained the missing rule: amber lamp behind the glass).
- `SkinManager::styleMainToolbar` resets the toolbar to icon-only before delegating so minimal''s text-only mode cannot leak across a live skin switch.
- Fixed a 200%-DPI defect in soft''s tile icons (glyph centred by physical pixel width; now by `deviceIndependentSize`, with 44/64px ladder entries for crisp 2x).

## Verification

- Differentiation gate: five toolbars identifiable by philosophy alone in both modes (gallery artifact).
- Interference: all **130 pre-existing gallery PNGs byte-identical** after integration; soft''s 26 non-toolbar PNGs unchanged by the DPI fix.
- Integrated gallery 140/140; cppcheck 2.21.0 clean; 10s offscreen MainWindow smoke run clean; per-agent non-interference verified against their own baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)