### PR TITLE
fix(ci): use the native ARM64 host compiler for the ARM64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -662,6 +662,14 @@ jobs:
         $platformToolset = if ("${{ matrix.platform }}" -eq "ARM64") { "v143" } else { "v145" }
         Write-Host "PlatformToolset=$platformToolset (platform ${{ matrix.platform }})"
 
+        # Host toolchain: on the ARM64 runner, "x64" resolves to the EMULATED
+        # 32-bit HostX86 cl.exe, whose 4 GB address space exhausts under /MP
+        # PCH builds (flaky C3859/C1076 seen on the v1.23.0 run, twice). The
+        # native 64-bit HostARM64 compiler avoids both the heap limit and the
+        # emulation tax. x64 images keep the 64-bit x64 host.
+        $toolArchitecture = if ("${{ matrix.platform }}" -eq "ARM64") { "ARM64" } else { "x64" }
+        Write-Host "PreferredToolArchitecture=$toolArchitecture"
+
         $buildParams = @(
           "/m",
           "/p:Configuration=${{ env.BUILD_CONFIGURATION }}",
@@ -677,7 +685,7 @@ jobs:
           "/p:VST3_SDK=$env:VST3_SDK",
           "/p:HIGHWAY_INCLUDE=$env:HIGHWAY_INCLUDE",
           "/p:PlatformToolset=$platformToolset",  # v145 on the VS 2026 x64 image, v143 on the VS 2022 ARM64 image (see above)
-          "/p:PreferredToolArchitecture=x64"  # 64-bit host cl.exe avoids the 32-bit PCH heap limit on ARM64
+          "/p:PreferredToolArchitecture=$toolArchitecture"  # 64-bit host cl.exe (native ARM64 on the ARM64 runner; see above)
         )
 
         $BuildPlatform = "${{ matrix.platform }}"


### PR DESCRIPTION
The v1.23.0 release run failed twice on the ARM64 leg with flaky `C3859: Failed to create virtual memory for PCH` / `C1076: internal heap limit reached` (Benchmark on the first run, Common on the rerun; the sse2 leg''s first failure was a separate Qt-mirror outage that passed on rerun).

Root cause: on the `windows-11-arm` runner, `PreferredToolArchitecture=x64` resolves to the **emulated 32-bit `HostX86\arm64\cl.exe`** (visible in the logs), whose 4 GB address space exhausts under `/MP` PCH builds — a flaky boundary that today''s growing PCH finally crossed. The fix selects the native 64-bit `HostARM64` toolchain on ARM64 (x64 images keep the x64 host), which removes both the heap ceiling and the emulation tax.

`fix`-typed deliberately: v1.23.0''s version bump landed but its artifacts never published, so this supersedes it with a clean v1.23.1 release (carrying the per-skin toolbar work from #85); the skipped v1.23.0 number matches the changelog''s existing precedent for skipped versions.

Note: the PR pipeline only builds avx2, so the real verification is the full-matrix main run after merge — it will be watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)