### PR TITLE
refactor(editor): self-register filter GUI factories (audit #109 F009)

### DIFF
--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -29,6 +29,7 @@ SOURCES += main.cpp\
 	../helpers/VelopackBootstrap.cpp \
 	../parser/LogicalOperators.cpp \
 	IFilterGUIFactory.cpp \
+	FilterGUIFactoryRegistry.cpp \
 	IFilterGUI.cpp \
 	guis/PreampFilterGUI.cpp \
 	guis/PreampFilterGUIFactory.cpp \
@@ -228,6 +229,7 @@ HEADERS  += \
 	../helpers/VelopackBootstrap.h \
 	../parser/LogicalOperators.h \
 	IFilterGUIFactory.h \
+	FilterGUIFactoryRegistry.h \
 	helpers/GUIHelper.h \
 	stable.h \
 	IFilterGUI.h \

--- a/Editor/FilterGUIFactoryRegistry.cpp
+++ b/Editor/FilterGUIFactoryRegistry.cpp
@@ -1,0 +1,61 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2015  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <algorithm>
+
+#include "FilterGUIFactoryRegistry.h"
+#include "IFilterGUIFactory.h"
+
+namespace
+{
+struct FilterGUIFactoryRegistration
+{
+	int order = 0;
+	FilterGUIFactoryCreator creator = nullptr;
+};
+
+// Construct-on-first-use so the list exists no matter the static-init order of
+// the factory translation units that fill it.
+QList<FilterGUIFactoryRegistration>& registrations()
+{
+	static QList<FilterGUIFactoryRegistration> registeredFactories;
+	return registeredFactories;
+}
+}
+
+bool FilterGUIFactoryRegistry::registerFactory(int order, FilterGUIFactoryCreator creator)
+{
+	registrations().append({order, creator});
+	return true;
+}
+
+QList<IFilterGUIFactory*> FilterGUIFactoryRegistry::createFactories()
+{
+	QList<FilterGUIFactoryRegistration> sortedRegistrations = registrations();
+	std::stable_sort(sortedRegistrations.begin(), sortedRegistrations.end(), [](const FilterGUIFactoryRegistration& left, const FilterGUIFactoryRegistration& right) {
+		return left.order < right.order;
+	});
+
+	QList<IFilterGUIFactory*> factories;
+	factories.reserve(sortedRegistrations.size());
+	for (const FilterGUIFactoryRegistration& registration : sortedRegistrations)
+		factories.append(registration.creator());
+
+	return factories;
+}

--- a/Editor/FilterGUIFactoryRegistry.h
+++ b/Editor/FilterGUIFactoryRegistry.h
@@ -1,0 +1,75 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2015  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <QList>
+
+class IFilterGUIFactory;
+
+using FilterGUIFactoryCreator = IFilterGUIFactory* (*)();
+
+// Single source of truth for the order in which FilterTable offers each parsed
+// configuration line to the GUI factories. Factories are sorted by ascending
+// order (lower runs first) in FilterGUIFactoryRegistry::createFactories(); the
+// first factory whose createFilterGUI() handles the line wins, so the order is
+// significant and these constants preserve the historical sequence.
+//
+// This mirrors the engine's FilterFactoryPriority (filters/FilterFactoryRegistry.h)
+// but the Editor roster is its own set: it has a Comment GUI and folds every
+// "Filter ..." line into one BiQuad GUI rather than the engine's IIR+BiQuad pair.
+// Changing a value here changes the matching order, so keep the numbering
+// contiguous and intentional.
+namespace FilterGUIFactoryOrder
+{
+	constexpr int Expression = 0;
+	constexpr int Comment = 1;
+	constexpr int Include = 2;
+	constexpr int Device = 3;
+	constexpr int Channel = 4;
+	constexpr int Stage = 5;
+	constexpr int Preamp = 6;
+	constexpr int BiQuad = 7;
+	constexpr int Delay = 8;
+	constexpr int Copy = 9;
+	constexpr int GraphicEQ = 10;
+	constexpr int Convolution = 11;
+	constexpr int VSTPlugin = 12;
+	constexpr int LoudnessCorrection = 13;
+}
+
+class FilterGUIFactoryRegistry
+{
+public:
+	static bool registerFactory(int order, FilterGUIFactoryCreator creator);
+
+	// Fresh factory instances in ascending order. The caller (FilterTable) takes
+	// ownership and deletes them, matching the historical hand-built list.
+	static QList<IFilterGUIFactory*> createFactories();
+};
+
+// Registers a GUI factory with its matching order. The factory's .cpp is compiled
+// straight into the Editor executable (not an archive), so its static initializer
+// always runs and no /WHOLEARCHIVE is needed. Each REGISTER line is the single
+// place a filter GUI joins the roster - FilterTable no longer hand-maintains it.
+#define REGISTER_FILTER_GUI_FACTORY(order, factoryType) \
+	namespace \
+	{ \
+		const bool factoryType##Registered = FilterGUIFactoryRegistry::registerFactory(order, []() -> IFilterGUIFactory* { return new factoryType; }); \
+	}

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -36,20 +36,7 @@
 #include "MainWindow.h"
 #include "FilterTableRow.h"
 #include "FilterTableMimeData.h"
-#include "guis/ExpressionFilterGUIFactory.h"
-#include "guis/CommentFilterGUIFactory.h"
-#include "guis/DeviceFilterGUIFactory.h"
-#include "guis/ChannelFilterGUIFactory.h"
-#include "guis/StageFilterGUIFactory.h"
-#include "guis/PreampFilterGUIFactory.h"
-#include "guis/BiQuadFilterGUIFactory.h"
-#include "guis/CopyFilterGUIFactory.h"
-#include "guis/DelayFilterGUIFactory.h"
-#include "guis/IncludeFilterGUIFactory.h"
-#include "guis/GraphicEQFilterGUIFactory.h"
-#include "guis/ConvolutionFilterGUIFactory.h"
-#include "guis/VSTPluginFilterGUIFactory.h"
-#include "guis/LoudnessCorrectionFilterGUIFactory.h"
+#include "FilterGUIFactoryRegistry.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "helpers/StringHelper.h"
 #include "helpers/LogHelper.h"
@@ -80,20 +67,11 @@ FilterTable::FilterTable(MainWindow* mainWindow, QWidget* parent)
 	insertArrow->setPixmap(icon.pixmap(GUIHelper::scale(QSize(24, 15))));
 	insertArrow->setVisible(false);
 
-	factories.append(new ExpressionFilterGUIFactory);
-	factories.append(new CommentFilterGUIFactory);
-	factories.append(new IncludeFilterGUIFactory);
-	factories.append(new DeviceFilterGUIFactory);
-	factories.append(new ChannelFilterGUIFactory);
-	factories.append(new StageFilterGUIFactory);
-	factories.append(new PreampFilterGUIFactory);
-	factories.append(new BiQuadFilterGUIFactory);
-	factories.append(new DelayFilterGUIFactory);
-	factories.append(new CopyFilterGUIFactory);
-	factories.append(new GraphicEQFilterGUIFactory);
-	factories.append(new ConvolutionFilterGUIFactory);
-	factories.append(new VSTPluginFilterGUIFactory);
-	factories.append(new LoudnessCorrectionFilterGUIFactory);
+	// The roster and its matching order live in the factory translation units
+	// themselves via REGISTER_FILTER_GUI_FACTORY (see FilterGUIFactoryRegistry),
+	// so adding a filter GUI no longer means editing this list. FilterTable owns
+	// the returned instances and deletes them in its destructor.
+	factories = FilterGUIFactoryRegistry::createFactories();
 
 	QApplication::instance()->installEventFilter(this);
 }

--- a/Editor/guis/BiQuadFilterGUIFactory.cpp
+++ b/Editor/guis/BiQuadFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "BiQuadFilterGUI.h"
 #include "BiQuadFilterGUIFactory.h"
 #include <filters/BiQuadFilterFactory.h>
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::BiQuad, BiQuadFilterGUIFactory)
 
 BiQuadFilterGUIFactory::BiQuadFilterGUIFactory()
 {

--- a/Editor/guis/BiQuadFilterGUIFactory.cpp
+++ b/Editor/guis/BiQuadFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "BiQuadFilterGUI.h"
 #include "BiQuadFilterGUIFactory.h"
 #include <filters/BiQuadFilterFactory.h>
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::BiQuad, BiQuadFilterGUIFactory)
 

--- a/Editor/guis/ChannelFilterGUIFactory.cpp
+++ b/Editor/guis/ChannelFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "Editor/FilterTable.h"
 #include "ChannelFilterGUI.h"
 #include "ChannelFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Channel, ChannelFilterGUIFactory)
 

--- a/Editor/guis/ChannelFilterGUIFactory.cpp
+++ b/Editor/guis/ChannelFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "Editor/FilterTable.h"
 #include "ChannelFilterGUI.h"
 #include "ChannelFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Channel, ChannelFilterGUIFactory)
 
 ChannelFilterGUIFactory::ChannelFilterGUIFactory()
 {

--- a/Editor/guis/CommentFilterGUIFactory.cpp
+++ b/Editor/guis/CommentFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "helpers/StringHelper.h"
 #include "CommentFilterGUI.h"
 #include "CommentFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Comment, CommentFilterGUIFactory)
 

--- a/Editor/guis/CommentFilterGUIFactory.cpp
+++ b/Editor/guis/CommentFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "helpers/StringHelper.h"
 #include "CommentFilterGUI.h"
 #include "CommentFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Comment, CommentFilterGUIFactory)
 
 using std::list;
 

--- a/Editor/guis/ConvolutionFilterGUIFactory.cpp
+++ b/Editor/guis/ConvolutionFilterGUIFactory.cpp
@@ -22,6 +22,9 @@
 #include "filters/ConvolutionCommand.h"
 #include "ConvolutionFilterGUI.h"
 #include "ConvolutionFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Convolution, ConvolutionFilterGUIFactory)
 
 using std::list;
 using std::shared_ptr;

--- a/Editor/guis/ConvolutionFilterGUIFactory.cpp
+++ b/Editor/guis/ConvolutionFilterGUIFactory.cpp
@@ -22,7 +22,7 @@
 #include "filters/ConvolutionCommand.h"
 #include "ConvolutionFilterGUI.h"
 #include "ConvolutionFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Convolution, ConvolutionFilterGUIFactory)
 

--- a/Editor/guis/CopyFilterGUIFactory.cpp
+++ b/Editor/guis/CopyFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "filters/CopyFilter.h"
 #include "CopyFilterGUI.h"
 #include "CopyFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Copy, CopyFilterGUIFactory)
 
 CopyFilterGUIFactory::CopyFilterGUIFactory()
 {

--- a/Editor/guis/CopyFilterGUIFactory.cpp
+++ b/Editor/guis/CopyFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "filters/CopyFilter.h"
 #include "CopyFilterGUI.h"
 #include "CopyFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Copy, CopyFilterGUIFactory)
 

--- a/Editor/guis/DelayFilterGUIFactory.cpp
+++ b/Editor/guis/DelayFilterGUIFactory.cpp
@@ -21,6 +21,9 @@
 #include "filters/DelayFilterFactory.h"
 #include "DelayFilterGUI.h"
 #include "DelayFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Delay, DelayFilterGUIFactory)
 
 DelayFilterGUIFactory::DelayFilterGUIFactory()
 {

--- a/Editor/guis/DelayFilterGUIFactory.cpp
+++ b/Editor/guis/DelayFilterGUIFactory.cpp
@@ -21,7 +21,7 @@
 #include "filters/DelayFilterFactory.h"
 #include "DelayFilterGUI.h"
 #include "DelayFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Delay, DelayFilterGUIFactory)
 

--- a/Editor/guis/DeviceFilterGUIFactory.cpp
+++ b/Editor/guis/DeviceFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "Editor/FilterTable.h"
 #include "DeviceFilterGUI.h"
 #include "DeviceFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Device, DeviceFilterGUIFactory)
 
 using std::list;
 using std::shared_ptr;

--- a/Editor/guis/DeviceFilterGUIFactory.cpp
+++ b/Editor/guis/DeviceFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "Editor/FilterTable.h"
 #include "DeviceFilterGUI.h"
 #include "DeviceFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Device, DeviceFilterGUIFactory)
 

--- a/Editor/guis/ExpressionFilterGUIFactory.cpp
+++ b/Editor/guis/ExpressionFilterGUIFactory.cpp
@@ -18,7 +18,7 @@
 */
 
 #include "ExpressionFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Expression, ExpressionFilterGUIFactory)
 

--- a/Editor/guis/ExpressionFilterGUIFactory.cpp
+++ b/Editor/guis/ExpressionFilterGUIFactory.cpp
@@ -18,6 +18,9 @@
 */
 
 #include "ExpressionFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Expression, ExpressionFilterGUIFactory)
 
 IFilterGUI* ExpressionFilterGUIFactory::createFilterGUI(QString& command, QString& parameters)
 {

--- a/Editor/guis/GraphicEQFilterGUIFactory.cpp
+++ b/Editor/guis/GraphicEQFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "filters/GraphicEQCommand.h"
 #include "GraphicEQFilterGUI.h"
 #include "GraphicEQFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::GraphicEQ, GraphicEQFilterGUIFactory)
 
 GraphicEQFilterGUIFactory::GraphicEQFilterGUIFactory()
 {

--- a/Editor/guis/GraphicEQFilterGUIFactory.cpp
+++ b/Editor/guis/GraphicEQFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "filters/GraphicEQCommand.h"
 #include "GraphicEQFilterGUI.h"
 #include "GraphicEQFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::GraphicEQ, GraphicEQFilterGUIFactory)
 

--- a/Editor/guis/IncludeFilterGUIFactory.cpp
+++ b/Editor/guis/IncludeFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "filters/IncludeCommand.h"
 #include "IncludeFilterGUI.h"
 #include "IncludeFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Include, IncludeFilterGUIFactory)
 

--- a/Editor/guis/IncludeFilterGUIFactory.cpp
+++ b/Editor/guis/IncludeFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "filters/IncludeCommand.h"
 #include "IncludeFilterGUI.h"
 #include "IncludeFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Include, IncludeFilterGUIFactory)
 
 IncludeFilterGUIFactory::IncludeFilterGUIFactory()
 {

--- a/Editor/guis/LoudnessCorrectionFilterGUIFactory.cpp
+++ b/Editor/guis/LoudnessCorrectionFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "filters/loudnessCorrection/LoudnessCorrectionCommand.h"
 #include "LoudnessCorrectionFilterGUI.h"
 #include "LoudnessCorrectionFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::LoudnessCorrection, LoudnessCorrectionFilterGUIFactory)
 
 LoudnessCorrectionFilterGUIFactory::LoudnessCorrectionFilterGUIFactory()
 {

--- a/Editor/guis/LoudnessCorrectionFilterGUIFactory.cpp
+++ b/Editor/guis/LoudnessCorrectionFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "filters/loudnessCorrection/LoudnessCorrectionCommand.h"
 #include "LoudnessCorrectionFilterGUI.h"
 #include "LoudnessCorrectionFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::LoudnessCorrection, LoudnessCorrectionFilterGUIFactory)
 

--- a/Editor/guis/PreampFilterGUIFactory.cpp
+++ b/Editor/guis/PreampFilterGUIFactory.cpp
@@ -20,7 +20,7 @@
 #include "PreampFilterGUI.h"
 #include <filters/PreampFilterFactory.h>
 #include "PreampFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Preamp, PreampFilterGUIFactory)
 

--- a/Editor/guis/PreampFilterGUIFactory.cpp
+++ b/Editor/guis/PreampFilterGUIFactory.cpp
@@ -20,6 +20,9 @@
 #include "PreampFilterGUI.h"
 #include <filters/PreampFilterFactory.h>
 #include "PreampFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Preamp, PreampFilterGUIFactory)
 
 QList<FilterTemplate> PreampFilterGUIFactory::createFilterTemplates()
 {

--- a/Editor/guis/StageFilterGUIFactory.cpp
+++ b/Editor/guis/StageFilterGUIFactory.cpp
@@ -19,6 +19,9 @@
 
 #include "StageFilterGUI.h"
 #include "StageFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Stage, StageFilterGUIFactory)
 
 QList<FilterTemplate> StageFilterGUIFactory::createFilterTemplates()
 {

--- a/Editor/guis/StageFilterGUIFactory.cpp
+++ b/Editor/guis/StageFilterGUIFactory.cpp
@@ -19,7 +19,7 @@
 
 #include "StageFilterGUI.h"
 #include "StageFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Stage, StageFilterGUIFactory)
 

--- a/Editor/guis/VSTPluginFilterGUIFactory.cpp
+++ b/Editor/guis/VSTPluginFilterGUIFactory.cpp
@@ -22,6 +22,9 @@
 #include "filters/VSTPluginCommand.h"
 #include "VSTPluginFilterGUI.h"
 #include "VSTPluginFilterGUIFactory.h"
+#include "Editor/FilterGUIFactoryRegistry.h"
+
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::VSTPlugin, VSTPluginFilterGUIFactory)
 
 using std::list;
 using std::unordered_map;

--- a/Editor/guis/VSTPluginFilterGUIFactory.cpp
+++ b/Editor/guis/VSTPluginFilterGUIFactory.cpp
@@ -22,7 +22,7 @@
 #include "filters/VSTPluginCommand.h"
 #include "VSTPluginFilterGUI.h"
 #include "VSTPluginFilterGUIFactory.h"
-#include "Editor/FilterGUIFactoryRegistry.h"
+#include "../FilterGUIFactoryRegistry.h"
 
 REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::VSTPlugin, VSTPluginFilterGUIFactory)
 


### PR DESCRIPTION
Deferred [#109](https://github.com/115dkk/EqualizerAPO-XT/issues/109) finding **F009** — the Editor's filter GUI factory roster was a hand-maintained list.

## What changed

`FilterTable`'s constructor hardcoded 14 `factories.append(new XFilterGUIFactory)` calls (plus 14 includes), with the matching order encoded only by line position. This mirrors the engine-side roster that #111 already converted to self-registration, so the Editor now gets the same treatment:

- **New `FilterGUIFactoryRegistry`** with a `REGISTER_FILTER_GUI_FACTORY(order, Type)` macro. Each `*FilterGUIFactory.cpp` self-registers. The factory objects link straight into the Editor executable (not a static archive), so their static initializers run without any `/WHOLEARCHIVE`.
- **`FilterGUIFactoryOrder`** gives each factory an explicit order constant, preserving the historical first-match-wins sequence exactly. The Editor roster is its own set (it has a Comment GUI and folds every `Filter ...` line into one BiQuad GUI, unlike the engine's IIR+BiQuad pair), so the order is kept Editor-specific rather than copied from `FilterFactoryPriority`.
- **`FilterTable`** now calls `FilterGUIFactoryRegistry::createFactories()` and drops the 14 `append()` calls and 14 factory includes. It still owns and deletes the instances exactly as before.

## Why it's safe

The roster contents and order are byte-for-byte the same. `FilterTable` is the only consumer — `EditorLogicTests` does not compile `FilterTable` or the factories, so nothing else is affected. Adding a filter GUI no longer means editing a central list.

## Verification

Local Editor `qmake`/`nmake` build passes. CI builds the Editor (qmake/nmake) on every PR.

No version bump (`refactor:` — internal structure only, no user-visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
