### PR TITLE
fix(editor): stop the start-up crash from re-homing the analysis dock after restoreState

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,14 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 일부 저장된 창 레이아웃에서 Editor가 시작되지 않던 크래시(액세스 위반)를
+  고쳤습니다. `loadPreferences()`가 `QMainWindow::restoreState()` 앞뒤로 분석
+  dock을 `removeDockWidget()` + `addDockWidget()`으로 다시 배치했는데,
+  `restoreState()`가 막 배치한 dock을 제거하면서 dock 영역이 아직 참조하던 레이아웃
+  아이템을 해제했고, 첫 창 표시에서 그 매달린 아이템을 역참조해(use-after-free)
+  창이 뜨지 않았습니다. 무겁거나 오래된 저장 레이아웃에서 #54/#75 시작 크래시가
+  재발한 것입니다. 이제 분석 dock은 목표 위치에 있지 않을 때만 다시 배치하므로,
+  불필요한 재배치가 사라지고 저장된 레이아웃은 초기화되지 않습니다. ([#118])
 - 고DPI(배율) 디스플레이에서 VST3 플러그인 에디터 창 크기가 어긋나던 문제를
   고쳤습니다. 에디터가 플러그인의 물리 픽셀 크기를 논리(장치 독립) 픽셀 단위로
   재는 Qt 위젯에 그대로 넘겨, 150%나 200% 모니터에서는 호스트 프레임이 너무 크게
@@ -434,3 +442,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
+[#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Fixed a start-up crash (access violation) where the Editor failed to launch on
+  some saved window layouts. `loadPreferences()` re-homed the analysis dock with
+  `removeDockWidget()` + `addDockWidget()` both before and after
+  `QMainWindow::restoreState()`; removing a dock that `restoreState()` had just
+  laid out freed a layout item the dock area still referenced, and the first
+  window show then dereferenced the dangling item (use-after-free). This was the
+  #54/#75 start-up crash recurring on heavy or stale saved layouts. The analysis
+  dock is now re-homed only when it is not already in the target area, removing
+  the redundant churn without resetting anyone's saved layout. ([#118])
 - Fixed VST3 plugin editor windows being mis-sized on high-DPI (scaled)
   displays. The editor handed the plugin's physical-pixel size straight to a Qt
   widget that measures in logical (device-independent) pixels, so on a 150% or
@@ -462,3 +471,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#105]: https://github.com/115dkk/EqualizerAPO-XT/pull/105
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
+[#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118

--- a/Editor/MainWindowParts/MainWindow.Preferences.cpp
+++ b/Editor/MainWindowParts/MainWindow.Preferences.cpp
@@ -376,13 +376,25 @@ void MainWindow::applyRedesignPreferences()
 
 	ui->analysisDockWidget->setWindowTitle(tr("Graph"));
 	bool graphWasShown = !ui->analysisDockWidget->isHidden();
-	removeDockWidget(ui->analysisDockWidget);
 	Qt::DockWidgetArea area = Qt::TopDockWidgetArea;
 	if (graphDockPosition == 1)
 		area = Qt::BottomDockWidgetArea;
 	else if (graphDockPosition == 2)
 		area = Qt::RightDockWidgetArea;
-	addDockWidget(area, ui->analysisDockWidget);
+	// Re-home the analysis dock only when it is not already in the target area.
+	// loadPreferences() runs this both before and after QMainWindow::restoreState();
+	// removing and re-adding a dock that restoreState has just laid out can free a
+	// QLayoutItem that the dock-area layout still references, and the first show()
+	// then dereferences the dangling item (use-after-free crash on heavy/stale saved
+	// layouts - the #54/#75 start-up crash). Skipping the churn when the dock is
+	// already placed avoids creating that dangling item without changing where the
+	// dock ends up; a genuine position change (the graph-position dropdown) still
+	// re-homes because the current area differs from the target.
+	if (dockWidgetArea(ui->analysisDockWidget) != area)
+	{
+		removeDockWidget(ui->analysisDockWidget);
+		addDockWidget(area, ui->analysisDockWidget);
+	}
 	ui->analysisDockWidget->setVisible(graphFullscreen || graphWasShown);
 
 	setCurrentRenderMode(currentRenderMode);


### PR DESCRIPTION
## What

Fixes the deterministic start-up access violation (the #54/#75 start-up crash recurring) where the Editor dies during the first `w.show()` while Qt activates `QMainWindowLayout`. Reported in the field as "this version won't run."

## Root cause (symbolized crash dump)

`loadPreferences()` calls `applyRedesignPreferences()` both **before and after** `QMainWindow::restoreState()`, and each call did `removeDockWidget()` + `addDockWidget()` to re-home the analysis dock to the configured graph position. Removing the dock right after `restoreState()` has laid out the dock area frees a `QLayoutItem` that the dock-area layout still references; the first `w.show()` then activates the layout and dereferences the dangling item (use-after-free — the faulting pointer carries the `0xABABABAB` freed-heap fill).

Symbolized stack (main thread, before the event loop):

```
Editor!MainWindow::MainWindow -> MainWindow::loadPreferences -> ... -> main.cpp:490 (w.show())
Qt6Widgets!QWidget::setVisible -> QWidgetPrivate::setVisible -> QLayout::activate -> QLayoutPrivate::doResize -> <freed QLayoutItem>
Editor!__scrt_common_main_seh   (i.e. the main thread, not a worker)
```

A multi-agent adversarial review plus this symbolized reproduction confirmed it is a single-threaded, main-thread layout-item lifetime bug — not a worker-thread Qt threading violation.

## Fix

Re-home the analysis dock only when `dockWidgetArea(analysisDockWidget) != area`, so the redundant remove/add after `restoreState()` (the operation that created the dangling item) no longer runs. The graph-position dropdown still re-homes a real position change (current area differs from the target). Where the dock ends up does not change.

`kWindowStateVersion` is intentionally left at 1: the dock/menu/toolbar structure has not changed since that gate was added (`dd6dff0`), so bumping it would discard every user's saved window layout for no structural reason. This guard fixes the fault and touches no one's saved layout.

## Validation

Same machine, same affected profile (`windowState` in the registry), same build path (current `main` + this guard), reproduced under cdb:

- **Unpatched:** faulted at the first `show()` — 4/4 (3 field crash dumps + 1 symbolized repro).
- **Patched:** no fault; reaches the event loop and the process stays alive on the same saved state.

## Known limitation

If a saved `windowState` ever placed the dock in an area different from the saved `graphDockPosition` (the two are written together and normally agree), the post-restore re-home still runs. The affected profile does not exercise that divergent-state edge; noted for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
