### PR TITLE
fix(ci): pass setup-msbuild a lowercase arm64 so ARM64 gets the native compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,14 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v3
       with:
-        msbuild-architecture: ${{ matrix.platform }}
+        # setup-msbuild compares this input CASE-SENSITIVELY against 'x64'/'arm64'
+        # and silently falls back to the 32-bit x86 MSBuild on any other value.
+        # matrix.platform is 'ARM64' (uppercase, the MSBuild $(Platform) name), so
+        # passing it here handed the ARM64 leg an x86 MSBuild, which in turn always
+        # selects the emulated 32-bit HostX86 cl.exe — the C3859/C1076 PCH
+        # virtual-memory failures. matrix.msvcdevplatform carries the lowercase
+        # host-architecture spelling ('x64'/'arm64') for exactly this purpose.
+        msbuild-architecture: ${{ matrix.msvcdevplatform }}
 
     # Pinned dependency tags/versions live in .github/simd-variants.psd1 so they are
     # defined once and shared with setup-build.ps1. Export them as job env vars for the
@@ -662,13 +669,26 @@ jobs:
         $platformToolset = if ("${{ matrix.platform }}" -eq "ARM64") { "v143" } else { "v145" }
         Write-Host "PlatformToolset=$platformToolset (platform ${{ matrix.platform }})"
 
-        # Host toolchain: on the ARM64 runner, "x64" resolves to the EMULATED
-        # 32-bit HostX86 cl.exe, whose 4 GB address space exhausts under /MP
-        # PCH builds (flaky C3859/C1076 seen on the v1.23.0 run, twice). The
-        # native 64-bit HostARM64 compiler avoids both the heap limit and the
-        # emulation tax. x64 images keep the 64-bit x64 host.
+        # Host toolchain: the emulated 32-bit HostX86 cl.exe exhausts its 4 GB
+        # address space under /MP PCH builds (flaky C3859/C1076 on the v1.23.0
+        # and v1.25.0 runs). The VC targets pick the host folder from the
+        # ARCHITECTURE OF THE MSBUILD PROCESS, so the real lever is handing
+        # setup-msbuild the lowercase 'arm64' (see "Add MSBuild to PATH");
+        # /p:PreferredToolArchitecture alone provably did not switch the host
+        # (the v1.24.0/v1.25.0 logs ran HostX86\arm64\CL.exe despite it). It is
+        # kept as documentation of intent and as a hint for the x64 images.
         $toolArchitecture = if ("${{ matrix.platform }}" -eq "ARM64") { "ARM64" } else { "x64" }
         Write-Host "PreferredToolArchitecture=$toolArchitecture"
+
+        # Fail loudly if the silent setup-msbuild fallback ever returns: an x86
+        # MSBuild on the ARM64 runner means emulated HostX86 cl.exe and a build
+        # that only fails minutes later with C3859, or worse, passes by luck.
+        $msbuildPath = (Get-Command msbuild).Source
+        Write-Host "msbuild on PATH: $msbuildPath"
+        if ("${{ matrix.platform }}" -eq "ARM64" -and $msbuildPath -notmatch '\\arm64\\') {
+          Write-Error "Expected the native arm64 MSBuild on PATH but got $msbuildPath. setup-msbuild falls back to the 32-bit x86 MSBuild when msbuild-architecture is not exactly 'arm64' (case-sensitive); that MSBuild always drives the emulated HostX86 cl.exe."
+          exit 1
+        }
 
         $buildParams = @(
           "/m",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1301,8 +1301,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     # The PR pipeline only builds AVX2, so there is nothing to compare
-    # across variants. The full SIMD diff stays on the push to main.
-    if: github.event_name != 'pull_request'
+    # across variants. The always() guard matters on workflow_dispatch runs:
+    # version-bump is skipped there, and GitHub propagates a skip through the
+    # needs chain unless the dependent job's condition overrides it - without
+    # always() the dispatch validation path silently lost this comparison
+    # (first seen on the run validating the arm64 msbuild fix).
+    if: always() && needs.build.result == 'success' && github.event_name != 'pull_request'
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6


### PR DESCRIPTION
## 문제

v1.25.0 릴리스 실행의 ARM64 leg가 또 C3859/C1076(PCH 가상 메모리 고갈)으로 실패했습니다. v1.23.0을 두 번 실패시킨 것과 같은 증상입니다.

## 근본 원인

[#87](https://github.com/115dkk/EqualizerAPO-XT/pull/87)의 `/p:PreferredToolArchitecture=ARM64`는 호스트 컴파일러를 바꾸지 못했습니다. 성공한 v1.24.0 릴리스의 ARM64 로그조차 14회 전부 `HostX86\arm64\CL.exe`(에뮬레이션된 32비트)로 컴파일했고, 그 릴리스는 운으로 통과한 것입니다.

진짜 원인은 setup-msbuild 액션의 입력 비교입니다. `msbuild-architecture`를 `'x64'`/`'arm64'`와 **대소문자 구분**으로 비교하고, 일치하지 않으면 경고 없이 32비트 x86 MSBuild로 폴백합니다. 우리는 `matrix.platform` 값인 대문자 `ARM64`를 넘기고 있었습니다. VC 타깃은 MSBuild 프로세스의 아키텍처를 따라 호스트 폴더를 고르므로, x86 MSBuild = HostX86 cl.exe이고, 32비트 주소 공간 4GB가 /MP 병렬 PCH 빌드에서 간헐적으로 터집니다.

## 수정

- setup-msbuild에 `New-BuildMatrix.ps1`이 이미 만들던 소문자 필드 `matrix.msvcdevplatform`(`'arm64'`/`'x64'`)을 넘깁니다.
- ARM64 leg의 빌드 단계에서 PATH의 msbuild가 네이티브 arm64가 아니면 즉시 실패하는 단언을 추가했습니다. 같은 폴백이 다시는 '플래키 컴파일러'로 위장하지 못합니다.
- 검증 중 발견한 부수 결함도 고쳤습니다: workflow_dispatch 실행에서 version-bump의 skip이 needs 체인으로 전파되어 cross-variant-compare가 조용히 건너뛰어졌습니다. `always() + needs.build.result` 가드로 살렸습니다(전체 매트릭스 검증 경로의 구멍).

## 검증

- [dispatch run 27439576390](https://github.com/115dkk/EqualizerAPO-XT/actions/runs/27439576390): 6변형 전체 green. ARM64 로그에서 `msbuild on PATH: ...\Bin\arm64\MSBuild.exe` + 솔루션 컴파일 14회 전부 `HostArm64\arm64\CL.exe` 확인. ARM64 빌드 시간 440초(에뮬레이션 제거로 단축).
- 두 번째 dispatch(cross-variant 가드 검증)는 PR CI와 병렬로 진행 중이며 머지 전 결과를 확인합니다.

머지되면 REVISION이 올라 v1.25.1 릴리스가 실패한 v1.25.0을 대체합니다(v1.23.x를 건너뛴 전례와 동일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)