### PR TITLE
refactor: address low-risk findings from biweekly audit #109

### DIFF
--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -37,6 +37,15 @@
 
 class MainWindow;
 
+// FilterTable's implementation is split across several translation units (all
+// listed in Editor.pro SOURCES). When looking for a method, check the matching
+// part file:
+//   FilterTable.cpp                            - ctor/dtor, row build/update
+//   FilterTableParts/FilterTable.Clipboard.cpp - cut/copy/paste, save prefs
+//   FilterTableParts/FilterTable.DragDrop.cpp  - drag-and-drop
+//   FilterTableParts/FilterTable.Events.cpp    - event filters / resize
+//   FilterTableParts/FilterTable.Model.cpp     - config lines <-> rows model
+//   FilterTableParts/FilterTable.Mouse.cpp     - mouse / selection
 class FilterTable : public QWidget
 {
 	Q_OBJECT

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -45,6 +45,18 @@ class MainWindow;
 class QLabel;
 class TitleBar;
 
+// MainWindow's implementation is split across several translation units (all
+// listed in Editor.pro SOURCES). When looking for a method, check the matching
+// part file:
+//   MainWindow.cpp                             - ctor/dtor, shared setup, doChecks
+//   MainWindowParts/MainWindow.Analysis.cpp    - instant mode + analysis panel
+//   MainWindowParts/MainWindow.Device.cpp      - device/channel selection + tabs
+//   MainWindowParts/MainWindow.Edit.cpp        - cut/copy/paste/undo edit actions
+//   MainWindowParts/MainWindow.FileActions.cpp - open/save/recent menu actions
+//   MainWindowParts/MainWindow.FileIO.cpp      - config load/save
+//   MainWindowParts/MainWindow.Frame.cpp       - custom window chrome / title bar
+//   MainWindowParts/MainWindow.Preferences.cpp - settings load/store
+//   MainWindowParts/MainWindow.ViewActions.cpp - view/skin/reset actions
 class MainWindow : public QMainWindow
 {
 	Q_OBJECT

--- a/Editor/guis/PreampFilterGUI.cpp
+++ b/Editor/guis/PreampFilterGUI.cpp
@@ -45,7 +45,7 @@ void PreampFilterGUI::store(QString& command, QString& parameters)
 	command = "Preamp";
 
 	// Read the widget into the shared command struct, then serialize it back into
-	// the canonical "<dB> dB" parameter string. serializePreampCommand uses %g,
+	// the canonical "<dB> dB" parameter string. PreampCommand::serialize uses %g,
 	// which reproduces the exact text QString("%1 dB").arg(value) emitted before
 	// (C locale, six significant digits, trailing zeros stripped) for the values
 	// this spin box can hold.
@@ -53,7 +53,7 @@ void PreampFilterGUI::store(QString& command, QString& parameters)
 	cmd.dbGain = ui->doubleSpinBox->value();
 	cmd.valid = true;
 	cmd.noOp = std::abs(cmd.dbGain) < 1e-9;
-	parameters = QString::fromStdWString(serializePreampCommand(cmd));
+	parameters = QString::fromStdWString(cmd.serialize());
 }
 
 void PreampFilterGUI::on_dial_valueChanged(int value)

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -106,7 +106,7 @@ void VSTPluginFilterGUI::store(QString& command, QString& parameters)
 	VSTPluginCommand cmd;
 	cmd.chunkData = chunkData;
 	cmd.paramMap = paramMap;
-	parameters += QString::fromStdWString(VSTPluginCommand::serialize(cmd));
+	parameters += QString::fromStdWString(cmd.serialize());
 }
 
 void VSTPluginFilterGUI::loadPreferences(const QVariantMap& prefs)

--- a/Tests/HybridConvTests/ParserPreampTests.cpp
+++ b/Tests/HybridConvTests/ParserPreampTests.cpp
@@ -50,7 +50,7 @@ void expectRoundTrip(const wstring& parameters, double expectedDb, const wstring
 	PreampCommand cmd = parsePreamp(parameters);
 	harness.expectTrue(cmd.valid, "well-formed preamp parameter should parse as valid");
 	harness.expectTrue(cmd.dbGain == expectedDb, "parsed preamp dB value mismatch");
-	harness.expectTrue(serializePreampCommand(cmd) == expectedSerialized,
+	harness.expectTrue(cmd.serialize() == expectedSerialized,
 		"serialize(parse(line)) should reproduce the canonical parameter string");
 }
 }

--- a/Tests/HybridConvTests/VSTPluginCommandTests.cpp
+++ b/Tests/HybridConvTests/VSTPluginCommandTests.cpp
@@ -54,7 +54,7 @@ void testLibraryOnly()
 	harness.expectTrue(cmd.libraryPath == L"C:\\plugins\\reverb.dll", "library-only: lib path");
 	harness.expectTrue(cmd.chunkData == L"", "library-only: no chunk data");
 	harness.expectEqual(cmd.paramMap.size(), (size_t)0, "library-only: no params");
-	harness.expectTrue(VSTPluginCommand::serialize(cmd) == L"", "library-only: empty body");
+	harness.expectTrue(cmd.serialize() == L"", "library-only: empty body");
 }
 
 void testQuotedPath()
@@ -75,7 +75,7 @@ void testChunkData()
 	harness.expectTrue(!cmd.libraryPath.empty(), "chunk: library resolved");
 	harness.expectTrue(cmd.chunkData == L"QUJDRA==", "chunk: chunk data");
 	harness.expectEqual(cmd.paramMap.size(), (size_t)0, "chunk: no params");
-	harness.expectTrue(VSTPluginCommand::serialize(cmd) == L" ChunkData \"QUJDRA==\"", "chunk: serialized body");
+	harness.expectTrue(cmd.serialize() == L" ChunkData \"QUJDRA==\"", "chunk: serialized body");
 }
 
 void testNamedParams()
@@ -129,12 +129,12 @@ void testNonNumericValueBranch()
 void expectBodyRoundTrip(const wstring& parameters, const wstring& expectedBody)
 {
 	VSTPluginCommand cmd = VSTPluginCommand::parse(L"", parameters);
-	wstring body = VSTPluginCommand::serialize(cmd);
+	wstring body = cmd.serialize();
 	harness.expectTrue(body == expectedBody,
 		"serialize(parse(...)) body mismatch for: " + std::string(parameters.begin(), parameters.end()));
 
 	VSTPluginCommand reparsed = VSTPluginCommand::parse(L"", L"Library C:\\plugins\\reverb.dll" + body);
-	harness.expectTrue(VSTPluginCommand::serialize(reparsed) == expectedBody,
+	harness.expectTrue(reparsed.serialize() == expectedBody,
 		"second round trip not stable for: " + std::string(parameters.begin(), parameters.end()));
 }
 
@@ -154,7 +154,7 @@ void testSerializeRoundTrip()
 	// A multi-param command is not asserted against a fixed string (map order is
 	// unspecified), but parse -> serialize -> parse must preserve the map.
 	VSTPluginCommand cmd = VSTPluginCommand::parse(L"", L"Library C:\\plugins\\reverb.dll Gain 0.5 Mix 0.25");
-	wstring body = VSTPluginCommand::serialize(cmd);
+	wstring body = cmd.serialize();
 	VSTPluginCommand reparsed = VSTPluginCommand::parse(L"", L"Library C:\\plugins\\reverb.dll" + body);
 	harness.expectEqual(reparsed.paramMap.size(), (size_t)2, "multi-param round trip: size");
 	harness.expectEqual(paramValue(reparsed.paramMap, L"Gain", "multi-param Gain"), 0.5f, "multi-param round trip: Gain");
@@ -165,7 +165,7 @@ void testSerializeRoundTrip()
 	VSTPluginCommand built;
 	built.libraryPath = L"C:\\plugins\\reverb.dll";
 	built.paramMap[L"Feedback"] = 0.6f;
-	wstring builtBody = VSTPluginCommand::serialize(built);
+	wstring builtBody = built.serialize();
 	harness.expectTrue(builtBody == L" Feedback 0.6", "hand-built body");
 	VSTPluginCommand builtReparsed = VSTPluginCommand::parse(L"", L"Library C:\\plugins\\reverb.dll" + builtBody);
 	harness.expectEqual(paramValue(builtReparsed.paramMap, L"Feedback", "hand-built Feedback"), 0.6f, "hand-built round trip");

--- a/filters/BiQuadFilterFactory.cpp
+++ b/filters/BiQuadFilterFactory.cpp
@@ -86,7 +86,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 		return false;
 
 	// Conversion to period as decimal mark, if needed
-	parameters = StringHelper::replaceCharacters(parameters, L",", L".");
+	parameters = StringHelper::normalizeDecimalComma(parameters);
 
 	wsmatch match;
 	wstring typeString;

--- a/filters/DelayFilterFactory.cpp
+++ b/filters/DelayFilterFactory.cpp
@@ -39,7 +39,7 @@ bool DelayFilterFactory::parseCommand(const wstring& command, wstring& parameter
 		return false;
 
 	// Conversion to period as decimal mark, if needed
-	wstring value = StringHelper::replaceCharacters(parameters, L",", L".");
+	wstring value = StringHelper::normalizeDecimalComma(parameters);
 
 	double delay = -1;
 	wstring unit;

--- a/filters/PreampCommand.cpp
+++ b/filters/PreampCommand.cpp
@@ -23,12 +23,12 @@
 
 #include <cstdio>
 
-std::wstring serializePreampCommand(const PreampCommand& command)
+std::wstring PreampCommand::serialize() const
 {
 	// %g matches QString::arg(double)'s default formatting (C locale, format 'g',
 	// six significant digits with trailing zeros stripped). The "<value> dB" shape
 	// is exactly what the factory parser reads back via swscanf_s(" %lf dB").
 	wchar_t buffer[64];
-	swprintf(buffer, sizeof(buffer) / sizeof(buffer[0]), L"%g dB", command.dbGain);
+	swprintf(buffer, sizeof(buffer) / sizeof(buffer[0]), L"%g dB", dbGain);
 	return std::wstring(buffer);
 }

--- a/filters/PreampCommand.h
+++ b/filters/PreampCommand.h
@@ -36,11 +36,11 @@ struct PreampCommand
 	double dbGain = 0.0;
 	bool valid = false;
 	bool noOp = false;
-};
 
-// Serializes a PreampCommand back into the canonical "<dB> dB" parameter string,
-// the same form PreampFilterGUI::store() emits and that the factory parser
-// accepts. Qt-free so both the Editor GUI and the round-trip tests can share it.
-// The dB value is formatted with %g (six significant digits, trailing zeros
-// stripped), matching what QString::arg(double) produced for these widget values.
-std::wstring serializePreampCommand(const PreampCommand& command);
+	// Serializes this PreampCommand back into the canonical "<dB> dB" parameter
+	// string, the same form PreampFilterGUI::store() emits and that the factory
+	// parser accepts. Qt-free so both the Editor GUI and the round-trip tests can
+	// share it. The dB value is formatted with %g (six significant digits, trailing
+	// zeros stripped), matching what QString::arg(double) produced for these values.
+	std::wstring serialize() const;
+};

--- a/filters/PreampFilterFactory.cpp
+++ b/filters/PreampFilterFactory.cpp
@@ -39,7 +39,7 @@ bool PreampFilterFactory::parseCommand(const wstring& command, const wstring& pa
 		return false;
 
 	// Conversion to period as decimal mark, if needed
-	wstring value = StringHelper::replaceCharacters(parameters, L",", L".");
+	wstring value = StringHelper::normalizeDecimalComma(parameters);
 
 	double preamp_dB;
 	int matched = swscanf_s(value.c_str(), L" %lf dB", &preamp_dB);

--- a/filters/VSTPluginCommand.cpp
+++ b/filters/VSTPluginCommand.cpp
@@ -90,7 +90,7 @@ VSTPluginCommand VSTPluginCommand::parse(const wstring& /*configPath*/, const ws
 	return cmd;
 }
 
-std::wstring VSTPluginCommand::serialize(const VSTPluginCommand& command)
+std::wstring VSTPluginCommand::serialize() const
 {
 	// Mirrors the body VSTPluginFilterGUI::store() appends after the "Library
 	// <path>" token. The Library token itself stays in store() because its
@@ -100,15 +100,15 @@ std::wstring VSTPluginCommand::serialize(const VSTPluginCommand& command)
 	// same leading space store() used, so store() can append it directly.
 	wstring result;
 
-	if (command.chunkData != L"")
+	if (chunkData != L"")
 	{
 		result += L" ChunkData \"";
-		result += command.chunkData;
+		result += chunkData;
 		result += L"\"";
 	}
 	else
 	{
-		for (const auto& it : command.paramMap)
+		for (const auto& it : paramMap)
 		{
 			// Quote the name when it contains a space or a quote, doubling any
 			// embedded quote, exactly as store() did with QString. splitQuoted

--- a/filters/VSTPluginCommand.h
+++ b/filters/VSTPluginCommand.h
@@ -57,5 +57,5 @@ struct VSTPluginCommand
 	// %g/QString::arg float formatting. The Library token itself stays in store()
 	// because its relative/absolute path resolution depends on Qt's QDir, so this
 	// serializer owns only the chunk/param body.
-	static std::wstring serialize(const VSTPluginCommand& command);
+	std::wstring serialize() const;
 };

--- a/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.cpp
+++ b/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.cpp
@@ -31,7 +31,7 @@
 #include "filters/FilterFactoryRegistry.h"
 #include "LoudnessCorrectionFilterFactory.h"
 
-REGISTER_FILTER_FACTORY(14, LoudnessCorrectionFilterFactory)
+REGISTER_FILTER_FACTORY(FilterFactoryPriority::LoudnessCorrection, LoudnessCorrectionFilterFactory)
 
 using std::regex;
 using std::vector;

--- a/helpers/StringHelper.cpp
+++ b/helpers/StringHelper.cpp
@@ -52,6 +52,11 @@ wstring StringHelper::replaceIllegalCharacters(const wstring& filename)
 	return replaceCharacters(filename, L"<>:\"/\\|?*", L"_");
 }
 
+wstring StringHelper::normalizeDecimalComma(const wstring& s)
+{
+	return replaceCharacters(s, L",", L".");
+}
+
 wstring StringHelper::toWString(const string& s, unsigned codepage)
 {
 	int length = MultiByteToWideChar(codepage, 0, s.c_str(), -1, nullptr, 0);

--- a/helpers/StringHelper.h
+++ b/helpers/StringHelper.h
@@ -28,6 +28,8 @@ public:
 	// replaces any occurrence of a character from chars in s with the replacement string
 	static std::wstring replaceCharacters(const std::wstring& s, const std::wstring& chars, const std::wstring& replacement);
 	static std::wstring replaceIllegalCharacters(const std::wstring& filename);
+	// Converts a decimal comma to a period so locale-formatted numbers parse.
+	static std::wstring normalizeDecimalComma(const std::wstring& s);
 	static std::wstring toWString(const std::string& s, unsigned codepage);
 	static std::string toString(const std::wstring& s, unsigned codepage);
 	static std::wstring toLowerCase(const std::wstring& s);

--- a/helpers/VelopackBootstrap.cpp
+++ b/helpers/VelopackBootstrap.cpp
@@ -19,6 +19,8 @@
 
 #include "VelopackBootstrap.h"
 
+#include "LogHelper.h"
+
 #include <cstdio>
 #include <cstdlib>
 #include <atomic>
@@ -57,11 +59,17 @@ bool fileExists(const std::wstring& path)
 
 std::wstring envVar(const wchar_t* name)
 {
-	wchar_t buffer[256];
-	DWORD length = GetEnvironmentVariableW(name, buffer, 256);
-	if (length == 0 || length >= 256)
+	// Probe the required size (includes the null terminator) so long values are
+	// not silently dropped. Not-found and empty still yield an empty string.
+	DWORD needed = GetEnvironmentVariableW(name, nullptr, 0);
+	if (needed == 0)
 		return std::wstring();
-	return std::wstring(buffer, length);
+	std::wstring value(needed, L'\0');
+	DWORD length = GetEnvironmentVariableW(name, value.data(), needed);
+	if (length == 0 || length >= needed)
+		return std::wstring();
+	value.resize(length);
+	return value;
 }
 
 // State for the staged update produced by the background worker. The UpdateManager
@@ -158,10 +166,12 @@ void VelopackBootstrap::startBackgroundDownload(const std::string& repoUrl, cons
 		}
 		catch (const std::exception& e)
 		{
+			LogFStatic(L"[VelopackBootstrap] background update failed: %S", e.what());
 			fprintf(stderr, "[VelopackBootstrap] background update failed: %s\n", e.what());
 		}
 		catch (...)
 		{
+			LogFStatic(L"[VelopackBootstrap] background update failed: unknown error");
 			fprintf(stderr, "[VelopackBootstrap] background update failed: unknown error\n");
 		}
 	}).detach();
@@ -186,6 +196,7 @@ void VelopackBootstrap::applyPendingUpdateAndExit()
 	}
 	catch (const std::exception& e)
 	{
+		LogFStatic(L"[VelopackBootstrap] apply update failed: %S", e.what());
 		fprintf(stderr, "[VelopackBootstrap] apply update failed: %s\n", e.what());
 		return;
 	}


### PR DESCRIPTION
Addresses the low-risk, byte-identical findings from the biweekly audit ([#109](https://github.com/115dkk/EqualizerAPO-XT/issues/109)). Each candidate was re-verified against the current tree by a parallel verification pass before applying — which also caught traps in several of the audit's own recipes, so those are deferred (below) rather than applied blindly.

## Applied (low risk, no observable behavior change)

- **F018** — Standardize the `*Command` `serialize()` shape on a `const` member. `PreampCommand::serialize()` (was the free `serializePreampCommand`) and `VSTPluginCommand::serialize()` (was `static`); the Editor GUI callers and the round-trip tests are updated. Output bytes unchanged.
- **F019** — Add `StringHelper::normalizeDecimalComma()` and route the three copy-pasted comma→dot parse fixups (BiQuad / Delay / Preamp factories) through it. The wrapper is exactly the previous `replaceCharacters(",", ".")` call, so parsing is unchanged. (`replaceCharacters` stays — it still backs `replaceIllegalCharacters` and a thousands-separator strip.)
- **F020** — Register `LoudnessCorrection` with `FilterFactoryPriority::LoudnessCorrection` instead of the literal `14`. The constant is defined as `14`, so registration order is byte-equivalent.
- **F025** — Size `VelopackBootstrap`'s env-var read from the WinAPI length probe instead of a fixed 256-wchar buffer. Defensive only (the `VELOPACK_*` markers are short); not-found/empty behavior preserved.
- **F031** — Also route the background-download and apply-update failure diagnostics through `LogHelper` (`LogFStatic`, since the methods are static) so the GUI tools — which have no console — can surface them; the `stderr` output is kept.
- **F033** — Document the `MainWindow` / `FilterTable` partial-class TU split in their headers, listing each part file's responsibility. Doc-only; binaries byte-identical.

No version bump (`refactor:` — no user-visible behavior change).

## Deferred (valuable but not safe/mechanical now — verification found real traps)

- **F006** (derive the command vocabulary from the factories) — sound and worth doing, but medium risk: it touches all 14 factories + the engine. The audit's single-`mayConsumeLineWithoutFilter()` recipe is **wrong** — `commandsWithoutFilter` is the union of *control-flow* commands and *valid-no-op* processing commands (Preamp 0 dB, Delay 0, Filter "ON None"); deriving it from one boolean would start emitting spurious "malformed parameters" warnings. Needs the two-method design from the verification pass; its own focused PR.
- **F007** (BiQuad `serialize()`) — the audit's "mirror Delay/Convolution" is **not** byte-identical: the BiQuad parser is intentionally asymmetric (it infers/normalizes magnitudes), so a symmetric `serialize()` would need the command struct + parser extended. Not the afternoon the audit estimated.
- **F010** (one `Dependencies.props`) — the include-path defaults are safe to hoist, but the `*_LIB` defaults **diverge** (some projects pick Debug/Release per config, others pin Release); a naive merge regresses Debug link paths. Needs a careful split.
- **F021** (vestigial factory includes in the engine partials) — likely droppable (factories self-register; linkage is forced by `/WHOLEARCHIVE:Common.lib` in the consumers, not by these includes), but it's 45 includes for ~no value and can't be fully proven read-only. Better to *document* the linkage guarantee than to delete blind.
- **F023** (`StringHelper::parseDouble`) — marginal; the `swscanf_s` sites must **not** be rerouted (format/return-code contract), so only the pure `wcstod` sites are byte-identical. Low value, and the file overlaps F019.
- **F004 / F005 / F009** — real but larger: Pester tests need a CI job to run them; the `Skins.cpp` split (2258 LOC) and the Editor filter-roster registration are their own refactors.

## Skipped

- **F022** — premise is false: neither `CLAUDE.md` nor `docs/RefactoringBaseline.md` actually describes `FilterEngine.cpp`/`DeviceAPOInfo.cpp` as root files, so there is nothing to correct. (F033 still adds the part-file map to the headers, which is the useful half.)

## Not touched (the audit's own "looks bad but is actually fine")

Left as-is per the audit: the `FilterConfiguration` macro/`switch(channelCount)` hot-path ladders (F037), the four deliberate error-handling models, the single guarded `catch(...)`, the C-style Win32/COM/VST casts, the Highway per-variant build outputs, and the engine/devices partial-class split itself.

## Verification

- Built `Common.lib` + `HybridConvTests` + `EditorLogicTests`; the VST/Preamp serialize round-trip suites pass (F018 byte-identity confirmed).
- CI exercises the AVX2 build + the full test set + the zero-baseline cppcheck gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
