### PR TITLE
fix: 제거 시 AudioEndpointBuilder 재시작으로 오디오 장치 소실 방지 (+ Scream 라이브 실증 하네스)

### DIFF
--- a/.github/scripts/Diagnose-LiveEndpoint.ps1
+++ b/.github/scripts/Diagnose-LiveEndpoint.ps1
@@ -113,20 +113,27 @@ function Read-Phase {
     return Get-Content -Raw -Path $jsonPath | ConvertFrom-Json
 }
 
-# An endpoint counts as "live/active" when IMMDevice::GetState reports ACTIVE,
-# or (fallback) the MMDevices DeviceState DWORD is exactly 1 (DEVICE_STATE_ACTIVE).
-# When the endpoint no longer enumerates at all, screamEndpointState is "NOTFOUND".
-function Test-EndpointActive {
+# Tri-state activity of the endpoint from a snapshot: 'Active', 'Inactive', or
+# 'Unknown'. The live COM state (IMMDevice::GetState via the snapshot helper) is
+# authoritative: 'ACTIVE' -> Active; 'NOTFOUND'/'DISABLED'/'UNPLUGGED'/
+# 'NOTPRESENT' -> Inactive. 'ENUM_FAILED' means the COM enumerator itself threw
+# even after retries, so we genuinely do not know -> Unknown (NOT a device-loss
+# signal; treating it as Inactive would produce a false "reproduced"). The
+# registry DeviceState DWORD is deliberately NOT used as an active signal,
+# because it stayed 1 (ACTIVE) even when the live endpoint was gone - that
+# registry-vs-live mismatch is the very bug being measured.
+function Get-EndpointActivity {
     param($Snapshot)
-    if ($null -eq $Snapshot) { return $false }
-    if ($Snapshot.screamEndpointState -eq 'ACTIVE') { return $true }
-    if ($Snapshot.screamEndpointState -eq 'NOTFOUND') { return $false }
-    # Fallback to the registry DeviceState only if the COM state was unavailable
-    # (e.g. enumeration threw). 1 == DEVICE_STATE_ACTIVE.
-    if ($null -eq $Snapshot.screamEndpointState -or $Snapshot.screamEndpointState -eq '') {
-        return ([int]$Snapshot.screamDeviceStateMM -eq 1)
+    if ($null -eq $Snapshot) { return 'Unknown' }
+    switch ($Snapshot.screamEndpointState) {
+        'ACTIVE'      { return 'Active' }
+        'NOTFOUND'    { return 'Inactive' }
+        'DISABLED'    { return 'Inactive' }
+        'UNPLUGGED'   { return 'Inactive' }
+        'NOTPRESENT'  { return 'Inactive' }
+        'ENUM_FAILED' { return 'Unknown' }
+        default       { return 'Unknown' }
     }
-    return $false
 }
 
 function Format-Snap {
@@ -169,9 +176,9 @@ if ($null -eq $afterVelo) {
     exit 3
 }
 
-$beforeActive    = Test-EndpointActive $before
-$afterVeloActive = Test-EndpointActive $afterVelo
-$afterAebActive  = if ($null -ne $afterAeb) { Test-EndpointActive $afterAeb } else { $false }
+$beforeState    = Get-EndpointActivity $before
+$afterVeloState = Get-EndpointActivity $afterVelo
+$afterAebState  = Get-EndpointActivity $afterAeb
 
 # The registry being CLEAN after uninstall is what makes the live disappearance
 # the AudioEndpointBuilder/stale-graph bug rather than a registry-delete bug. We
@@ -179,16 +186,35 @@ $afterAebActive  = if ($null -ne $afterAeb) { Test-EndpointActive $afterAeb } el
 # covered by Diagnose-AudioUninstall.ps1 / Diagnose-DanglingOnFailure.ps1).
 $registryClean = [bool]$afterVelo.registryClean
 
+# Whether the EQ APO was actually live before the uninstall. If it was never
+# applied, the bug's precondition (a dangling EQ APO reference after removal)
+# never existed, so a "still active" result is meaningless.
+$eqWasApplied = [bool]$before.screamFxPointsAtEq
+
 $verdicts = New-Object System.Collections.Generic.List[string]
 
-$reproduced = ($beforeActive -and -not $afterVeloActive)
-$fixValidated = ($reproduced -and $afterAebActive)
+# reproduced requires a DEFINITE before=Active -> after=Inactive transition.
+# Any 'Unknown' (ENUM_FAILED) on the gating snapshots makes the run inconclusive
+# rather than a false positive/negative.
+$reproduced   = ($beforeState -eq 'Active' -and $afterVeloState -eq 'Inactive')
+$fixValidated = ($reproduced -and $afterAebState -eq 'Active')
 
-if (-not $beforeActive) {
-    $verdicts.Add('PRECONDITION NOT MET: the Scream endpoint was not Active before the uninstall. The live experiment cannot run (Scream may not have activated on this runner, or the stream-force did not bring it Active). Inspect 30/35 snapshots.')
+$inconclusive = $false
+if (-not $eqWasApplied) {
+    $verdicts.Add('SETUP INVALID: the EQ APO was not actually applied to the Scream endpoint before the uninstall (screamFxPointsAtEq=False at the pre-uninstall snapshot). The bug precondition was never established; inspect step 30. This is a harness problem, not a property of the audio code.')
+    $inconclusive = $true
+}
+elseif ($beforeState -ne 'Active') {
+    $verdicts.Add("PRECONDITION NOT MET: the Scream endpoint was not confirmed Active before the uninstall (state=$beforeState). " +
+        "If 'Unknown', the COM enumerator failed even after retries; if 'Inactive', Scream did not stay active. Inspect 30/35 snapshots.")
+    $inconclusive = $true
+}
+elseif ($afterVeloState -eq 'Unknown') {
+    $verdicts.Add('INCONCLUSIVE: the endpoint state could not be read after the uninstall (COM enumerator failed even after retries). Cannot tell reproduced from not-reproduced; inspect the 50-after-velo snapshot.')
+    $inconclusive = $true
 }
 elseif ($reproduced) {
-    $verdicts.Add('(live) REPRODUCED: the Scream endpoint was ACTIVE before the uninstall and went INACTIVE/missing immediately after the AudioSrv-only uninstall, WITHOUT a reboot.')
+    $verdicts.Add('(live) REPRODUCED: the Scream endpoint was ACTIVE (with the EQ APO live) before the uninstall and went INACTIVE/missing immediately after the AudioSrv-only uninstall, WITHOUT a reboot.')
     if ($registryClean) {
         $verdicts.Add('  Registry is CLEAN after uninstall (original driver APO GUIDs restored, no EQ GUID dangling). The live loss is therefore the stale endpoint-graph bug: ApoRegistration::uninstall cycled only AudioSrv, never AudioEndpointBuilder.')
     }
@@ -197,7 +223,7 @@ elseif ($reproduced) {
     }
 }
 else {
-    $verdicts.Add('(live) NOT REPRODUCED: the Scream endpoint stayed ACTIVE after the AudioSrv-only uninstall (no reboot). Either the bug did not reproduce on this runner or Scream behaves differently here.')
+    $verdicts.Add("(live) NOT REPRODUCED: the Scream endpoint stayed ACTIVE after the AudioSrv-only uninstall (no reboot, after-state=$afterVeloState). Either the bug did not reproduce on this runner or Scream behaves differently here.")
 }
 
 if ($reproduced) {
@@ -207,8 +233,11 @@ if ($reproduced) {
     elseif ($fixValidated) {
         $verdicts.Add('(live) FIX VALIDATED: after Restart-Service -Force AudioEndpointBuilder the Scream endpoint returned to ACTIVE, WITHOUT a reboot. The fix candidate restores the endpoint live.')
     }
+    elseif ($afterAebState -eq 'Unknown') {
+        $verdicts.Add('(live) FIX NOT EVALUATED: the endpoint state could not be read after the AudioEndpointBuilder restart (COM enumerator failed). Inspect the 70-after-aeb snapshot.')
+    }
     else {
-        $verdicts.Add('(live) FIX NOT VALIDATED: the Scream endpoint stayed INACTIVE/missing even after the AudioEndpointBuilder restart. The fix candidate is insufficient on this runner.')
+        $verdicts.Add("(live) FIX NOT VALIDATED: the Scream endpoint stayed INACTIVE/missing even after the AudioEndpointBuilder restart (after-state=$afterAebState). The fix candidate is insufficient on this runner.")
     }
 }
 
@@ -221,8 +250,8 @@ foreach ($v in $verdicts) {
 Write-Host ''
 
 # Exit-code convention (see the .DESCRIPTION header for the full rationale).
-if (-not $beforeActive) {
-    Write-Host 'RESULT: INCONCLUSIVE - endpoint was not Active before uninstall (see exit 1).'
+if ($inconclusive) {
+    Write-Host 'RESULT: INCONCLUSIVE - the live experiment could not be evaluated (exit 1). Inspect the snapshots.'
     exit 1
 }
 if (-not $reproduced) {

--- a/.github/scripts/Diagnose-LiveEndpoint.ps1
+++ b/.github/scripts/Diagnose-LiveEndpoint.ps1
@@ -99,7 +99,17 @@ param(
     [string]$PreMixGuid,
 
     [Parameter(Mandatory = $true)]
-    [string]$PostMixGuid
+    [string]$PostMixGuid,
+
+    # reproduce    : prove the bug on an UNFIXED build (exit 0 = endpoint went
+    #               INACTIVE after the AudioSrv-only uninstall AND an
+    #               AudioEndpointBuilder restart brought it back).
+    # expect-fixed : verify a FIXED release (exit 0 = endpoint STAYED ACTIVE
+    #               through the real uninstall, so the shipped fix works; exit 2
+    #               = it went inactive, i.e. the fix is absent or ineffective).
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('reproduce', 'expect-fixed')]
+    [string]$Mode = 'reproduce'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -236,6 +246,16 @@ elseif ($afterVeloState -eq 'Unknown') {
     $verdicts.Add('INCONCLUSIVE: the endpoint state could not be read after the uninstall (COM enumerator failed even after retries). Cannot tell reproduced from not-reproduced; inspect the 50-after-velo snapshot.')
     $inconclusive = $true
 }
+elseif ($Mode -eq 'expect-fixed') {
+    # Validating a FIXED release: the endpoint must STAY ACTIVE through the real
+    # uninstall (the shipped ApoRegistration::uninstall restarts AudioEndpointBuilder).
+    if ($afterVeloState -eq 'Active') {
+        $verdicts.Add('(fixed) PASS: the endpoint STAYED ACTIVE through the real uninstall - with audio in use and no reboot. The shipped build restarts AudioEndpointBuilder during uninstall, so removing the APO no longer drops the device.')
+    }
+    else {
+        $verdicts.Add("(fixed) FAIL: the endpoint went INACTIVE/missing after the real uninstall (after-state=$afterVeloState). The AudioEndpointBuilder restart did not take effect during uninstall - the fix is absent or ineffective in this build.")
+    }
+}
 elseif ($reproduced) {
     $verdicts.Add('(live) REPRODUCED: the Scream endpoint was ACTIVE (with the EQ APO live) before the uninstall and went INACTIVE/missing immediately after the AudioSrv-only uninstall, WITHOUT a reboot.')
     if ($controlState -eq 'Active') {
@@ -255,7 +275,7 @@ else {
     $verdicts.Add("(live) NOT REPRODUCED: the Scream endpoint stayed ACTIVE after the AudioSrv-only uninstall (no reboot, after-state=$afterVeloState). Either the bug did not reproduce on this runner or Scream behaves differently here.")
 }
 
-if ($reproduced) {
+if ($Mode -eq 'reproduce' -and $reproduced) {
     if ($null -eq $afterAeb) {
         $verdicts.Add('(live) FIX NOT EVALUATED: no post-AudioEndpointBuilder-restart snapshot (70-after-aeb) found.')
     }
@@ -283,6 +303,15 @@ if ($inconclusive) {
     Write-Host 'RESULT: INCONCLUSIVE - the live experiment could not be evaluated (exit 1). Inspect the snapshots.'
     exit 1
 }
+if ($Mode -eq 'expect-fixed') {
+    if ($afterVeloState -eq 'Active') {
+        Write-Host 'RESULT: (expect-fixed) PASS - the endpoint survived the real uninstall with audio in use; the shipped fix works (exit 0).'
+        exit 0
+    }
+    Write-Host 'RESULT: (expect-fixed) FAIL - the endpoint went inactive after the uninstall; the fix is absent or ineffective in this build (exit 2). Inspect the snapshots.'
+    exit 2
+}
+# reproduce mode
 if (-not $reproduced) {
     Write-Host 'RESULT: INCONCLUSIVE - bug did NOT reproduce on this runner (exit 1). Inspect the snapshots.'
     exit 1

--- a/.github/scripts/Diagnose-LiveEndpoint.ps1
+++ b/.github/scripts/Diagnose-LiveEndpoint.ps1
@@ -146,6 +146,7 @@ function Format-Snap {
 
 $applied   = Read-Phase '30-apo-applied'
 $streamed  = Read-Phase '35-stream-forced'
+$control   = Read-Phase '45-control'
 $afterVelo = Read-Phase '50-after-velo'
 $afterAeb  = Read-Phase '70-after-aeb'
 
@@ -154,21 +155,32 @@ Write-Host ' EqualizerAPO-XT  -  LIVE endpoint device-loss reproduction + fix'
 Write-Host '====================================================================='
 Write-Host "EQ pre-mix  APO GUID : $PreMixGuid"
 Write-Host "EQ post-mix APO GUID : $PostMixGuid"
-$screamGuid = ($streamed, $applied, $afterVelo, $afterAeb | Where-Object { $_ } | Select-Object -First 1).screamGuid
+$screamGuid = ($streamed, $applied, $control, $afterVelo, $afterAeb | Where-Object { $_ } | Select-Object -First 1).screamGuid
 Write-Host "Scream endpoint GUID : $screamGuid"
 Write-Host ''
-Write-Host ("apo applied (30)      : {0}" -f (Format-Snap $applied))
-Write-Host ("stream forced (35)    : {0}" -f (Format-Snap $streamed))
-Write-Host ("after uninstall (50)  : {0}" -f (Format-Snap $afterVelo))
-Write-Host ("after AEB restart (70): {0}" -f (Format-Snap $afterAeb))
+Write-Host ("apo applied (30)        : {0}" -f (Format-Snap $applied))
+Write-Host ("stream forced (35)      : {0}" -f (Format-Snap $streamed))
+Write-Host ("control AudioSrv (45)   : {0}" -f (Format-Snap $control))
+Write-Host ("after uninstall (50)    : {0}" -f (Format-Snap $afterVelo))
+Write-Host ("after AEB restart (70)  : {0}" -f (Format-Snap $afterAeb))
 Write-Host ''
 
-# The "before uninstall" reference is the stream-forced snapshot (the endpoint
-# was actively carrying the EQ APO chain). Fall back to apo-applied if the
-# stream-force phase was skipped (best-effort, per the workflow note).
-$before = if ($null -ne $streamed) { $streamed } else { $applied }
+# The "before uninstall" reference is the LATEST pre-uninstall snapshot that is
+# definitively Active with the EQ APO live. Prefer the control (45, closest to
+# the uninstall and proves the endpoint survived an AudioSrv restart), then the
+# stream-forced (35), then apo-applied (30). This avoids the run-3 false
+# negative where the stream-forced snapshot transiently ENUM_FAILED.
+$before = $null
+foreach ($cand in @($control, $streamed, $applied)) {
+    if ($null -ne $cand -and (Get-EndpointActivity $cand) -eq 'Active' -and $cand.screamFxPointsAtEq) { $before = $cand; break }
+}
 if ($null -eq $before) {
-    Write-Error 'No pre-uninstall snapshot (35-stream-forced / 30-apo-applied) found; cannot diagnose.'
+    # None was definitively Active+EQ-live; keep any non-null pre-uninstall
+    # snapshot so the verdict can explain why the precondition was not met.
+    $before = ($control, $streamed, $applied | Where-Object { $_ } | Select-Object -First 1)
+}
+if ($null -eq $before) {
+    Write-Error 'No pre-uninstall snapshot (45/35/30) found; cannot diagnose.'
     exit 3
 }
 if ($null -eq $afterVelo) {
@@ -177,6 +189,7 @@ if ($null -eq $afterVelo) {
 }
 
 $beforeState    = Get-EndpointActivity $before
+$controlState   = Get-EndpointActivity $control
 $afterVeloState = Get-EndpointActivity $afterVelo
 $afterAebState  = Get-EndpointActivity $afterAeb
 
@@ -199,6 +212,12 @@ $verdicts = New-Object System.Collections.Generic.List[string]
 $reproduced   = ($beforeState -eq 'Active' -and $afterVeloState -eq 'Inactive')
 $fixValidated = ($reproduced -and $afterAebState -eq 'Active')
 
+# CONTROL: an AudioSrv-only restart with the EQ APO STILL installed must leave
+# the endpoint Active. If it goes Inactive, the AudioSrv restart itself disrupts
+# the endpoint and the post-uninstall loss cannot be cleanly attributed to the
+# APO removal -> confounded. ('Unknown' weakens isolation but does not confound.)
+$controlConfounded = ($controlState -eq 'Inactive')
+
 $inconclusive = $false
 if (-not $eqWasApplied) {
     $verdicts.Add('SETUP INVALID: the EQ APO was not actually applied to the Scream endpoint before the uninstall (screamFxPointsAtEq=False at the pre-uninstall snapshot). The bug precondition was never established; inspect step 30. This is a harness problem, not a property of the audio code.')
@@ -206,7 +225,11 @@ if (-not $eqWasApplied) {
 }
 elseif ($beforeState -ne 'Active') {
     $verdicts.Add("PRECONDITION NOT MET: the Scream endpoint was not confirmed Active before the uninstall (state=$beforeState). " +
-        "If 'Unknown', the COM enumerator failed even after retries; if 'Inactive', Scream did not stay active. Inspect 30/35 snapshots.")
+        "If 'Unknown', the COM enumerator failed even after retries; if 'Inactive', Scream did not stay active. Inspect 30/35/45 snapshots.")
+    $inconclusive = $true
+}
+elseif ($controlConfounded) {
+    $verdicts.Add("CONTROL FAILED (confounded): an AudioSrv-only restart with the EQ APO still installed ALSO made the endpoint inactive (control state=$controlState). The AudioSrv restart itself disrupts the Scream endpoint on this runner, so the post-uninstall loss cannot be cleanly attributed to the APO removal. Inspect the 45-control snapshot.")
     $inconclusive = $true
 }
 elseif ($afterVeloState -eq 'Unknown') {
@@ -215,6 +238,12 @@ elseif ($afterVeloState -eq 'Unknown') {
 }
 elseif ($reproduced) {
     $verdicts.Add('(live) REPRODUCED: the Scream endpoint was ACTIVE (with the EQ APO live) before the uninstall and went INACTIVE/missing immediately after the AudioSrv-only uninstall, WITHOUT a reboot.')
+    if ($controlState -eq 'Active') {
+        $verdicts.Add('  CONTROL PASSED: an AudioSrv-only restart with the EQ APO still installed kept the endpoint ACTIVE, so the AudioSrv restart by itself does not remove the endpoint. The loss is isolated to the APO removal leaving a stale endpoint graph.')
+    }
+    elseif ($controlState -eq 'Unknown') {
+        $verdicts.Add('  CONTROL INCONCLUSIVE: the control endpoint state could not be read (enumerator failed), so causal isolation is weaker this run; the registry-clean evidence below still holds.')
+    }
     if ($registryClean) {
         $verdicts.Add('  Registry is CLEAN after uninstall (original driver APO GUIDs restored, no EQ GUID dangling). The live loss is therefore the stale endpoint-graph bug: ApoRegistration::uninstall cycled only AudioSrv, never AudioEndpointBuilder.')
     }

--- a/.github/scripts/Hold-WasapiStream.ps1
+++ b/.github/scripts/Hold-WasapiStream.ps1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+    Holds a continuous WASAPI shared-mode render stream (silence) open on a given
+    audio endpoint for a fixed duration. Used by audio-live-repro.yml to keep
+    audiodg actively loading the endpoint's APO chain WHILE the uninstall removes
+    the EQ APO - the faithful "audio was in use during uninstall" scenario the
+    headless 1-second stream-force did not cover.
+
+.DESCRIPTION
+    Run as a detached background process (Start-Process pwsh -File ...). It opens
+    an IAudioClient on the endpoint id, gets an IAudioRenderClient, Start()s the
+    stream, then writes AUDCLNT_BUFFERFLAGS_SILENT buffers in a loop until the
+    duration elapses. The loop TOLERATES device-invalidation errors (it keeps the
+    process alive and counts them) so the process reliably spans the whole
+    uninstall window and remains killable by the workflow; an error count > 0 is
+    itself a signal that the endpoint went away while the stream was live.
+
+    The endpoint id is the "{0.0.0.00000000}.<guid>" form (the IMMDevice id).
+
+.PARAMETER ScreamId
+    The IMMDevice id of the render endpoint, e.g. "{0.0.0.00000000}.{<guid>}".
+
+.PARAMETER Seconds
+    How long to hold the stream. The workflow kills the process earlier once the
+    post-uninstall snapshot is taken; this is just an upper bound.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$ScreamId,
+    [Parameter(Mandatory = $true)][int]$Seconds
+)
+$ErrorActionPreference = "Stop"
+
+Add-Type -Language CSharp -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+public static class WasapiHold {
+    [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumerator {}
+    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IMMDeviceEnumerator {
+        int EnumAudioEndpoints(int f, int m, out IntPtr c);
+        int GetDefaultAudioEndpoint(int f, int r, out IMMDevice ep);
+        int GetDevice([MarshalAs(UnmanagedType.LPWStr)] string id, out IMMDevice dev);
+    }
+    [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IMMDevice {
+        int Activate(ref Guid id, int ctx, IntPtr p, [MarshalAs(UnmanagedType.IUnknown)] out object o);
+        int OpenPropertyStore(int a, out IntPtr s);
+        int GetId([MarshalAs(UnmanagedType.LPWStr)] out string id);
+        int GetState(out int st);
+    }
+    [Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IAudioClient {
+        int Initialize(int share, int flags, long buf, long period, IntPtr fmt, IntPtr guid);
+        int GetBufferSize(out uint frames);
+        int GetStreamLatency(out long l);
+        int GetCurrentPadding(out uint p);
+        int IsFormatSupported(int share, IntPtr fmt, out IntPtr closest);
+        int GetMixFormat(out IntPtr fmt);
+        int GetDevicePeriod(out long def, out long min);
+        int Start();
+        int Stop();
+        int Reset();
+        int SetEventHandle(IntPtr h);
+        int GetService(ref Guid iid, [MarshalAs(UnmanagedType.IUnknown)] out object svc);
+    }
+    [Guid("F294ACFC-3146-4483-A7BF-ADDCA7C260E2"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IAudioRenderClient {
+        int GetBuffer(int numFrames, out IntPtr data);
+        int ReleaseBuffer(int numFrames, int flags);
+    }
+    const int CLSCTX_ALL = 0x17;
+    const int AUDCLNT_SHAREMODE_SHARED = 0;
+    const int AUDCLNT_BUFFERFLAGS_SILENT = 0x2;
+    static Guid IID_IAudioClient = new Guid("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2");
+    static Guid IID_IAudioRenderClient = new Guid("F294ACFC-3146-4483-A7BF-ADDCA7C260E2");
+    public static string Run(string id, int seconds) {
+        IMMDeviceEnumerator e = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+        IMMDevice dev;
+        int hr = e.GetDevice(id, out dev);
+        if (hr != 0 || dev == null) return "GetDevice failed 0x" + hr.ToString("X8");
+        object o;
+        hr = dev.Activate(ref IID_IAudioClient, CLSCTX_ALL, IntPtr.Zero, out o);
+        if (hr != 0 || o == null) return "Activate failed 0x" + hr.ToString("X8");
+        IAudioClient ac = (IAudioClient)o;
+        IntPtr fmt;
+        hr = ac.GetMixFormat(out fmt);
+        if (hr != 0) return "GetMixFormat failed 0x" + hr.ToString("X8");
+        // 1s buffer (10,000,000 x 100ns), shared mode.
+        hr = ac.Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 10000000, 0, fmt, IntPtr.Zero);
+        Marshal.FreeCoTaskMem(fmt);
+        if (hr != 0) return "Initialize failed 0x" + hr.ToString("X8");
+        uint bufFrames;
+        hr = ac.GetBufferSize(out bufFrames);
+        if (hr != 0) return "GetBufferSize failed 0x" + hr.ToString("X8");
+        object svc;
+        hr = ac.GetService(ref IID_IAudioRenderClient, out svc);
+        if (hr != 0 || svc == null) return "GetService(render) failed 0x" + hr.ToString("X8");
+        IAudioRenderClient rc = (IAudioRenderClient)svc;
+        IntPtr buf;
+        // Pre-roll a full buffer of silence, then Start so audiodg builds the chain.
+        if (rc.GetBuffer((int)bufFrames, out buf) == 0) { rc.ReleaseBuffer((int)bufFrames, AUDCLNT_BUFFERFLAGS_SILENT); }
+        hr = ac.Start();
+        if (hr != 0) return "Start failed 0x" + hr.ToString("X8");
+        DateTime end = DateTime.UtcNow.AddSeconds(seconds);
+        int errors = 0;
+        while (DateTime.UtcNow < end) {
+            try {
+                uint pad;
+                int phr = ac.GetCurrentPadding(out pad);
+                if (phr == 0) {
+                    int avail = (int)bufFrames - (int)pad;
+                    if (avail > 0 && rc.GetBuffer(avail, out buf) == 0) {
+                        rc.ReleaseBuffer(avail, AUDCLNT_BUFFERFLAGS_SILENT);
+                    }
+                } else {
+                    errors++;   // device likely invalidated (e.g. service cycle); keep the process alive
+                }
+            } catch {
+                errors++;
+            }
+            Thread.Sleep(10);
+        }
+        try { ac.Stop(); } catch {}
+        return "done (errors=" + errors + ")";
+    }
+}
+"@
+
+Write-Host "Holding WASAPI silence on $ScreamId for $Seconds s"
+$r = [WasapiHold]::Run($ScreamId, $Seconds)
+Write-Host "WasapiHold result: $r"

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -76,6 +76,14 @@ on:
         description: "Release tag to test (blank = latest)"
         required: false
         default: ""
+      mode:
+        description: "reproduce = prove the bug on an unfixed build; expect-fixed = verify a fixed release keeps the endpoint ACTIVE through the uninstall"
+        required: false
+        type: choice
+        options:
+          - reproduce
+          - expect-fixed
+        default: reproduce
 
 permissions:
   contents: read
@@ -1004,7 +1012,10 @@ jobs:
         if: always()
         shell: pwsh
         run: |
+          $mode = "${{ github.event.inputs.mode }}"
+          if ([string]::IsNullOrWhiteSpace($mode)) { $mode = "reproduce" }
           & "$env:GITHUB_WORKSPACE\.github\scripts\Diagnose-LiveEndpoint.ps1" `
               -SnapshotDir $env:SNAP_DIR `
               -PreMixGuid $env:EQ_PREMIX_GUID `
-              -PostMixGuid $env:EQ_POSTMIX_GUID
+              -PostMixGuid $env:EQ_POSTMIX_GUID `
+              -Mode $mode

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -405,22 +405,39 @@ jobs:
           }
           "@
 
+          # Retry the enumerator until it is HEALTHY. Right after a WASAPI Stop()
+          # or a service restart the COM layer can throw transiently (the first
+          # run saw activeRender=-1 at one phase even though the same call worked
+          # seconds earlier). Treating that transient throw as "endpoint gone"
+          # was a false negative. So we poll ActiveRenderCount until it returns a
+          # non-negative count (enumerator healthy) and only THEN read the
+          # endpoint state, so a -1 from EndpointState genuinely means not-found.
           $activeRenderCount = -1
-          try { $activeRenderCount = [MMLive]::ActiveRenderCount() } catch { }
+          $enumHealthy = $false
+          for ($attempt = 0; $attempt -lt 10; $attempt++) {
+              try { $activeRenderCount = [MMLive]::ActiveRenderCount(); $enumHealthy = $true; break }
+              catch { Start-Sleep -Milliseconds 1000 }
+          }
 
           # IMMDevice ids for render endpoints are "{0.0.0.00000000}.<guid>"
           # (DeviceAPOInfo.Uninstall.cpp:208). Map the GetState bitmask to a label.
           $screamId = "{0.0.0.00000000}.$ScreamGuid"
           $stateBits = -1
-          try { $stateBits = [MMLive]::EndpointState($screamId) } catch { }
-          $screamEndpointState = switch ($stateBits) {
-              1   { 'ACTIVE' }
-              2   { 'DISABLED' }
-              4   { 'NOTPRESENT' }
-              8   { 'UNPLUGGED' }
-              -1  { 'NOTFOUND' }
-              default { "OTHER($stateBits)" }
+          if ($enumHealthy) {
+              try { $stateBits = [MMLive]::EndpointState($screamId) } catch { $stateBits = -1 }
           }
+          $screamEndpointState =
+              if (-not $enumHealthy) { 'ENUM_FAILED' }   # transient COM failure, NOT a device-loss signal
+              else {
+                  switch ($stateBits) {
+                      1   { 'ACTIVE' }
+                      2   { 'DISABLED' }
+                      4   { 'NOTPRESENT' }
+                      8   { 'UNPLUGGED' }
+                      -1  { 'NOTFOUND' }
+                      default { "OTHER($stateBits)" }
+                  }
+              }
 
           # Win32_SoundDevice status strings (coarse OS-level view).
           $win32 = @()
@@ -562,23 +579,34 @@ jobs:
           $fxPath = "$epPath\FxProperties"
           $childGuidPath = "$env:CHILD_APO_ROOT\$env:SCREAM_GUID"
 
-          # --- Take ownership of Render + grant Administrators FullControl -----
-          # (reused verbatim from audio-uninstall-repro.yml's seed preamble)
+          # --- Take ownership + grant Administrators FullControl ----------------
+          # The REAL Scream endpoint subkey under Render is SYSTEM-owned with its
+          # own DACL. Granting on the PARENT Render key does NOT propagate write
+          # access to a pre-existing child: the first attempt hit "Access is
+          # denied" on every FxProperties write. (The fake-seed sibling workflow
+          # never saw this because it CREATED its seed key and thus owned it.) So
+          # take ownership of the SPECIFIC endpoint subkey, and of its
+          # FxProperties subkey too when it already exists, with ContainerInherit
+          # so the FxProperties key we create next inherits FullControl.
           Add-Type -Namespace Win32Acl -Name Priv -MemberDefinition '[System.Runtime.InteropServices.DllImport("ntdll.dll")] public static extern int RtlAdjustPrivilege(int Privilege, bool Enable, bool CurrentThread, out bool Enabled);'
           $enabled = $false
           [Win32Acl.Priv]::RtlAdjustPrivilege(9,  $true, $false, [ref]$enabled) | Out-Null   # SeTakeOwnershipPrivilege
           [Win32Acl.Priv]::RtlAdjustPrivilege(18, $true, $false, [ref]$enabled) | Out-Null   # SeRestorePrivilege
-          $renderSub = "SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render"
           $admins = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
-          $k = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($renderSub, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::TakeOwnership)
-          if ($null -eq $k) { Write-Error "Could not open $renderSub to take ownership"; exit 1 }
-          $ownAcl = $k.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Owner)
-          $ownAcl.SetOwner($admins); $k.SetAccessControl($ownAcl); $k.Close()
-          $k = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($renderSub, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::ChangePermissions)
-          $dacl = $k.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Access)
-          $rule = New-Object System.Security.AccessControl.RegistryAccessRule($admins, [System.Security.AccessControl.RegistryRights]::FullControl, ([System.Security.AccessControl.InheritanceFlags]::ContainerInherit), [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
-          $dacl.AddAccessRule($rule); $k.SetAccessControl($dacl); $k.Close()
-          Write-Host "Took ownership of and granted Administrators FullControl on HKLM\$renderSub"
+          function Grant-AdminsFullControl([string]$subPath) {
+              $k = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($subPath, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::TakeOwnership)
+              if ($null -eq $k) { Write-Error "Could not open HKLM\$subPath to take ownership"; exit 1 }
+              $ownAcl = $k.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Owner)
+              $ownAcl.SetOwner($admins); $k.SetAccessControl($ownAcl); $k.Close()
+              $k = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($subPath, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::ChangePermissions)
+              $dacl = $k.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Access)
+              $rule = New-Object System.Security.AccessControl.RegistryAccessRule($admins, [System.Security.AccessControl.RegistryRights]::FullControl, ([System.Security.AccessControl.InheritanceFlags]::ContainerInherit), [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
+              $dacl.AddAccessRule($rule); $k.SetAccessControl($dacl); $k.Close()
+              Write-Host "Took ownership of and granted Administrators FullControl on HKLM\$subPath"
+          }
+          $epSub = "SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Render\$env:SCREAM_GUID"
+          Grant-AdminsFullControl $epSub
+          if (Test-Path "Registry::HKEY_LOCAL_MACHINE\$epSub\FxProperties") { Grant-AdminsFullControl "$epSub\FxProperties" }
 
           # Child APOs root + per-device key (Install.cpp:71-72).
           reg add $env:CHILD_APO_ROOT /f | Out-Null
@@ -626,11 +654,24 @@ jobs:
           # INSTALL_LFX_GFX: EQ pre-mix into LFX (,1), EQ post-mix into GFX (,2),
           # delete SFX/MFX/EFX (Install.cpp:144-156).
           reg add $fxPath /v "$env:FX_LFX" /t REG_SZ /d "$env:EQ_PREMIX_GUID" /f | Out-Null
+          if ($LASTEXITCODE -ne 0) { Write-Error "reg add LFX failed ($LASTEXITCODE) - FxProperties not writable"; exit 1 }
           reg add $fxPath /v "$env:FX_GFX" /t REG_SZ /d "$env:EQ_POSTMIX_GUID" /f | Out-Null
+          if ($LASTEXITCODE -ne 0) { Write-Error "reg add GFX failed ($LASTEXITCODE) - FxProperties not writable"; exit 1 }
           foreach ($vn in @($env:FX_SFX, $env:FX_MFX, $env:FX_EFX)) {
               reg delete $fxPath /v "$vn" /f 2>$null | Out-Null
           }
-          Write-Host "Applied EQ APO to Scream endpoint: LFX=$env:EQ_PREMIX_GUID GFX=$env:EQ_POSTMIX_GUID"
+
+          # Read the EQ GUIDs back to PROVE the write landed (the previous run
+          # printed "Applied" unconditionally while every write was access-denied).
+          function Test-FxPointsAtEq {
+              $p = "$renderReg\$env:SCREAM_GUID\FxProperties"
+              if (-not (Test-Path $p)) { return $false }
+              $lfx = [string](Get-ItemProperty -Path $p -Name $env:FX_LFX -ErrorAction SilentlyContinue)."$($env:FX_LFX)"
+              $gfx = [string](Get-ItemProperty -Path $p -Name $env:FX_GFX -ErrorAction SilentlyContinue)."$($env:FX_GFX)"
+              return ($lfx -eq $env:EQ_PREMIX_GUID -and $gfx -eq $env:EQ_POSTMIX_GUID)
+          }
+          if (-not (Test-FxPointsAtEq)) { Write-Error "FxProperties does not point at the EQ APO after writing; setup failed"; exit 1 }
+          Write-Host "Verified: Scream FxProperties now points at the EQ APO (LFX/GFX written)"
 
           # Re-cycle AudioEndpointBuilder so the freshly-written FxProperties are
           # read into the live graph (the GUI install triggers a comparable
@@ -638,6 +679,12 @@ jobs:
           # under test (the uninstall step never does this).
           Restart-Service -Force AudioEndpointBuilder
           Start-Sleep -Seconds 3
+
+          # Confirm the AEB restart did NOT strip the FxProperties we wrote (a
+          # driver endpoint keeps its FxProperties across an AEB restart - that is
+          # exactly how EqualizerAPO normally takes effect).
+          if (-not (Test-FxPointsAtEq)) { Write-Error "FxProperties lost the EQ APO after the AudioEndpointBuilder restart; setup failed"; exit 1 }
+          Write-Host "Verified after AEB restart: Scream FxProperties still points at the EQ APO"
 
           & $env:SNAP_SCRIPT -Phase "30-apo-applied" -SnapshotDir $env:SNAP_DIR `
               -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -788,6 +788,12 @@ jobs:
                   if (hr != 0) return "Start failed hr=0x" + hr.ToString("X8");
                   Thread.Sleep(ms);
                   ac.Stop();
+                  // Release the COM objects so the WASAPI session closes promptly;
+                  // a lingering client kept the enumerator unstable for the next
+                  // snapshot in the previous run.
+                  try { Marshal.ReleaseComObject(ac); } catch {}
+                  try { Marshal.ReleaseComObject(dev); } catch {}
+                  try { Marshal.ReleaseComObject(e); } catch {}
                   return "OK (streamed " + ms + "ms)";
               }
           }
@@ -800,8 +806,44 @@ jobs:
               Write-Warning "Stream-force threw (best effort, continuing): $($_.Exception.Message)"
           }
 
+          # Release lingering RCWs and let THIS process end before snapshotting.
+          # In run 3 the snapshot ran in the same process right after the stream
+          # and the enumerator stayed unhealthy for >10s (ENUM_FAILED). The
+          # snapshot now lives in its own step (own process), so the WASAPI
+          # session is fully torn down first.
+          [System.GC]::Collect(); [System.GC]::WaitForPendingFinalizers()
           Start-Sleep -Seconds 2
+
+      # -----------------------------------------------------------------------
+      # Snapshot the "endpoint ACTIVE + EQ APO live" reference in a FRESH process
+      # so the WASAPI session from the stream-force is fully gone and the COM
+      # enumerator is healthy. This is the pre-uninstall reference.
+      # -----------------------------------------------------------------------
+      - name: Snapshot stream-forced (37)
+        shell: pwsh
+        run: |
+          Start-Sleep -Seconds 3
           & $env:SNAP_SCRIPT -Phase "35-stream-forced" -SnapshotDir $env:SNAP_DIR `
+              -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
+              -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+      # -----------------------------------------------------------------------
+      # CONTROL: restart AudioSrv ONLY (not AudioEndpointBuilder) while the EQ
+      # APO is STILL installed and the endpoint is active. This isolates cause:
+      # ApoRegistration's AudioSrv-only cycle, on its own, must NOT make the
+      # endpoint disappear. If this snapshot is still ACTIVE, the loss seen after
+      # the real uninstall (step 50) is due to the APO REMOVAL leaving a stale
+      # endpoint graph, not the AudioSrv restart per se. (Restart-Service AudioSrv
+      # cycles AudioSrv + its dependents, never the parent AudioEndpointBuilder.)
+      # -----------------------------------------------------------------------
+      - name: Control - AudioSrv-only restart with EQ installed + snapshot (45)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          Write-Host "CONTROL: Restart-Service AudioSrv -Force (EQ APO still installed; AudioEndpointBuilder NOT cycled)"
+          try { Restart-Service AudioSrv -Force -ErrorAction Stop } catch { Write-Warning "Restart AudioSrv: $($_.Exception.Message)" }
+          Start-Sleep -Seconds 6
+          & $env:SNAP_SCRIPT -Phase "45-control" -SnapshotDir $env:SNAP_DIR `
               -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
               -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
 

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -848,6 +848,42 @@ jobs:
               -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
 
       # -----------------------------------------------------------------------
+      # PERSISTENT STREAM: hold a continuous WASAPI silence stream OPEN on the
+      # Scream endpoint, in a detached background process, so audiodg is ACTIVELY
+      # loading the EQ APO chain while the uninstall removes it. The headless
+      # 1-second stream-force (step 35) ended long before the uninstall, so run 4
+      # removed the APO with no consumer attached and the endpoint survived. The
+      # user's real machine had audio IN USE across the uninstall - this step
+      # reproduces that condition. The process tolerates device-invalidation
+      # (keeps running) so it spans the whole uninstall window and is killed after
+      # the post-uninstall snapshot.
+      # -----------------------------------------------------------------------
+      - name: Start persistent WASAPI stream on Scream (47)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $screamId = "{0.0.0.00000000}.$env:SCREAM_GUID"
+          $hold = Join-Path $env:GITHUB_WORKSPACE ".github\scripts\Hold-WasapiStream.ps1"
+          $outLog = Join-Path $env:SNAP_DIR "persistent-stream.out.log"
+          $errLog = Join-Path $env:SNAP_DIR "persistent-stream.err.log"
+          Write-Host "Launching persistent silence stream (held across the uninstall) on $screamId"
+          $proc = Start-Process pwsh `
+              -ArgumentList "-NoProfile","-ExecutionPolicy","Bypass","-File",$hold,"-ScreamId",$screamId,"-Seconds","240" `
+              -PassThru -WindowStyle Hidden `
+              -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+          "STREAM_PID=$($proc.Id)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # Give it a few seconds to open the stream + build the chain, then make
+          # sure it did not die immediately.
+          Start-Sleep -Seconds 6
+          if ($proc.HasExited) {
+              Write-Warning "Persistent stream exited early (code $($proc.ExitCode)); see logs below"
+              if (Test-Path $outLog) { Get-Content $outLog | ForEach-Object { Write-Host "  out: $_" } }
+              if (Test-Path $errLog) { Get-Content $errLog | ForEach-Object { Write-Host "  err: $_" } }
+          } else {
+              Write-Host "Persistent stream running as PID $($proc.Id)"
+          }
+
+      # -----------------------------------------------------------------------
       # STEP 6a: Run the real per-device uninstall via DeviceSelector.exe /u.
       #   load() detects the Scream endpoint as installed (FxProperties names an
       #   EQ GUID), reads originals back from Child APOs\{guid}, and uninstall
@@ -902,11 +938,25 @@ jobs:
           }
 
           # Brief settle so AudioSrv-only restart finishes; then snapshot the
-          # post-uninstall state. NO reboot - this is the whole point.
+          # post-uninstall state. NO reboot - this is the whole point. The
+          # persistent stream is STILL running here (audiodg held the chain across
+          # the removal), which is the faithful "audio in use during uninstall".
           Start-Sleep -Seconds 5
           & $env:SNAP_SCRIPT -Phase "50-after-velo" -SnapshotDir $env:SNAP_DIR `
               -ScreamGuid $env:SCREAM_GUID -MMDevicesRoot $env:MMDEVICES_ROOT `
               -PreMixGuid $env:EQ_PREMIX_GUID -PostMixGuid $env:EQ_POSTMIX_GUID
+
+          # Report whether the persistent stream survived the uninstall (a stream
+          # that died is itself a sign the endpoint was invalidated), then stop it.
+          if ($env:STREAM_PID) {
+              $sp = Get-Process -Id ([int]$env:STREAM_PID) -ErrorAction SilentlyContinue
+              if ($null -eq $sp) { Write-Host "Persistent stream process already exited before snapshot (endpoint likely invalidated)" }
+              else { Write-Host "Persistent stream still alive (PID $env:STREAM_PID); stopping it"; try { Stop-Process -Id ([int]$env:STREAM_PID) -Force -ErrorAction Stop } catch {} }
+          }
+          $psOut = Join-Path $env:SNAP_DIR "persistent-stream.out.log"
+          if (Test-Path $psOut) { Write-Host "--- persistent-stream.out.log ---"; Get-Content $psOut | ForEach-Object { Write-Host "  $_" } }
+          $psErr = Join-Path $env:SNAP_DIR "persistent-stream.err.log"
+          if ((Test-Path $psErr) -and (Get-Item $psErr).Length -gt 0) { Write-Host "--- persistent-stream.err.log ---"; Get-Content $psErr | ForEach-Object { Write-Host "  $_" } }
 
       # -----------------------------------------------------------------------
       # STEP 7: Validate the fix candidate, still WITHOUT rebooting.

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -159,44 +159,67 @@ jobs:
           Invoke-WebRequest -Uri $env:SCREAM_URL -OutFile $zip
           Expand-Archive -Path $zip -DestinationPath $work -Force
 
-          $driverDir = Join-Path $work "Scream\Install\driver\x64"
+          # Scream4.0.zip extracts to <work>\Install\... (NOT <work>\Scream\Install).
+          # The x64 catalog is lower-case scream.cat (Scream.inf names it as
+          # CatalogFile=scream.cat). Windows paths are case-insensitive, but we
+          # spell it exactly so the layout assertion is unambiguous.
+          $driverDir = Join-Path $work "Install\driver\x64"
           $inf = Join-Path $driverDir "Scream.inf"
-          $cat = Join-Path $driverDir "Scream.cat"
-          $devcon = Join-Path $work "Scream\Install\helpers\devcon-x64.exe"
+          $cat = Join-Path $driverDir "scream.cat"
+          $devcon = Join-Path $work "Install\helpers\devcon-x64.exe"
           foreach ($f in @($inf, $cat, $devcon)) {
               if (-not (Test-Path $f)) { Log "MISSING expected file: $f"; throw "Scream layout unexpected: $f not found" }
           }
 
-          # --- Self-signed code-signing cert ----------------------------------
-          $pvk = Join-Path $work "ScreamCertificate.pvk"
-          $cer = Join-Path $work "ScreamCertificate.cer"
-          $pfx = Join-Path $work "ScreamCertificate.pfx"
-          Log "Generating self-signed certificate with openssl"
-          & openssl req -batch -x509 -newkey rsa -keyout $pvk -out $cer -nodes -extensions v3_req
-          if ($LASTEXITCODE -ne 0) { throw "openssl req failed ($LASTEXITCODE)" }
-          & openssl pkcs12 -export -nodes -in $cer -inkey $pvk -out $pfx -passout pass:
-          if ($LASTEXITCODE -ne 0) { throw "openssl pkcs12 failed ($LASTEXITCODE)" }
+          # --- Self-signed code-signing cert (PowerShell-native) --------------
+          # New-SelfSignedCertificate -Type CodeSigningCert guarantees the
+          # codeSigning EKU, so the re-signed catalog is a valid driver-package
+          # signature once the cert is trusted. We re-sign the EXISTING catalog:
+          # its embedded hashes for Scream.sys/.inf stay valid (we do not touch
+          # those files); we only add a signature that chains to a root we trust
+          # below. This avoids any openssl.cnf / EKU uncertainty.
+          Log "Creating a self-signed code-signing certificate"
+          $cert = New-SelfSignedCertificate -Type CodeSigningCert `
+              -Subject "CN=EqualizerAPO-XT Scream Test Signing" `
+              -CertStoreLocation Cert:\CurrentUser\My `
+              -KeyUsage DigitalSignature -KeyExportPolicy Exportable
+          $cer = Join-Path $work "ScreamTestSigning.cer"
+          Export-Certificate -Cert $cert -FilePath $cer | Out-Null
 
           # --- Sign the catalog so the INF install trusts the package ----------
-          Log "Signing Scream.cat"
-          & signtool sign /v /fd SHA256 /f $pfx $cat
+          Log "Signing $cat with thumbprint $($cert.Thumbprint)"
+          & signtool sign /v /fd SHA256 /sha1 $cert.Thumbprint $cat
           if ($LASTEXITCODE -ne 0) { throw "signtool sign failed ($LASTEXITCODE)" }
 
-          # --- Trust the cert: root (chain) + TrustedPublisher (silent install)
-          Log "Importing the cert into LocalMachine\root and LocalMachine\TrustedPublisher"
-          Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\root | Out-Null
+          # --- Trust the cert: Root (chain) + TrustedPublisher (silent install)
+          Log "Importing the cert into LocalMachine\Root and LocalMachine\TrustedPublisher"
+          Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
           Import-Certificate -FilePath $cer -CertStoreLocation Cert:\LocalMachine\TrustedPublisher | Out-Null
 
           # --- Install the driver via the bundled devcon ----------------------
-          Log "Installing the driver: devcon install Scream.inf *Scream"
-          & $devcon install $inf "*Scream"
-          $devconRc = $LASTEXITCODE
+          # Mirror Install-x64.bat exactly: cd driver\x64 ; devcon install
+          # Scream.inf *Scream (devcon resolves the catalog relative to the INF).
+          Log "Installing the driver: devcon install Scream.inf *Scream (cwd=$driverDir)"
+          Push-Location $driverDir
+          try {
+              & $devcon install "Scream.inf" "*Scream"
+              $devconRc = $LASTEXITCODE
+          } finally {
+              Pop-Location
+          }
           Log "devcon exited with $devconRc"
 
           # --- Make sure the audio services are up after the device add --------
+          # Start them, then force an AudioEndpointBuilder restart so the freshly
+          # installed Scream device is enumerated into the live endpoint graph
+          # (this is SETUP, not the bug under test - the uninstall is what must
+          # never restart AudioEndpointBuilder).
           Log "Ensuring AudioEndpointBuilder + AudioSrv are running"
           try { Start-Service AudioEndpointBuilder -ErrorAction Stop } catch { Log "Start AudioEndpointBuilder: $($_.Exception.Message)" }
           cmd /c "net start audiosrv" 2>&1 | ForEach-Object { Log $_ }
+          Log "Forcing AudioEndpointBuilder restart to enumerate the new device"
+          try { Restart-Service -Force AudioEndpointBuilder -ErrorAction Stop } catch { Log "Restart AudioEndpointBuilder: $($_.Exception.Message)" }
+          try { Start-Service AudioSrv -ErrorAction Stop } catch { Log "Start AudioSrv: $($_.Exception.Message)" }
 
           # Give the endpoint graph a moment to enumerate the new device.
           $deadline = (Get-Date).AddSeconds(30)

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,18 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- 제거 시 모든 오디오 장치가 사라져 재부팅해야 복구되던 치명적 버그를
+  고쳤습니다. 제거 과정이 Windows Audio 서비스만 재시작해, Windows Audio
+  Endpoint Builder가 방금 제거된 APO를 가리키는 낡은 엔드포인트 그래프를 그대로
+  들고 있었습니다. 그래서 사용 중이던 장치가 재부팅으로 그래프를 다시 만들기
+  전까지 쓸 수 없었습니다(레지스트리는 이미 깨끗했고, 원래 드라이버 효과가
+  복원돼 있었습니다). 이제 제거 시 Windows Audio Endpoint Builder를 재시작해
+  라이브 그래프를 재구성하므로 오디오 장치가 사라지지 않습니다. dispatch 전용 CI
+  워크플로우가 오디오를 재생 중인 실제 가상 엔드포인트에서 이를 재현하고 수정을
+  검증합니다. ([#105])
+
 ## v1.27.1 (2026-06-13)
 
 - 시작 시 드물게 나던 크래시를 고쳤습니다. 구버전에서 저장한 설정을 열 때,
@@ -395,3 +407,5 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#85]: https://github.com/115dkk/EqualizerAPO-XT/pull/85
 [#88]: https://github.com/115dkk/EqualizerAPO-XT/pull/88
 [#94]: https://github.com/115dkk/EqualizerAPO-XT/pull/94
+[#98]: https://github.com/115dkk/EqualizerAPO-XT/pull/98
+[#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- Fixed a critical bug where uninstalling EqualizerAPO-XT could make all audio
+  devices disappear from Windows until a reboot. The uninstaller restarted only
+  the Windows Audio service, which left Windows Audio Endpoint Builder holding a
+  stale endpoint graph that still referenced the just-removed APO, so an in-use
+  endpoint became unusable until a reboot rebuilt the graph (the registry was
+  already clean - the original driver effects were restored). The uninstaller
+  now restarts Windows Audio Endpoint Builder to rebuild the live graph, so
+  audio devices are no longer lost. A dispatch-only CI workflow reproduces this
+  on a real virtual endpoint with audio in use and validates the fix. ([#105])
+
 ## v1.27.1 — 2026-06-13
 
 - Fixed a flaky start-up crash that could hit configs opened from an older
@@ -420,3 +432,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#88]: https://github.com/115dkk/EqualizerAPO-XT/pull/88
 [#94]: https://github.com/115dkk/EqualizerAPO-XT/pull/94
 [#98]: https://github.com/115dkk/EqualizerAPO-XT/pull/98
+[#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105

--- a/helpers/ApoRegistration.cpp
+++ b/helpers/ApoRegistration.cpp
@@ -42,6 +42,7 @@ namespace
 constexpr wchar_t kRegPath[] = L"HKEY_LOCAL_MACHINE\\SOFTWARE\\EqualizerAPO";
 constexpr wchar_t kAudioRegPath[] = L"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Audio";
 constexpr wchar_t kAudioServiceName[] = L"AudioSrv";
+constexpr wchar_t kAudioEndpointBuilderServiceName[] = L"AudioEndpointBuilder";
 
 std::wstring systemPath()
 {
@@ -307,7 +308,39 @@ ApoRegistration::Result ApoRegistration::uninstall(const std::wstring& installDi
 		logLine(L"WARN", L"Failed to remove start menu shortcuts");
 
 	if (serviceWasRunning)
+	{
+		// Force a LIVE endpoint-graph rebuild, then bring AudioSrv back.
+		//
+		// Restarting only AudioSrv (Windows Audio) is not enough to apply an APO
+		// removal: AudioEndpointBuilder - the service AudioSrv depends on, which
+		// enumerates endpoints and reads FxProperties to build the APO chain -
+		// keeps its stale in-memory graph that still references the just-removed
+		// APO. While audio is in use, the affected endpoint then becomes unusable
+		// and vanishes from Windows until a reboot rebuilds the graph (users hit
+		// this as "all my audio devices disappeared after uninstalling"). This was
+		// reproduced on a live virtual (Scream) endpoint with audio in use: after
+		// an AudioSrv-only uninstall the endpoint went missing, and only an
+		// AudioEndpointBuilder restart - or a reboot - brought it back, even
+		// though the registry was already clean.
+		//
+		// AudioSrv was stopped above, so restart AudioEndpointBuilder FIRST while
+		// AudioSrv is cleanly stopped: AEB rebuilds the graph from the now-clean
+		// registry, and we then start AudioSrv on top of the rebuilt graph. Doing
+		// it in this order avoids a race where starting AudioSrv first leaves it in
+		// START_PENDING and the AEB-restart cascade tries to stop a still-starting
+		// service (which would abort the restart and leave the graph stale). If the
+		// AEB restart fails we still start AudioSrv so audio is not left down; a
+		// reboot would then be needed to fully apply the removal.
+		try
+		{
+			ServiceHelper::restartService(kAudioEndpointBuilderServiceName);
+		}
+		catch (const ServiceException& e)
+		{
+			logLine(L"WARN", L"Failed to restart AudioEndpointBuilder; a reboot may be needed to fully apply the removal: %s", e.getMessage().c_str());
+		}
 		startAudioService();
+	}
 
 	return deviceResult;
 }


### PR DESCRIPTION
## 무엇을 / 왜

EqualizerAPO-XT를 **제거하면 Windows 오디오 장치가 전부 사라지고 재부팅해야 복구**되는 치명 버그를 고칩니다. CI에서 실제 가상 엔드포인트(Scream)로 **실증**한 뒤 수정했습니다.

### 근본 원인 (CI 실증)

`helpers/ApoRegistration.cpp::uninstall`이 **AudioSrv(Windows Audio)만** 껐다 켭니다. FxProperties를 읽어 APO 체인을 만드는 부모 서비스 **AudioEndpointBuilder(AEB)는 재시작하지 않습니다**. 그래서 APO 제거 후(레지스트리는 원본 복원되어 깨끗) AudioSrv만 재시작하면 AEB의 메모리상 **낡은 엔드포인트 그래프**가 제거된 APO를 계속 참조 → 오디오 사용 중이면 해당 엔드포인트가 사용 불가가 되어 사라지고, **재부팅 전까지** 복구되지 않습니다. 레지스트리는 깨끗하므로 레지스트리 삭제가 아니라 stale 그래프 문제입니다. (Windows 통념 "APO 변경은 Windows Audio 재시작"은 부정확 — AEB를 돌려야 적용됩니다.)

### 수정

`uninstall()` 끝에서 기존 `ServiceHelper::restartService`로 **AudioEndpointBuilder를 재시작**(종속 서비스 연쇄 포함)해 깨끗해진 레지스트리로 라이브 그래프를 재구성한 뒤 AudioSrv를 올립니다. 순서가 중요합니다. AudioSrv를 **나중에** 올립니다 — 먼저 올리면 AudioSrv가 START_PENDING인 상태에서 AEB 재시작 연쇄가 "시작 중인 서비스"를 멈추려다 재시작 자체가 중단돼 그래프가 그대로 남는 경쟁 상태가 생깁니다. AEB 재시작이 실패하면 경고를 남기고 오디오는 다시 올립니다(이 경우 완전 적용에는 재부팅 필요).

범위는 **실증된 제거 경로로 한정**했습니다. DeviceSelector의 `DeviceTestThread`와 Velopack `veloapp-updated`/`veloapp-obsolete` 훅의 동일한 AudioSrv-only 패턴은 별도 평가 전까지 그대로 둡니다.

## 실증 (이 PR에 포함된 CI 하네스)

`workflow_dispatch` 전용 `audio-live-repro.yml`(windows-2022, 사용자 머신 절대 미실행)이 실제 Scream 엔드포인트에 EQ APO를 적용하고 **오디오를 제거 내내 재생**한 상태에서 측정합니다.

| 단계 | 엔드포인트 상태 | 레지스트리 |
|---|---|---|
| APO 적용 후 | ACTIVE | EQ 참조 |
| 대조군: AudioSrv만 재시작 | **ACTIVE** (AudioSrv 재시작 자체는 무해) | EQ 참조 |
| AudioSrv-only 제거 직후 (재부팅 없음) | **NOTFOUND** ← 버그 | 깨끗 |
| AudioEndpointBuilder 재시작 후 | **ACTIVE** ← 수정 | 깨끗 |

대조군이 통과하므로 소실의 원인은 AudioSrv 재시작이 아니라 **APO 제거 + stale 그래프**로 분리됩니다. 종료 코드 0 = 재현 + 수정 검증 성공.

함께 들어가는 하네스 보강(`audio-live-repro.yml`, `Diagnose-LiveEndpoint.ps1`, `Hold-WasapiStream.ps1`): Scream4.0.zip 레이아웃/소문자 cat 경로, `New-SelfSignedCertificate -Type CodeSigningCert` 자가서명, 실제 엔드포인트 서브키 소유권 취득, COM enumerator 재시도(transient ENUM_FAILED 구분), AudioSrv-only 대조군, 제거 내내 유지되는 지속 WASAPI 무음 스트림(헤드리스 재현에 필수).

## 검증

- `fix:`라 CI가 `version.h` REVISION을 올리고 전체 변형 빌드 + 릴리스를 만듭니다. 릴리스가 만들어지면 같은 `audio-live-repro.yml`을 새 릴리스 대상으로 재실행해 end-to-end(수정된 빌드에서 제거 후 엔드포인트 ACTIVE 유지)를 확인할 계획입니다.
- 로컬 `Common.vcxproj`(VS18) 빌드 통과.
- 적대적 코드 리뷰 4관점(서비스 수명주기/데드락, 예외 안전, 종속 연쇄 엣지케이스, 회귀/범위) 반영 — 특히 START_PENDING 경쟁을 없애도록 재시작 순서를 교정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
