### PR TITLE
fix: size VST3 plugin editor windows in logical pixels on high-DPI displays

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,15 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 고DPI(배율) 디스플레이에서 VST3 플러그인 에디터 창 크기가 어긋나던 문제를
+  고쳤습니다. 에디터가 플러그인의 물리 픽셀 크기를 논리(장치 독립) 픽셀 단위로
+  재는 Qt 위젯에 그대로 넘겨, 150%나 200% 모니터에서는 호스트 프레임이 너무 크게
+  잡히고 플러그인(예: FabFilter Pro-Q)이 어긋난 캔버스에 그려졌습니다. 그래서
+  게인 0 dB의 평평한 EQ 곡선이 왜곡돼 보이고 패널에 빈 여백이 생겼습니다. 이제
+  임베드 패널, '패널 열기' 다이얼로그, 카드 임베드 모두 프레임의 device pixel
+  ratio로 플러그인의 물리 크기를 논리 픽셀로 바꾸고, 네이티브 호스트 창은 물리
+  픽셀로 유지하며, DPI를 인식하는 플러그인에는 `IPlugViewContentScaleSupport`로
+  호스트 배율을 알려줍니다. 100%에서는 동작이 그대로입니다. ([#108])
 - 제거 시 모든 오디오 장치가 사라져 재부팅해야 복구되던 치명적 버그를
   고쳤습니다. 제거 과정이 Windows Audio 서비스만 재시작해, Windows Audio
   Endpoint Builder가 방금 제거된 APO를 가리키는 낡은 엔드포인트 그래프를 그대로
@@ -424,3 +433,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#98]: https://github.com/115dkk/EqualizerAPO-XT/pull/98
 [#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
+[#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Fixed VST3 plugin editor windows being mis-sized on high-DPI (scaled)
+  displays. The editor handed the plugin's physical-pixel size straight to a Qt
+  widget that measures in logical (device-independent) pixels, so on a 150% or
+  200% monitor the host frame came out too large and the plugin (for example
+  FabFilter Pro-Q) rendered against a mismatched canvas, so a flat 0 dB EQ
+  curve looked distorted and the panel had empty margins. The embedded panel,
+  the "Open panel" dialog and the card embed now convert the plugin's physical
+  size to logical pixels with the frame's device pixel ratio, keep the native
+  host window in physical pixels, and tell DPI-aware plugins the host scale via
+  `IPlugViewContentScaleSupport`. At 100% nothing changes. ([#108])
 - Fixed a critical bug where uninstalling EqualizerAPO-XT could make all audio
   devices disappear from Windows until a reboot. The uninstaller restarted only
   the Windows Audio service, which left Windows Audio Endpoint Builder holding a
@@ -451,3 +461,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#98]: https://github.com/115dkk/EqualizerAPO-XT/pull/98
 [#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
+[#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -398,7 +398,7 @@ bool VSTPluginFilterGUI::embedPlugin()
 		HWND hwnd = (HWND)ui->frame->winId();
 		short width, height;
 
-		effect->startEditing(hwnd, &width, &height);
+		effect->startEditing(hwnd, &width, &height, ui->frame->devicePixelRatioF());
 
 		ui->frame->setFixedSize(width, height);
 	}

--- a/Editor/guis/VSTPluginFilterGUIDialog.cpp
+++ b/Editor/guis/VSTPluginFilterGUIDialog.cpp
@@ -40,7 +40,10 @@ VSTPluginFilterGUIDialog::VSTPluginFilterGUIDialog(QWidget* parent, VSTPluginIns
 
 	short width, height;
 
-	effect->startEditing(hwnd, &width, &height);
+	// Size the plugin for the monitor the dialog opens on. The parent is already
+	// shown, so its device pixel ratio is reliable; the dialog's own is not yet.
+	double scaleFactor = (parent != nullptr) ? parent->devicePixelRatioF() : devicePixelRatioF();
+	effect->startEditing(hwnd, &width, &height, scaleFactor);
 
 	ui->frame->setFixedSize(width, height);
 	effect->setSizeWindowFunc(bind(&VSTPluginFilterGUIDialog::onSizeWindow, this, _1, _2));

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -452,7 +452,7 @@ bool VSTCardEditor::embedPlugin()
 
 		HWND hwnd = (HWND)frame->winId();
 		short width, height;
-		effect->startEditing(hwnd, &width, &height);
+		effect->startEditing(hwnd, &width, &height, frame->devicePixelRatioF());
 		frame->setFixedSize(width, height);
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)

--- a/helpers/VST3PluginIIDs.cpp
+++ b/helpers/VST3PluginIIDs.cpp
@@ -5,6 +5,7 @@
 #include "pluginterfaces/base/ipluginbase.h"
 #include "pluginterfaces/base/ibstream.h"
 #include "pluginterfaces/gui/iplugview.h"
+#include "pluginterfaces/gui/iplugviewcontentscalesupport.h"
 #include "pluginterfaces/vst/ivstaudioprocessor.h"
 #include "pluginterfaces/vst/ivstcomponent.h"
 #include "pluginterfaces/vst/ivsteditcontroller.h"

--- a/helpers/VSTPluginInstance.Editor.cpp
+++ b/helpers/VSTPluginInstance.Editor.cpp
@@ -21,6 +21,7 @@
 #include "VSTPluginLibrary.h"
 #include "VSTPluginInstance.h"
 #include "VSTPluginInstanceInternal.h"
+#include "pluginterfaces/gui/iplugviewcontentscalesupport.h"
 
 using namespace std;
 using namespace Steinberg;
@@ -50,12 +51,28 @@ static void registerVST3EditorHostWindowClass()
 	registered = true;
 }
 
-bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height)
+bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height, double scaleFactor)
 {
+	// VST3 ViewRect sizes are in physical pixels, but the Qt frame that hosts the
+	// plugin lives in logical (device-independent) pixels. Keep them apart: the
+	// native host window is sized in physical px, while *width/*height report
+	// logical px so the caller's QWidget geometry is correct on a high-DPI
+	// monitor. scaleFactor is the host frame's device pixel ratio; 1.0 (a 100%
+	// display) makes every conversion below a no-op, so nothing changes there.
+	if (scaleFactor <= 0.0)
+		scaleFactor = 1.0;
+	editorScaleFactor = scaleFactor;
+
+	auto toLogical = [scaleFactor](int physical) -> short {
+		return (short)max(1, (int)(physical / scaleFactor + 0.5));
+	};
+
+	int physWidth = 400;
+	int physHeight = 300;
 	if (width != NULL)
-		*width = 400;
+		*width = toLogical(physWidth);
 	if (height != NULL)
-		*height = 300;
+		*height = toLogical(physHeight);
 
 	if (library->isVST3())
 	{
@@ -66,13 +83,27 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height)
 		if (vst3View == NULL)
 			return false;
 		vst3View->setFrame(vst3HostContext);
+
+		// Hand DPI-aware plugins (FabFilter Pro-Q, etc.) the host scale before
+		// they lay out, so getSize() returns a rect that matches the real
+		// monitor. Plugins without this interface fall back to reading the DPI
+		// from their parent window, which is per-monitor aware in this process.
+		IPlugViewContentScaleSupport* scaleSupport = NULL;
+		if (vst3View->queryInterface(IPlugViewContentScaleSupport::iid, (void**)&scaleSupport) == kResultOk && scaleSupport != NULL)
+		{
+			scaleSupport->setContentScaleFactor((IPlugViewContentScaleSupport::ScaleFactor)scaleFactor);
+			scaleSupport->release();
+		}
+
 		ViewRect rect;
 		if (vst3View->getSize(&rect) == kResultOk)
 		{
+			physWidth = max<int32>(1, rect.getWidth());
+			physHeight = max<int32>(1, rect.getHeight());
 			if (width != NULL)
-				*width = (short)max<int32>(1, rect.getWidth());
+				*width = toLogical(physWidth);
 			if (height != NULL)
-				*height = (short)max<int32>(1, rect.getHeight());
+				*height = toLogical(physHeight);
 		}
 		tresult platformResult = vst3View->isPlatformTypeSupported(kPlatformTypeHWND);
 		if (platformResult != kResultOk && platformResult != kNotImplemented)
@@ -83,7 +114,7 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height)
 		registerVST3EditorHostWindowClass();
 		vst3EditorHostWindow = CreateWindowExW(0, vst3EditorHostWindowClass, L"",
 			WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_VISIBLE,
-			0, 0, *width, *height, hWnd, NULL, GetModuleHandleW(NULL), NULL);
+			0, 0, physWidth, physHeight, hWnd, NULL, GetModuleHandleW(NULL), NULL);
 		if (vst3EditorHostWindow == NULL)
 		{
 			stopEditing();
@@ -96,13 +127,15 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height)
 		}
 		if (vst3View->getSize(&rect) == kResultOk)
 		{
+			physWidth = max<int32>(1, rect.getWidth());
+			physHeight = max<int32>(1, rect.getHeight());
 			if (width != NULL)
-				*width = (short)max<int32>(1, rect.getWidth());
+				*width = toLogical(physWidth);
 			if (height != NULL)
-				*height = (short)max<int32>(1, rect.getHeight());
+				*height = toLogical(physHeight);
 			vst3View->onSize(&rect);
 		}
-		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, *width, *height, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, physWidth, physHeight, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
 		EnumChildWindows(vst3EditorHostWindow, showChildWindow, 0);
 		return true;
 	}

--- a/helpers/VSTPluginInstance.cpp
+++ b/helpers/VSTPluginInstance.cpp
@@ -423,7 +423,18 @@ bool VSTPluginInstance::getEditorSize(int* width, int* height)
 void VSTPluginInstance::onSizeWindow(int w, int h)
 {
 	if (vst3EditorHostWindow != NULL)
+	{
+		// w/h arrive in physical pixels from the plugin's resizeView request.
+		// The native host window takes physical px; the Qt frame
+		// (sizeWindowFunc) takes logical px, so divide by the editor scale.
 		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+		if (sizeWindowFunc)
+		{
+			double s = editorScaleFactor > 0.0 ? editorScaleFactor : 1.0;
+			sizeWindowFunc(max(1, (int)(w / s + 0.5)), max(1, (int)(h / s + 0.5)));
+		}
+		return;
+	}
 	if (sizeWindowFunc)
 		sizeWindowFunc(w, h);
 }

--- a/helpers/VSTPluginInstance.h
+++ b/helpers/VSTPluginInstance.h
@@ -68,7 +68,7 @@ public:
 	void process(float** inputArray, float** outputArray, int frameCount);
 	void stopProcessing();
 
-	bool startEditing(HWND hWnd, short* width, short* height);
+	bool startEditing(HWND hWnd, short* width, short* height, double scaleFactor = 1.0);
 	void doIdle();
 	void stopEditing();
 
@@ -110,6 +110,7 @@ private:
 	Steinberg::Vst::TSamples vst3SamplePosition = 0;
 	std::function<void()> automateFunc;
 	std::function<void(int, int)> sizeWindowFunc;
+	double editorScaleFactor = 1.0;
 	float sampleRate = 0.0f;
 	int usedChannelCount = -1;
 	int processLevel = 0;


### PR DESCRIPTION
## Problem

Two related VST3 reports on a high-DPI (scaled) display:

- **Window size misinterpreted on import.** When a VST3 plugin's editor was shown, the host frame came out the wrong size.
- **FabFilter Pro-Q graph distorted.** A single EQ band at 0 dB gain should draw a flat response curve, but it rendered distorted.

Both trace to one root cause. The editor handed the plugin's **physical-pixel** `ViewRect` straight to a Qt widget whose `setFixedSize` measures in **logical (device-independent) pixels**. On a 150%/200% monitor the host frame ended up `devicePixelRatio` times too large, and the plugin (which renders into the correctly-sized native child window) sat in a mismatched frame, so its graph looked wrong and the panel had empty margins. At 100% (`dpr == 1.0`) physical equals logical, so the bug only appears on scaled monitors. The reporting machine runs a monitor at 200%.

## Fix

All DPI conversion is centralised in the host helper:

- `VSTPluginInstance::startEditing(hWnd, w, h, scaleFactor)` now takes the host frame's device pixel ratio. It keeps the native host window (`vst3EditorHostWindow`) sized in **physical** pixels, returns the **logical** size (`physical / dpr`) for the Qt frame, and queries `IPlugViewContentScaleSupport::setContentScaleFactor(dpr)` so DPI-aware plugins (Pro-Q etc.) lay out for the real monitor before the first `getSize`.
- `onSizeWindow` (the plugin's own `resizeView` path) does the same split: host window physical, Qt frame logical.
- The three embed sites — embedded panel (`VSTPluginFilterGUI`), the **Open panel** dialog (`VSTPluginFilterGUIDialog`), and the card embed (`VSTCardEditor`) — pass `devicePixelRatioF()`. The dialog uses the already-shown **parent's** ratio, which is reliable before the dialog itself is shown.
- `IPlugViewContentScaleSupport::iid` is defined by adding its header to the header-only SDK IID file `helpers/VST3PluginIIDs.cpp`.

VST2 hosting is unchanged. **At 100% scaling this is a no-op**, so non-HiDPI users see no change.

## Verification

- Built locally: `Common.lib` (v143) + Editor (qmake/nmake) link clean.
- `Editor.exe --selftest-vst` (VST store/parse round-trip) passes.
- CI exercises the full 6-variant build matrix + tests + cppcheck.

**Not done:** interactive on-screen verification on the 200% monitor. The computer-use access dialog could not be approved in this session (operator away), so the editor could not be driven to embed a plugin and capture before/after screenshots. The fix is verified by build + self-test + reasoning; a quick visual check on a scaled display is still worth doing.

## Out of scope

A separately reported "crash the moment a VST3 is added to the config" could not be reproduced headlessly (a console `FilterEngine` host hangs rather than crashes, and is not a faithful proxy for the editor's analysis-thread path), and the faithful editor repro needs computer use, which was unavailable. Per the report (give up if it does not reproduce) it is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
