### PR TITLE
ci: treat a breaking footer (not prose) as the major bump trigger

### DIFF
--- a/.github/scripts/Bump-Version.ps1
+++ b/.github/scripts/Bump-Version.ps1
@@ -39,7 +39,13 @@ function Get-BumpKind {
   #   fix:                                            → patch
   #   feat:                                           → minor
   #   BREAKING CHANGE or `<type>!:`                   → major
-  if ($joined -match "BREAKING CHANGE" -or $joined -match "(^|\n)\w+(\([^)]+\))?!:") {
+  # Match the breaking change as an actual Conventional Commits footer
+  # (uppercase, at the start of a line, with the colon) - or "BREAKING-CHANGE:" -
+  # not as a bare substring. A commit that merely mentions the words in prose
+  # (for example release tooling or a changelog entry that documents this rule)
+  # must not trip a major bump; matching the bare substring is exactly what once
+  # cut a spurious 2.0.0 release from a ci: commit whose body discussed the rule.
+  if ($joined -cmatch "(^|\r?\n)BREAKING[ -]CHANGE:" -or $joined -match "(^|\n)\w+(\([^)]+\))?!:") {
     return "major"
   }
   if ($joined -match "(^|\n)feat(\([^)]+\))?:") {

--- a/.github/scripts/Tests/Bump-Version.Tests.ps1
+++ b/.github/scripts/Tests/Bump-Version.Tests.ps1
@@ -133,6 +133,27 @@ Describe "Bump-Version.ps1" {
             Get-FixtureVersion -Repo $repo | Should -Be "2.0.0"
         }
 
+        It "does not bump major when 'BREAKING CHANGE' only appears in prose, not as a footer" {
+            # Regression: a ci: commit whose body merely discusses the rule (no
+            # real footer, no type-bang marker) once matched the bare substring and
+            # cut a spurious 2.0.0 release. It must stay a no-bump.
+            $repo = New-FixtureRepo
+            Set-FixtureVersion -Repo $repo -Major 1 -Minor 2 -Revision 3
+            Add-FixtureCommit -Repo $repo -Subject "ci: add tests for the version bump rule" -Body "Coverage documents that a type-bang marker or a BREAKING CHANGE footer maps to a major bump."
+            $r = Invoke-Bump -Repo $repo
+            $r.ExitCode | Should -Be 0
+            Get-FixtureVersion -Repo $repo | Should -Be "1.2.3"
+        }
+
+        It "bumps the major for a BREAKING-CHANGE footer (hyphen spelling)" {
+            $repo = New-FixtureRepo
+            Set-FixtureVersion -Repo $repo -Major 1 -Minor 2 -Revision 3
+            Add-FixtureCommit -Repo $repo -Subject "fix: tweak parsing" -Body "BREAKING-CHANGE: the old syntax is gone"
+            $r = Invoke-Bump -Repo $repo
+            $r.ExitCode | Should -Be 0
+            Get-FixtureVersion -Repo $repo | Should -Be "2.0.0"
+        }
+
         It "does not bump for non-release types (chore/docs/refactor)" {
             $repo = New-FixtureRepo
             Set-FixtureVersion -Repo $repo -Major 1 -Minor 2 -Revision 3


### PR DESCRIPTION
## What

`Bump-Version.ps1` decided a **major** bump by matching the bare substring `BREAKING CHANGE` anywhere in the joined commit messages. A commit that only *mentions* those words in prose was therefore read as a breaking change.

This already misfired once: PR #113 (a `ci:` commit that added the bump-rule tests) documented the rule in its body, the substring matched, and CI cut a spurious **1.27.4 → 2.0.0** major release from a non-bumping commit.

## Fix

Match the footer the way Conventional Commits defines it — uppercase, at the start of a line, with the colon (`BREAKING CHANGE:` or `BREAKING-CHANGE:`), case-sensitive:

```diff
-  if ($joined -match "BREAKING CHANGE" -or $joined -match "(^|\n)\w+(\([^)]+\))?!:") {
+  if ($joined -cmatch "(^|\r?\n)BREAKING[ -]CHANGE:" -or $joined -match "(^|\n)\w+(\([^)]+\))?!:") {
```

The `<type>!:` marker rule is unchanged. Prose mentions and changelog text no longer trigger a major.

## Tests

Two new Pester cases lock it in: a `ci:` commit that only discusses the rule in its body stays a no-bump (the #113 regression), and the hyphen-spelled footer is still recognised. The existing `BREAKING CHANGE:` footer case still bumps major. Full suite — **18/18 pass** locally on Pester 5.6.1.

## Note on the existing 2.0.0 release

`v2.0.0` is already published; it is a clean, working build (the version number has no runtime effect). It is intentionally **not** rolled back: Velopack runs with `AllowVersionDowngrade = false`, so lowering the public version would strand anyone who already updated to 2.0.0. Versions simply continue forward from 2.0.x with the detection fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
