### PR TITLE
chore(editor): exit the headless skin-gallery instead of hanging on teardown

### DIFF
--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -1,5 +1,8 @@
 #include "SkinGallery.h"
 
+#include <cstdio>
+#include <cstdlib>
+
 #include <QApplication>
 #include <QCheckBox>
 #include <QDir>
@@ -379,6 +382,15 @@ int run(const QStringList& arguments)
 		failures += renderSkin(outDir, skinId.trimmed(), false);
 	}
 
-	return failures == 0 ? 0 : 1;
+	// --skin-gallery is a headless one-shot: by this point every screenshot has
+	// been rendered and flushed to disk. Returning normally would unwind into the
+	// QApplication / global teardown, which on the offscreen platform never
+	// finishes - a leftover background resource keeps the process alive, so the
+	// renders all succeed but the process hangs on exit and any driving script
+	// has to time out and kill it. Nothing is left to persist, so flush the
+	// diagnostic stream and exit immediately with the failure status instead.
+	const int status = failures == 0 ? 0 : 1;
+	std::fflush(nullptr);
+	std::_Exit(status);
 }
 }


### PR DESCRIPTION
## Problem

`Editor --skin-gallery <dir>` (the headless skin-screenshot harness) **renders every PNG correctly but then hangs on exit**: it returns normally into the `QApplication` / global teardown, which on the `offscreen` platform never finishes (a leftover background resource keeps the process alive). A script driving it has to time out and kill it.

This is **pre-existing**, not from the recent skin-file split — verified by running the same `--skin-gallery --skin-gallery-skins studio` offscreen on the pre-split (06-17) Editor and on the post-split Editor: **both hang identically** (>120s, process alive). Earlier gallery tasks still got their PNGs because they read the images and never relied on a clean exit.

## Fix

`--skin-gallery` is a one-shot: by the time the render loop finishes, all PNGs are flushed to disk and nothing is left to persist. So instead of returning (and unwinding into the hang-prone teardown), it now flushes the diagnostic stream and `std::_Exit(status)` with the failure count.

## Verification (offscreen, `QT_QPA_PLATFORM=offscreen`)

| | before | after |
|---|---|---|
| process | alive past 120s timeout, killed | exits in ~2s |
| exit code | n/a (killed) | `0` |
| PNGs (studio dark+light) | 50 (already worked) | 50 |

Localised the hang point with temporary flushed `fprintf` markers (reverted): the last marker was the final screenshot grab, i.e. the render fully completed and only teardown hung.

No user-facing change (`--skin-gallery` is a dev/test flag), so no version bump (`chore:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
