### PR TITLE
chore: hoist shared dependency include paths into Directory.Build.props (audit #109 F010)

### DIFF
--- a/Benchmark/Benchmark.vcxproj
+++ b/Benchmark/Benchmark.vcxproj
@@ -95,13 +95,9 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\deps\libsndfile\build\Release</LIBSNDFILE_LIB>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\fftw\include</FFTW_INCLUDE>
     <FFTW_LIB Condition="'$(FFTW_LIB)'==''">$(MSBuildThisFileDirectory)..\deps\fftw\Release</FFTW_LIB>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\muparserx\parser</MUPARSERX_INCLUDE>
     <MUPARSERX_LIB Condition="'$(MUPARSERX_LIB)'==''">$(MSBuildThisFileDirectory)..\deps\muparserx\build\Release</MUPARSERX_LIB>
-    <TCLAP_ROOT Condition="'$(TCLAP_ROOT)'==''">$(MSBuildThisFileDirectory)..\deps\tclap</TCLAP_ROOT>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -97,14 +97,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\libsndfile\include</LIBSNDFILE_INCLUDE>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\fftw\include</FFTW_INCLUDE>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\muparserx\parser</MUPARSERX_INCLUDE>
-    <TCLAP_ROOT Condition="'$(TCLAP_ROOT)'==''">$(MSBuildThisFileDirectory)deps\tclap</TCLAP_ROOT>
-    <VST3_SDK Condition="'$(VST3_SDK)'==''">$(MSBuildThisFileDirectory)deps\vst3sdk</VST3_SDK>
-    <HIGHWAY_INCLUDE Condition="'$(HIGHWAY_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\highway</HIGHWAY_INCLUDE>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)deps\libsndfile\build\Debug</LIBSNDFILE_LIB>
     <FFTW_LIB Condition="'$(FFTW_LIB)'==''">$(MSBuildThisFileDirectory)deps\fftw\Debug</FFTW_LIB>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Shared dependency *include* path defaults for every MSBuild (.vcxproj) project
+  in the tree. MSBuild auto-imports the nearest Directory.Build.props from the
+  repo root, so each project no longer repeats these six paths. The Condition
+  guards mean CI's /p:FFTW_INCLUDE=... (and the other dependency overrides) still
+  win, exactly as before.
+
+  The paths are root-relative ($(MSBuildThisFileDirectory) is this file's folder,
+  i.e. the repo root), which resolves to the same <root>\deps\... that each
+  project used via its own deps / ..\deps / ..\..\deps prefix.
+
+  Library (*_LIB) paths are intentionally NOT hoisted here: they diverge per
+  project - the APO/engine/Voicemeeter projects pick Debug vs Release libs per
+  configuration, while the console and test projects pin Release even in Debug -
+  so collapsing them into one block would change effective Debug link paths.
+  They stay in each .vcxproj.
+-->
+<Project>
+  <PropertyGroup>
+    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\libsndfile\include</LIBSNDFILE_INCLUDE>
+    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\fftw\include</FFTW_INCLUDE>
+    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\muparserx\parser</MUPARSERX_INCLUDE>
+    <TCLAP_ROOT Condition="'$(TCLAP_ROOT)'==''">$(MSBuildThisFileDirectory)deps\tclap</TCLAP_ROOT>
+    <VST3_SDK Condition="'$(VST3_SDK)'==''">$(MSBuildThisFileDirectory)deps\vst3sdk</VST3_SDK>
+    <HIGHWAY_INCLUDE Condition="'$(HIGHWAY_INCLUDE)'==''">$(MSBuildThisFileDirectory)deps\highway</HIGHWAY_INCLUDE>
+  </PropertyGroup>
+</Project>

--- a/EqualizerAPO/EqualizerAPO.vcxproj
+++ b/EqualizerAPO/EqualizerAPO.vcxproj
@@ -104,10 +104,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\fftw\include</FFTW_INCLUDE>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\muparserx\parser</MUPARSERX_INCLUDE>
-    <TCLAP_ROOT Condition="'$(TCLAP_ROOT)'==''">$(MSBuildThisFileDirectory)..\deps\tclap</TCLAP_ROOT>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\deps\libsndfile\build\Debug</LIBSNDFILE_LIB>

--- a/Tests/AudioRegressionTests/AudioRegressionTests.vcxproj
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.vcxproj
@@ -69,11 +69,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\include</FFTW_INCLUDE>
     <FFTW_LIB Condition="'$(FFTW_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\Release</FFTW_LIB>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\build\Release</LIBSNDFILE_LIB>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\parser</MUPARSERX_INCLUDE>
     <MUPARSERX_LIB Condition="'$(MUPARSERX_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\build\Release</MUPARSERX_LIB>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj
@@ -69,11 +69,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\include</FFTW_INCLUDE>
     <FFTW_LIB Condition="'$(FFTW_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\Release</FFTW_LIB>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\build\Release</LIBSNDFILE_LIB>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\parser</MUPARSERX_INCLUDE>
     <MUPARSERX_LIB Condition="'$(MUPARSERX_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\build\Release</MUPARSERX_LIB>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/Tests/HybridConvTests/HybridConvTests.vcxproj
+++ b/Tests/HybridConvTests/HybridConvTests.vcxproj
@@ -69,13 +69,9 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\include</FFTW_INCLUDE>
     <FFTW_LIB Condition="'$(FFTW_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\fftw\Release</FFTW_LIB>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\libsndfile\build\Release</LIBSNDFILE_LIB>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\parser</MUPARSERX_INCLUDE>
     <MUPARSERX_LIB Condition="'$(MUPARSERX_LIB)'==''">$(MSBuildThisFileDirectory)..\..\deps\muparserx\build\Release</MUPARSERX_LIB>
-    <VST3_SDK Condition="'$(VST3_SDK)'==''">$(MSBuildThisFileDirectory)..\..\deps\vst3sdk</VST3_SDK>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(MSBuildThisFileDirectory)..\..;$(FFTW_INCLUDE);$(LIBSNDFILE_INCLUDE);$(MUPARSERX_INCLUDE);$(VST3_SDK);$(IncludePath)</IncludePath>

--- a/VoicemeeterClient/VoicemeeterClient.vcxproj
+++ b/VoicemeeterClient/VoicemeeterClient.vcxproj
@@ -95,10 +95,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <LIBSNDFILE_INCLUDE Condition="'$(LIBSNDFILE_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\libsndfile\include</LIBSNDFILE_INCLUDE>
-    <FFTW_INCLUDE Condition="'$(FFTW_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\fftw\include</FFTW_INCLUDE>
-    <MUPARSERX_INCLUDE Condition="'$(MUPARSERX_INCLUDE)'==''">$(MSBuildThisFileDirectory)..\deps\muparserx\parser</MUPARSERX_INCLUDE>
-    <TCLAP_ROOT Condition="'$(TCLAP_ROOT)'==''">$(MSBuildThisFileDirectory)..\deps\tclap</TCLAP_ROOT>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LIBSNDFILE_LIB Condition="'$(LIBSNDFILE_LIB)'==''">$(MSBuildThisFileDirectory)..\deps\libsndfile\build\Debug</LIBSNDFILE_LIB>


### PR DESCRIPTION
Deferred [#109](https://github.com/115dkk/EqualizerAPO-XT/issues/109) finding **F010** — no shared MSBuild props; dependency paths copy-pasted across projects.

## What changed

The FFTW / muparserx / libsndfile / TCLAP / VST3-SDK / Highway **include** path defaults were repeated in seven `.vcxproj` files. They all resolve to `<root>\deps\...`, so they now live once in a root `Directory.Build.props` (auto-imported by MSBuild), and each project's redundant defs are removed (28 lines). The `Condition="'$(X)'==''"` guards are preserved, so CI's `/p:..._INCLUDE=...` overrides still win exactly as before.

## Why library paths are *not* hoisted

The verification pass flagged a trap in the audit's "single Dependencies.props" recommendation: the `*_LIB` defaults **diverge** by project group. The APO / engine / Voicemeeter projects pick Debug-vs-Release libs per configuration; the console and test projects pin Release even in Debug builds. Collapsing them into one shared block would change effective Debug link paths — and since CI only builds Release, that regression wouldn't be caught. So only the config-independent **include** paths are hoisted; the `*_LIB` defaults stay per-project. The props file documents this.

## Verification

Built Common + Benchmark + HybridConvTests **with no dependency `/p:` overrides**, so the new `Directory.Build.props` defaults (and the per-project Release `*_LIB` defaults) are what actually resolve — all compile and link, and HybridConvTests passes. CI runs the full AVX2 build of the solution + the cppcheck gate.

No version bump (`chore:` — build configuration only, no source/behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
