### PR TITLE
ci(audio-repro): Scream 라이브 엔드포인트 소실 실증 + AudioEndpointBuilder 수정 검증

### DIFF
--- a/.github/scripts/Diagnose-LiveEndpoint.ps1
+++ b/.github/scripts/Diagnose-LiveEndpoint.ps1
@@ -1,0 +1,237 @@
+<#
+.SYNOPSIS
+    Diagnoses the LIVE audio-device-loss bug on a real (Scream) render endpoint,
+    and validates the fix candidate. Reads the JSON snapshots produced by the
+    audio-live-repro workflow and prints a combined verdict.
+
+.DESCRIPTION
+    This is the live counterpart to Diagnose-AudioUninstall.ps1. That script
+    proves the REGISTRY outcome on a fake seeded endpoint. This one proves the
+    LIVE KERNEL outcome on a real virtual audio endpoint installed via Scream,
+    so it can demonstrate the actual symptom the user reported: after the app
+    uninstall, the endpoint goes INACTIVE/missing in Windows and only a REBOOT
+    restores it. The fix candidate replaces the reboot with a single
+    `Restart-Service AudioEndpointBuilder`.
+
+    THE DIAGNOSED BUG (what these snapshots must demonstrate)
+      helpers/ApoRegistration.cpp::uninstall cycles ONLY the AudioSrv service
+      (kAudioServiceName = "AudioSrv", ApoRegistration.cpp:44; stop at :252,
+      start at :310). It never cycles AudioEndpointBuilder - the service that
+      enumerates/activates endpoints and reads FxProperties to build the APO
+      chain - nor audiodg.exe. So after uninstall removes the EQ APO
+      (DllUnregisterServer + the EqualizerAPO.dll deletion) and restarts only
+      AudioSrv, AudioEndpointBuilder keeps its stale endpoint graph and the
+      affected endpoint stays inactive until a reboot rebuilds the graph.
+
+    THE FIX CANDIDATE (what the validation snapshot must confirm)
+      Restart-Service -Force AudioEndpointBuilder cascades its dependent
+      AudioSrv and forces a LIVE endpoint-graph rebuild, bringing the endpoint
+      back to Active WITHOUT a reboot.
+
+    SNAPSHOT PHASES (each is a <phase>-live.json file in $SnapshotDir, written
+    by the workflow with a shared snapshot helper):
+      30-apo-applied   : after the EQ APO was registered on the real Scream
+                         endpoint (baseline-installed state).
+      35-stream-forced : after a short WASAPI stream forced audiodg to build the
+                         endpoint's APO chain. This is the "endpoint is ACTIVE
+                         and the EQ APO is live" reference point.
+      50-after-velo    : IMMEDIATELY after the AudioSrv-only uninstall, NO reboot.
+                         The REPRODUCTION check reads this.
+      70-after-aeb     : after Restart-Service -Force AudioEndpointBuilder, still
+                         NO reboot. The FIX-VALIDATION check reads this.
+
+    Each snapshot carries, for the discovered Scream endpoint:
+      screamGuid            : the {guid} of the Scream Render endpoint
+      activeRenderCount     : DEVICE_STATE_ACTIVE render-endpoint count from
+                              IMMDeviceEnumerator (the live-graph signal)
+      screamDeviceStateMM   : the MMDevices Render\{guid}\DeviceState DWORD
+                              (1 = ACTIVE; other bits = DISABLED/UNPLUGGED/NOTPRESENT)
+      screamEndpointState   : IMMDevice::GetState for the Scream endpoint, when
+                              still resolvable ("ACTIVE"/"DISABLED"/... or
+                              "NOTFOUND" when it no longer enumerates)
+      screamFxPointsAtEq    : whether FxProperties still names an EQ APO GUID
+      registryClean         : whether the original driver APO GUIDs were restored
+                              (no EQ GUID dangling) - the registry is proven clean,
+                              so a live disappearance is NOT a registry-delete bug
+      win32SoundDeviceStatus: Get-CimInstance Win32_SoundDevice Status strings
+
+    VERDICT
+      "(live) REPRODUCED": the Scream endpoint was Active before uninstall and
+        became INACTIVE/missing after the AudioSrv-only uninstall (no reboot),
+        while the registry is clean.
+      "(live) FIX VALIDATED": after Restart-Service AudioEndpointBuilder the
+        endpoint returned to Active (no reboot).
+
+    EXIT-CODE CONVENTION (documented loudly here and echoed at runtime):
+      exit 0  -> the experiment FULLY SUCCEEDED: the bug REPRODUCED (endpoint
+                 went inactive after the AudioSrv-only uninstall) AND the fix
+                 VALIDATED (AudioEndpointBuilder restart brought it back). This
+                 is the only "everything we set out to prove was proven" state.
+      exit 1  -> the endpoint did NOT go inactive after the uninstall. Either the
+                 bug did not reproduce on this runner, or Scream behaves
+                 differently here. Inspect the uploaded snapshots; the live
+                 experiment is inconclusive.
+      exit 2  -> the bug REPRODUCED but the fix did NOT validate (endpoint stayed
+                 inactive after the AudioEndpointBuilder restart). The fix
+                 candidate is insufficient on this runner; inspect snapshots.
+      exit 3  -> a required snapshot is missing; cannot diagnose.
+    NOTE: this convention is deliberate. Unlike a normal "green = healthy"
+    job, green here means "the device-loss bug was reproduced AND the fix
+    worked", because the whole purpose is to confirm the diagnosis and the fix
+    on a real endpoint. Read the printed RESULT line, not just the colour.
+
+.PARAMETER SnapshotDir
+    Directory containing the *-live.json snapshots.
+
+.PARAMETER PreMixGuid
+    EqualizerAPO pre-mix APO CLSID string, e.g. {EACD2258-FCAC-4FF4-B36D-419E924A6D79}.
+
+.PARAMETER PostMixGuid
+    EqualizerAPO post-mix APO CLSID string, e.g. {EC1CC9CE-FAED-4822-828A-82A81A6F018F}.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SnapshotDir,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PreMixGuid,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PostMixGuid
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Read-Phase {
+    param([string]$Phase)
+    $jsonPath = Join-Path $SnapshotDir "$Phase-live.json"
+    if (-not (Test-Path $jsonPath)) {
+        return $null
+    }
+    return Get-Content -Raw -Path $jsonPath | ConvertFrom-Json
+}
+
+# An endpoint counts as "live/active" when IMMDevice::GetState reports ACTIVE,
+# or (fallback) the MMDevices DeviceState DWORD is exactly 1 (DEVICE_STATE_ACTIVE).
+# When the endpoint no longer enumerates at all, screamEndpointState is "NOTFOUND".
+function Test-EndpointActive {
+    param($Snapshot)
+    if ($null -eq $Snapshot) { return $false }
+    if ($Snapshot.screamEndpointState -eq 'ACTIVE') { return $true }
+    if ($Snapshot.screamEndpointState -eq 'NOTFOUND') { return $false }
+    # Fallback to the registry DeviceState only if the COM state was unavailable
+    # (e.g. enumeration threw). 1 == DEVICE_STATE_ACTIVE.
+    if ($null -eq $Snapshot.screamEndpointState -or $Snapshot.screamEndpointState -eq '') {
+        return ([int]$Snapshot.screamDeviceStateMM -eq 1)
+    }
+    return $false
+}
+
+function Format-Snap {
+    param($Snapshot)
+    if ($null -eq $Snapshot) { return '<no snapshot>' }
+    return ("epState={0} mmState={1} activeRender={2} fxPointsAtEq={3} registryClean={4}" -f `
+            $Snapshot.screamEndpointState, $Snapshot.screamDeviceStateMM, `
+            $Snapshot.activeRenderCount, $Snapshot.screamFxPointsAtEq, $Snapshot.registryClean)
+}
+
+$applied   = Read-Phase '30-apo-applied'
+$streamed  = Read-Phase '35-stream-forced'
+$afterVelo = Read-Phase '50-after-velo'
+$afterAeb  = Read-Phase '70-after-aeb'
+
+Write-Host '====================================================================='
+Write-Host ' EqualizerAPO-XT  -  LIVE endpoint device-loss reproduction + fix'
+Write-Host '====================================================================='
+Write-Host "EQ pre-mix  APO GUID : $PreMixGuid"
+Write-Host "EQ post-mix APO GUID : $PostMixGuid"
+$screamGuid = ($streamed, $applied, $afterVelo, $afterAeb | Where-Object { $_ } | Select-Object -First 1).screamGuid
+Write-Host "Scream endpoint GUID : $screamGuid"
+Write-Host ''
+Write-Host ("apo applied (30)      : {0}" -f (Format-Snap $applied))
+Write-Host ("stream forced (35)    : {0}" -f (Format-Snap $streamed))
+Write-Host ("after uninstall (50)  : {0}" -f (Format-Snap $afterVelo))
+Write-Host ("after AEB restart (70): {0}" -f (Format-Snap $afterAeb))
+Write-Host ''
+
+# The "before uninstall" reference is the stream-forced snapshot (the endpoint
+# was actively carrying the EQ APO chain). Fall back to apo-applied if the
+# stream-force phase was skipped (best-effort, per the workflow note).
+$before = if ($null -ne $streamed) { $streamed } else { $applied }
+if ($null -eq $before) {
+    Write-Error 'No pre-uninstall snapshot (35-stream-forced / 30-apo-applied) found; cannot diagnose.'
+    exit 3
+}
+if ($null -eq $afterVelo) {
+    Write-Error 'No post-uninstall snapshot (50-after-velo) found; cannot diagnose.'
+    exit 3
+}
+
+$beforeActive    = Test-EndpointActive $before
+$afterVeloActive = Test-EndpointActive $afterVelo
+$afterAebActive  = if ($null -ne $afterAeb) { Test-EndpointActive $afterAeb } else { $false }
+
+# The registry being CLEAN after uninstall is what makes the live disappearance
+# the AudioEndpointBuilder/stale-graph bug rather than a registry-delete bug. We
+# report it but do not gate on it (a not-clean registry is a different finding,
+# covered by Diagnose-AudioUninstall.ps1 / Diagnose-DanglingOnFailure.ps1).
+$registryClean = [bool]$afterVelo.registryClean
+
+$verdicts = New-Object System.Collections.Generic.List[string]
+
+$reproduced = ($beforeActive -and -not $afterVeloActive)
+$fixValidated = ($reproduced -and $afterAebActive)
+
+if (-not $beforeActive) {
+    $verdicts.Add('PRECONDITION NOT MET: the Scream endpoint was not Active before the uninstall. The live experiment cannot run (Scream may not have activated on this runner, or the stream-force did not bring it Active). Inspect 30/35 snapshots.')
+}
+elseif ($reproduced) {
+    $verdicts.Add('(live) REPRODUCED: the Scream endpoint was ACTIVE before the uninstall and went INACTIVE/missing immediately after the AudioSrv-only uninstall, WITHOUT a reboot.')
+    if ($registryClean) {
+        $verdicts.Add('  Registry is CLEAN after uninstall (original driver APO GUIDs restored, no EQ GUID dangling). The live loss is therefore the stale endpoint-graph bug: ApoRegistration::uninstall cycled only AudioSrv, never AudioEndpointBuilder.')
+    }
+    else {
+        $verdicts.Add('  WARNING: registry is NOT clean after uninstall (an EQ APO GUID is still named or originals were not restored). The live loss may be compounded by a dangling-reference bug; see Diagnose-AudioUninstall.ps1.')
+    }
+}
+else {
+    $verdicts.Add('(live) NOT REPRODUCED: the Scream endpoint stayed ACTIVE after the AudioSrv-only uninstall (no reboot). Either the bug did not reproduce on this runner or Scream behaves differently here.')
+}
+
+if ($reproduced) {
+    if ($null -eq $afterAeb) {
+        $verdicts.Add('(live) FIX NOT EVALUATED: no post-AudioEndpointBuilder-restart snapshot (70-after-aeb) found.')
+    }
+    elseif ($fixValidated) {
+        $verdicts.Add('(live) FIX VALIDATED: after Restart-Service -Force AudioEndpointBuilder the Scream endpoint returned to ACTIVE, WITHOUT a reboot. The fix candidate restores the endpoint live.')
+    }
+    else {
+        $verdicts.Add('(live) FIX NOT VALIDATED: the Scream endpoint stayed INACTIVE/missing even after the AudioEndpointBuilder restart. The fix candidate is insufficient on this runner.')
+    }
+}
+
+Write-Host '--------------------------------------------------------------------'
+Write-Host ' VERDICT'
+Write-Host '--------------------------------------------------------------------'
+foreach ($v in $verdicts) {
+    Write-Host " - $v"
+}
+Write-Host ''
+
+# Exit-code convention (see the .DESCRIPTION header for the full rationale).
+if (-not $beforeActive) {
+    Write-Host 'RESULT: INCONCLUSIVE - endpoint was not Active before uninstall (see exit 1).'
+    exit 1
+}
+if (-not $reproduced) {
+    Write-Host 'RESULT: INCONCLUSIVE - bug did NOT reproduce on this runner (exit 1). Inspect the snapshots.'
+    exit 1
+}
+if (-not $fixValidated) {
+    Write-Host 'RESULT: REPRODUCED but FIX NOT VALIDATED (exit 2). Inspect the snapshots.'
+    exit 2
+}
+Write-Host 'RESULT: live device-loss bug REPRODUCED and the AudioEndpointBuilder-restart fix VALIDATED (exit 0). Experiment fully succeeded.'
+exit 0

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -1,0 +1,848 @@
+# =============================================================================
+# LIVE audio-endpoint device-loss reproduction + fix validation
+# =============================================================================
+#
+# WHY THIS EXISTS
+#   A user reported that UNINSTALLING EqualizerAPO-XT makes ALL audio devices
+#   vanish from Windows until a REBOOT (a reboot fully restores them, and the
+#   post-uninstall registry has already been proven CLEAN: the original driver
+#   APO GUIDs are restored). The sibling workflow audio-uninstall-repro.yml
+#   proves the REGISTRY behaviour on a fake seeded endpoint, but it explicitly
+#   CANNOT prove the live kernel disappearance because a headless runner has no
+#   audiodg.exe loading an APO chain for a fake endpoint.
+#
+#   THIS workflow closes that gap. It installs a REAL virtual audio endpoint
+#   (Scream, a kernel render driver) with a self-signed catalog, registers the
+#   EQ APO on that real endpoint, forces audiodg to build the live APO chain,
+#   then runs the real uninstall and measures whether the endpoint goes
+#   INACTIVE/missing WITHOUT a reboot - and whether the fix candidate revives it.
+#
+# THE DIAGNOSED ROOT CAUSE (what this job demonstrates on a real endpoint)
+#   helpers/ApoRegistration.cpp::uninstall cycles ONLY the AudioSrv service
+#   (kAudioServiceName = "AudioSrv", line 44; stopAudioService at 252,
+#   startAudioService at 310). It never cycles AudioEndpointBuilder - the
+#   service that enumerates/activates endpoints and reads FxProperties to build
+#   the APO chain - nor audiodg.exe. So after the uninstall removes the EQ APO
+#   (DllUnregisterServer + the EqualizerAPO.dll deletion) and restarts only
+#   AudioSrv, AudioEndpointBuilder keeps its STALE endpoint graph and the
+#   affected endpoint stays inactive until a reboot rebuilds the graph.
+#
+# THE FIX CANDIDATE (what this job validates without a reboot)
+#   Restart-Service -Force AudioEndpointBuilder. -Force cascades the dependent
+#   AudioSrv, forcing a LIVE endpoint-graph rebuild that brings the endpoint back
+#   to Active without a reboot. (A future code fix in ApoRegistration would cycle
+#   AudioEndpointBuilder instead of, or in addition to, AudioSrv.)
+#
+# EXPERIMENT OUTLINE
+#   1. Install Scream as a real ACTIVE virtual render endpoint (self-signed,
+#      unattended - feasible because GitHub runners have Secure Boot OFF).
+#   2. Discover the Scream Render endpoint's GUID at runtime.
+#   3. Install the released x64-avx2 build silently.
+#   4. Register the EQ APO on the REAL Scream endpoint (replicating
+#      DeviceAPOInfo::install on the discovered GUID).
+#   5. Force audiodg to build the live APO chain (short WASAPI stream).
+#   6. Run the real (AudioSrv-only) uninstall. Snapshot WITHOUT rebooting ->
+#      REPRODUCTION check.
+#   7. Restart-Service -Force AudioEndpointBuilder. Snapshot WITHOUT rebooting
+#      -> FIX-VALIDATION check.
+#   8. Diagnose + verdict (.github/scripts/Diagnose-LiveEndpoint.ps1).
+#
+# SAFETY / SCOPE
+#   - on: workflow_dispatch ONLY. This MUST NEVER auto-run: it installs a kernel
+#     driver, writes HKLM, runs an uninstaller, and cycles audio services. It is
+#     a deliberate, manually-triggered diagnostic on a DISPOSABLE GitHub runner,
+#     never a developer machine.
+#   - runs-on: windows-2022 (NOT windows-latest). windows-latest migrated to
+#     Server 2025; the Scream self-signed-driver recipe is only confirmed on
+#     Server 2022. Pin it so the experiment stays reproducible.
+#
+# EXIT-CODE CONVENTION (see Diagnose-LiveEndpoint.ps1 for the full rationale)
+#   exit 0 = bug REPRODUCED (endpoint went inactive after the AudioSrv-only
+#            uninstall, no reboot) AND fix VALIDATED (AudioEndpointBuilder
+#            restart revived it). The experiment fully succeeded.
+#   exit 1 = endpoint did NOT go inactive after uninstall (bug did not reproduce
+#            here, or Scream behaves differently) - inspect snapshots.
+#   exit 2 = reproduced but the fix did not validate - inspect snapshots.
+#   Green here means "the device-loss bug was reproduced AND the fix worked",
+#   NOT "everything is healthy". Read the printed RESULT line.
+# =============================================================================
+
+name: Audio live endpoint reproduction
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to test (blank = latest)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  # EqualizerAPO APO CLSIDs (helpers/RegistryHelper.h:29,31). Upper-case so they
+  # match StringFromCLSID output (RegistryHelper::getGuidString), which is what
+  # install writes into FxProperties.
+  EQ_PREMIX_GUID: "{EACD2258-FCAC-4FF4-B36D-419E924A6D79}"
+  EQ_POSTMIX_GUID: "{EC1CC9CE-FAED-4822-828A-82A81A6F018F}"
+  # The APO value-name fmtid + indices written under FxProperties
+  # (devices/DeviceAPOInfo.Install.cpp:38-47).
+  FX_LFX: "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},1"
+  FX_GFX: "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},2"
+  FX_SFX: "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},5"
+  FX_MFX: "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},6"
+  FX_EFX: "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},7"
+  # The {b3f8fa53-...},6 device-friendly-name value used to spot the Scream
+  # endpoint (devices/DeviceAPOInfo.Install.cpp:34, deviceValueName).
+  DEVICE_FRIENDLY_VALUE: "{b3f8fa53-0004-438e-9003-51a46e139bfc},6"
+  # Registry roots (mirrors the #define paths in DeviceAPOInfo.*.cpp:24-27).
+  MMDEVICES_ROOT: "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\MMDevices\\Audio"
+  CHILD_APO_ROOT: "HKLM\\SOFTWARE\\EqualizerAPO\\Child APOs"
+  # Scream release pin (the self-signed recipe is verified against 4.0).
+  SCREAM_VERSION: "4.0"
+  SCREAM_URL: "https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip"
+
+jobs:
+  live-repro:
+    runs-on: windows-2022
+    timeout-minutes: 30
+
+    steps:
+      # -----------------------------------------------------------------------
+      # Checkout (for the diagnosis script) + a snapshot directory.
+      # -----------------------------------------------------------------------
+      - name: Checkout (for the diagnosis script)
+        uses: actions/checkout@v4
+
+      - name: Prepare snapshot directory
+        shell: pwsh
+        run: |
+          $dir = Join-Path $env:RUNNER_TEMP "audio-live-snapshots"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          "SNAP_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Snapshots will be written to $dir"
+
+      # signtool lives in the Windows SDK; ilammy/msvc-dev-cmd puts it on PATH.
+      - name: Add MSVC / SDK tools (signtool) to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      # -----------------------------------------------------------------------
+      # STEP 1: Install Scream as a REAL active virtual render endpoint.
+      #
+      #   GitHub-hosted runners have Secure Boot OFF, so a self-signed kernel
+      #   driver is accepted with NO test-signing mode and NO reboot. The recipe:
+      #     - download + expand the pinned Scream release,
+      #     - generate a self-signed code-signing cert (openssl),
+      #     - sign Scream.cat with it (signtool),
+      #     - trust the cert in LocalMachine\root AND \TrustedPublisher,
+      #     - install the INF with the bundled devcon,
+      #     - start the audio services and confirm a real ACTIVE render endpoint.
+      #
+      #   This installs a genuine kernel audio device, so audiodg.exe will load
+      #   the EQ APO chain for it later - which is exactly what the fake-seed
+      #   sibling workflow cannot do.
+      # -----------------------------------------------------------------------
+      - name: Install Scream virtual audio driver (10)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $work = Join-Path $env:RUNNER_TEMP "scream"
+          New-Item -ItemType Directory -Force -Path $work | Out-Null
+          $log = Join-Path $env:SNAP_DIR "10-scream-install.log"
+          function Log($m) { $line = "[scream] $m"; Write-Host $line; Add-Content -Path $log -Value $line }
+
+          $zip = Join-Path $work "Scream.zip"
+          Log "Downloading Scream $env:SCREAM_VERSION from $env:SCREAM_URL"
+          Invoke-WebRequest -Uri $env:SCREAM_URL -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $work -Force
+
+          $driverDir = Join-Path $work "Scream\Install\driver\x64"
+          $inf = Join-Path $driverDir "Scream.inf"
+          $cat = Join-Path $driverDir "Scream.cat"
+          $devcon = Join-Path $work "Scream\Install\helpers\devcon-x64.exe"
+          foreach ($f in @($inf, $cat, $devcon)) {
+              if (-not (Test-Path $f)) { Log "MISSING expected file: $f"; throw "Scream layout unexpected: $f not found" }
+          }
+
+          # --- Self-signed code-signing cert ----------------------------------
+          $pvk = Join-Path $work "ScreamCertificate.pvk"
+          $cer = Join-Path $work "ScreamCertificate.cer"
+          $pfx = Join-Path $work "ScreamCertificate.pfx"
+          Log "Generating self-signed certificate with openssl"
+          & openssl req -batch -x509 -newkey rsa -keyout $pvk -out $cer -nodes -extensions v3_req
+          if ($LASTEXITCODE -ne 0) { throw "openssl req failed ($LASTEXITCODE)" }
+          & openssl pkcs12 -export -nodes -in $cer -inkey $pvk -out $pfx -passout pass:
+          if ($LASTEXITCODE -ne 0) { throw "openssl pkcs12 failed ($LASTEXITCODE)" }
+
+          # --- Sign the catalog so the INF install trusts the package ----------
+          Log "Signing Scream.cat"
+          & signtool sign /v /fd SHA256 /f $pfx $cat
+          if ($LASTEXITCODE -ne 0) { throw "signtool sign failed ($LASTEXITCODE)" }
+
+          # --- Trust the cert: root (chain) + TrustedPublisher (silent install)
+          Log "Importing the cert into LocalMachine\root and LocalMachine\TrustedPublisher"
+          Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\root | Out-Null
+          Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\TrustedPublisher | Out-Null
+
+          # --- Install the driver via the bundled devcon ----------------------
+          Log "Installing the driver: devcon install Scream.inf *Scream"
+          & $devcon install $inf "*Scream"
+          $devconRc = $LASTEXITCODE
+          Log "devcon exited with $devconRc"
+
+          # --- Make sure the audio services are up after the device add --------
+          Log "Ensuring AudioEndpointBuilder + AudioSrv are running"
+          try { Start-Service AudioEndpointBuilder -ErrorAction Stop } catch { Log "Start AudioEndpointBuilder: $($_.Exception.Message)" }
+          cmd /c "net start audiosrv" 2>&1 | ForEach-Object { Log $_ }
+
+          # Give the endpoint graph a moment to enumerate the new device.
+          $deadline = (Get-Date).AddSeconds(30)
+          do {
+              Start-Sleep -Milliseconds 1500
+              $render = @()
+              if (Test-Path "Registry::$env:MMDEVICES_ROOT\Render") {
+                  $render = Get-ChildItem "Registry::$env:MMDEVICES_ROOT\Render" -ErrorAction SilentlyContinue
+              }
+              $screamSeen = $false
+              foreach ($k in $render) {
+                  $propPath = "$($k.PSPath)\Properties"
+                  if (Test-Path $propPath) {
+                      $name = (Get-ItemProperty -Path $propPath -Name $env:DEVICE_FRIENDLY_VALUE -ErrorAction SilentlyContinue)."$($env:DEVICE_FRIENDLY_VALUE)"
+                      if ($name -and $name -match 'Scream') { $screamSeen = $true; break }
+                  }
+              }
+          } while (-not $screamSeen -and (Get-Date) -lt $deadline)
+          Log "Scream endpoint visible in MMDevices: $screamSeen"
+
+          # Forensic enumeration into the log.
+          Log "Win32_SoundDevice:"
+          Get-CimInstance Win32_SoundDevice | Select-Object Name, Status, StatusInfo |
+              Format-Table -AutoSize | Out-String | ForEach-Object { Add-Content -Path $log -Value $_ }
+          Log "Get-PnpDevice -Class AudioEndpoint:"
+          try {
+              Get-PnpDevice -Class AudioEndpoint -ErrorAction Stop | Select-Object Status, FriendlyName, InstanceId |
+                  Format-Table -AutoSize | Out-String | ForEach-Object { Add-Content -Path $log -Value $_ }
+          } catch { Log "Get-PnpDevice failed: $($_.Exception.Message)" }
+
+      # -----------------------------------------------------------------------
+      # STEP 2: Discover the Scream Render endpoint's GUID at runtime.
+      #
+      #   We do NOT invent a GUID. We scan HKLM ...\MMDevices\Audio\Render\* for
+      #   the subkey whose Properties friendly name ({b3f8fa53-...},6) matches
+      #   "Scream", and require it to be ACTIVE (DeviceState DWORD == 1). If no
+      #   Active Scream render endpoint exists, we FAIL early - the entire point
+      #   is a real endpoint, so we never fall back to a registry seed.
+      # -----------------------------------------------------------------------
+      - name: Discover the Scream render endpoint GUID (15)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $renderPath = "$env:MMDEVICES_ROOT\Render"
+          if (-not (Test-Path "Registry::$renderPath")) {
+              Write-Error "No MMDevices Render key present; Scream did not install an endpoint."
+              exit 1
+          }
+
+          $match = $null
+          foreach ($k in (Get-ChildItem "Registry::$renderPath" -ErrorAction SilentlyContinue)) {
+              $guid = $k.PSChildName
+              $propPath = "$($k.PSPath)\Properties"
+              $name = $null
+              if (Test-Path $propPath) {
+                  $name = (Get-ItemProperty -Path $propPath -Name $env:DEVICE_FRIENDLY_VALUE -ErrorAction SilentlyContinue)."$($env:DEVICE_FRIENDLY_VALUE)"
+              }
+              $state = (Get-ItemProperty -Path $k.PSPath -Name DeviceState -ErrorAction SilentlyContinue).DeviceState
+              if ($name -and $name -match 'Scream') {
+                  Write-Host "Candidate Scream endpoint: $guid name='$name' DeviceState=$state"
+                  if ([int]$state -eq 1) { $match = $guid; break }   # 1 == DEVICE_STATE_ACTIVE
+                  if (-not $match) { $match = $guid }                 # remember first match as fallback
+              }
+          }
+
+          if (-not $match) {
+              Write-Error "No Scream render endpoint found in MMDevices. Scream failed to produce an endpoint; aborting (we do NOT seed a fake one)."
+              exit 1
+          }
+
+          $finalState = (Get-ItemProperty -Path "Registry::$renderPath\$match" -Name DeviceState -ErrorAction SilentlyContinue).DeviceState
+          if ([int]$finalState -ne 1) {
+              # The whole point is a real ACTIVE endpoint; do NOT silently fall
+              # back to a registry seed. Fail early with a clear message.
+              Write-Error "Scream render endpoint $match exists but is not ACTIVE (DeviceState=$finalState, expected 1). Aborting: a real Active endpoint is required and we do NOT seed a fake one."
+              exit 1
+          }
+
+          Write-Host "Selected Scream render endpoint GUID: $match (DeviceState=ACTIVE)"
+          "SCREAM_GUID=$match" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      # -----------------------------------------------------------------------
+      # Snapshot helper. It captures, per phase, the LIVE state of the Scream
+      # endpoint plus the registry facts the diagnosis needs. The live signals
+      # come from an inline C# IMMDeviceEnumerator client (Add-Type): the active
+      # render-endpoint count and the specific endpoint's IMMDevice::GetState,
+      # mirroring the product's DeviceAPOInfo::testAPOInstallation use of
+      # GetDevice/GetState (devices/DeviceAPOInfo.Uninstall.cpp:196-218).
+      # -----------------------------------------------------------------------
+      - name: Write snapshot helper (live)
+        shell: pwsh
+        run: |
+          $helper = @'
+          [CmdletBinding()]
+          param(
+              [Parameter(Mandatory=$true)][string]$Phase,
+              [Parameter(Mandatory=$true)][string]$SnapshotDir,
+              [Parameter(Mandatory=$true)][string]$ScreamGuid,
+              [Parameter(Mandatory=$true)][string]$MMDevicesRoot,
+              [Parameter(Mandatory=$true)][string]$PreMixGuid,
+              [Parameter(Mandatory=$true)][string]$PostMixGuid
+          )
+          $ErrorActionPreference = "Stop"
+
+          # 1) Full MMDevices\Audio tree as a .reg export (forensic record).
+          $regFile = Join-Path $SnapshotDir "$Phase-mmdevices.reg"
+          reg export $MMDevicesRoot $regFile /y | Out-Null
+
+          $renderPath = "$MMDevicesRoot\Render"
+          $epKeyPS = "Registry::$renderPath\$ScreamGuid"
+          $fxKeyPS = "$epKeyPS\FxProperties"
+
+          $endpointKeyPresent = Test-Path $epKeyPS
+          $fxPresent = Test-Path $fxKeyPS
+
+          # MMDevices DeviceState DWORD (registry view of activeness; 1 == ACTIVE).
+          $mmState = $null
+          if ($endpointKeyPresent) {
+              $mmState = (Get-ItemProperty -Path $epKeyPS -Name DeviceState -ErrorAction SilentlyContinue).DeviceState
+          }
+
+          # FxProperties APO GUID values + whether any names an EQ APO GUID.
+          $preMix = $PreMixGuid.Trim().ToUpperInvariant()
+          $postMix = $PostMixGuid.Trim().ToUpperInvariant()
+          $fxValues = [ordered]@{}
+          $pointsAtEq = $false
+          if ($fxPresent) {
+              $item = Get-Item $fxKeyPS
+              foreach ($name in $item.GetValueNames()) {
+                  if ($name -like '{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},*') {
+                      $v = [string](Get-ItemProperty -Path $fxKeyPS -Name $name)."$name"
+                      $fxValues[$name] = $v
+                      if (-not [string]::IsNullOrWhiteSpace($v)) {
+                          $n = $v.Trim().ToUpperInvariant()
+                          if ($n -eq $preMix -or $n -eq $postMix) { $pointsAtEq = $true }
+                      }
+                  }
+              }
+          }
+          # "Registry clean" = endpoint present AND no EQ GUID dangling in FxProperties.
+          $registryClean = ($endpointKeyPresent -and -not $pointsAtEq)
+
+          # 2) LIVE endpoint state via IMMDeviceEnumerator (the kernel-graph view).
+          #    activeRenderCount = number of DEVICE_STATE_ACTIVE render endpoints.
+          #    screamEndpointState = IMMDevice::GetState for the Scream endpoint, or
+          #    "NOTFOUND" when it no longer enumerates.
+          Add-Type -Language CSharp -TypeDefinition @"
+          using System;
+          using System.Runtime.InteropServices;
+          public static class MMLive {
+              [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumerator {}
+              [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+              interface IMMDeviceEnumerator {
+                  int EnumAudioEndpoints(int dataFlow, int stateMask, out IMMDeviceCollection devices);
+                  int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice ep);
+                  int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string id, out IMMDevice dev);
+              }
+              [Guid("0BD7A1BE-7A1A-44DB-8397-CC5392387B5E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+              interface IMMDeviceCollection { int GetCount(out int count); int Item(int n, out IMMDevice dev); }
+              [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+              interface IMMDevice {
+                  int Activate(ref Guid id, int ctx, IntPtr p, [MarshalAs(UnmanagedType.IUnknown)] out object o);
+                  int OpenPropertyStore(int access, out IntPtr store);
+                  int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+                  int GetState(out int state);
+              }
+              const int eRender = 0;
+              const int DEVICE_STATE_ACTIVE = 0x1;
+              const int DEVICE_STATEMASK_ALL = 0x0000000F;
+              public static int ActiveRenderCount() {
+                  var e = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+                  IMMDeviceCollection col; e.EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, out col);
+                  int n; col.GetCount(out n); return n;
+              }
+              // Returns the GetState bitmask for the endpoint id, or -1 if not found.
+              public static int EndpointState(string id) {
+                  var e = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+                  IMMDevice d;
+                  int hr = e.GetDevice(id, out d);
+                  if (hr != 0 || d == null) return -1;
+                  int st; if (d.GetState(out st) != 0) return -1; return st;
+              }
+          }
+          "@
+
+          $activeRenderCount = -1
+          try { $activeRenderCount = [MMLive]::ActiveRenderCount() } catch { }
+
+          # IMMDevice ids for render endpoints are "{0.0.0.00000000}.<guid>"
+          # (DeviceAPOInfo.Uninstall.cpp:208). Map the GetState bitmask to a label.
+          $screamId = "{0.0.0.00000000}.$ScreamGuid"
+          $stateBits = -1
+          try { $stateBits = [MMLive]::EndpointState($screamId) } catch { }
+          $screamEndpointState = switch ($stateBits) {
+              1   { 'ACTIVE' }
+              2   { 'DISABLED' }
+              4   { 'NOTPRESENT' }
+              8   { 'UNPLUGGED' }
+              -1  { 'NOTFOUND' }
+              default { "OTHER($stateBits)" }
+          }
+
+          # Win32_SoundDevice status strings (coarse OS-level view).
+          $win32 = @()
+          try {
+              $win32 = Get-CimInstance Win32_SoundDevice -ErrorAction Stop |
+                  Select-Object Name, Status, StatusInfo
+          } catch { }
+
+          $obj = [ordered]@{
+              phase                  = $Phase
+              screamGuid             = $ScreamGuid
+              endpointKeyPresent     = $endpointKeyPresent
+              fxPropertiesPresent    = $fxPresent
+              fxValues               = $fxValues
+              screamFxPointsAtEq     = $pointsAtEq
+              registryClean          = $registryClean
+              screamDeviceStateMM    = $mmState
+              activeRenderCount      = $activeRenderCount
+              screamEndpointState    = $screamEndpointState
+              win32SoundDeviceStatus = $win32
+          }
+          $obj | ConvertTo-Json -Depth 6 |
+              Out-File -FilePath (Join-Path $SnapshotDir "$Phase-live.json") -Encoding utf8
+          Write-Host "[$Phase] epState=$screamEndpointState mmState=$mmState activeRender=$activeRenderCount fxPointsAtEq=$pointsAtEq registryClean=$registryClean"
+          '@
+          $path = Join-Path $env:RUNNER_TEMP "snapshot-live.ps1"
+          $helper | Out-File -FilePath $path -Encoding utf8
+          "SNAP_SCRIPT=$path" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Snapshot baseline-live (20)
+        shell: pwsh
+        run: |
+          & $env:SNAP_SCRIPT -Phase "20-baseline" -SnapshotDir $env:SNAP_DIR `
+              -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
+              -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+      # -----------------------------------------------------------------------
+      # STEP 3: Download + silently install the latest released x64-avx2 build.
+      #   Same logic as audio-uninstall-repro.yml: the Setup asset name doubles
+      #   the channel because the packId already embeds it
+      #   (Installer/AutoInstaller.cpp:179-182), Setup.exe accepts --silent, and
+      #   we verify against SHA256SUMS.txt if present.
+      # -----------------------------------------------------------------------
+      - name: Download + silently install x64-avx2 release (25)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $repo = "${{ github.repository }}"
+          $tag = "${{ github.event.inputs.release_tag }}"
+
+          $asset = "EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe"
+          $dl = Join-Path $env:RUNNER_TEMP "release-dl"
+          New-Item -ItemType Directory -Force -Path $dl | Out-Null
+
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+              gh release download --repo $repo --pattern $asset --dir $dl --clobber
+              gh release download --repo $repo --pattern "SHA256SUMS.txt" --dir $dl --clobber
+          } else {
+              gh release download $tag --repo $repo --pattern $asset --dir $dl --clobber
+              gh release download $tag --repo $repo --pattern "SHA256SUMS.txt" --dir $dl --clobber
+          }
+
+          $setup = Join-Path $dl $asset
+          if (-not (Test-Path $setup)) { Write-Error "Could not download $asset"; exit 1 }
+
+          $sums = Join-Path $dl "SHA256SUMS.txt"
+          if (Test-Path $sums) {
+              $line = Get-Content $sums | Where-Object { $_ -match [regex]::Escape($asset) + '$' } | Select-Object -First 1
+              if ($line) {
+                  $expected = ($line -split '\s+')[0].ToLowerInvariant()
+                  $actual = (Get-FileHash -Path $setup -Algorithm SHA256).Hash.ToLowerInvariant()
+                  if ($expected -ne $actual) { Write-Error "Checksum mismatch for $asset (expected $expected, got $actual)"; exit 1 }
+                  Write-Host "Checksum OK for $asset"
+              } else {
+                  Write-Warning "SHA256SUMS.txt present but does not list $asset; skipping verification"
+              }
+          } else {
+              Write-Warning "No SHA256SUMS.txt asset on the release; skipping verification"
+          }
+
+          Write-Host "Running silent install: $setup --silent"
+          $p = Start-Process -FilePath $setup -ArgumentList "--silent" -PassThru -Wait
+          Write-Host "Setup exited with $($p.ExitCode)"
+
+          $candidates = @(
+              (Join-Path $env:LOCALAPPDATA "EqualizerAPO-XT-x64-avx2"),
+              (Join-Path ${env:ProgramData} "EqualizerAPO-XT-x64-avx2")
+          )
+          $root = $candidates | Where-Object { Test-Path (Join-Path $_ "Update.exe") } | Select-Object -First 1
+          if (-not $root) {
+              $root = Get-ChildItem -Path $env:LOCALAPPDATA -Directory -ErrorAction SilentlyContinue |
+                  Where-Object { $_.Name -like "EqualizerAPO-XT*" -and (Test-Path (Join-Path $_.FullName "Update.exe")) } |
+                  Select-Object -ExpandProperty FullName -First 1
+          }
+          if (-not $root) { Write-Error "Velopack install root not found after install"; exit 1 }
+          $current = Join-Path $root "current"
+          Write-Host "Install root: $root"
+          Write-Host "Bin dir:      $current"
+          "VELO_ROOT=$root"       | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "VELO_CURRENT=$current" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      # -----------------------------------------------------------------------
+      # STEP 4: Register the EQ APO on the REAL Scream endpoint.
+      #
+      #   The released DeviceSelector has /u (uninstall-all) but NO install-all
+      #   CLI, and its GUI install needs a real device + interaction. So we apply
+      #   the same registry writes DeviceAPOInfo::install would for the default
+      #   render state (INSTALL_LFX_GFX, installPreMix=true, installPostMix=true),
+      #   on the DISCOVERED Scream GUID. This mirrors the "Replicate per-device
+      #   APO install" step in audio-uninstall-repro.yml, but on a REAL endpoint.
+      #
+      #   MMDevices\Audio\Render is owned by SYSTEM; even an elevated admin gets
+      #   "Access is denied" until ownership is taken and Administrators are
+      #   granted full control (the product does the same takeOwnership/
+      #   makeWritable dance in DeviceAPOInfo.Install.cpp:88-92 when FxProperties
+      #   is locked). We reuse the exact RtlAdjustPrivilege take-ownership
+      #   preamble from audio-uninstall-repro.yml's "Seed" step. The real
+      #   DeviceSelector /u (step 6) does its own access handling, so this grant
+      #   does not change the product behaviour under test.
+      #
+      #   Scream's FxProperties did NOT previously name an EQ GUID; whether the
+      #   key exists depends on the driver. We handle both:
+      #     - if FxProperties has APO values -> "else" branch: save each existing
+      #       value (or "!VALUE") into Child APOs\{guid}, write EQ pre-mix into
+      #       LFX (,1) and EQ post-mix into GFX (,2), delete SFX/MFX/EFX.
+      #     - if FxProperties is absent/empty -> NOKEY branch: create it, save all
+      #       five as "!KEY", then write the EQ GUIDs.
+      #   This matches DeviceAPOInfo.Install.cpp:80-156 so the real uninstall's
+      #   load()/uninstall() restore path has a faithful footprint to act on.
+      # -----------------------------------------------------------------------
+      - name: Register EQ APO on the Scream endpoint (30)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $renderReg = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render"
+          $epPath = "$env:MMDEVICES_ROOT\Render\$env:SCREAM_GUID"
+          $fxPath = "$epPath\FxProperties"
+          $childGuidPath = "$env:CHILD_APO_ROOT\$env:SCREAM_GUID"
+
+          # --- Take ownership of Render + grant Administrators FullControl -----
+          # (reused verbatim from audio-uninstall-repro.yml's seed preamble)
+          Add-Type -Namespace Win32Acl -Name Priv -MemberDefinition '[System.Runtime.InteropServices.DllImport("ntdll.dll")] public static extern int RtlAdjustPrivilege(int Privilege, bool Enable, bool CurrentThread, out bool Enabled);'
+          $enabled = $false
+          [Win32Acl.Priv]::RtlAdjustPrivilege(9,  $true, $false, [ref]$enabled) | Out-Null   # SeTakeOwnershipPrivilege
+          [Win32Acl.Priv]::RtlAdjustPrivilege(18, $true, $false, [ref]$enabled) | Out-Null   # SeRestorePrivilege
+          $renderSub = "SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render"
+          $admins = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+          $k = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($renderSub, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::TakeOwnership)
+          if ($null -eq $k) { Write-Error "Could not open $renderSub to take ownership"; exit 1 }
+          $ownAcl = $k.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Owner)
+          $ownAcl.SetOwner($admins); $k.SetAccessControl($ownAcl); $k.Close()
+          $k = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($renderSub, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::ChangePermissions)
+          $dacl = $k.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Access)
+          $rule = New-Object System.Security.AccessControl.RegistryAccessRule($admins, [System.Security.AccessControl.RegistryRights]::FullControl, ([System.Security.AccessControl.InheritanceFlags]::ContainerInherit), [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
+          $dacl.AddAccessRule($rule); $k.SetAccessControl($dacl); $k.Close()
+          Write-Host "Took ownership of and granted Administrators FullControl on HKLM\$renderSub"
+
+          # Child APOs root + per-device key (Install.cpp:71-72).
+          reg add $env:CHILD_APO_ROOT /f | Out-Null
+          reg add $childGuidPath /f | Out-Null
+
+          $fxExists = Test-Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render\$env:SCREAM_GUID\FxProperties"
+          $hasApoValues = $false
+          if ($fxExists) {
+              $fxItem = Get-Item "$renderReg\$env:SCREAM_GUID\FxProperties"
+              $existingNames = $fxItem.GetValueNames()
+              foreach ($vn in @($env:FX_LFX, $env:FX_GFX, $env:FX_SFX, $env:FX_MFX, $env:FX_EFX)) {
+                  if ($existingNames -contains $vn) { $hasApoValues = $true }
+              }
+          }
+
+          if ($fxExists -and $hasApoValues) {
+              Write-Host "FxProperties exists with APO values -> 'else' branch (save originals)"
+              foreach ($vn in @($env:FX_LFX, $env:FX_GFX, $env:FX_SFX, $env:FX_MFX, $env:FX_EFX)) {
+                  if ($existingNames -contains $vn) {
+                      $val = [string](Get-ItemProperty -Path "$renderReg\$env:SCREAM_GUID\FxProperties" -Name $vn)."$vn"
+                  } else {
+                      $val = "!VALUE"   # APOGUID_NOVALUE (DeviceAPOInfo.h:29)
+                  }
+                  reg add $childGuidPath /v "$vn" /t REG_SZ /d "$val" /f | Out-Null
+              }
+              # PreMix/PostMixChild get the originals when useOriginalAPO* default true.
+              $origLfx = [string](Get-ItemProperty -Path "$renderReg\$env:SCREAM_GUID\FxProperties" -Name $env:FX_LFX -ErrorAction SilentlyContinue)."$($env:FX_LFX)"
+              $origGfx = [string](Get-ItemProperty -Path "$renderReg\$env:SCREAM_GUID\FxProperties" -Name $env:FX_GFX -ErrorAction SilentlyContinue)."$($env:FX_GFX)"
+              reg add $childGuidPath /v "PreMixChild"  /t REG_SZ /d "$origLfx" /f | Out-Null
+              reg add $childGuidPath /v "PostMixChild" /t REG_SZ /d "$origGfx" /f | Out-Null
+          } else {
+              Write-Host "FxProperties absent or has no APO values -> NOKEY branch (!KEY sentinels)"
+              reg add $fxPath /f | Out-Null
+              reg add $fxPath /v "{b725f130-47ef-101a-a5f1-02608c9eebac},10" /t REG_SZ /d "Equalizer APO" /f | Out-Null
+              foreach ($vn in @($env:FX_LFX, $env:FX_GFX, $env:FX_SFX, $env:FX_MFX, $env:FX_EFX)) {
+                  reg add $childGuidPath /v "$vn" /t REG_SZ /d "!KEY" /f | Out-Null   # APOGUID_NOKEY (DeviceAPOInfo.h:28)
+              }
+              reg add $childGuidPath /v "PreMixChild"  /t REG_SZ /d "" /f | Out-Null
+              reg add $childGuidPath /v "PostMixChild" /t REG_SZ /d "" /f | Out-Null
+          }
+
+          reg add $childGuidPath /v "AllowSilentBufferModification" /t REG_SZ /d "false" /f | Out-Null
+          reg add $childGuidPath /v "Version" /t REG_SZ /d "2" /f | Out-Null
+
+          # INSTALL_LFX_GFX: EQ pre-mix into LFX (,1), EQ post-mix into GFX (,2),
+          # delete SFX/MFX/EFX (Install.cpp:144-156).
+          reg add $fxPath /v "$env:FX_LFX" /t REG_SZ /d "$env:EQ_PREMIX_GUID" /f | Out-Null
+          reg add $fxPath /v "$env:FX_GFX" /t REG_SZ /d "$env:EQ_POSTMIX_GUID" /f | Out-Null
+          foreach ($vn in @($env:FX_SFX, $env:FX_MFX, $env:FX_EFX)) {
+              reg delete $fxPath /v "$vn" /f 2>$null | Out-Null
+          }
+          Write-Host "Applied EQ APO to Scream endpoint: LFX=$env:EQ_PREMIX_GUID GFX=$env:EQ_POSTMIX_GUID"
+
+          # Re-cycle AudioEndpointBuilder so the freshly-written FxProperties are
+          # read into the live graph (the GUI install triggers a comparable
+          # refresh). This is part of MAKING the APO live, not part of the bug
+          # under test (the uninstall step never does this).
+          Restart-Service -Force AudioEndpointBuilder
+          Start-Sleep -Seconds 3
+
+          & $env:SNAP_SCRIPT -Phase "30-apo-applied" -SnapshotDir $env:SNAP_DIR `
+              -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
+              -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+      # -----------------------------------------------------------------------
+      # STEP 5: Force audiodg to build the endpoint's APO chain.
+      #
+      #   So the later removal is a LIVE removal (the user's scenario, not a cold
+      #   registry edit), we open a short WASAPI render stream on the Scream
+      #   endpoint and Start() it for ~1s. This mirrors the product's
+      #   DeviceAPOInfo::testAPOInstallation (Uninstall.cpp:196-252):
+      #   Activate(IAudioClient) -> GetMixFormat -> Initialize (retry with
+      #   AUTOCONVERTPCM on E_INVALIDARG) -> Start. We additionally Start the
+      #   client so audiodg actually instantiates and runs the APO chain.
+      #
+      #   BEST EFFORT: if forcing a stream fails, we log it and proceed; the
+      #   endpoint-state check is the primary signal. The snapshot here is the
+      #   "endpoint ACTIVE + EQ APO live" reference for the diagnosis.
+      # -----------------------------------------------------------------------
+      - name: Force audiodg to build the APO chain (35)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $screamId = "{0.0.0.00000000}.$env:SCREAM_GUID"
+          Write-Host "Forcing a short WASAPI stream on $screamId"
+
+          Add-Type -Language CSharp -TypeDefinition @"
+          using System;
+          using System.Runtime.InteropServices;
+          using System.Threading;
+          public static class WasapiForce {
+              [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumerator {}
+              [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+              interface IMMDeviceEnumerator {
+                  int EnumAudioEndpoints(int f, int m, out IntPtr c);
+                  int GetDefaultAudioEndpoint(int f, int r, out IMMDevice ep);
+                  int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string id, out IMMDevice dev);
+              }
+              [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+              interface IMMDevice {
+                  int Activate(ref Guid id, int ctx, IntPtr p, [MarshalAs(UnmanagedType.IUnknown)] out object o);
+                  int OpenPropertyStore(int a, out IntPtr s);
+                  int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+                  int GetState(out int st);
+              }
+              [Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+              interface IAudioClient {
+                  int Initialize(int share, int flags, long buf, long period, IntPtr fmt, IntPtr guid);
+                  int GetBufferSize(out uint frames);
+                  int GetStreamLatency(out long l);
+                  int GetCurrentPadding(out uint p);
+                  int IsFormatSupported(int share, IntPtr fmt, out IntPtr closest);
+                  int GetMixFormat(out IntPtr fmt);
+                  int GetDevicePeriod(out long def, out long min);
+                  int Start();
+                  int Stop();
+                  int Reset();
+                  int SetEventHandle(IntPtr h);
+                  int GetService(ref Guid iid, [MarshalAs(UnmanagedType.IUnknown)] out object svc);
+              }
+              const int CLSCTX_ALL = 0x17;
+              const int AUDCLNT_SHAREMODE_SHARED = 0;
+              // Stream flags for the retry: 0x80000000 = AUTOCONVERTPCM,
+              // 0x08000000 = SRC_DEFAULT_QUALITY -> combined 0x88000000.
+              static Guid IID_IAudioClient = new Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2");
+              // Returns a status string describing how far the stream got.
+              public static string Run(string id, int ms) {
+                  IMMDeviceEnumerator e = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+                  IMMDevice dev;
+                  int hr = e.GetDevice(id, out dev);
+                  if (hr != 0 || dev == null) return "GetDevice failed hr=0x" + hr.ToString("X8");
+                  object o;
+                  hr = dev.Activate(ref IID_IAudioClient, CLSCTX_ALL, IntPtr.Zero, out o);
+                  if (hr != 0 || o == null) return "Activate failed hr=0x" + hr.ToString("X8");
+                  IAudioClient ac = (IAudioClient)o;
+                  IntPtr fmt;
+                  hr = ac.GetMixFormat(out fmt);
+                  if (hr != 0) return "GetMixFormat failed hr=0x" + hr.ToString("X8");
+                  // 100 ms buffer, like testAPOInstallation.
+                  hr = ac.Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 1000000, 0, fmt, IntPtr.Zero);
+                  if (hr != 0) {
+                      // Retry with engine auto-conversion (mirrors the product retry).
+                      object o2; int hr2 = dev.Activate(ref IID_IAudioClient, CLSCTX_ALL, IntPtr.Zero, out o2);
+                      if (hr2 == 0 && o2 != null) {
+                          IAudioClient ac2 = (IAudioClient)o2;
+                          unchecked {
+                              hr = ac2.Initialize(AUDCLNT_SHAREMODE_SHARED, (int)0x88000000, 1000000, 0, fmt, IntPtr.Zero);
+                          }
+                          Marshal.FreeCoTaskMem(fmt);
+                          if (hr != 0) return "Initialize(retry) failed hr=0x" + hr.ToString("X8");
+                          ac = ac2;
+                      } else {
+                          Marshal.FreeCoTaskMem(fmt);
+                          return "Initialize failed and retry Activate failed";
+                      }
+                  } else {
+                      Marshal.FreeCoTaskMem(fmt);
+                  }
+                  hr = ac.Start();
+                  if (hr != 0) return "Start failed hr=0x" + hr.ToString("X8");
+                  Thread.Sleep(ms);
+                  ac.Stop();
+                  return "OK (streamed " + ms + "ms)";
+              }
+          }
+          "@
+
+          try {
+              $result = [WasapiForce]::Run($screamId, 1000)
+              Write-Host "Stream-force result: $result"
+          } catch {
+              Write-Warning "Stream-force threw (best effort, continuing): $($_.Exception.Message)"
+          }
+
+          Start-Sleep -Seconds 2
+          & $env:SNAP_SCRIPT -Phase "35-stream-forced" -SnapshotDir $env:SNAP_DIR `
+              -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
+              -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+      # -----------------------------------------------------------------------
+      # STEP 6a: Run the real per-device uninstall via DeviceSelector.exe /u.
+      #   load() detects the Scream endpoint as installed (FxProperties names an
+      #   EQ GUID), reads originals back from Child APOs\{guid}, and uninstall
+      #   restores them (DeviceAPOInfo.Uninstall.cpp:66-102). Run with the bin
+      #   dir as CWD (DeviceSelector's addLibraryPath("qt") is cwd-relative) and a
+      #   bounded WaitForExit + Kill, reusing the audio-uninstall-repro pattern.
+      # -----------------------------------------------------------------------
+      - name: Run DeviceSelector.exe /u (40)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $devsel = Join-Path $env:VELO_CURRENT "DeviceSelector.exe"
+          if (-not (Test-Path $devsel)) {
+              Write-Warning "DeviceSelector.exe not found at $devsel; skipping (Velopack uninstall still runs the AudioSrv-only path)"
+          } else {
+              Write-Host "Running $devsel /u (cwd=$env:VELO_CURRENT)"
+              $p = Start-Process -FilePath $devsel -ArgumentList "/u" -WorkingDirectory $env:VELO_CURRENT -PassThru
+              if (-not $p.WaitForExit(120000)) {
+                  Write-Warning "DeviceSelector /u did not exit within 120s; killing it (likely a modal dialog on the headless runner)"
+                  try { $p.Kill() } catch {}
+              } else {
+                  Write-Host "DeviceSelector /u exited with $($p.ExitCode)"
+              }
+          }
+
+      # -----------------------------------------------------------------------
+      # STEP 6b: Run the full Velopack app uninstall. Update.exe --uninstall runs
+      #   the --veloapp-uninstall hook -> ApoRegistration::uninstall, which is the
+      #   AUDIOSRV-ONLY path: it stops AudioSrv (line 252), restores/cleans the
+      #   per-device FxProperties + Child APOs, DllUnregisterServer's the COM
+      #   server, then starts ONLY AudioSrv again (line 310). AudioEndpointBuilder
+      #   is never cycled. THIS is the code under test.
+      #
+      #   Snapshot IMMEDIATELY, WITHOUT rebooting -> the REPRODUCTION check.
+      # -----------------------------------------------------------------------
+      - name: Run Velopack app uninstall (AudioSrv-only path) + snapshot (50)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $update = Join-Path $env:VELO_ROOT "Update.exe"
+          if (-not (Test-Path $update)) {
+              Write-Warning "Update.exe not found at $update; skipping Velopack uninstall"
+          } else {
+              Write-Host "Running $update --uninstall --silent (cwd=$env:VELO_ROOT)"
+              $p = Start-Process -FilePath $update -ArgumentList "--uninstall","--silent" -WorkingDirectory $env:VELO_ROOT -PassThru
+              if (-not $p.WaitForExit(180000)) {
+                  Write-Warning "Update.exe --uninstall did not exit within 180s; killing it"
+                  try { $p.Kill() } catch {}
+              } else {
+                  Write-Host "Update.exe --uninstall exited with $($p.ExitCode)"
+              }
+          }
+
+          # Brief settle so AudioSrv-only restart finishes; then snapshot the
+          # post-uninstall state. NO reboot - this is the whole point.
+          Start-Sleep -Seconds 5
+          & $env:SNAP_SCRIPT -Phase "50-after-velo" -SnapshotDir $env:SNAP_DIR `
+              -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
+              -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+      # -----------------------------------------------------------------------
+      # STEP 7: Validate the fix candidate, still WITHOUT rebooting.
+      #   Restart-Service -Force AudioEndpointBuilder. -Force cascades the
+      #   dependent AudioSrv; we then make sure AudioSrv is running. This forces a
+      #   LIVE endpoint-graph rebuild. Snapshot again -> the FIX-VALIDATION check.
+      # -----------------------------------------------------------------------
+      - name: Restart AudioEndpointBuilder (fix candidate) + snapshot (70)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          Write-Host "Restart-Service -Force AudioEndpointBuilder (cascades dependent AudioSrv)"
+          try {
+              Restart-Service -Force AudioEndpointBuilder -ErrorAction Stop
+          } catch {
+              Write-Warning "Restart-Service AudioEndpointBuilder failed: $($_.Exception.Message)"
+          }
+          # -Force stops dependents (AudioSrv) but does not always restart them;
+          # ensure AudioSrv is running so the endpoint graph is fully back up.
+          try { Start-Service AudioSrv -ErrorAction Stop } catch { Write-Warning "Start AudioSrv: $($_.Exception.Message)" }
+
+          # Give the rebuilt graph a moment to re-activate the endpoint.
+          Start-Sleep -Seconds 8
+          & $env:SNAP_SCRIPT -Phase "70-after-aeb" -SnapshotDir $env:SNAP_DIR `
+              -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
+              -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+      # -----------------------------------------------------------------------
+      # Always upload every snapshot + the Scream install log so a failed or
+      # inconclusive run is still fully inspectable.
+      # -----------------------------------------------------------------------
+      - name: Upload snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: audio-live-snapshots
+          path: ${{ env.SNAP_DIR }}/**
+          if-no-files-found: warn
+
+      # -----------------------------------------------------------------------
+      # STEP 8: Diagnose + verdict. Exit-code convention is documented in the job
+      #   banner and in Diagnose-LiveEndpoint.ps1: exit 0 = reproduced AND fixed.
+      # -----------------------------------------------------------------------
+      - name: Diagnose (live)
+        if: always()
+        shell: pwsh
+        run: |
+          & "$env:GITHUB_WORKSPACE\.github\scripts\Diagnose-LiveEndpoint.ps1" `
+              -SnapshotDir $env:SNAP_DIR `
+              -PreMixGuid $env:EQ_PREMIX_GUID `
+              -PostMixGuid $env:EQ_POSTMIX_GUID


### PR DESCRIPTION
## 무엇을 / 왜

제거 시 오디오 장치가 사라지는 치명적 버그(재부팅하면 복구됨)를 **실제 커널 오디오 엔드포인트**에서 실증하고, 수정 후보까지 한 번에 검증하는 `workflow_dispatch` 전용 진단 워크플로우입니다.

기존 [audio-uninstall-repro.yml](https://github.com/115dkk/EqualizerAPO-XT/blob/main/.github/workflows/audio-uninstall-repro.yml)은 **가짜로 심은 엔드포인트의 레지스트리 결과**만 증명할 수 있습니다(헤드리스 러너에는 가짜 엔드포인트의 APO 체인을 올리는 audiodg가 없으므로). 그 사각을 이 워크플로우가 메웁니다.

## 진단된 근본 원인

`helpers/ApoRegistration.cpp::uninstall`은 **AudioSrv만** 껐다 켭니다(`kAudioServiceName`, ApoRegistration.cpp:44; stop :252 / start :310). FxProperties를 읽어 APO 체인을 만드는 **AudioEndpointBuilder는 절대 재시작하지 않습니다**. 그래서 EQ APO 제거(DllUnregisterServer + DLL 삭제) 후 AudioSrv만 재시작하면 AudioEndpointBuilder의 엔드포인트 그래프가 낡은 채로 남고, 엔드포인트는 **재부팅으로 그래프를 다시 만들기 전까지 비활성**으로 남습니다. 제거 후 레지스트리는 이미 깨끗함이 확인되었으므로(원래 드라이버 APO GUID 복원됨), 이 라이브 소실은 레지스트리 삭제 버그가 아니라 **낡은 엔드포인트 그래프** 문제입니다.

## 실험 흐름

1. Scream(가상 커널 렌더 드라이버)을 self-signed 카탈로그로 무인 설치합니다(GitHub 러너는 Secure Boot OFF라 자가서명 수용, test-signing·재부팅 불필요).
2. Scream 렌더 엔드포인트 GUID를 런타임에 탐색합니다(ACTIVE가 아니면 조기 실패 — 가짜로 대체하지 않음).
3. 릴리즈된 x64-avx2 빌드를 무인 설치합니다.
4. 탐색한 Scream GUID에 EQ APO를 등록합니다(`DeviceAPOInfo::install` 재현, Render 키 소유권 취득 preamble 포함).
5. 짧은 WASAPI 스트림으로 audiodg가 라이브 APO 체인을 만들게 강제합니다.
6. 실제 제거(AudioSrv-only 경로)를 실행하고 **재부팅 없이** 스냅샷 → **재현 판정**.
7. `Restart-Service -Force AudioEndpointBuilder`(종속 AudioSrv까지 연쇄) 후 **재부팅 없이** 스냅샷 → **수정 검증 판정**.

## 종료 코드 규약

이 잡은 "녹색=정상"이 아니라 **"녹색=버그 재현 + 수정 검증 성공"**입니다.

- `exit 0` — 재현(AudioSrv-only 제거 후 엔드포인트 비활성) **그리고** 수정 검증(AudioEndpointBuilder 재시작으로 복구) 모두 성공.
- `exit 1` — 제거 후에도 비활성이 안 됨(이 러너에서 재현 안 됨 / Scream 동작 차이) — 스냅샷 확인.
- `exit 2` — 재현됐으나 수정 후보가 부족.
- `exit 3` — 필요한 스냅샷 누락.

## 안전 / 범위

- `on: workflow_dispatch` **전용**. 커널 드라이버 설치 + HKLM 쓰기 + 제거 + 오디오 서비스 재시작을 하므로 **절대 자동 실행되지 않습니다**. 일회용 GitHub 러너에서만 수동으로 돌립니다(사용자 머신에서는 절대 실행 금지라는 제약 준수).
- `runs-on: windows-2022` 고정. `windows-latest`는 Server 2025로 이전했고, Scream 자가서명 레시피는 Server 2022에서만 확인됨.
- 버전 무변경(`ci:`)이라 빌드 매트릭스/릴리스는 건너뜁니다.

머지해도 자동 실행되지 않으며, 기본 브랜치에 워크플로우가 있어야 `gh workflow run`으로 dispatch할 수 있어 머지가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
