### PR TITLE
feat(editor): custom window chrome - per-skin title bar, menu bar and menus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1038,9 +1038,9 @@ jobs:
         }
         $pngs = @(Get-ChildItem $outDir -Filter *.png)
         Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # 5 skins x 2 modes x (4 rows x 3 states + 1 filter picker + 1 toolbar)
-        if ($pngs.Count -ne 140) {
-          Write-Error "Expected 140 gallery PNGs, got $($pngs.Count)"
+        # 5 skins x 2 modes x (4 rows x 3 states + picker + toolbar + titlebar + menubar + menu)
+        if ($pngs.Count -ne 170) {
+          Write-Error "Expected 170 gallery PNGs, got $($pngs.Count)"
           exit 1
         }
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,20 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16은 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- Editor가 창 chrome을 직접 그립니다. 네이티브 윈도우 제목 표시줄이 스킨별
+  타이틀바로 바뀌었고(드래그·스냅·모서리 리사이즈·더블클릭 최대화는 네이티브
+  그대로), 메뉴바와 모든 드롭다운 메뉴가 스킨의 디자인 언어를 따릅니다.
+  Studio Glass는 발광 구분선의 유리 패널, Precision Minimal은 아이콘 없는
+  모노 메뉴의 터미널 타이틀 라인, Soft Lab은 차분한 둥근 헤더와 메뉴 카드,
+  Hardware Rack은 LED 체크가 달린 각인 금속 패널, Signal Matrix는 셀 메뉴의
+  모눈 마스트헤드입니다. Edit 메뉴에 남아 있던 2005년풍 아이콘도 모던
+  스트로크 아이콘으로 교체했습니다. Interface 메뉴의 "Native title bar"
+  토글로 재시작 후 순정 캡션으로 돌아갈 수 있습니다. 오프스크린 갤러리가
+  스킨별 타이틀바·메뉴바·열린 메뉴를 한글 샘플과 함께 캡처해, 현장에서
+  보고된 한글 씹힘을 상시 감시합니다. ([#88])
+
 ## v1.24.0 (2026-06-12)
 
 - 메인 툴바가 윈도우 기본 모습과 2005년풍 아이콘에서 벗어났습니다. 새
@@ -358,3 +372,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78
 [#81]: https://github.com/115dkk/EqualizerAPO-XT/pull/81
 [#85]: https://github.com/115dkk/EqualizerAPO-XT/pull/85
+[#88]: https://github.com/115dkk/EqualizerAPO-XT/pull/88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ were never released). Tags up to v1.10.1 carried a `-main.<run>` suffix; from v1
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- The Editor draws its own window chrome: the native Windows caption is
+  replaced by a skinnable title bar (dragging, snapping, edge resizing and
+  double-click maximize stay native), and the menu bar plus every dropdown
+  menu now follow each skin's design language — lit glass with luminous
+  separators (Studio Glass), a terminal title line with icon-free mono menus
+  (Precision Minimal), a calm rounded header and menu cards (Soft Lab), an
+  engraved brushed panel with LED checks (Hardware Rack), and a grid masthead
+  with cell menus (Signal Matrix). The Edit menu's remaining 2005-era icons
+  were replaced with modern stroke icons. A "Native title bar" toggle in the
+  Interface menu restores the stock caption after a restart. The offscreen
+  gallery now captures title bar, menu bar and an open menu per skin with
+  Korean sample text, guarding against the Hangul clipping reported from the
+  field. ([#88])
+
 ## v1.24.0 — 2026-06-12
 
 - The main toolbar lost its stock Windows look and 2005-era icons. A new
@@ -378,3 +394,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#78]: https://github.com/115dkk/EqualizerAPO-XT/pull/78
 [#81]: https://github.com/115dkk/EqualizerAPO-XT/pull/81
 [#85]: https://github.com/115dkk/EqualizerAPO-XT/pull/85
+[#88]: https://github.com/115dkk/EqualizerAPO-XT/pull/88

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -117,6 +117,7 @@ SOURCES += main.cpp\
 	MainWindowParts/MainWindow.Edit.cpp \
 	MainWindowParts/MainWindow.FileActions.cpp \
 	MainWindowParts/MainWindow.FileIO.cpp \
+	MainWindowParts/MainWindow.Frame.cpp \
 	MainWindowParts/MainWindow.Preferences.cpp \
 	MainWindowParts/MainWindow.ViewActions.cpp \
 	ConfigFileCodec.cpp \
@@ -202,6 +203,7 @@ SOURCES += main.cpp\
 	widgets/FilterCardModel.cpp \
 	widgets/FilterCardRow.cpp \
 	widgets/FilterPickerView.cpp \
+	widgets/TitleBar.cpp \
 	widgets/routing/CopyRoutingAdapter.cpp \
 	widgets/routing/CrosspointMatrixRoutingRenderer.cpp \
 	widgets/routing/StepListRoutingRenderer.cpp \
@@ -382,6 +384,7 @@ HEADERS  += \
 	widgets/FilterCardModel.h \
 	widgets/FilterCardRow.h \
 	widgets/FilterPickerView.h \
+	widgets/TitleBar.h \
 	widgets/routing/CopyRoutingAdapter.h \
 	widgets/routing/IRoutingRenderer.h \
 	widgets/routing/CrosspointMatrixRoutingRenderer.h \

--- a/Editor/Editor.qrc
+++ b/Editor/Editor.qrc
@@ -42,6 +42,15 @@
         <file>icons/modern/save-as.svg</file>
         <file>icons/modern/soft-toggle-knob-off.svg</file>
         <file>icons/modern/soft-toggle-knob-on.svg</file>
+        <file>icons/modern/cut.svg</file>
+        <file>icons/modern/copy.svg</file>
+        <file>icons/modern/paste.svg</file>
+        <file>icons/modern/trash.svg</file>
+        <file>icons/modern/select-all.svg</file>
+        <file>icons/modern/window-min.svg</file>
+        <file>icons/modern/window-max.svg</file>
+        <file>icons/modern/window-restore.svg</file>
+        <file>icons/modern/window-close.svg</file>
         <file>translations/Editor_zh_CN.qm</file>
         <file>translations/qtbase_zh_CN.qm</file>
         <file>translations/Editor_fr.qm</file>

--- a/Editor/Editor.qrc
+++ b/Editor/Editor.qrc
@@ -51,6 +51,8 @@
         <file>icons/modern/window-max.svg</file>
         <file>icons/modern/window-restore.svg</file>
         <file>icons/modern/window-close.svg</file>
+        <file>icons/modern/matrix-grid-dark.svg</file>
+        <file>icons/modern/matrix-grid-light.svg</file>
         <file>translations/Editor_zh_CN.qm</file>
         <file>translations/qtbase_zh_CN.qm</file>
         <file>translations/Editor_fr.qm</file>

--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -95,6 +95,11 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 		version += QString(".%0").arg(REVISION);
 	setWindowTitle(tr("Equalizer APO %0 Configuration Editor").arg(version));
 
+	// Custom window chrome (title bar + menu bar in the menu-widget slot);
+	// must run after the title is set so the TitleBar picks it up, and before
+	// preferences apply skin icons to it.
+	setupWindowChrome();
+
 	ui->mainToolBar->setObjectName(QStringLiteral("MainToolBar"));
 
 	QWidget* spacer = new QWidget;

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -43,6 +43,7 @@ class MainWindow;
 }
 
 class QLabel;
+class TitleBar;
 
 class MainWindow : public QMainWindow
 {
@@ -61,6 +62,9 @@ public:
 
 protected:
 	void closeEvent(QCloseEvent* event) override;
+	// Custom window chrome: removes the native caption while keeping native
+	// move/snap/resize (see MainWindowParts/MainWindow.Frame.cpp).
+	bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
 
 private slots:
 	void deviceSelected(int index);
@@ -98,6 +102,7 @@ private slots:
 	void darkThemeToggled(bool checked);
 	void knobRangeSelected(QAction* action);
 	void on_graphPositionComboBox_currentIndexChanged(int index);
+	void nativeTitleBarToggled(bool checked);
 	void toggleGraphFullscreen();
 	void on_actionResetAllGlobalPreferences_triggered();
 	void on_actionResetAllFileSpecificPreferences_triggered();
@@ -112,6 +117,7 @@ private:
 	void savePreferences();
 	void updateRecentFiles();
 	void setupRedesignActions();
+	void setupWindowChrome();
 	void applyRedesignPreferences();
 	void syncKnobRangeActions();
 	void setCurrentRenderMode(FilterTable::RenderMode mode);
@@ -149,6 +155,10 @@ private:
 	QActionGroup* skinActionGroup = nullptr;
 	QAction* darkThemeAction = nullptr;
 	QActionGroup* knobRangeActionGroup = nullptr;
+	// Custom window chrome (frameless caption); nullptr when the
+	// interface/nativeTitleBar escape hatch keeps the stock caption.
+	TitleBar* titleBar = nullptr;
+	bool useCustomFrame = true;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<AbstractAPOInfo>)

--- a/Editor/MainWindowParts/MainWindow.Frame.cpp
+++ b/Editor/MainWindowParts/MainWindow.Frame.cpp
@@ -1,0 +1,132 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Custom window chrome: the native Windows caption is removed (the window
+	keeps its WS_CAPTION/WS_THICKFRAME styles so DWM snap, animations and
+	native resize stay intact) and a skinnable TitleBar widget plus the menu
+	bar take its place via QMainWindow::setMenuWidget. WM_NCCALCSIZE consumes
+	the caption area; WM_NCHITTEST hands back HTCAPTION over the title strip
+	and the resize-border codes along the edges, so moving, snapping and
+	resizing remain native. interface/nativeTitleBar (registry) is the escape
+	hatch: machines where custom chrome misbehaves (see the PC-bang reports in
+	issue #75) can restore the stock caption with one toggle + restart.
+*/
+
+#include <QLayout>
+#include <QMenuBar>
+#include <QSettings>
+#include <QVBoxLayout>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <windowsx.h>
+
+#include "Editor/widgets/TitleBar.h"
+#include "MainWindow.h"
+#include "ui_MainWindow.h"
+
+void MainWindow::setupWindowChrome()
+{
+	QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+	useCustomFrame = !settings.value("interface/nativeTitleBar", false).toBool();
+	if (!useCustomFrame)
+		return;
+
+	// The title strip and the menu bar share the QMainWindow menu-widget slot.
+	titleBar = new TitleBar(this);
+	QWidget* chromeHost = new QWidget(this);
+	chromeHost->setObjectName(QStringLiteral("WindowChromeHost"));
+	chromeHost->setAttribute(Qt::WA_StyledBackground, true);
+	QVBoxLayout* chromeLayout = new QVBoxLayout(chromeHost);
+	chromeLayout->setContentsMargins(0, 0, 0, 0);
+	chromeLayout->setSpacing(0);
+	chromeLayout->addWidget(titleBar);
+	QMenuBar* menu = ui->menuBar;
+	menu->setParent(chromeHost);
+	chromeLayout->addWidget(menu);
+	setMenuWidget(chromeHost);
+
+	// Recalculate the non-client area now that WM_NCCALCSIZE is handled.
+	HWND hwnd = reinterpret_cast<HWND>(winId());
+	SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
+		SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+bool MainWindow::nativeEvent(const QByteArray& eventType, void* message, qintptr* result)
+{
+	if (!useCustomFrame || eventType != QByteArrayLiteral("windows_generic_MSG"))
+		return QMainWindow::nativeEvent(eventType, message, result);
+
+	MSG* msg = static_cast<MSG*>(message);
+	switch (msg->message)
+	{
+	case WM_NCCALCSIZE:
+	{
+		if (msg->wParam == TRUE)
+		{
+			// Claim the whole window rect as client area (the caption is
+			// gone). A maximized window extends past the monitor edge by the
+			// frame thickness, so inset all four sides to keep the content
+			// on screen.
+			NCCALCSIZE_PARAMS* params = reinterpret_cast<NCCALCSIZE_PARAMS*>(msg->lParam);
+			if (IsZoomed(msg->hwnd))
+			{
+				const int frame = GetSystemMetrics(SM_CXSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER);
+				params->rgrc[0].left += frame;
+				params->rgrc[0].top += frame;
+				params->rgrc[0].right -= frame;
+				params->rgrc[0].bottom -= frame;
+			}
+			*result = 0;
+			return true;
+		}
+		break;
+	}
+	case WM_NCHITTEST:
+	{
+		// Work in window-relative LOGICAL coordinates: physical offset from
+		// the window origin divided by the window's device pixel ratio. This
+		// avoids mixed-DPI global-coordinate mapping entirely.
+		RECT windowRect;
+		GetWindowRect(msg->hwnd, &windowRect);
+		const double scale = devicePixelRatioF();
+		const QPoint rel(
+			qRound((GET_X_LPARAM(msg->lParam) - windowRect.left) / scale),
+			qRound((GET_Y_LPARAM(msg->lParam) - windowRect.top) / scale));
+
+		const int border = 6;
+		if (!isMaximized())
+		{
+			const bool left = rel.x() < border;
+			const bool right = rel.x() >= width() - border;
+			const bool top = rel.y() < border;
+			const bool bottom = rel.y() >= height() - border;
+			if (top && left) { *result = HTTOPLEFT; return true; }
+			if (top && right) { *result = HTTOPRIGHT; return true; }
+			if (bottom && left) { *result = HTBOTTOMLEFT; return true; }
+			if (bottom && right) { *result = HTBOTTOMRIGHT; return true; }
+			if (top) { *result = HTTOP; return true; }
+			if (bottom) { *result = HTBOTTOM; return true; }
+			if (left) { *result = HTLEFT; return true; }
+			if (right) { *result = HTRIGHT; return true; }
+		}
+
+		if (titleBar != nullptr)
+		{
+			const QPoint inTitleBar = titleBar->mapFrom(this, rel);
+			if (titleBar->isCaptionPoint(inTitleBar))
+			{
+				// Native caption semantics: drag to move, drag to the screen
+				// edge to snap, double-click to maximize/restore.
+				*result = HTCAPTION;
+				return true;
+			}
+		}
+		break;
+	}
+	default:
+		break;
+	}
+
+	return QMainWindow::nativeEvent(eventType, message, result);
+}

--- a/Editor/MainWindowParts/MainWindow.Preferences.cpp
+++ b/Editor/MainWindowParts/MainWindow.Preferences.cpp
@@ -25,6 +25,7 @@
 #include "Editor/helpers/GUIChannelHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "version.h"
+#include "Editor/widgets/TitleBar.h"
 #include "FilterTable.h"
 #include "MainWindow.h"
 #include "SkinManager.h"
@@ -271,6 +272,15 @@ void MainWindow::setupRedesignActions()
 	QAction* fullscreenGraphAction = interfaceMenu->addAction(tr("Fullscreen graph"));
 	fullscreenGraphAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Alt+F")));
 	connect(fullscreenGraphAction, SIGNAL(triggered()), this, SLOT(toggleGraphFullscreen()));
+
+	// Escape hatch for the custom window chrome: machines where the
+	// frameless caption misbehaves can restore the stock Windows title bar
+	// (takes effect after a restart, mirroring the language flow).
+	interfaceMenu->addSeparator();
+	QAction* nativeTitleAction = interfaceMenu->addAction(tr("Native title bar"));
+	nativeTitleAction->setCheckable(true);
+	nativeTitleAction->setChecked(!useCustomFrame);
+	connect(nativeTitleAction, SIGNAL(toggled(bool)), this, SLOT(nativeTitleBarToggled(bool)));
 }
 
 void MainWindow::syncKnobRangeActions()
@@ -309,11 +319,22 @@ void MainWindow::applyRedesignPreferences()
 
 	// The toolbar is dressed by the active skin (icons + chrome); re-run on
 	// every skin/dark switch so the tinted icons follow the new ink. The
-	// menu-only Save As action gets the matching neutral icon here - it is
-	// not on the toolbar, so the skin hook never sees it.
+	// menu-only actions (Save As + the Edit menu set) get the matching
+	// neutral stroke icons here - they are not on the toolbar, so the skin
+	// hook never sees them. This retires the last of the 2005-era .ico set
+	// from the dropdowns.
 	SkinManager::instance()->styleMainToolbar(ui->mainToolBar);
-	ui->actionSaveAs->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/save-as.svg"),
-		QColor(SkinManager::instance()->tokens().text), 18));
+	const QColor menuInk(SkinManager::instance()->tokens().text);
+	ui->actionSaveAs->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/save-as.svg"), menuInk, 18));
+	ui->actionCut->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/cut.svg"), menuInk, 18));
+	ui->actionCopy->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/copy.svg"), menuInk, 18));
+	ui->actionPaste->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/paste.svg"), menuInk, 18));
+	ui->actionDelete->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/trash.svg"), menuInk, 18));
+	ui->actionSelectAll->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/select-all.svg"), menuInk, 18));
+
+	// The custom title bar follows the same ink.
+	if (titleBar != nullptr)
+		titleBar->applySkinIcons();
 
 	if (interfaceModeActionGroup != nullptr)
 	{

--- a/Editor/MainWindowParts/MainWindow.ViewActions.cpp
+++ b/Editor/MainWindowParts/MainWindow.ViewActions.cpp
@@ -173,6 +173,27 @@ void MainWindow::toggleGraphFullscreen()
 	ui->analysisDockWidget->setVisible(true);
 }
 
+void MainWindow::nativeTitleBarToggled(bool checked)
+{
+	QAction* action = qobject_cast<QAction*>(sender());
+
+	// Frame styles can only change cleanly before the window exists, so this
+	// follows the language flow: persist the choice and offer a restart.
+	if (QMessageBox::question(this, tr("Restart required"), tr("Configuration Editor will be restarted to apply the changed settings. Proceed?")) == QMessageBox::Yes)
+	{
+		QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+		settings.setValue("interface/nativeTitleBar", checked);
+		restart = true;
+		close();
+	}
+	else if (action != nullptr)
+	{
+		action->blockSignals(true);
+		action->setChecked(!checked);
+		action->blockSignals(false);
+	}
+}
+
 void MainWindow::languageSelected(bool selected)
 {
 	QAction* action = qobject_cast<QAction*>(sender());

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -4,6 +4,8 @@
 #include <QCheckBox>
 #include <QDir>
 #include <QLabel>
+#include <QMenu>
+#include <QMenuBar>
 #include <QPixmap>
 #include <QScrollArea>
 #include <QString>
@@ -17,6 +19,7 @@
 #include "Editor/widgets/FilterCardRow.h"
 #include "Editor/widgets/FilterPickerView.h"
 #include "Editor/widgets/SkinComboBox.h"
+#include "Editor/widgets/TitleBar.h"
 
 namespace
 {
@@ -244,6 +247,58 @@ int renderSkin(const QDir& outDir, const QString& skinId, bool dark)
 		QApplication::processEvents();
 		failures += saveGrab(toolBar, outDir, skinId, mode, QStringLiteral("toolbar"), QStringLiteral("normal")) ? 0 : 1;
 		delete toolBar;
+	}
+
+	// Window chrome: the custom title bar over a dummy host. The Korean text
+	// in the title is deliberate - it makes Hangul clipping/shaping defects
+	// (reported from the field as "설정" rendering like "ㅅ정") visible in the
+	// gallery on every machine, including CI.
+	{
+		QWidget host;
+		host.setWindowTitle(QStringLiteral("Equalizer APO Configuration Editor — 설정.txt"));
+		TitleBar* bar = new TitleBar(&host, nullptr);
+		bar->resize(960, bar->sizeHint().height());
+		bar->show();
+		QApplication::processEvents();
+		failures += saveGrab(bar, outDir, skinId, mode, QStringLiteral("titlebar"), QStringLiteral("normal")) ? 0 : 1;
+		delete bar;
+	}
+
+	// Menu bar replica with the real top-level titles plus a Korean sample.
+	{
+		QMenuBar* menuBar = new QMenuBar(nullptr);
+		menuBar->setObjectName(QStringLiteral("GalleryMenuBar"));
+		menuBar->addMenu(QStringLiteral("File"));
+		menuBar->addMenu(QStringLiteral("Edit"));
+		menuBar->addMenu(QStringLiteral("View"));
+		menuBar->addMenu(QStringLiteral("Settings"));
+		menuBar->addMenu(QStringLiteral("설정"));
+		menuBar->resize(960, menuBar->sizeHint().height());
+		menuBar->show();
+		QApplication::processEvents();
+		failures += saveGrab(menuBar, outDir, skinId, mode, QStringLiteral("menubar"), QStringLiteral("normal")) ? 0 : 1;
+		delete menuBar;
+	}
+
+	// An open dropdown menu with representative content: modern tinted icons,
+	// a checkable item, a separator, a disabled item and a Korean label.
+	{
+		const QColor ink(SkinManager::instance()->tokens().text);
+		QMenu* menu = new QMenu();
+		menu->setObjectName(QStringLiteral("GalleryMenu"));
+		menu->addAction(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/cut.svg"), ink, 18), QStringLiteral("Cut"));
+		menu->addAction(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/copy.svg"), ink, 18), QStringLiteral("Copy"));
+		menu->addAction(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/paste.svg"), ink, 18), QStringLiteral("Paste"));
+		menu->addSeparator();
+		QAction* checkable = menu->addAction(QStringLiteral("설정 항목 (Instant mode)"));
+		checkable->setCheckable(true);
+		checkable->setChecked(true);
+		QAction* disabled = menu->addAction(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/trash.svg"), ink, 18), QStringLiteral("Delete"));
+		disabled->setEnabled(false);
+		menu->show();
+		QApplication::processEvents();
+		failures += saveGrab(menu, outDir, skinId, mode, QStringLiteral("menu"), QStringLiteral("normal")) ? 0 : 1;
+		delete menu;
 	}
 	return failures;
 }

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -159,6 +159,12 @@ FilterPickerView* SkinManager::createFilterPicker(QWidget* parent) const
 	return new DefaultFilterPickerView(parent);
 }
 
+void SkinManager::paintTitleBarChrome(QPainter& painter, const QRect& rect) const
+{
+	if (activeSkin != nullptr)
+		activeSkin->paintTitleBarChrome(painter, rect, currentTokens);
+}
+
 void SkinManager::styleMainToolbar(QToolBar* toolBar) const
 {
 	if (toolBar == nullptr || activeSkin == nullptr)

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -52,6 +52,9 @@ public:
 	// Main toolbar icons/chrome for the active skin (ISkin::styleMainToolbar).
 	void styleMainToolbar(QToolBar* toolBar) const;
 
+	// Painted title-bar decoration for the active skin (ISkin::paintTitleBarChrome).
+	void paintTitleBarChrome(QPainter& painter, const QRect& rect) const;
+
 signals:
 	void skinChanged(const SkinTokens& tokens);
 

--- a/Editor/icons/modern/copy.svg
+++ b/Editor/icons/modern/copy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="9" y="9" width="10.5" height="10.5" rx="1.5"/>
+  <path d="M5.5 14.5H4.8A1.3 1.3 0 0 1 3.5 13.2V4.8A1.3 1.3 0 0 1 4.8 3.5h8.4a1.3 1.3 0 0 1 1.3 1.3v.7"/>
+</svg>

--- a/Editor/icons/modern/cut.svg
+++ b/Editor/icons/modern/cut.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="7" cy="17.5" r="2.3"/>
+  <circle cx="17" cy="17.5" r="2.3"/>
+  <path d="M8.6 15.8L18 4.5"/>
+  <path d="M15.4 15.8L6 4.5"/>
+</svg>

--- a/Editor/icons/modern/matrix-grid-dark.svg
+++ b/Editor/icons/modern/matrix-grid-dark.svg
@@ -1,0 +1,7 @@
+<!-- Signal Matrix: 24px column-grid tile for QSS background-image (dark).
+     One 1px vertical rule at the tile's right edge; tiled, it reproduces the
+     gridPitch-24 graph paper the painted board layers draw elsewhere. Ink is
+     the dark border token #233443 at the painted grid's alpha (55/255). -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <line x1="23.5" y1="0" x2="23.5" y2="24" stroke="#233443" stroke-opacity="0.22" stroke-width="1"/>
+</svg>

--- a/Editor/icons/modern/matrix-grid-light.svg
+++ b/Editor/icons/modern/matrix-grid-light.svg
@@ -1,0 +1,6 @@
+<!-- Signal Matrix: 24px column-grid tile for QSS background-image (light).
+     Same construction as the dark tile; the light border token #D4E2E8 needs
+     more alpha (90/255) to stay visible as graph paper on white surfaces. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <line x1="23.5" y1="0" x2="23.5" y2="24" stroke="#D4E2E8" stroke-opacity="0.35" stroke-width="1"/>
+</svg>

--- a/Editor/icons/modern/paste.svg
+++ b/Editor/icons/modern/paste.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 5H6.5A1.5 1.5 0 0 0 5 6.5v13A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5v-13A1.5 1.5 0 0 0 17.5 5H15"/>
+  <rect x="9" y="3" width="6" height="3.6" rx="1.2"/>
+  <path d="M9 12h6"/>
+  <path d="M9 15.5h6"/>
+</svg>

--- a/Editor/icons/modern/select-all.svg
+++ b/Editor/icons/modern/select-all.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 7V5.8A1.3 1.3 0 0 1 5.8 4.5H7"/>
+  <path d="M11 4.5h2"/>
+  <path d="M17 4.5h1.2a1.3 1.3 0 0 1 1.3 1.3V7"/>
+  <path d="M19.5 11v2"/>
+  <path d="M19.5 17v1.2a1.3 1.3 0 0 1-1.3 1.3H17"/>
+  <path d="M13 19.5h-2"/>
+  <path d="M7 19.5H5.8a1.3 1.3 0 0 1-1.3-1.3V17"/>
+  <path d="M4.5 13v-2"/>
+  <path d="M8.5 12l2.4 2.4 4.6-4.8"/>
+</svg>

--- a/Editor/icons/modern/trash.svg
+++ b/Editor/icons/modern/trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 6.5h15"/>
+  <path d="M9 6.5V4.8A1.3 1.3 0 0 1 10.3 3.5h3.4A1.3 1.3 0 0 1 15 4.8v1.7"/>
+  <path d="M6.5 6.5l1 12.6A1.5 1.5 0 0 0 9 20.5h6a1.5 1.5 0 0 0 1.5-1.4l1-12.6"/>
+  <path d="M10 10.5v6"/>
+  <path d="M14 10.5v6"/>
+</svg>

--- a/Editor/icons/modern/window-close.svg
+++ b/Editor/icons/modern/window-close.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7 7l10 10"/>
+  <path d="M17 7L7 17"/>
+</svg>

--- a/Editor/icons/modern/window-max.svg
+++ b/Editor/icons/modern/window-max.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6.5" y="6.5" width="11" height="11" rx="1.2"/>
+</svg>

--- a/Editor/icons/modern/window-min.svg
+++ b/Editor/icons/modern/window-min.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 12h12"/>
+</svg>

--- a/Editor/icons/modern/window-restore.svg
+++ b/Editor/icons/modern/window-restore.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6" y="9" width="9" height="9" rx="1.2"/>
+  <path d="M9.5 9V7.2A1.2 1.2 0 0 1 10.7 6H16.8A1.2 1.2 0 0 1 18 7.2v6.1a1.2 1.2 0 0 1-1.2 1.2H15"/>
+</svg>

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -135,6 +135,11 @@ FilterPickerView* ISkin::createFilterPicker(QWidget* parent) const
 	return new DefaultFilterPickerView(parent);
 }
 
+void ISkin::paintTitleBarChrome(QPainter&, const QRect&, const SkinTokens&) const
+{
+	// Neutral default: the QSS background is the whole story.
+}
+
 void ISkin::styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const
 {
 	if (toolBar == nullptr)

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -131,6 +131,12 @@ public:
 	// usual QWidget parent mechanism.
 	virtual FilterPickerView* createFilterPicker(QWidget* parent) const;
 
+	// Painted decoration over the custom title bar's QSS background (screws,
+	// grid texture, glows - whatever the skin's constitution calls for).
+	// Drawn by TitleBar::paintEvent after the stylesheet background and
+	// before child widgets. Default: no-op.
+	virtual void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens) const;
+
 	// Dress the main toolbar in this skin's language. Called from
 	// applyRedesignPreferences at startup and again on every skin/dark
 	// switch, so implementations must be idempotent. The default replaces the

--- a/Editor/skins/RackChrome.cpp
+++ b/Editor/skins/RackChrome.cpp
@@ -21,6 +21,7 @@
 #include <QtMath>
 
 #include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
 #include "ISkin.h"
 
 namespace
@@ -698,6 +699,68 @@ void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, con
 		painter.setPen(ledInk);
 		painter.drawText(window, Qt::AlignCenter, state.valueText);
 	}
+}
+
+void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens)
+{
+	const bool dark = isDarkPanel(tokens);
+	painter.setRenderHint(QPainter::Antialiasing);
+	const QRectF r(rect);
+
+	// Brushed-metal sheen: the rolled top edge falling into shadow, the same
+	// finish as the card faceplates and the master rail - one machine.
+	QLinearGradient sheen(r.topLeft(), r.bottomLeft());
+	if (dark)
+	{
+		sheen.setColorAt(0.0, QColor(255, 255, 255, 26));
+		sheen.setColorAt(0.14, QColor(255, 255, 255, 10));
+		sheen.setColorAt(0.55, QColor(255, 255, 255, 0));
+		sheen.setColorAt(1.0, QColor(0, 0, 0, 52));
+	}
+	else
+	{
+		sheen.setColorAt(0.0, QColor(255, 255, 255, 120));
+		sheen.setColorAt(0.5, QColor(255, 255, 255, 0));
+		sheen.setColorAt(1.0, QColor(0, 0, 0, 30));
+	}
+	painter.fillRect(r, sheen);
+
+	// Horizontal brushing texture.
+	painter.setPen(QPen(dark ? QColor(255, 255, 255, 5) : QColor(96, 84, 64, 8), 1));
+	for (qreal y = r.top() + 3; y < r.bottom() - 2; y += 3)
+		painter.drawLine(QPointF(r.left() + 2, y), QPointF(r.right() - 2, y));
+
+	// The caption-button block is the panel's right ear: a slightly recessed
+	// zone behind the three machined caps, set off by a machined groove. The
+	// caps are fixed-size (TitleBar::makeCaptionButton), so the groove sits at
+	// the same scaled offset the layout gives them.
+	const qreal capsWidth = qreal(GUIHelper::scale(40.0)) * 3.0;
+	const qreal grooveX = r.right() - capsWidth - 6.0;
+	const bool earFits = grooveX > r.left() + 120.0;
+	if (earFits)
+	{
+		painter.fillRect(QRectF(grooveX, r.top(), r.right() - grooveX, r.height()),
+			QColor(0, 0, 0, dark ? 52 : 20));
+		painter.setPen(QPen(QColor(0, 0, 0, dark ? 120 : 60), 1));
+		painter.drawLine(QPointF(grooveX, r.top()), QPointF(grooveX, r.bottom()));
+		painter.setPen(QPen(QColor(255, 255, 255, dark ? 26 : 120), 1));
+		painter.drawLine(QPointF(grooveX + 1, r.top()), QPointF(grooveX + 1, r.bottom()));
+	}
+
+	// Machined edges across the full rail (over the ear fill): lit top
+	// chamfer, shadowed bottom groove against the menu bar below.
+	painter.setPen(QPen(QColor(255, 255, 255, dark ? 36 : 150), 1));
+	painter.drawLine(QPointF(r.left(), r.top() + 0.5), QPointF(r.right(), r.top() + 0.5));
+	painter.setPen(QPen(QColor(0, 0, 0, dark ? 150 : 70), 1));
+	painter.drawLine(QPointF(r.left(), r.bottom() - 0.5), QPointF(r.right(), r.bottom() - 0.5));
+
+	// Two rail screws bolting the top panel down: one at the left end before
+	// the engraved designation, one on the blank panel before the caption
+	// ear. Slot angles differ - hand-tightened, like everywhere else.
+	const uint seed = uint(qHash(QStringLiteral("top-panel")));
+	paintScrew(painter, QPointF(r.left() + 10.0, r.center().y()), 4.0, qreal(seed % 180u), dark);
+	if (earFits)
+		paintScrew(painter, QPointF(grooveX - 12.0, r.center().y()), 4.0, qreal((seed + 73u) % 180u), dark);
 }
 
 void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens)

--- a/Editor/skins/RackChrome.h
+++ b/Editor/skins/RackChrome.h
@@ -37,6 +37,13 @@ void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo&
 // Skeuomorphic pointer knob with a panel-printed scale.
 void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens);
 
+// The custom title bar as the unit's top panel: brushed sheen and brushing
+// lines, machined top/bottom edges, the caption-button block set off by a
+// machined groove (the same ear grammar as the cards and the master rail)
+// and two hand-tightened rail screws. Drawn by TitleBar::paintEvent between
+// the QSS background and the child widgets.
+void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens);
+
 // Mount (or refresh) the master-rail chrome on the main toolbar: a painted
 // overlay widget (brushed strip, machined edges, end screws, engraved series
 // marking and the instant-mode power LED) kept below the toolbar's controls.

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -116,6 +116,49 @@ public:
 		return new StudioFilterPickerView(parent);
 	}
 
+	// The title bar is the topmost edge of the window's glass. The QSS keeps
+	// the strip on the deep stage colour; this hook lays the light on it - a
+	// whisper of reflection along the full top edge plus a faint accent-to-
+	// violet arc caught on that edge, echoing the picker panel and the knob
+	// arcs (accent2 stays at the spectrum's end, per the one-light rule).
+	// Both are plain strokes: bloom first, then the core - glow is faked with
+	// layered strokes, never effects.
+	void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens) const override
+	{
+		const bool dark = studioIsDark(tokens);
+		painter.save();
+
+		// The 1px lighter top edge of the glass formula, quieter than a
+		// panel's reflection - the bar is the stage's edge, not a card.
+		painter.fillRect(QRectF(rect.left(), rect.top(), rect.width(), 1.0),
+			QColor(255, 255, 255, dark ? 30 : 235));
+
+		painter.setRenderHint(QPainter::Antialiasing);
+		const double span = rect.width() * 0.42;
+		const double x0 = rect.left() + (rect.width() - span) / 2.0;
+		const double y = rect.top() + 0.5;
+		QLinearGradient bloom(x0, y, x0 + span, y);
+		bloom.setColorAt(0.0, studioAlpha(tokens.accent, 0));
+		bloom.setColorAt(0.35, studioAlpha(tokens.accent, dark ? 70 : 55));
+		bloom.setColorAt(0.7, studioAlpha(tokens.accent2, dark ? 52 : 42));
+		bloom.setColorAt(1.0, studioAlpha(tokens.accent2, 0));
+		QPen bloomPen(QBrush(bloom), 4.0);
+		bloomPen.setCapStyle(Qt::RoundCap);
+		painter.setPen(bloomPen);
+		painter.drawLine(QPointF(x0, y), QPointF(x0 + span, y));
+		QLinearGradient core(x0, y, x0 + span, y);
+		core.setColorAt(0.0, studioAlpha(tokens.accent, 0));
+		core.setColorAt(0.35, studioAlpha(tokens.accent, dark ? 215 : 195));
+		core.setColorAt(0.7, studioAlpha(tokens.accent2, dark ? 175 : 155));
+		core.setColorAt(1.0, studioAlpha(tokens.accent2, 0));
+		QPen corePen(QBrush(core), 1.5);
+		corePen.setCapStyle(Qt::RoundCap);
+		painter.setPen(corePen);
+		painter.drawLine(QPointF(x0, y), QPointF(x0 + span, y));
+
+		painter.restore();
+	}
+
 	// The toolbar is the top edge of the window's glass. The QSS sheets own
 	// the strip itself (deep background, a 1px reflection along the bottom
 	// edge, accent light pooling under hovered buttons, the Instant mode

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -1632,6 +1632,29 @@ public:
 		}
 	}
 
+	// The board's masthead: the faint 24px column grid behind the title
+	// readout and a doubled bottom rule (this inner line plus the QSS bottom
+	// border), so the strip closes like a board's title rule, not a plain
+	// window edge - the same construction MatrixToolbarBoard gives the
+	// toolbar strip. The caption cells stay transparent in QSS so the grid
+	// runs through them, exactly like the toolbar's function cells.
+	void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens) const override
+	{
+		painter.setRenderHint(QPainter::Antialiasing, false);
+
+		// The hook carries no mode flag; infer it from the surface lightness
+		// (the studioIsDark pattern). The light border ink needs more alpha
+		// than the dark one to stay visible as graph paper on white.
+		QColor grid(tokens.border);
+		grid.setAlpha(QColor(tokens.surface).lightness() < 128 ? 55 : 90);
+		painter.setPen(QPen(grid, 1));
+		for (int x = rect.left() + MatrixMetrics::gridPitch; x < rect.right(); x += MatrixMetrics::gridPitch)
+			painter.drawLine(x, rect.top(), x, rect.bottom());
+
+		painter.setPen(QPen(QColor(tokens.border), 1));
+		painter.drawLine(rect.left(), rect.bottom() - 3, rect.right(), rect.bottom() - 3);
+	}
+
 	// The board's header strip. The neutral stroke icons stay, tinted in
 	// plain ink (the catalog is monochrome - colour belongs to the status
 	// lamp); the QSS dresses every toolbar item as a square 1px cell, and

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -709,6 +709,17 @@ public:
 		return new SoftFilterPickerView(parent);
 	}
 
+	// Window chrome: deliberately NO paintTitleBarChrome override. The
+	// constitutional tiebreaker ("when in doubt, remove the element and add
+	// whitespace") answers painted caption decoration directly - the calm app
+	// header is already complete in the QSS sheets: the surface one value
+	// step off the window, a friendly-weight title in full ink, caption
+	// buttons resting as soft rounded squares whose hover lifts one value
+	// step on a stadium highlight, and a close button that warms with the
+	// dirty-badge amber instead of alarming red. Anything painted on top
+	// (screws, glows, grids) belongs to the neighbours' vocabularies and
+	// would only make the header more anxious.
+
 	SkinTokens tokens(bool dark) const override
 	{
 		SkinTokens t;

--- a/Editor/skins/Skins.cpp
+++ b/Editor/skins/Skins.cpp
@@ -1055,6 +1055,15 @@ public:
 		RackChrome::paintCardChrome(painter, rect, info, tokens);
 	}
 
+	void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens) const override
+	{
+		// The caption strip is the unit's top panel: brushed sheen, machined
+		// edges, the caption-ear groove and two rail screws (RackChrome). QSS
+		// prints the model designation and dresses the caption buttons as
+		// machined caps.
+		RackChrome::paintTitleBarChrome(painter, rect, tokens);
+	}
+
 	FilterPickerView* createFilterPicker(QWidget* parent) const override
 	{
 		// The module library browser: a brushed 1U faceplate with engraved

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -1027,3 +1027,26 @@ QLineEdit#CrosspointEditor {
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -41,58 +41,80 @@ QToolTip {
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 
-/* ===== Menu Bar / Menus ===== */
+/* ===== Menu Bar / Menus: the board's header row =====
+   The menu bar is a row of board cells with 1px rules sitting on the same
+   24px column-grid tile the painted board layers draw elsewhere. Hover =
+   dim cell pre-light, open menu = engaged crosspoint (accent fill + accent
+   rule) - the toolbar function cells' grammar. */
 QMenuBar {
-    background: @SURFACE@;
+    background-color: @SURFACE@;
+    background-image: url(:/icons/modern/matrix-grid-dark.svg);
     color: @TEXT@;
-    padding: 2px 4px;
+    padding: 0 0 0 4px;
     border: 0;
     border-bottom: 1px solid @BORDER@;
 }
 QMenuBar::item {
     background: transparent;
-    padding: 6px 12px;
+    border: 1px solid @BORDER@;
     border-radius: 0;
+    padding: 4px 14px;
+    margin: 4px 4px 4px 0;
 }
-QMenuBar::item:selected,
+QMenuBar::item:selected {
+    background: rgba(34, 211, 238, 0.10);
+    color: @TEXT@;
+}
 QMenuBar::item:pressed {
-    background: rgba(34, 211, 238, 0.18);
+    background: rgba(34, 211, 238, 0.28);
+    border-color: @ACCENT@;
     color: @TEXT@;
 }
 
+/* Dropdowns: square panels on the grid texture. Items are cells (generous
+   padding keeps Hangul shaped and unclipped), the selected item is an
+   engaged crosspoint (translucent accent + 1px accent rule), separators are
+   full-width 1px rules, the check indicator is a square LED, and a disabled
+   item is a cancelled departure: dashed outer rule, never hidden. */
 QMenu {
-    background: @SURFACE@;
+    background-color: @SURFACE@;
+    background-image: url(:/icons/modern/matrix-grid-dark.svg);
     color: @TEXT@;
     border: 1px solid @BORDER@;
     border-radius: 0;
-    padding: 2px;
+    padding: 0;
 }
 QMenu::item {
     background: transparent;
-    padding: 6px 22px 6px 22px;
+    border: 1px solid transparent;
     border-radius: 0;
-    min-width: 140px;
+    padding: 7px 26px 7px 12px;
+    min-width: 168px;
 }
 QMenu::item:selected {
-    background: rgba(34, 211, 238, 0.20);
+    background: rgba(34, 211, 238, 0.16);
+    border: 1px solid @ACCENT@;
     color: @TEXT@;
 }
 QMenu::item:disabled {
     color: #4A6470;
+    border: 1px dashed @BORDER@;
 }
 QMenu::separator {
     height: 1px;
     background: @BORDER@;
-    margin: 4px 6px;
+    margin: 5px 0;
 }
 QMenu::indicator {
-    width: 14px;
-    height: 14px;
-    margin-left: 4px;
+    width: 10px;
+    height: 10px;
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+    margin-left: 6px;
 }
 QMenu::indicator:checked {
     background: @ACCENT@;
-    border-radius: 0;
+    border-color: @ACCENT@;
 }
 QMenu::icon {
     padding-left: 8px;
@@ -1028,25 +1050,47 @@ QLineEdit#CrosspointEditor {
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome: the board's masthead =====
+   MatrixSkin::paintTitleBarChrome draws the faint 24px column grid and the
+   inner line of the doubled bottom rule; the QSS bottom border is the outer
+   line. The title is a mono readout line; the caption buttons are function
+   cells in a single-ruled train (min/max drop their right rule so adjacent
+   cells share one 1px line): monochrome at rest, dim accent pre-light on
+   hover, engaged accent fill while pressed. The close cell pre-lights danger
+   on hover - closing is a state change, and status colour is reserved for
+   exactly that. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
+    border-bottom: 1px solid @BORDER@;
 }
 QLabel#TitleBarText {
     background: transparent;
-    color: @MUTED@;
+    color: @TEXT@;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-size: 9pt;
+    letter-spacing: 1px;
 }
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
     background: transparent;
-    border: 0;
+    border: 1px solid @BORDER@;
     border-radius: 0;
+    margin: 2px 0 4px 0;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax {
+    border-right: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: rgba(34, 211, 238, 0.10);
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: rgba(34, 211, 238, 0.28);
+    border-color: @ACCENT@;
 }
 QToolButton#TitleBarClose:hover {
+    background: rgba(239, 68, 68, 0.18);
+    border-color: @DANGER@;
+}
+QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
+    border-color: @DANGER@;
 }

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -1023,3 +1023,26 @@ QLineEdit#CrosspointEditor {
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -41,58 +41,80 @@ QToolTip {
     font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
 }
 
-/* ===== Menu Bar / Menus ===== */
+/* ===== Menu Bar / Menus: the board's header row =====
+   The menu bar is a row of board cells with 1px rules sitting on the same
+   24px column-grid tile the painted board layers draw elsewhere. Hover =
+   dim cell pre-light, open menu = engaged crosspoint (accent fill + accent
+   rule) - the toolbar function cells' grammar. */
 QMenuBar {
-    background: @SURFACE@;
+    background-color: @SURFACE@;
+    background-image: url(:/icons/modern/matrix-grid-light.svg);
     color: @TEXT@;
-    padding: 2px 4px;
+    padding: 0 0 0 4px;
     border: 0;
     border-bottom: 1px solid @BORDER@;
 }
 QMenuBar::item {
     background: transparent;
-    padding: 6px 12px;
+    border: 1px solid @BORDER@;
     border-radius: 0;
+    padding: 4px 14px;
+    margin: 4px 4px 4px 0;
 }
-QMenuBar::item:selected,
+QMenuBar::item:selected {
+    background: rgba(0, 142, 170, 0.08);
+    color: @TEXT@;
+}
 QMenuBar::item:pressed {
-    background: rgba(0, 142, 170, 0.14);
+    background: rgba(0, 142, 170, 0.16);
+    border-color: @ACCENT@;
     color: @TEXT@;
 }
 
+/* Dropdowns: square panels on the grid texture. Items are cells (generous
+   padding keeps Hangul shaped and unclipped), the selected item is an
+   engaged crosspoint (translucent accent + 1px accent rule), separators are
+   full-width 1px rules, the check indicator is a square LED, and a disabled
+   item is a cancelled departure: dashed outer rule, never hidden. */
 QMenu {
-    background: @SURFACE@;
+    background-color: @SURFACE@;
+    background-image: url(:/icons/modern/matrix-grid-light.svg);
     color: @TEXT@;
     border: 1px solid @BORDER@;
     border-radius: 0;
-    padding: 2px;
+    padding: 0;
 }
 QMenu::item {
     background: transparent;
-    padding: 6px 22px;
+    border: 1px solid transparent;
     border-radius: 0;
-    min-width: 140px;
+    padding: 7px 26px 7px 12px;
+    min-width: 168px;
 }
 QMenu::item:selected {
-    background: rgba(0, 142, 170, 0.14);
+    background: rgba(0, 142, 170, 0.12);
+    border: 1px solid @ACCENT@;
     color: @TEXT@;
 }
 QMenu::item:disabled {
     color: #9DB4BD;
+    border: 1px dashed @BORDER@;
 }
 QMenu::separator {
     height: 1px;
     background: @BORDER@;
-    margin: 4px 6px;
+    margin: 5px 0;
 }
 QMenu::indicator {
-    width: 14px;
-    height: 14px;
-    margin-left: 4px;
+    width: 10px;
+    height: 10px;
+    background: @GRAPH@;
+    border: 1px solid @BORDER@;
+    margin-left: 6px;
 }
 QMenu::indicator:checked {
     background: @ACCENT@;
-    border-radius: 0;
+    border-color: @ACCENT@;
 }
 QMenu::icon {
     padding-left: 8px;
@@ -1024,25 +1046,47 @@ QLineEdit#CrosspointEditor {
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome: the board's masthead =====
+   MatrixSkin::paintTitleBarChrome draws the faint 24px column grid and the
+   inner line of the doubled bottom rule; the QSS bottom border is the outer
+   line. The title is a mono readout line; the caption buttons are function
+   cells in a single-ruled train (min/max drop their right rule so adjacent
+   cells share one 1px line): monochrome at rest, dim accent pre-light on
+   hover, engaged accent fill while pressed. The close cell pre-lights danger
+   on hover - closing is a state change, and status colour is reserved for
+   exactly that. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
+    border-bottom: 1px solid @BORDER@;
 }
 QLabel#TitleBarText {
     background: transparent;
-    color: @MUTED@;
+    color: @TEXT@;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
     font-size: 9pt;
+    letter-spacing: 1px;
 }
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
     background: transparent;
-    border: 0;
+    border: 1px solid @BORDER@;
     border-radius: 0;
+    margin: 2px 0 4px 0;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax {
+    border-right: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: rgba(0, 142, 170, 0.08);
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: rgba(0, 142, 170, 0.16);
+    border-color: @ACCENT@;
 }
 QToolButton#TitleBarClose:hover {
+    background: rgba(220, 38, 38, 0.12);
+    border-color: @DANGER@;
+}
+QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
+    border-color: @DANGER@;
 }

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -30,23 +30,45 @@ QToolTip {
     padding: 4px 8px;
 }
 
+/* Menu bar: the TUI menu line. The entries share the command line's
+   grammar (uppercase mono, 1px tracking, bold); rest is bare type on the
+   strip, hover climbs exactly one background-value step, and the open
+   entry is the inverted block - the terminal's cursor sitting on the
+   menu line. One full-width hairline rules the strip off below. */
 QMenuBar {
     background: @SURFACE@; color: @TEXT@;
     padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
 }
-QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 0; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: @CARD_HOVER@; color: #ffffff; }
+QMenuBar::item { background: transparent; padding: 5px 12px; border-radius: 0; }
+QMenuBar::item:selected { background: @CARD@; color: @TEXT@; }
+QMenuBar::item:pressed { background: @TEXT@; color: @SURFACE@; }
 
+/* Dropdown: a square console panel. 1px hairline frame on the console
+   ground, zero panel padding so every separator rules the full width.
+   Items are dense plain mono lines; the pictograms vanish (icon-size 0)
+   because they only duplicate their labels - in this skin a glyph must
+   carry information or it does not exist. Selection is the bluntest
+   cursor a text instrument has: the inverted block. Disabled lines drop
+   to secondary ink and refuse the cursor. */
 QMenu {
-    background: @SURFACE@; color: @TEXT@;
-    border: 1px solid @BORDER@; border-radius: 0; padding: 2px;
+    background: @BG@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 0; padding: 0;
+    icon-size: 0px;
 }
-QMenu::item { background: transparent; padding: 4px 22px; border-radius: 0; min-width: 140px; }
-QMenu::item:selected { background: @CARD_HOVER@; color: #ffffff; }
-QMenu::item:disabled { color: #555555; }
-QMenu::separator { height: 1px; background: @BORDER@; margin: 4px 6px; }
-QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
-QMenu::indicator:checked { background: @ACCENT@; }
+QMenu::item { background: transparent; padding: 5px 28px 5px 14px; border-radius: 0; min-width: 150px; }
+QMenu::item:selected { background: @TEXT@; color: @BG@; }
+QMenu::item:disabled { color: @MUTED@; background: transparent; }
+QMenu::item:disabled:selected { color: @MUTED@; background: transparent; }
+QMenu::separator { height: 1px; background: @BORDER@; margin: 0; }
+/* Checked state as a terminal flag: an empty hairline square at rest,
+   the accent block when armed (the active-state tag, as on the toolbar).
+   A checkable line carries the flag inline before its label, like the
+   "[x] option" column of a TUI menu - so only flag lines indent (Qt adds
+   the check column on top of the item padding; that offset is the flag
+   column, not misalignment). */
+QMenu::indicator { width: 12px; height: 12px; margin-left: 6px; background: transparent; border: 1px solid @BORDER@; }
+QMenu::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
 
 QToolBar {
     background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@;
@@ -412,25 +434,41 @@ QScrollArea#MinimalPickerScroll, QScrollArea#MinimalPickerScroll > QWidget > QWi
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome: a tiling WM running a terminal =====
+   The title strip is the terminal's title line: a flat surface with one
+   full-width hairline rule below, and the window title as quiet tracked
+   mono - chrome is metadata, so it gets secondary ink (importance =
+   brightness, as everywhere in this skin). No painted decoration: the
+   skin's paintTitleBarChrome stays the no-op default on purpose. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
+    border: 0;
+    border-bottom: 1px solid @BORDER@;
 }
 QLabel#TitleBarText {
     background: transparent;
     color: @MUTED@;
     font-size: 9pt;
+    letter-spacing: 1px;
 }
+/* Caption buttons: square pure glyphs at rest. Hover is exactly one
+   background-value step, pressed lands on the deepest grey step of the
+   ladder (the stroke glyph keeps its ink, so a true fg/bg swap would
+   erase it - the ladder is the honest alternative). Close answers with
+   the inverted danger block; its glyph stays legible on the block. */
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
     background: transparent;
     border: 0;
     border-radius: 0;
+    margin: 0;
+    padding: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: @CARD@;
 }
-QToolButton#TitleBarClose:hover {
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: @BORDER@;
+}
+QToolButton#TitleBarClose:hover, QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
 }

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -411,3 +411,26 @@ QScrollArea#MinimalPickerScroll, QScrollArea#MinimalPickerScroll > QWidget > QWi
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -350,3 +350,26 @@ QScrollArea#MinimalPickerScroll, QScrollArea#MinimalPickerScroll > QWidget > QWi
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -26,17 +26,45 @@ QMainWindow::separator { background: @BORDER@; width: 1px; height: 1px; }
 
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 0; padding: 4px 8px; }
 
-QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 0; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: #d0d0d0; color: #000000; }
+/* Menu bar: the TUI menu line, printed. The entries share the command
+   line's grammar (uppercase mono, 1px tracking, bold); rest is bare type
+   on the strip, hover is exactly one value step down on the paper, and
+   the open entry is the inverted block - the print head's cursor on the
+   menu line. One full-width hairline rules the strip off below. */
+QMenuBar {
+    background: @SURFACE@; color: @TEXT@;
+    padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+QMenuBar::item { background: transparent; padding: 5px 12px; border-radius: 0; }
+QMenuBar::item:selected { background: @CARD_HOVER@; color: @TEXT@; }
+QMenuBar::item:pressed { background: @TEXT@; color: @SURFACE@; }
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 0; padding: 2px; }
-QMenu::item { background: transparent; padding: 4px 22px; border-radius: 0; min-width: 140px; }
-QMenu::item:selected { background: #e0e0e0; color: #000000; }
-QMenu::item:disabled { color: #999999; }
-QMenu::separator { height: 1px; background: @BORDER@; margin: 4px 6px; }
-QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
-QMenu::indicator:checked { background: @ACCENT@; }
+/* Dropdown: a square panel of print. 1px hairline frame on the paper
+   ground, zero panel padding so every separator rules the full width.
+   Items are dense plain mono lines; the pictograms vanish (icon-size 0)
+   because they only duplicate their labels - in this skin a glyph must
+   carry information or it does not exist. Selection is the bluntest
+   cursor a text instrument has: the inverted block. Disabled lines drop
+   to secondary ink and refuse the cursor. */
+QMenu {
+    background: @BG@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 0; padding: 0;
+    icon-size: 0px;
+}
+QMenu::item { background: transparent; padding: 5px 28px 5px 14px; border-radius: 0; min-width: 150px; }
+QMenu::item:selected { background: @TEXT@; color: @BG@; }
+QMenu::item:disabled { color: @MUTED@; background: transparent; }
+QMenu::item:disabled:selected { color: @MUTED@; background: transparent; }
+QMenu::separator { height: 1px; background: @BORDER@; margin: 0; }
+/* Checked state as a terminal flag: an empty hairline square at rest,
+   the accent block when armed (the active-state tag, as on the toolbar).
+   A checkable line carries the flag inline before its label, like the
+   "[x] option" column of a TUI menu - so only flag lines indent (Qt adds
+   the check column on top of the item padding; that offset is the flag
+   column, not misalignment). */
+QMenu::indicator { width: 12px; height: 12px; margin-left: 6px; background: transparent; border: 1px solid @BORDER@; }
+QMenu::indicator:checked { background: @ACCENT@; border-color: @ACCENT@; }
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 2px 4px; spacing: 2px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 4px 6px; }
@@ -351,25 +379,41 @@ QScrollArea#MinimalPickerScroll, QScrollArea#MinimalPickerScroll > QWidget > QWi
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome: a tiling WM running a terminal (printed) =====
+   The title strip is the terminal's title line: a flat sheet with one
+   full-width hairline rule below, and the window title as quiet tracked
+   mono - chrome is metadata, so it gets secondary ink (importance =
+   brightness, as everywhere in this skin). No painted decoration: the
+   skin's paintTitleBarChrome stays the no-op default on purpose. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
+    border: 0;
+    border-bottom: 1px solid @BORDER@;
 }
 QLabel#TitleBarText {
     background: transparent;
     color: @MUTED@;
     font-size: 9pt;
+    letter-spacing: 1px;
 }
+/* Caption buttons: square pure glyphs at rest. Hover is exactly one
+   value step down on the paper, pressed lands on the deepest grey step
+   of the ladder (the stroke glyph keeps its ink, so a true fg/bg swap
+   would erase it - the ladder is the honest alternative). Close answers
+   with the inverted danger block; its glyph stays legible on the block. */
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
     background: transparent;
     border: 0;
     border-radius: 0;
+    margin: 0;
+    padding: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
     background: @CARD_HOVER@;
 }
-QToolButton#TitleBarClose:hover {
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: @BORDER@;
+}
+QToolButton#TitleBarClose:hover, QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
 }

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -410,3 +410,26 @@ QLabel#IncludeCardStatus { color: @DANGER@; font-size: 8pt; }
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -28,17 +28,66 @@ QMainWindow::separator { background: @BORDER@; width: 1px; height: 1px; }
 
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; padding: 4px 8px; }
 
-QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 2px; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: @CARD_HOVER@; color: #FFFFFF; }
+/* ── Menu bar: the engraved function row ─────────────────────────────────
+   A milled strip under the top panel; the section names are faceplate
+   printing (uppercase, letter-spaced, engraved muted ink). Hovering an item
+   pre-heats its lamp (a faint amber wash rising from the panel edge); the
+   open item is backlit by the lamp at full warmth. */
+QMenuBar {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #1B2126, stop:0.18 #171C21, stop:1 #11151A);
+    color: @TEXT@;
+    padding: 3px 8px;
+    border: 0; border-top: 1px solid #262D33; border-bottom: 1px solid #060809;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QMenuBar::item { background: transparent; color: @MUTED@; padding: 5px 12px; border-radius: 2px; }
+QMenuBar::item:selected {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgba(244, 184, 96, 0.05), stop:1 rgba(244, 184, 96, 0.18));
+    color: #F2DDB4;
+}
+QMenuBar::item:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgba(244, 184, 96, 0.12), stop:1 rgba(244, 184, 96, 0.40));
+    color: #FFE9C8;
+}
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; padding: 2px; }
-QMenu::item { background: transparent; padding: 5px 22px; border-radius: 2px; min-width: 140px; }
-QMenu::item:selected { background: @CARD_HOVER@; color: #FFFFFF; }
-QMenu::item:disabled { color: #4E4A40; }
-QMenu::separator { height: 1px; background: @BORDER@; margin: 4px 6px; }
-QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
-QMenu::indicator:checked { background: @ACCENT@; }
+/* ── Dropdown menus: panels of the same metal ────────────────────────────
+   A machined sub-panel hinged off the function row: lit top chamfer over a
+   dark milled edge, engraved uppercase items, grooved separators (dark cut
+   over a lit lower lip), and a lamp at the left slot edge backlighting the
+   selected item. The check indicator is a bezel-set panel LED: a dark lens
+   at rest, lit amber when engaged - state is a lamp, as everywhere on this
+   machine. */
+QMenu {
+    background: @CARD@;
+    color: @TEXT@;
+    border: 1px solid #060809; border-top-color: #3E474F;
+    border-radius: 3px;
+    padding: 5px 4px;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+QMenu::item { background: transparent; padding: 6px 26px; border-radius: 2px; min-width: 170px; }
+QMenu::item:selected {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 rgba(244, 184, 96, 0.55), stop:0.07 rgba(244, 184, 96, 0.26), stop:1 rgba(244, 184, 96, 0.05));
+    color: #FFE9C8;
+}
+QMenu::item:disabled { color: #4E4A40; background: transparent; }
+QMenu::separator {
+    height: 2px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #06080A, stop:1 #39424A);
+    margin: 5px 10px;
+}
+QMenu::icon { margin-left: 6px; }
+QMenu::indicator {
+    width: 12px; height: 12px; border-radius: 6px; margin-left: 6px;
+    border: 1px solid #060809;
+    background: qradialgradient(cx:0.35, cy:0.3, radius:1.2, stop:0 #2A3036, stop:1 #0B0E11);
+}
+QMenu::indicator:checked {
+    border: 1px solid #6B4A10;
+    background: qradialgradient(cx:0.4, cy:0.35, radius:1.0, stop:0 #FFE9C0, stop:0.45 @ACCENT@, stop:1 #8A5C12);
+}
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 2px 4px; spacing: 2px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 4px 6px; }
@@ -411,25 +460,45 @@ QLabel#IncludeCardStatus { color: @DANGER@; font-size: 8pt; }
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome: the unit's top panel =====
+   RackChrome::paintTitleBarChrome supplies the metal (brushed sheen,
+   machined edges, the caption-ear groove, two rail screws); QSS prints the
+   model designation and dresses the caption buttons as machined caps -
+   raised at rest, recessed when pressed. The close cap warms into a danger
+   lamp on hover, so it stays unmistakably the close button. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
 }
+/* The title is the printed model designation: uppercase, letter-spaced,
+   engraved muted ink. padding-left clears the left rail screw. */
 QLabel#TitleBarText {
     background: transparent;
     color: @MUTED@;
-    font-size: 9pt;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+    padding-left: 14px;
 }
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    border: 1px solid #11161A; border-top-color: #3E474F;
+    border-radius: 2px;
+    margin: 5px 3px;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #343C44, stop:1 #20272D);
+    border-color: @ACCENT@; border-top-color: #3E474F;
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #14181C, stop:1 #232A30);
+    border-color: @ACCENT@; border-top-color: #0C1013;
 }
 QToolButton#TitleBarClose:hover {
-    background: @DANGER@;
+    background: qradialgradient(cx:0.5, cy:0.45, radius:0.9, fx:0.5, fy:0.4,
+        stop:0 #C2503C, stop:0.6 #872E1F, stop:1 #571B10);
+    border-color: #D96A52; border-top-color: #E8836B;
+}
+QToolButton#TitleBarClose:pressed {
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.9, fx:0.5, fy:0.5,
+        stop:0 #8A2E1E, stop:1 #4A180D);
+    border-color: @DANGER@; border-top-color: #3A130A;
 }

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -412,3 +412,26 @@ QLabel#IncludeCardStatus { color: #B3261E; font-size: 8pt; }
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -28,17 +28,66 @@ QMainWindow::separator { background: @BORDER@; width: 1px; height: 1px; }
 
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; padding: 4px 8px; }
 
-QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 2px 4px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 4px 10px; border-radius: 2px; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: #E2D8C2; color: #000000; }
+/* ── Menu bar: the engraved function row ─────────────────────────────────
+   A milled cream-aluminium strip under the top panel; the section names are
+   faceplate printing (uppercase, letter-spaced, engraved muted ink).
+   Hovering an item pre-heats its lamp (a faint amber wash rising from the
+   panel edge); the open item is backlit by the lamp at full warmth. */
+QMenuBar {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFDF6, stop:0.2 #F6F1E6, stop:1 #EAE4D6);
+    color: @TEXT@;
+    padding: 3px 8px;
+    border: 0; border-top: 1px solid #FFFFFF; border-bottom: 1px solid #AFA288;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QMenuBar::item { background: transparent; color: @MUTED@; padding: 5px 12px; border-radius: 2px; }
+QMenuBar::item:selected {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgba(182, 106, 0, 0.06), stop:1 rgba(182, 106, 0, 0.18));
+    color: #7A4A05;
+}
+QMenuBar::item:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgba(182, 106, 0, 0.14), stop:1 rgba(182, 106, 0, 0.36));
+    color: #5C3A00;
+}
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 2px; padding: 2px; }
-QMenu::item { background: transparent; padding: 5px 22px; border-radius: 2px; min-width: 140px; }
-QMenu::item:selected { background: #EFE5CE; color: #000000; }
-QMenu::item:disabled { color: #A99F8E; }
-QMenu::separator { height: 1px; background: @BORDER@; margin: 4px 6px; }
-QMenu::indicator { width: 12px; height: 12px; margin-left: 4px; }
-QMenu::indicator:checked { background: @ACCENT@; }
+/* ── Dropdown menus: panels of the same metal ────────────────────────────
+   A machined cream sub-panel hinged off the function row: lit top chamfer
+   over a dark milled edge, engraved uppercase items, grooved separators
+   (dark cut over a lit lower lip), and a lamp at the left slot edge
+   backlighting the selected item. The check indicator is a bezel-set panel
+   LED whose lens stays dark even on the cream plate (a lens is a lens),
+   lit amber when engaged. */
+QMenu {
+    background: @CARD@;
+    color: @TEXT@;
+    border: 1px solid #8F8268; border-top-color: #FFFFFF;
+    border-radius: 3px;
+    padding: 5px 4px;
+    font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
+}
+QMenu::item { background: transparent; padding: 6px 26px; border-radius: 2px; min-width: 170px; }
+QMenu::item:selected {
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 rgba(182, 106, 0, 0.48), stop:0.07 rgba(182, 106, 0, 0.20), stop:1 rgba(182, 106, 0, 0.05));
+    color: #4A2E00;
+}
+QMenu::item:disabled { color: #A99F8E; background: transparent; }
+QMenu::separator {
+    height: 2px;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B4A88F, stop:1 #FFFFFF);
+    margin: 5px 10px;
+}
+QMenu::icon { margin-left: 6px; }
+QMenu::indicator {
+    width: 12px; height: 12px; border-radius: 6px; margin-left: 6px;
+    border: 1px solid #8F8268;
+    background: qradialgradient(cx:0.35, cy:0.3, radius:1.2, stop:0 #5A544A, stop:1 #2E2A24);
+}
+QMenu::indicator:checked {
+    border: 1px solid #8A5C12;
+    background: qradialgradient(cx:0.4, cy:0.35, radius:1.0, stop:0 #FFE2A4, stop:0.45 #E89B2A, stop:1 #8A5C12);
+}
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 2px 4px; spacing: 2px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 4px 6px; }
@@ -413,25 +462,45 @@ QLabel#IncludeCardStatus { color: #B3261E; font-size: 8pt; }
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome: the unit's top panel =====
+   RackChrome::paintTitleBarChrome supplies the metal (brushed sheen,
+   machined edges, the caption-ear groove, two rail screws); QSS prints the
+   model designation and dresses the caption buttons as machined caps -
+   raised at rest, recessed when pressed. The close cap warms into a danger
+   lamp on hover, so it stays unmistakably the close button. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
 }
+/* The title is the printed model designation: uppercase, letter-spaced,
+   engraved muted ink. padding-left clears the left rail screw. */
 QLabel#TitleBarText {
     background: transparent;
     color: @MUTED@;
-    font-size: 9pt;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 1px;
+    padding-left: 14px;
 }
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
+    border-radius: 2px;
+    margin: 5px 3px;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #F0E8D6);
+    border-color: @ACCENT@; border-top-color: #FFFFFF;
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #D8CFBB, stop:1 #EFE8D8);
+    border-color: @ACCENT@; border-top-color: #B8AC92;
 }
 QToolButton#TitleBarClose:hover {
-    background: @DANGER@;
+    background: qradialgradient(cx:0.5, cy:0.45, radius:0.9, fx:0.5, fy:0.4,
+        stop:0 #E8745C, stop:0.6 #C84A33, stop:1 #98301E);
+    border-color: #8A2A1A; border-top-color: #F09078;
+}
+QToolButton#TitleBarClose:pressed {
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.9, fx:0.5, fy:0.5,
+        stop:0 #A83A26, stop:1 #7A2415);
+    border-color: #6B1D10; border-top-color: #581808;
 }

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -383,3 +383,26 @@ QComboBox#ToolBarComboBox {
 }
 QComboBox#ToolBarComboBox:hover { background: @CARD_HOVER@; border-color: @BORDER@; }
 QComboBox#ToolBarComboBox:focus, QComboBox#ToolBarComboBox:on { border: 1px solid @ACCENT@; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -28,17 +28,28 @@ QMainWindow::separator { background: @SURFACE@; width: 6px; height: 6px; }
 
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; padding: 6px 12px; }
 
-QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 6px 8px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 10px; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.22); color: @TEXT@; }
+/* Menu bar: a roomy strip of the same calm header surface. No hairline
+   below - whitespace is the separator (a dividing line is exactly the kind
+   of element this skin removes). Items are stadium pills: hover lifts one
+   value step, the open menu rests on the pastel accent. */
+QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 7px 10px; border: 0; }
+QMenuBar::item { background: transparent; padding: 6px 16px; border-radius: 14px; }
+QMenuBar::item:selected { background: @CARD_HOVER@; color: @TEXT@; }
+QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.22); color: @TEXT@; }
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 12px; padding: 6px; }
-QMenu::item { background: transparent; padding: 8px 22px; border-radius: 10px; min-width: 140px; }
+/* Dropdowns: rounded menu cards straight from a consumer settings app.
+   12px card, one value step up plus the very light 1px border (the
+   constitutional fake shadow), generous item padding so Hangul never feels
+   cramped, stadium highlight, separators as short inset soft rules and the
+   checked state as a calm accent dot. */
+QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 12px; padding: 8px 6px; }
+QMenu::item { background: transparent; padding: 9px 26px 9px 16px; border-radius: 16px; min-width: 170px; }
 QMenu::item:selected { background: rgba(59, 130, 246, 0.25); color: @TEXT@; }
-QMenu::item:disabled { color: rgba(167, 174, 194, 0.55); }
-QMenu::separator { height: 1px; background: @BORDER@; margin: 6px 8px; }
-QMenu::indicator { width: 14px; height: 14px; margin-left: 4px; }
-QMenu::indicator:checked { background: @ACCENT@; border-radius: 4px; }
+QMenu::item:disabled { color: rgba(167, 174, 194, 0.50); }
+QMenu::separator { height: 2px; background: rgba(58, 64, 86, 0.60); border-radius: 1px; margin: 7px 18px; }
+QMenu::indicator { width: 10px; height: 10px; margin-left: 8px; border-radius: 5px; background: transparent; }
+QMenu::indicator:checked { background: @ACCENT@; }
+QMenu::icon { padding-left: 6px; }
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 6px 8px; spacing: 6px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 6px 8px; }
@@ -384,25 +395,53 @@ QComboBox#ToolBarComboBox {
 QComboBox#ToolBarComboBox:hover { background: @CARD_HOVER@; border-color: @BORDER@; }
 QComboBox#ToolBarComboBox:focus, QComboBox#ToolBarComboBox:on { border: 1px solid @ACCENT@; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome (custom title bar) - Soft Lab: the calm app header =====
+   One value step off the window, no hairline anywhere (whitespace
+   separates it from the content). The title wears a friendly weight in the
+   full ink instead of caption-grey, and the caption buttons rest as soft
+   rounded squares - a card face one step up with the very light 1px border,
+   the constitutional fake shadow. Hover lifts them one more value step on a
+   fully rounded (stadium) highlight. Close never alarms: it warms with the
+   dirty-badge amber pastel, the same "warmer, not alarmed" grammar as the
+   save-state pill; the red X is exactly the kind of anxious element this
+   skin removes. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
+    border: 0;
 }
 QLabel#TitleBarText {
     background: transparent;
-    color: @MUTED@;
-    font-size: 9pt;
+    color: @TEXT@;
+    font-size: 10pt;
+    font-weight: 600;
 }
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
+    background: @CARD@;
+    border: 1px solid @BORDER@;
+    border-radius: 8px;
+    margin: 3px 2px;
+    /* Neutralize the generic QToolButton padding/min-height: the caption
+       buttons are fixed 40x30 and the inherited box pushed the pill past
+       the bar's bottom edge. */
+    padding: 0;
+    min-height: 0;
+    min-width: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
     background: @CARD_HOVER@;
+    border-radius: 12px;
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: @CARD_SELECTED@;
+    border-radius: 12px;
 }
 QToolButton#TitleBarClose:hover {
-    background: @DANGER@;
+    background: rgba(245, 158, 11, 0.20);
+    border: 1px solid rgba(245, 158, 11, 0.34);
+    border-radius: 12px;
+}
+QToolButton#TitleBarClose:pressed {
+    background: rgba(245, 158, 11, 0.32);
+    border: 1px solid rgba(245, 158, 11, 0.46);
+    border-radius: 12px;
 }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -28,17 +28,29 @@ QMainWindow::separator { background: @SURFACE@; width: 6px; height: 6px; }
 
 QToolTip { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 10px; padding: 6px 12px; }
 
-QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 6px 8px; border: 0; border-bottom: 1px solid @BORDER@; }
-QMenuBar::item { background: transparent; padding: 6px 14px; border-radius: 10px; }
-QMenuBar::item:selected, QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
+/* Menu bar: a roomy strip of the same calm header surface. No hairline
+   below - whitespace is the separator (a dividing line is exactly the kind
+   of element this skin removes). Items are stadium pills: hover lifts one
+   value step (the warm cream, not a grey), the open menu rests on the
+   pastel accent. */
+QMenuBar { background: @SURFACE@; color: @TEXT@; padding: 7px 10px; border: 0; }
+QMenuBar::item { background: transparent; padding: 6px 16px; border-radius: 14px; }
+QMenuBar::item:selected { background: @CARD_HOVER@; color: @TEXT@; }
+QMenuBar::item:pressed { background: rgba(59, 130, 246, 0.16); color: @TEXT@; }
 
-QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 12px; padding: 6px; }
-QMenu::item { background: transparent; padding: 8px 22px; border-radius: 10px; min-width: 140px; }
-QMenu::item:selected { background: rgba(59, 130, 246, 0.18); color: @TEXT@; }
-QMenu::item:disabled { color: rgba(120, 111, 103, 0.55); }
-QMenu::separator { height: 1px; background: @BORDER@; margin: 6px 8px; }
-QMenu::indicator { width: 14px; height: 14px; margin-left: 4px; }
-QMenu::indicator:checked { background: @ACCENT@; border-radius: 4px; }
+/* Dropdowns: rounded menu cards straight from a consumer settings app.
+   12px card, one value step up plus the very light 1px border (the
+   constitutional fake shadow), generous item padding so Hangul never feels
+   cramped, stadium highlight, separators as short inset soft rules and the
+   checked state as a calm accent dot. */
+QMenu { background: @CARD@; color: @TEXT@; border: 1px solid @BORDER@; border-radius: 12px; padding: 8px 6px; }
+QMenu::item { background: transparent; padding: 9px 26px 9px 16px; border-radius: 16px; min-width: 170px; }
+QMenu::item:selected { background: rgba(59, 130, 246, 0.16); color: @TEXT@; }
+QMenu::item:disabled { color: rgba(120, 111, 103, 0.50); }
+QMenu::separator { height: 2px; background: rgba(233, 222, 209, 0.85); border-radius: 1px; margin: 7px 18px; }
+QMenu::indicator { width: 10px; height: 10px; margin-left: 8px; border-radius: 5px; background: transparent; }
+QMenu::indicator:checked { background: @ACCENT@; }
+QMenu::icon { padding-left: 6px; }
 
 QToolBar { background: @SURFACE@; border: 0; border-bottom: 1px solid @BORDER@; padding: 6px 8px; spacing: 6px; }
 QToolBar::separator { background: @BORDER@; width: 1px; margin: 6px 8px; }
@@ -384,25 +396,53 @@ QComboBox#ToolBarComboBox {
 QComboBox#ToolBarComboBox:hover { background: @CARD_HOVER@; border-color: @BORDER@; }
 QComboBox#ToolBarComboBox:focus, QComboBox#ToolBarComboBox:on { border: 1px solid @ACCENT@; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome (custom title bar) - Soft Lab: the calm app header =====
+   One value step off the window, no hairline anywhere (whitespace
+   separates it from the content). The title wears a friendly weight in the
+   full ink instead of caption-grey, and the caption buttons rest as soft
+   rounded squares - a card face one step up with the very light 1px border,
+   the constitutional fake shadow. Hover lifts them one more value step on a
+   fully rounded (stadium) highlight. Close never alarms: it warms with the
+   dirty-badge amber pastel, the same "warmer, not alarmed" grammar as the
+   save-state pill; the red X is exactly the kind of anxious element this
+   skin removes. */
 QWidget#AppTitleBar {
     background: @SURFACE@;
+    border: 0;
 }
 QLabel#TitleBarText {
     background: transparent;
-    color: @MUTED@;
-    font-size: 9pt;
+    color: @TEXT@;
+    font-size: 10pt;
+    font-weight: 600;
 }
 QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
+    background: @CARD@;
+    border: 1px solid @BORDER@;
+    border-radius: 8px;
+    margin: 3px 2px;
+    /* Neutralize the generic QToolButton padding/min-height: the caption
+       buttons are fixed 40x30 and the inherited box pushed the pill past
+       the bar's bottom edge. */
+    padding: 0;
+    min-height: 0;
+    min-width: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
     background: @CARD_HOVER@;
+    border-radius: 12px;
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: @CARD_SELECTED@;
+    border-radius: 12px;
 }
 QToolButton#TitleBarClose:hover {
-    background: @DANGER@;
+    background: rgba(245, 158, 11, 0.16);
+    border: 1px solid rgba(245, 158, 11, 0.38);
+    border-radius: 12px;
+}
+QToolButton#TitleBarClose:pressed {
+    background: rgba(245, 158, 11, 0.28);
+    border: 1px solid rgba(245, 158, 11, 0.50);
+    border-radius: 12px;
 }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -383,3 +383,26 @@ QComboBox#ToolBarComboBox {
 }
 QComboBox#ToolBarComboBox:hover { background: @CARD_HOVER@; border-color: @BORDER@; }
 QComboBox#ToolBarComboBox:focus, QComboBox#ToolBarComboBox:on { border: 1px solid @ACCENT@; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -1002,3 +1002,26 @@ QPlainTextEdit#VSTCardWarning {
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -42,59 +42,85 @@ QToolTip {
     padding: 6px 10px;
 }
 
-/* ===== Menu Bar / Menus ===== */
+/* ===== Menu Bar - continues the window's glass =====
+   Same deep stage colour as the title bar above it; items are unboxed
+   quiet ink (muted lifted halfway toward the text ink, the toolbar's
+   dialect) that only lights up when light pools under them. Hover/open is
+   a radial accent pool rising from the glass floor - the open menu's
+   parent item stays lit because Qt keeps it :selected while its menu is
+   up. The bottom edge is a hairline that dissolves at both ends instead
+   of a hard seam. */
 QMenuBar {
-    background: @SURFACE@;
-    color: @TEXT@;
-    padding: 4px 6px;
+    background: @BG@;
+    color: #BCC7DA;
+    padding: 4px 8px;
     border: 0;
-    border-bottom: 1px solid @BORDER@;
+    border-bottom: 1px solid qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 rgba(38, 50, 74, 0), stop:0.5 rgba(38, 50, 74, 0.9), stop:1 rgba(38, 50, 74, 0));
 }
 QMenuBar::item {
     background: transparent;
-    padding: 6px 12px;
-    border-radius: 6px;
+    padding: 6px 13px;
+    border-radius: 0;
 }
-QMenuBar::item:selected,
+QMenuBar::item:selected {
+    background: qradialgradient(cx:0.5, cy:1.0, radius:1.0, fx:0.5, fy:1.0,
+        stop:0 rgba(91, 140, 255, 0.34), stop:0.55 rgba(91, 140, 255, 0.14), stop:1 rgba(91, 140, 255, 0));
+    color: @TEXT@;
+}
 QMenuBar::item:pressed {
-    background: rgba(91, 140, 255, 0.22);
+    background: qradialgradient(cx:0.5, cy:1.0, radius:1.0, fx:0.5, fy:1.0,
+        stop:0 rgba(91, 140, 255, 0.48), stop:0.55 rgba(91, 140, 255, 0.20), stop:1 rgba(91, 140, 255, 0));
     color: @TEXT@;
 }
 
+/* ===== Menus - floating glass panels (the picker's dialect) =====
+   Alpha card fill over the deep stage, an icy 1px reflection on the top
+   border dissolving into accent light toward the bottom (the picker's
+   edge), 8px glass round. The highlighted item glows from within (radial
+   accent pool); separators are luminous accent-to-violet hairlines that
+   dissolve at both ends; the checked indicator is a lit signal lamp.
+   Disabled items are switched off, never warned. */
 QMenu {
-    background: @CARD@;
+    background: rgba(18, 26, 44, 0.97);
     color: @TEXT@;
-    border: 1px solid @BORDER@;
-    border-top-color: rgba(255, 255, 255, 0.10);
+    border: 1px solid qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgba(255, 255, 255, 0.16), stop:0.45 @BORDER@, stop:1 rgba(91, 140, 255, 0.38));
     border-radius: 8px;
-    padding: 6px;
+    padding: 8px 6px;
 }
 QMenu::item {
     background: transparent;
-    padding: 6px 22px 6px 22px;
-    border-radius: 6px;
-    min-width: 140px;
+    padding: 7px 26px 7px 14px;
+    border-radius: 8px;
+    min-width: 150px;
 }
 QMenu::item:selected {
-    background: rgba(91, 140, 255, 0.25);
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.7, fx:0.5, fy:0.5,
+        stop:0 rgba(91, 140, 255, 0.40), stop:0.7 rgba(91, 140, 255, 0.16), stop:1 rgba(91, 140, 255, 0.06));
     color: @TEXT@;
 }
 QMenu::item:disabled {
-    color: #5a5a72;
+    background: transparent;
+    color: rgba(145, 160, 186, 0.45);
 }
 QMenu::separator {
     height: 1px;
-    background: @BORDER@;
-    margin: 6px 8px;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 rgba(91, 140, 255, 0), stop:0.35 rgba(91, 140, 255, 0.45),
+        stop:0.7 rgba(166, 108, 255, 0.30), stop:1 rgba(166, 108, 255, 0));
+    margin: 6px 10px;
 }
 QMenu::indicator {
     width: 14px;
     height: 14px;
     margin-left: 4px;
+    border-radius: 7px;
 }
 QMenu::indicator:checked {
-    background: @ACCENT@;
-    border-radius: 3px;
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5,
+        stop:0 @ACCENT@, stop:0.4 rgba(91, 140, 255, 0.9),
+        stop:0.7 rgba(91, 140, 255, 0.3), stop:1 rgba(91, 140, 255, 0));
 }
 QMenu::icon {
     padding-left: 8px;
@@ -1003,11 +1029,16 @@ QPlainTextEdit#VSTCardWarning {
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome - the topmost edge of the glass =====
+   The strip stays on the deep stage colour (it is the stage's edge, not a
+   panel); StudioSkin::paintTitleBarChrome lays a 1px reflection and a
+   faint accent-to-violet arc on the top edge, echoing the picker. The
+   title is quiet muted ink. Caption buttons are unboxed; hover pools
+   light under the cursor and pressing turns the light up - the close
+   button pools danger-tinted light so it stays recognizably a close
+   button without wearing a box. */
 QWidget#AppTitleBar {
-    background: @SURFACE@;
+    background: @BG@;
 }
 QLabel#TitleBarText {
     background: transparent;
@@ -1018,10 +1049,21 @@ QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
     background: transparent;
     border: 0;
     border-radius: 0;
+    padding: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.65, fx:0.5, fy:0.55,
+        stop:0 rgba(91, 140, 255, 0.34), stop:0.6 rgba(91, 140, 255, 0.12), stop:1 rgba(91, 140, 255, 0));
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.7, fx:0.5, fy:0.55,
+        stop:0 rgba(91, 140, 255, 0.50), stop:0.6 rgba(91, 140, 255, 0.20), stop:1 rgba(91, 140, 255, 0));
 }
 QToolButton#TitleBarClose:hover {
-    background: @DANGER@;
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.65, fx:0.5, fy:0.55,
+        stop:0 rgba(239, 68, 68, 0.46), stop:0.6 rgba(239, 68, 68, 0.16), stop:1 rgba(239, 68, 68, 0));
+}
+QToolButton#TitleBarClose:pressed {
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.7, fx:0.5, fy:0.55,
+        stop:0 rgba(239, 68, 68, 0.64), stop:0.6 rgba(239, 68, 68, 0.26), stop:1 rgba(239, 68, 68, 0));
 }

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -634,3 +634,26 @@ QPlainTextEdit#VSTCardWarning {
 /* Toolbar/Tab spacers and labels transparent so parent bg shows through */
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
+
+/* ===== Window chrome (custom title bar) - neutral baseline =====
+   Per-skin differentiation lands on the toolbar/window-chrome branches; this
+   block only keeps the title strip intentional until then. */
+QWidget#AppTitleBar {
+    background: @SURFACE@;
+}
+QLabel#TitleBarText {
+    background: transparent;
+    color: @MUTED@;
+    font-size: 9pt;
+}
+QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+}
+QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
+    background: @CARD_HOVER@;
+}
+QToolButton#TitleBarClose:hover {
+    background: @DANGER@;
+}

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -42,58 +42,84 @@ QToolTip {
     padding: 6px 10px;
 }
 
+/* ===== Menu Bar - continues the window's glass =====
+   Same airy stage colour as the title bar above it; items are unboxed
+   quiet ink (muted lifted halfway toward the text ink) that only lights
+   up when light pools under them. Hover/open is a radial accent pool
+   rising from the glass floor - the open menu's parent item stays lit
+   because Qt keeps it :selected while its menu is up. The bottom edge is
+   a hairline that dissolves at both ends instead of a hard seam. */
 QMenuBar {
-    background: @SURFACE@;
-    color: @TEXT@;
-    padding: 4px 6px;
+    background: @BG@;
+    color: #3F495E;
+    padding: 4px 8px;
     border: 0;
-    border-bottom: 1px solid @BORDER@;
+    border-bottom: 1px solid qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 rgba(216, 224, 239, 0), stop:0.5 rgba(216, 224, 239, 0.95), stop:1 rgba(216, 224, 239, 0));
 }
 QMenuBar::item {
     background: transparent;
-    padding: 6px 12px;
-    border-radius: 6px;
+    padding: 6px 13px;
+    border-radius: 0;
 }
-QMenuBar::item:selected,
+QMenuBar::item:selected {
+    background: qradialgradient(cx:0.5, cy:1.0, radius:1.0, fx:0.5, fy:1.0,
+        stop:0 rgba(47, 107, 255, 0.26), stop:0.55 rgba(47, 107, 255, 0.11), stop:1 rgba(47, 107, 255, 0));
+    color: @TEXT@;
+}
 QMenuBar::item:pressed {
-    background: rgba(47, 107, 255, 0.18);
+    background: qradialgradient(cx:0.5, cy:1.0, radius:1.0, fx:0.5, fy:1.0,
+        stop:0 rgba(47, 107, 255, 0.38), stop:0.55 rgba(47, 107, 255, 0.16), stop:1 rgba(47, 107, 255, 0));
     color: @TEXT@;
 }
 
+/* ===== Menus - floating glass panels (the picker's dialect) =====
+   Alpha card fill over the airy stage, an icy 1px reflection on the top
+   border dissolving into accent light toward the bottom (the picker's
+   edge), 8px glass round. The highlighted item glows from within (radial
+   accent pool); separators are luminous accent-to-violet hairlines that
+   dissolve at both ends; the checked indicator is a lit signal lamp.
+   Disabled items are switched off, never warned. */
 QMenu {
-    background: @CARD@;
+    background: rgba(255, 255, 255, 0.97);
     color: @TEXT@;
-    border: 1px solid @BORDER@;
-    border-top-color: rgba(255, 255, 255, 0.95);
+    border: 1px solid qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgba(255, 255, 255, 0.95), stop:0.45 @BORDER@, stop:1 rgba(47, 107, 255, 0.30));
     border-radius: 8px;
-    padding: 6px;
+    padding: 8px 6px;
 }
 QMenu::item {
     background: transparent;
-    padding: 6px 22px;
-    border-radius: 6px;
-    min-width: 140px;
+    padding: 7px 26px 7px 14px;
+    border-radius: 8px;
+    min-width: 150px;
 }
 QMenu::item:selected {
-    background: rgba(47, 107, 255, 0.18);
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.7, fx:0.5, fy:0.5,
+        stop:0 rgba(47, 107, 255, 0.30), stop:0.7 rgba(47, 107, 255, 0.12), stop:1 rgba(47, 107, 255, 0.05));
     color: @TEXT@;
 }
 QMenu::item:disabled {
-    color: #a0a0b4;
+    background: transparent;
+    color: rgba(102, 114, 138, 0.55);
 }
 QMenu::separator {
     height: 1px;
-    background: @BORDER@;
-    margin: 6px 8px;
+    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop:0 rgba(47, 107, 255, 0), stop:0.35 rgba(47, 107, 255, 0.40),
+        stop:0.7 rgba(138, 77, 255, 0.28), stop:1 rgba(138, 77, 255, 0));
+    margin: 6px 10px;
 }
 QMenu::indicator {
     width: 14px;
     height: 14px;
     margin-left: 4px;
+    border-radius: 7px;
 }
 QMenu::indicator:checked {
-    background: @ACCENT@;
-    border-radius: 3px;
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5,
+        stop:0 @ACCENT@, stop:0.4 rgba(47, 107, 255, 0.9),
+        stop:0.7 rgba(47, 107, 255, 0.3), stop:1 rgba(47, 107, 255, 0));
 }
 
 QToolBar {
@@ -635,11 +661,16 @@ QPlainTextEdit#VSTCardWarning {
 QLabel { background: transparent; }
 QWidget#ToolBarSpacer { background: transparent; }
 
-/* ===== Window chrome (custom title bar) - neutral baseline =====
-   Per-skin differentiation lands on the toolbar/window-chrome branches; this
-   block only keeps the title strip intentional until then. */
+/* ===== Window chrome - the topmost edge of the glass =====
+   The strip stays on the airy stage colour (it is the stage's edge, not a
+   panel); StudioSkin::paintTitleBarChrome lays a 1px reflection and a
+   faint accent-to-violet arc on the top edge, echoing the picker. The
+   title is quiet muted ink. Caption buttons are unboxed; hover pools
+   light under the cursor and pressing turns the light up - the close
+   button pools danger-tinted light so it stays recognizably a close
+   button without wearing a box. */
 QWidget#AppTitleBar {
-    background: @SURFACE@;
+    background: @BG@;
 }
 QLabel#TitleBarText {
     background: transparent;
@@ -650,10 +681,21 @@ QToolButton#TitleBarMin, QToolButton#TitleBarMax, QToolButton#TitleBarClose {
     background: transparent;
     border: 0;
     border-radius: 0;
+    padding: 0;
 }
 QToolButton#TitleBarMin:hover, QToolButton#TitleBarMax:hover {
-    background: @CARD_HOVER@;
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.65, fx:0.5, fy:0.55,
+        stop:0 rgba(47, 107, 255, 0.26), stop:0.6 rgba(47, 107, 255, 0.10), stop:1 rgba(47, 107, 255, 0));
+}
+QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.7, fx:0.5, fy:0.55,
+        stop:0 rgba(47, 107, 255, 0.40), stop:0.6 rgba(47, 107, 255, 0.16), stop:1 rgba(47, 107, 255, 0));
 }
 QToolButton#TitleBarClose:hover {
-    background: @DANGER@;
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.65, fx:0.5, fy:0.55,
+        stop:0 rgba(239, 68, 68, 0.40), stop:0.6 rgba(239, 68, 68, 0.14), stop:1 rgba(239, 68, 68, 0));
+}
+QToolButton#TitleBarClose:pressed {
+    background: qradialgradient(cx:0.5, cy:0.55, radius:0.7, fx:0.5, fy:0.55,
+        stop:0 rgba(239, 68, 68, 0.58), stop:0.6 rgba(239, 68, 68, 0.22), stop:1 rgba(239, 68, 68, 0));
 }

--- a/Editor/widgets/TitleBar.cpp
+++ b/Editor/widgets/TitleBar.cpp
@@ -1,0 +1,133 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "TitleBar.h"
+
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QStyleOption>
+#include <QToolButton>
+
+#include "Editor/SkinManager.h"
+#include "Editor/helpers/GUIHelper.h"
+
+namespace
+{
+QToolButton* makeCaptionButton(const char* objectName, QWidget* parent)
+{
+	QToolButton* button = new QToolButton(parent);
+	button->setObjectName(QLatin1String(objectName));
+	button->setFocusPolicy(Qt::NoFocus);
+	// Caption buttons are wider than tall, like the native ones, so the hit
+	// targets stay comfortable; QSS may restyle freely.
+	button->setFixedSize(GUIHelper::scale(QSize(40, 30)));
+	return button;
+}
+}
+
+TitleBar::TitleBar(QWidget* window, QWidget* parent)
+	: QWidget(parent), hostWindow(window)
+{
+	setObjectName(QStringLiteral("AppTitleBar"));
+	setAttribute(Qt::WA_StyledBackground, true);
+	setFixedHeight(GUIHelper::scale(34.0));
+
+	QHBoxLayout* layout = new QHBoxLayout(this);
+	layout->setContentsMargins(GUIHelper::scale(12.0), 0, 0, 0);
+	layout->setSpacing(0);
+
+	titleLabel = new QLabel(hostWindow->windowTitle(), this);
+	titleLabel->setObjectName(QStringLiteral("TitleBarText"));
+	layout->addWidget(titleLabel);
+	// The title follows the window (dirty markers, file names) live.
+	connect(hostWindow, &QWidget::windowTitleChanged, titleLabel, &QLabel::setText);
+
+	layout->addStretch(1);
+
+	minimizeButton = makeCaptionButton("TitleBarMin", this);
+	connect(minimizeButton, &QToolButton::clicked, hostWindow, &QWidget::showMinimized);
+	layout->addWidget(minimizeButton);
+
+	maximizeButton = makeCaptionButton("TitleBarMax", this);
+	connect(maximizeButton, &QToolButton::clicked, this, [this]() {
+		if (hostWindow->isMaximized())
+			hostWindow->showNormal();
+		else
+			hostWindow->showMaximized();
+	});
+	layout->addWidget(maximizeButton);
+
+	closeButton = makeCaptionButton("TitleBarClose", this);
+	connect(closeButton, &QToolButton::clicked, hostWindow, &QWidget::close);
+	layout->addWidget(closeButton);
+
+	// Track maximize/restore from any source (snap, double-click, keyboard).
+	hostWindow->installEventFilter(this);
+	applySkinIcons();
+}
+
+bool TitleBar::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == hostWindow && event->type() == QEvent::WindowStateChange)
+		updateMaximizeButton();
+	return QWidget::eventFilter(watched, event);
+}
+
+void TitleBar::applySkinIcons()
+{
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const QColor ink(tokens.text);
+	minimizeButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/window-min.svg"), ink, 14));
+	maximizeButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/window-max.svg"), ink, 14));
+	closeButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/window-close.svg"), ink, 14));
+	updateMaximizeButton();
+}
+
+void TitleBar::updateMaximizeButton()
+{
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const QColor ink(tokens.text);
+	const bool maximized = hostWindow->isMaximized();
+	maximizeButton->setIcon(GUIHelper::tintedIcon(
+		maximized ? QStringLiteral(":/icons/modern/window-restore.svg")
+		: QStringLiteral(":/icons/modern/window-max.svg"), ink, 14));
+	maximizeButton->setToolTip(maximized ? tr("Restore") : tr("Maximize"));
+}
+
+bool TitleBar::isCaptionPoint(const QPoint& point) const
+{
+	if (!rect().contains(point))
+		return false;
+	const QWidget* child = childAt(point);
+	return child == nullptr || child == titleLabel;
+}
+
+void TitleBar::paintEvent(QPaintEvent*)
+{
+	QPainter painter(this);
+	// The stylesheet background first (the WA_StyledBackground default we are
+	// replacing by overriding paintEvent)...
+	QStyleOption option;
+	option.initFrom(this);
+	style()->drawPrimitive(QStyle::PE_Widget, &option, &painter, this);
+	// ...then the skin's painted chrome on top, under the child widgets.
+	SkinManager::instance()->paintTitleBarChrome(painter, rect());
+}
+
+void TitleBar::mouseDoubleClickEvent(QMouseEvent* event)
+{
+	if (isCaptionPoint(event->pos()))
+	{
+		if (hostWindow->isMaximized())
+			hostWindow->showNormal();
+		else
+			hostWindow->showMaximized();
+		event->accept();
+		return;
+	}
+	QWidget::mouseDoubleClickEvent(event);
+}

--- a/Editor/widgets/TitleBar.h
+++ b/Editor/widgets/TitleBar.h
@@ -1,0 +1,53 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Custom window title bar for the frameless main window. The native Windows
+	caption clashed with every skin (and the menu bar under it), so the window
+	draws its own: app title text and the minimize / maximize / close buttons,
+	all QSS-targetable (#AppTitleBar, #TitleBarText, #TitleBarMin, #TitleBarMax,
+	#TitleBarClose) and re-iconed through the skin layer. The frameless window
+	plumbing (WM_NCCALCSIZE / WM_NCHITTEST) lives in MainWindow::nativeEvent;
+	this widget is presentation plus button wiring only. A registry escape
+	hatch (interface/nativeTitleBar) restores the native caption for machines
+	where custom chrome misbehaves.
+*/
+
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+class QToolButton;
+
+class TitleBar : public QWidget
+{
+	Q_OBJECT
+
+public:
+	explicit TitleBar(QWidget* window, QWidget* parent = nullptr);
+
+	// Re-tint the caption button icons from the active skin's tokens. Called
+	// by MainWindow::applyRedesignPreferences on every skin/dark switch.
+	void applySkinIcons();
+
+	// True when the given point (in this widget's coordinates) sits on the
+	// draggable caption area (i.e. not on one of the buttons). Used by the
+	// host's WM_NCHITTEST handler.
+	bool isCaptionPoint(const QPoint& point) const;
+
+protected:
+	bool eventFilter(QObject* watched, QEvent* event) override;
+	void mouseDoubleClickEvent(QMouseEvent* event) override;
+	// QSS background first, then the active skin's painted chrome
+	// (ISkin::paintTitleBarChrome), then children.
+	void paintEvent(QPaintEvent* event) override;
+
+private:
+	void updateMaximizeButton();
+
+	QWidget* hostWindow = nullptr;
+	QLabel* titleLabel = nullptr;
+	QToolButton* minimizeButton = nullptr;
+	QToolButton* maximizeButton = nullptr;
+	QToolButton* closeButton = nullptr;
+};


### PR DESCRIPTION
The window still wore the stock Windows caption, the menu bar was generic, and the dropdowns kept the last 2005-era .ico icons. This round replaces all three layers, per skin, and adds a standing Hangul-rendering watchdog (a field machine showed "설정" clipping into "ㅅ정/서정" in menus).

## Phase 0 (shared groundwork)

- **Custom title bar**: `TitleBar` widget (title + min/max/restore/close, QSS-targetable) hosted with the menu bar via `setMenuWidget`. `MainWindow.Frame.cpp` removes only the native caption (WM_NCCALCSIZE) and routes WM_NCHITTEST, so dragging, edge resizing, snap and double-click maximize stay native. Hit testing in window-origin logical coordinates avoids mixed-DPI mapping.
- **Escape hatch**: `interface/nativeTitleBar` + an Interface menu toggle (restart flow) restores the stock caption — relevant for the issue #75 field machine.
- New `ISkin::paintTitleBarChrome` hook (neutral no-op, pixel-identity proven).
- Edit menu actions get modern stroke SVGs (cut/copy/paste/trash/select-all), retiring the remaining .ico set.
- Gallery captures title bar / menu bar / open menu per skin/mode, each with Korean sample text ("설정.txt", "설정", "설정 항목") so Hangul defects become visible on CI; expected count is now **170**.

## Per-skin chrome (5 isolated agents; record on `chrome/<skin>` branches)

- **studio** — the top edge of the lit glass: 1px reflection + faint accent-to-violet arc painted on the title bar, unboxed caption buttons pooling light on hover (danger-tinted for close), menus as floating glass panels with luminous separators and a signal-lamp check.
- **minimal** — a tiling WM running a terminal: hairline title line with mono metadata title, glyph caption buttons on the value-step ladder, TUI menu line (open item = inverted block), square dense menus with **icons removed** (`icon-size: 0` — a glyph duplicating its label carries no information) and an inline [x]-style check flag.
- **soft** — the calm settings header: one shared surface a value step off the window, no hairlines anywhere, stadium hover lifts, rounded menu cards with generous padding and a calm accent-dot check.
- **rack** — the unit''s top panel: brushed strip with rail screws and an engraved uppercase nameplate title, machined caption caps, engraved uppercase menu items with lamp-glow hover and an amber LED check.
- **matrix** — the board''s masthead: mono readout title on the 24px grid texture, function-cell caption buttons (engaged accent when pressed), menus as cells on graph paper with full-width rules and a square LED check.

## Verification

- Differentiation gate passed: five title bars and five open menus identifiable by philosophy alone, both modes.
- **Hangul renders clean in all 30 chrome captures** (every agent gated on it).
- Interference: exactly the 30 chrome PNGs changed; the other **140 PNGs byte-identical** to the Phase 0 baseline; each agent also verified non-interference against its own pre-change baseline.
- Integrated build clean; cppcheck 2.21.0 clean; 10s offscreen MainWindow smoke run clean.

Note for reviewers: frameless caption behavior (drag/snap/restore) follows the standard WM_NCCALCSIZE/WM_NCHITTEST recipe but could not be exercised interactively in this environment — the Native title bar toggle is the runtime fallback if anything misbehaves on real desktops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)