### PR TITLE
docs: record why BiQuad has no command serialize() (audit #109 F007)

### DIFF
--- a/Editor/guis/BiQuadFilterGUI.cpp
+++ b/Editor/guis/BiQuadFilterGUI.cpp
@@ -101,6 +101,10 @@ BiQuadFilterGUI::~BiQuadFilterGUI()
 	delete ui;
 }
 
+// This is the sole BiQuad serializer; the engine only parses. It emits from the
+// combo-box mode selectors (Fixed/Q/BW/Slope, centre/corner) rather than from a
+// BiQuadCommand, because those modes are not recoverable from the normalized
+// struct - see BiQuadCommand.h for why there is no BiQuadCommand::serialize().
 void BiQuadFilterGUI::store(QString& command, QString& parameters)
 {
 	BiQuad::Type type = (BiQuad::Type)ui->typeComboBox->currentData().toInt();

--- a/filters/BiQuadCommand.h
+++ b/filters/BiQuadCommand.h
@@ -44,6 +44,24 @@ struct BiQuadCommand
 	bool enabled = true;
 };
 
+// There is deliberately no BiQuadCommand::serialize() counterpart to the
+// PreampCommand / VSTPluginCommand serializers (biweekly-audit #109 F007). Those
+// round-trip because their parse is symmetric; the BiQuad parse is not. A "Filter:"
+// line cannot be reproduced from this struct alone, because BiQuadFilterFactory's
+// parser is intentionally lossy and normalizing:
+//   - A missing Q / BW / slope token is replaced by a synthesized default
+//     (M_SQRT1_2 for LP/HP/BP, 0.9 for shelves, 30 for notch), so "no token" and
+//     "a token whose value equals the default" collapse to identical fields.
+//   - LP/LPQ, HP/HPQ and LS/LSC all map to one BiQuad::Type; the spelling that
+//     was written is not recorded.
+//   - A shelf slope is stored divided by 12, not as it was typed.
+// The Editor's BiQuadFilterGUI::store() is therefore the single serializer, and it
+// emits from the GUI mode selectors (the Fixed/Q/BW/Slope and centre/corner combo
+// boxes) - state this Qt-free struct does not carry. A shared serializer would have
+// to live in the GUI and read those widgets, so it would relocate store() rather
+// than remove a duplicate: the engine never serializes BiQuad lines, so no second
+// serializer exists to consolidate.
+
 // Maps a config-line type keyword (e.g. L"PK", L"LSC", L"Modal") to a BiQuad
 // type. Returns false for unknown keywords. This is the single owner of the
 // keyword -> type vocabulary used by both the parser and the Editor.


### PR DESCRIPTION
Deferred [#109](https://github.com/115dkk/EqualizerAPO-XT/issues/109) finding **F007** — verified as **not applicable**, rationale recorded in code.

## The finding

F007 recommended adding a `BiQuadCommand::serialize()` that the Editor's `store()` would share, "like Delay/Convolution". Checked against the code, the premise does not hold for BiQuad.

## Why it does not apply

- **There is no duplicate to consolidate.** `BiQuadFilterGUI::store()` is the *only* BiQuad serializer; the engine only ever parses BiQuad lines (`BiQuadFilterFactory::parseCommand`). Delay/Convolution round-trip cleanly because their grammar is symmetric; BiQuad's is not.
- **The parser is intentionally lossy/normalizing**, so `parse → struct` discards what a serializer needs:
  - a missing `Q` / `BW` / slope token is replaced by a synthesized default (`M_SQRT1_2` for LP/HP/BP, `0.9` for shelves, `30` for notch), so "no token" and "a token equal to the default" collapse to identical fields;
  - `LP`/`LPQ`, `HP`/`HPQ`, `LS`/`LSC` all map to one `BiQuad::Type` — the spelling written is not recorded;
  - a shelf slope is stored divided by 12, not as typed.
- **`store()` emits from GUI mode selectors** (the Fixed/Q/BW/Slope and centre/corner combo boxes) that the Qt-free `BiQuadCommand` deliberately does not carry. A shared serializer would have to read those widgets, i.e. *relocate* `store()` into the GUI rather than remove a duplicate.

Forcing the change would either alter config-output behaviour (a config-format-adjacent regression risk) or add a struct + translation layer for a single logical serializer — net-negative.

## What changed

Comment only. The rationale now lives on `BiQuadCommand` (where a `serialize()` would be declared) and at `store()`, so the next audit pass or maintainer does not re-attempt a byte-breaking "dedup". No behaviour change.

No version bump (`docs:` — documentation/comment only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
