### PR TITLE
fix: load the effect on modern Windows (APOInitSystemEffects2) and stop the skin-switch crash

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -17,6 +17,20 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
   라이브 그래프를 재구성하므로 오디오 장치가 사라지지 않습니다. dispatch 전용 CI
   워크플로우가 오디오를 재생 중인 실제 가상 엔드포인트에서 이를 재현하고 수정을
   검증합니다. ([#105])
+- 현재 Windows에서 시스템 효과가 실제로는 한 번도 로드되지 않아 EQ가 조용히 꺼져
+  있던 문제와, 일부 장치에서 Device Selector 설치 테스트가 `Initialize failed for
+  device "..." (매개변수가 틀립니다)`로 실패하던 문제를 고쳤습니다. APO가
+  `IAudioSystemEffects2`를 노출하기 시작하면서 오디오 엔진이 `Initialize`에 더 큰
+  `APOInitSystemEffects2` 구조체를 넘기는데, APO는 옛 `APOInitSystemEffects` 크기만
+  정확히 받아들여 모든 초기화를 `E_INVALIDARG`로 거부하고 로드 전에 빠져나왔습니다.
+  이제 더 큰 구조체를 받아들이므로(모든 `APOInitSystemEffects` 버전이 앞부분 필드를
+  공유) 효과가 다시 로드되어 오디오를 처리하고, 장치 테스트도 통과합니다. ([#107])
+- minimal·soft·rack 스킨으로 바꿀 때, 그리고 일반 재적용이나 다크 모드 토글에서
+  간헐적으로 Editor가 죽던 문제를 고쳤습니다. 스킨 전환은 속도를 위해 전역
+  스타일시트를 바꾸기 전에 필터 행을 먼저 철거하는데, 스타일시트가 유발한 재배치가
+  그리드 레이아웃이 잠깐 사라진 사이에 필터 테이블의 크기 힌트 갱신을 다시 호출해 널
+  포인터를 역참조했습니다. 이제 행을 다시 만드는 동안에는 갱신이 아무 일도 하지
+  않습니다. ([#107])
 
 ## v1.27.1 (2026-06-13)
 
@@ -409,3 +423,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#94]: https://github.com/115dkk/EqualizerAPO-XT/pull/94
 [#98]: https://github.com/115dkk/EqualizerAPO-XT/pull/98
 [#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105
+[#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
   now restarts Windows Audio Endpoint Builder to rebuild the live graph, so
   audio devices are no longer lost. A dispatch-only CI workflow reproduces this
   on a real virtual endpoint with audio in use and validates the fix. ([#105])
+- Fixed the system effect never actually loading on current Windows, which
+  left the EQ silently inactive and made the Device Selector install test fail
+  on some endpoints with `Initialize failed for device "..." (the parameter is
+  incorrect)`. Once the APO began exposing `IAudioSystemEffects2`, the audio
+  engine started passing `Initialize` the larger `APOInitSystemEffects2`
+  struct, but the APO still required the exact size of the base
+  `APOInitSystemEffects` and rejected every init with `E_INVALIDARG`, so it
+  bailed before loading. It now accepts the larger struct (all
+  `APOInitSystemEffects` versions share the same leading fields), so the effect
+  loads and processes audio again and the device test passes. ([#107])
+- Fixed the editor crashing when switching to the minimal, soft, or rack skin,
+  and intermittently on a plain restyle or dark-mode toggle. A skin switch
+  tears the filter rows down before swapping the global stylesheet for speed,
+  and the relayout the stylesheet triggers could re-enter the filter table's
+  size-hint update while its grid layout was momentarily gone, dereferencing a
+  null pointer. The update now does nothing while the rows are being
+  rebuilt. ([#107])
 
 ## v1.27.1 — 2026-06-13
 
@@ -433,3 +450,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#94]: https://github.com/115dkk/EqualizerAPO-XT/pull/94
 [#98]: https://github.com/115dkk/EqualizerAPO-XT/pull/98
 [#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105
+[#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -362,6 +362,15 @@ int FilterTable::getPreferredWidth()
 
 void FilterTable::updateSizeHints()
 {
+	// gridLayout is briefly null between clearRows() and updateGuis(): a skin
+	// switch (MainWindow::skinSelected) and the dark-mode toggle tear every tab's
+	// rows down BEFORE qApp->setStyleSheet for performance, and that stylesheet
+	// swap re-lays-out the window, delivering a scrollArea Resize through this
+	// object's event filter while the layout is gone. Dereferencing it here then
+	// faults (the minimal/soft/rack skin-switch crash, and the intermittent
+	// crash on a plain restyle). Nothing to size while the rows are being rebuilt.
+	if (gridLayout == nullptr)
+		return;
 	for (int i = 0; i < items.size(); i++)
 	{
 		QLayoutItem* layoutItem = gridLayout->itemAtPosition(i, 0);

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -198,13 +198,23 @@ HRESULT EqualizerAPO::Initialize(UINT32 cbDataSize, BYTE* pbyData)
 {
 	LogHelper::reset();
 
-	TraceF(L"Initialize");
+	TraceF(L"Initialize: cbDataSize=%u (APOInitSystemEffects=%u)", cbDataSize, static_cast<unsigned>(sizeof(APOInitSystemEffects)));
 
 	if ((nullptr == pbyData) && (0 != cbDataSize))
 		return E_INVALIDARG;
 	if ((nullptr != pbyData) && (0 == cbDataSize))
 		return E_POINTER;
-	if (cbDataSize != sizeof(APOInitSystemEffects))
+	// Since 64970cd this APO exposes IAudioSystemEffects2, so the audio engine
+	// hands Initialize the larger APOInitSystemEffects2 struct (and would hand a
+	// future IAudioSystemEffects3 build an APOInitSystemEffects3) rather than the
+	// base APOInitSystemEffects. Demanding the exact v1 size rejected every modern
+	// init with E_INVALIDARG, so the effect never actually loaded - the device
+	// test reported "Initialize failed ... (the parameter is incorrect)" and the
+	// EQ was silently inactive on endpoints whose effect slot does not tolerate a
+	// failing APO. Every APOInitSystemEffects* version shares the same leading
+	// members (APOInit, pAPOEndpointProperties, ...), so accept any struct at
+	// least the base size and keep reading those common fields below.
+	if (cbDataSize < sizeof(APOInitSystemEffects))
 		return E_INVALIDARG;
 
 	resetChild();


### PR DESCRIPTION
Two field-reported failures on a Windows 10 USB-audio machine, both root-caused with a debugger (cdb) and an audiodg APO trace, then verified end to end.

## fix(apo): the EQ never actually loaded; Device Selector test failed with "the parameter is incorrect"

Since `64970cd` the APO implements `IAudioSystemEffects2`, so the audio engine hands `Initialize` an `APOInitSystemEffects2` struct (88 bytes on x64) instead of the base `APOInitSystemEffects` (56 bytes). `Initialize` still demanded the exact v1 size and returned `E_INVALIDARG` for every init, so the effect never loaded:

- The EQ was **silently inactive** on the endpoint (the APO bailed right after the entry trace line).
- On effect slots that do not tolerate a failing APO (SFX/EFX on the USB device), `IAudioClient::Initialize` itself failed, and the Device Selector install test surfaced it as `Initialize failed for device "USB Audio Device" (매개변수가 틀립니다 / the parameter is incorrect)`.

Fix: accept any struct at least the base size. All `APOInitSystemEffects*` versions share the same leading members, so the existing field reads stay valid.

**Verified** in an `audiodg` trace after the fix: `Initialize: cbDataSize=88 (APOInitSystemEffects=56)` now passes the size check, and the APO proceeds through `APO GUID` → `Endpoint GUID` → child APO → **`LockForProcess successful`** and loads `config.txt` — i.e. the effect actually processes audio on the USB device, and the install test passes with no error dialog.

## fix(editor): switching to the minimal / soft / rack skins crashed the editor

`MainWindow::skinSelected` and the dark-mode toggle `clearRows()` on every tab before `qApp->setStyleSheet` (a deliberate optimisation), which leaves `FilterTable::gridLayout` null until `updateGuis()` rebuilds it. `setStyleSheet` re-lays-out the window and delivers a `scrollArea` Resize through `FilterTable`'s event filter *during* that teardown window, so `updateSizeHints()` dereferenced the null layout and crashed with an access violation (0xC0000005). It killed the minimal/soft/rack skins outright and fired intermittently on a plain restyle, depending on whether the new skin's QSS forced the scroll area to resize — which is why it reproduced on field machines but not the dev machine.

Fix: guard `updateSizeHints()` the same way `swapRow()` in the same file already guards the pointer. There is nothing to size while the rows are being rebuilt.

**Verified** under cdb with `sxe av` armed: switching through all five skins (studio, matrix, minimal, soft, rack) in both light and dark mode no longer faults; the three saved crash dumps (`applySkin minimal/soft/rack`, 0xC0000005) point at exactly this call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
