### PR TITLE
feat(editor): pick Device filter endpoints inline instead of a separate dialog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1066,9 +1066,9 @@ jobs:
         }
         $pngs = @(Get-ChildItem $outDir -Filter *.png)
         Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # 5 skins x 2 modes x (6 rows x 3 states + 3 picker states + toolbar + titlebar + menubar + menu)
-        if ($pngs.Count -ne 250) {
-          Write-Error "Expected 250 gallery PNGs, got $($pngs.Count)"
+        # 5 skins x 2 modes x (7 rows x 3 states + 3 picker states + toolbar + titlebar + menubar + menu)
+        if ($pngs.Count -ne 280) {
+          Write-Error "Expected 280 gallery PNGs, got $($pngs.Count)"
           exit 1
         }
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,13 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- Device 필터 행에서 장치를 카드 안에서 바로 고릅니다. `Device:` 줄이 어떤 재생·
+  녹음 장치에 적용될지 정할 때 더는 별도 다이얼로그를 열지 않습니다. 카드 본문에
+  장치마다 체크 가능한 칩과 'All devices' 칩이 나오고, APO가 설치되지 않은 장치는
+  'Show all' 토글 뒤에 숨깁니다. 칩은 네이티브 Windows 장치 트리 대신 카드의 나머지
+  요소처럼 각 스킨 스타일로 그려지며, 기록되는 줄은 기존 변경 버튼 다이얼로그가
+  만들던 것과 바이트 단위로 같습니다(`EditorLogicTests`의 회귀 테스트가 이
+  직렬화를 고정합니다). ([#120])
 - 일부 저장된 창 레이아웃에서 Editor가 시작되지 않던 크래시(액세스 위반)를
   고쳤습니다. `loadPreferences()`가 `QMainWindow::restoreState()` 앞뒤로 분석
   dock을 `removeDockWidget()` + `addDockWidget()`으로 다시 배치했는데,
@@ -443,3 +450,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
+[#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Device filter rows now pick endpoints inline. Choosing which playback or
+  capture devices a `Device:` line applies to no longer opens a separate
+  dialog: the card body shows one checkable chip per endpoint plus an "All
+  devices" chip, with devices that do not have the APO installed kept behind a
+  "Show all" reveal. The chips are styled by each skin like the rest of the
+  card instead of the native Windows device tree, and the written line stays
+  byte-identical with what the old change-button dialog produced (a regression
+  test in `EditorLogicTests` locks that serialization). ([#120])
 - Fixed a start-up crash (access violation) where the Editor failed to launch on
   some saved window layouts. `loadPreferences()` re-homed the analysis dock with
   `removeDockWidget()` + `addDockWidget()` both before and after
@@ -472,3 +480,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
+[#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -195,10 +195,13 @@ SOURCES += main.cpp\
 	skins/pickers/SoftFilterPicker.cpp \
 	skins/pickers/RackFilterPicker.cpp \
 	widgets/AudioKnob.cpp \
+	widgets/FlowLayout.cpp \
 	widgets/CommandRowFrame.cpp \
 	widgets/SkinComboBox.cpp \
 	widgets/cards/ChannelCardEditor.cpp \
 	widgets/cards/ChannelSelectionModel.cpp \
+	widgets/cards/DeviceCardEditor.cpp \
+	widgets/cards/DeviceSelectionModel.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \
 	widgets/cards/IncludeCardEditor.cpp \
 	widgets/cards/PreampCardEditor.cpp \
@@ -379,10 +382,13 @@ HEADERS  += \
 	skins/pickers/SoftFilterPicker.h \
 	skins/pickers/RackFilterPicker.h \
 	widgets/AudioKnob.h \
+	widgets/FlowLayout.h \
 	widgets/CommandRowFrame.h \
 	widgets/SkinComboBox.h \
 	widgets/cards/ChannelCardEditor.h \
 	widgets/cards/ChannelSelectionModel.h \
+	widgets/cards/DeviceCardEditor.h \
+	widgets/cards/DeviceSelectionModel.h \
 	widgets/cards/FilterCardEditorFactory.h \
 	widgets/cards/IncludeCardEditor.h \
 	widgets/cards/PreampCardEditor.h \

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -47,6 +47,7 @@ QList<GalleryRow> galleryRows()
 		{ QStringLiteral("gain0db"), QStringLiteral("Filter 3: ON PK Fc 1000 Hz Gain 0 dB Q 1") },
 		{ QStringLiteral("include"), QStringLiteral("Include: example.txt") },
 		{ QStringLiteral("vst"), QStringLiteral("VSTPlugin: Library example.dll") },
+		{ QStringLiteral("device"), QStringLiteral("Device: all") },
 		{ QStringLiteral("copy_empty"), QStringLiteral("Copy:") }
 	};
 }

--- a/Editor/widgets/FlowLayout.cpp
+++ b/Editor/widgets/FlowLayout.cpp
@@ -23,9 +23,12 @@ FlowLayout::FlowLayout(int margin, int hSpacing, int vSpacing)
 
 FlowLayout::~FlowLayout()
 {
-	QLayoutItem* item;
-	while ((item = takeAt(0)) != nullptr)
+	// Delete the owned items directly rather than through the virtual takeAt(),
+	// which must not be dispatched from a destructor. This is the concrete
+	// most-derived layout and owns every item in itemList.
+	for (QLayoutItem* item : itemList)
 		delete item;
+	itemList.clear();
 }
 
 void FlowLayout::addItem(QLayoutItem* item)
@@ -117,10 +120,10 @@ int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
 			continue;
 
 		int spaceX = horizontalSpacing();
-		int spaceY = verticalSpacing();
 		int nextX = x + item->sizeHint().width() + spaceX;
 		if (nextX - spaceX > effectiveRect.right() && lineHeight > 0)
 		{
+			int spaceY = verticalSpacing();
 			x = effectiveRect.x();
 			y = y + lineHeight + spaceY;
 			nextX = x + item->sizeHint().width() + spaceX;

--- a/Editor/widgets/FlowLayout.cpp
+++ b/Editor/widgets/FlowLayout.cpp
@@ -1,0 +1,150 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Canonical Qt FlowLayout (wrapping layout) example, trimmed for the cards.
+	See FlowLayout.h.
+*/
+
+#include "FlowLayout.h"
+
+#include <QWidget>
+
+FlowLayout::FlowLayout(QWidget* parent, int margin, int hSpacing, int vSpacing)
+	: QLayout(parent), m_hSpace(hSpacing), m_vSpace(vSpacing)
+{
+	setContentsMargins(margin, margin, margin, margin);
+}
+
+FlowLayout::FlowLayout(int margin, int hSpacing, int vSpacing)
+	: m_hSpace(hSpacing), m_vSpace(vSpacing)
+{
+	setContentsMargins(margin, margin, margin, margin);
+}
+
+FlowLayout::~FlowLayout()
+{
+	QLayoutItem* item;
+	while ((item = takeAt(0)) != nullptr)
+		delete item;
+}
+
+void FlowLayout::addItem(QLayoutItem* item)
+{
+	itemList.append(item);
+}
+
+int FlowLayout::horizontalSpacing() const
+{
+	if (m_hSpace >= 0)
+		return m_hSpace;
+	return smartSpacing(QStyle::PM_LayoutHorizontalSpacing);
+}
+
+int FlowLayout::verticalSpacing() const
+{
+	if (m_vSpace >= 0)
+		return m_vSpace;
+	return smartSpacing(QStyle::PM_LayoutVerticalSpacing);
+}
+
+int FlowLayout::count() const
+{
+	return itemList.size();
+}
+
+QLayoutItem* FlowLayout::itemAt(int index) const
+{
+	return itemList.value(index);
+}
+
+QLayoutItem* FlowLayout::takeAt(int index)
+{
+	if (index >= 0 && index < itemList.size())
+		return itemList.takeAt(index);
+	return nullptr;
+}
+
+Qt::Orientations FlowLayout::expandingDirections() const
+{
+	return Qt::Orientations();
+}
+
+bool FlowLayout::hasHeightForWidth() const
+{
+	return true;
+}
+
+int FlowLayout::heightForWidth(int width) const
+{
+	return doLayout(QRect(0, 0, width, 0), true);
+}
+
+void FlowLayout::setGeometry(const QRect& rect)
+{
+	QLayout::setGeometry(rect);
+	doLayout(rect, false);
+}
+
+QSize FlowLayout::sizeHint() const
+{
+	return minimumSize();
+}
+
+QSize FlowLayout::minimumSize() const
+{
+	QSize size;
+	for (const QLayoutItem* item : itemList)
+		size = size.expandedTo(item->minimumSize());
+
+	const QMargins margins = contentsMargins();
+	size += QSize(margins.left() + margins.right(), margins.top() + margins.bottom());
+	return size;
+}
+
+int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
+{
+	int left, top, right, bottom;
+	getContentsMargins(&left, &top, &right, &bottom);
+	const QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
+	int x = effectiveRect.x();
+	int y = effectiveRect.y();
+	int lineHeight = 0;
+
+	for (QLayoutItem* item : itemList)
+	{
+		const QWidget* widget = item->widget();
+		if (widget != nullptr && widget->isHidden())
+			continue;
+
+		int spaceX = horizontalSpacing();
+		int spaceY = verticalSpacing();
+		int nextX = x + item->sizeHint().width() + spaceX;
+		if (nextX - spaceX > effectiveRect.right() && lineHeight > 0)
+		{
+			x = effectiveRect.x();
+			y = y + lineHeight + spaceY;
+			nextX = x + item->sizeHint().width() + spaceX;
+			lineHeight = 0;
+		}
+
+		if (!testOnly)
+			item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+
+		x = nextX;
+		lineHeight = qMax(lineHeight, item->sizeHint().height());
+	}
+	return y + lineHeight - rect.y() + bottom;
+}
+
+int FlowLayout::smartSpacing(QStyle::PixelMetric pm) const
+{
+	QObject* parent = this->parent();
+	if (parent == nullptr)
+		return -1;
+	if (parent->isWidgetType())
+	{
+		QWidget* pw = static_cast<QWidget*>(parent);
+		return pw->style()->pixelMetric(pm, nullptr, pw);
+	}
+	return static_cast<QLayout*>(parent)->spacing();
+}

--- a/Editor/widgets/FlowLayout.h
+++ b/Editor/widgets/FlowLayout.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	A left-to-right layout that wraps its items onto the next line when they
+	run out of horizontal room, like word wrap for widgets. Used by the
+	in-card device chips so a machine with many endpoints grows the card
+	downward instead of overflowing the row (the gallery fails a row that
+	needs a horizontal scroll bar). This is the canonical Qt FlowLayout
+	example, trimmed to what the cards need.
+*/
+
+#pragma once
+
+#include <QLayout>
+#include <QList>
+#include <QRect>
+#include <QStyle>
+
+class FlowLayout : public QLayout
+{
+public:
+	explicit FlowLayout(QWidget* parent, int margin = 0, int hSpacing = 6, int vSpacing = 6);
+	explicit FlowLayout(int margin = 0, int hSpacing = 6, int vSpacing = 6);
+	~FlowLayout() override;
+
+	void addItem(QLayoutItem* item) override;
+	int horizontalSpacing() const;
+	int verticalSpacing() const;
+	Qt::Orientations expandingDirections() const override;
+	bool hasHeightForWidth() const override;
+	int heightForWidth(int width) const override;
+	int count() const override;
+	QLayoutItem* itemAt(int index) const override;
+	QSize minimumSize() const override;
+	void setGeometry(const QRect& rect) override;
+	QSize sizeHint() const override;
+	QLayoutItem* takeAt(int index) override;
+
+private:
+	int doLayout(const QRect& rect, bool testOnly) const;
+	int smartSpacing(QStyle::PixelMetric pm) const;
+
+	QList<QLayoutItem*> itemList;
+	int m_hSpace;
+	int m_vSpace;
+};

--- a/Editor/widgets/cards/DeviceCardEditor.cpp
+++ b/Editor/widgets/cards/DeviceCardEditor.cpp
@@ -1,0 +1,170 @@
+#include "DeviceCardEditor.h"
+
+#include <QToolButton>
+
+#include "Editor/FilterTable.h"
+#include "Editor/widgets/FlowLayout.h"
+#include <AbstractAPOInfo.h>
+
+using std::shared_ptr;
+
+namespace
+{
+QList<DeviceEntry> buildEntries(FilterTable* filterTable)
+{
+	QList<DeviceEntry> entries;
+	if (filterTable == nullptr)
+		return entries;
+
+	// Output devices then input devices, matching the order the legacy device
+	// dialog grouped (Playback then Capture) so the serialized line order stays
+	// byte-identical.
+	const QList<shared_ptr<AbstractAPOInfo>> groups[] = {
+		filterTable->getOutputDevices(),
+		filterTable->getInputDevices()
+	};
+	for (const QList<shared_ptr<AbstractAPOInfo>>& devices : groups)
+	{
+		for (const shared_ptr<AbstractAPOInfo>& apoInfo : devices)
+		{
+			DeviceEntry entry;
+			entry.deviceString = QString::fromStdWString(apoInfo->getDeviceString());
+			entry.name = QString::fromStdWString(apoInfo->getDeviceName());
+			entry.connection = QString::fromStdWString(apoInfo->getConnectionName());
+			entry.installed = apoInfo->isInstalled();
+			entry.isInput = apoInfo->isInput();
+			entries.append(entry);
+		}
+	}
+	return entries;
+}
+}
+
+DeviceCardEditor::DeviceCardEditor(FilterTable* filterTable, const QString& parameters, QWidget* parent)
+	: IFilterGUI(parent)
+{
+	setObjectName(QStringLiteral("DeviceCardEditor"));
+	setAttribute(Qt::WA_StyledBackground, true);
+
+	flow = new FlowLayout(this, 0, 6, 6);
+
+	// Persistent controls live at flow indices 0 and 1; reloadChips() only ever
+	// rebuilds the device chips after them, so a chip can never delete the
+	// control whose signal triggered the rebuild (the Channel card's rule).
+	allChip = new QToolButton(this);
+	allChip->setObjectName(QStringLiteral("DeviceChip"));
+	allChip->setText(tr("All devices"));
+	allChip->setCheckable(true);
+	allChip->setProperty("allDevices", true);
+	allChip->setToolTip(tr("Apply to every device"));
+	connect(allChip, SIGNAL(toggled(bool)), this, SLOT(allToggled(bool)));
+	flow->addWidget(allChip);
+
+	showAllButton = new QToolButton(this);
+	showAllButton->setObjectName(QStringLiteral("DeviceChipMore"));
+	showAllButton->setCheckable(true);
+	showAllButton->setToolTip(tr("Show devices that do not have the APO installed"));
+	connect(showAllButton, SIGNAL(toggled(bool)), this, SLOT(showAllToggled(bool)));
+	flow->addWidget(showAllButton);
+
+	model.load(parameters, buildEntries(filterTable));
+	reloadChips();
+}
+
+void DeviceCardEditor::store(QString& command, QString& parameters)
+{
+	command = QStringLiteral("Device");
+	parameters = model.serialize();
+}
+
+void DeviceCardEditor::allToggled(bool checked)
+{
+	if (updating)
+		return;
+
+	model.setAllSelected(checked);
+	// "All devices" wins over individual selections, like the legacy dialog;
+	// the device chips stay visible but inert while it is checked. Only enabled
+	// states change here - rebuilding the chip row inside a chip's own toggled
+	// signal would delete the emitting button.
+	for (int i = 2; i < flow->count(); i++)
+	{
+		if (QWidget* chip = flow->itemAt(i)->widget())
+			chip->setEnabled(!checked);
+	}
+	showAllButton->setEnabled(!checked);
+	emit updateModel();
+}
+
+void DeviceCardEditor::showAllToggled(bool checked)
+{
+	if (updating)
+		return;
+
+	showAll = checked;
+	// Safe to rebuild: the sender is the persistent reveal toggle, not a chip.
+	reloadChips();
+}
+
+void DeviceCardEditor::reloadChips()
+{
+	updating = true;
+
+	// Drop the device chips (everything after the two persistent controls),
+	// keeping allChip (0) and showAllButton (1).
+	while (flow->count() > 2)
+	{
+		QLayoutItem* child = flow->takeAt(flow->count() - 1);
+		delete child->widget();
+		delete child;
+	}
+
+	const bool all = model.allSelected();
+	allChip->setChecked(all);
+
+	hiddenUninstalled = 0;
+	for (const DeviceChipInfo& chip : model.chips())
+	{
+		// By default show installed devices and whatever is currently selected;
+		// keep machines with many idle endpoints from filling the card.
+		const bool visible = showAll || chip.installed || chip.selected;
+		if (!visible)
+		{
+			hiddenUninstalled++;
+			continue;
+		}
+
+		QToolButton* button = new QToolButton(this);
+		button->setObjectName(QStringLiteral("DeviceChip"));
+		button->setText(chip.connection.isEmpty() ? chip.name : chip.connection);
+		button->setCheckable(true);
+		button->setChecked(chip.selected);
+		button->setEnabled(!all);
+		// Skins may dim not-installed chips or distinguish capture devices.
+		button->setProperty("deviceInstalled", chip.installed);
+		button->setProperty("deviceInput", chip.isInput);
+		QString tip = chip.connection.isEmpty() ? chip.name : chip.connection + " - " + chip.name;
+		tip += "\n" + (chip.isInput ? tr("Capture") : tr("Playback"));
+		tip += "\n" + (chip.installed ? tr("APO installed") : tr("APO not installed"));
+		button->setToolTip(tip);
+		const QString deviceString = chip.deviceString;
+		connect(button, &QToolButton::toggled, this, [this, deviceString](bool) {
+			if (updating)
+				return;
+			model.toggle(deviceString);
+			emit updateModel();
+		});
+		flow->addWidget(button);
+	}
+
+	// The reveal toggle only matters when some devices are hidden, or while it
+	// is already revealing them (so the user can collapse again).
+	showAllButton->setVisible(hiddenUninstalled > 0 || showAll);
+	showAllButton->setEnabled(!all);
+	showAllButton->blockSignals(true);
+	showAllButton->setChecked(showAll);
+	showAllButton->setText(showAll ? tr("Show fewer") : tr("Show all (+%1)").arg(hiddenUninstalled));
+	showAllButton->blockSignals(false);
+
+	updating = false;
+}

--- a/Editor/widgets/cards/DeviceCardEditor.h
+++ b/Editor/widgets/cards/DeviceCardEditor.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	In-place device picker for "Device:" card rows. Replaces the read-only
+	device table plus modal change-dialog with checkable chips directly in the
+	card body: one chip per endpoint (installed devices and the current
+	selection shown by default, the rest behind a reveal toggle), plus an "All
+	devices" chip. Selection state and serialization live in
+	DeviceSelectionModel; the written line goes through the shared DeviceCommand
+	codec and stays byte-identical with what the legacy dialog produced. The
+	chips are plain checkable QToolButtons (objectName "DeviceChip"), so each
+	skin's QToolButton styling dresses them instead of the native tree.
+*/
+
+#pragma once
+
+#include "Editor/IFilterGUI.h"
+#include "DeviceSelectionModel.h"
+
+class FilterTable;
+class FlowLayout;
+class QToolButton;
+
+class DeviceCardEditor : public IFilterGUI
+{
+	Q_OBJECT
+
+public:
+	explicit DeviceCardEditor(FilterTable* filterTable, const QString& parameters, QWidget* parent = nullptr);
+
+	void store(QString& command, QString& parameters) override;
+
+private slots:
+	void allToggled(bool checked);
+	void showAllToggled(bool checked);
+
+private:
+	void reloadChips();
+
+	DeviceSelectionModel model;
+	FlowLayout* flow = nullptr;
+	QToolButton* allChip = nullptr;
+	QToolButton* showAllButton = nullptr;
+	int hiddenUninstalled = 0;
+	bool showAll = false;
+	bool updating = false;
+};

--- a/Editor/widgets/cards/DeviceSelectionModel.cpp
+++ b/Editor/widgets/cards/DeviceSelectionModel.cpp
@@ -1,0 +1,74 @@
+#include "DeviceSelectionModel.h"
+
+#include "filters/DeviceCommand.h"
+
+void DeviceSelectionModel::load(const QString& parameters, const QList<DeviceEntry>& devices)
+{
+	chipList.clear();
+	// The legacy dialog treated the literal lowercase "all" line as the
+	// all-devices state and ignored individual matches; mirror that exactly.
+	all = parameters.trimmed() == QStringLiteral("all");
+
+	// Match through the shared codec so a chip is pre-selected exactly when the
+	// engine would match that device for this pattern.
+	DeviceCommand cmd = DeviceCommand::fromPattern(parameters.toStdWString());
+
+	for (const DeviceEntry& entry : devices)
+	{
+		DeviceChipInfo chip;
+		chip.name = entry.name;
+		chip.connection = entry.connection;
+		chip.deviceString = entry.deviceString;
+		chip.installed = entry.installed;
+		chip.isInput = entry.isInput;
+		chip.selected = !all && cmd.matches(entry.deviceString.toStdWString());
+		chipList.append(chip);
+	}
+}
+
+const QList<DeviceChipInfo>& DeviceSelectionModel::chips() const
+{
+	return chipList;
+}
+
+bool DeviceSelectionModel::allSelected() const
+{
+	return all;
+}
+
+void DeviceSelectionModel::setAllSelected(bool on)
+{
+	all = on;
+}
+
+void DeviceSelectionModel::toggle(const QString& deviceString)
+{
+	for (DeviceChipInfo& chip : chipList)
+	{
+		if (chip.deviceString == deviceString)
+		{
+			chip.selected = !chip.selected;
+			return;
+		}
+	}
+}
+
+QString DeviceSelectionModel::serialize() const
+{
+	// Byte-identical with the legacy DeviceFilterGUIDialog::getPattern(): "all"
+	// when the all-devices state is set, otherwise each selected device's device
+	// string joined with "; " in list order (output devices then input).
+	if (all)
+		return QStringLiteral("all");
+
+	QString pattern;
+	for (const DeviceChipInfo& chip : chipList)
+	{
+		if (!chip.selected)
+			continue;
+		if (!pattern.isEmpty())
+			pattern += QStringLiteral("; ");
+		pattern += chip.deviceString;
+	}
+	return pattern;
+}

--- a/Editor/widgets/cards/DeviceSelectionModel.h
+++ b/Editor/widgets/cards/DeviceSelectionModel.h
@@ -1,0 +1,64 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Selection logic behind the in-place device picker (DeviceCardEditor).
+	Pure Qt Core so EditorLogicTests can exercise it: it maps a "Device:"
+	parameter string onto a chip list (one chip per available endpoint, plus
+	an implicit "all" flag) and serializes back to the same pattern the legacy
+	change-button dialog produced - "all", or the selected devices' device
+	strings joined with "; " in list order - so equivalent selections stay
+	byte-identical with configs written by the old flow. Matching uses the
+	shared DeviceCommand codec, the same one the engine uses.
+*/
+
+#pragma once
+
+#include <QList>
+#include <QString>
+
+// One available endpoint, fed into the model from the Editor's device list.
+struct DeviceEntry
+{
+	// apoInfo->getDeviceString(): the engine's match key and the token written
+	// back into the "Device:" line.
+	QString deviceString;
+	// Friendly name (getDeviceName) shown on the chip.
+	QString name;
+	// Connection name (getConnectionName), shown in the tooltip.
+	QString connection;
+	bool installed = false;
+	bool isInput = false;
+};
+
+// One selectable device chip.
+struct DeviceChipInfo
+{
+	QString name;
+	QString connection;
+	QString deviceString;
+	bool selected = false;
+	bool installed = false;
+	bool isInput = false;
+};
+
+class DeviceSelectionModel
+{
+public:
+	// Build the chip list from the line's parameters and the available device
+	// list, pre-selecting the devices the engine would match for the pattern.
+	void load(const QString& parameters, const QList<DeviceEntry>& devices);
+
+	const QList<DeviceChipInfo>& chips() const;
+	bool allSelected() const;
+
+	void setAllSelected(bool on);
+	void toggle(const QString& deviceString);
+
+	// Canonical parameter string for the current selection ("all" wins, like
+	// the legacy dialog), byte-identical with the old change-button flow.
+	QString serialize() const;
+
+private:
+	QList<DeviceChipInfo> chipList;
+	bool all = false;
+};

--- a/Editor/widgets/cards/FilterCardEditorFactory.cpp
+++ b/Editor/widgets/cards/FilterCardEditorFactory.cpp
@@ -6,6 +6,7 @@
 
 #include "Editor/IFilterGUI.h"
 #include "ChannelCardEditor.h"
+#include "DeviceCardEditor.h"
 #include "IncludeCardEditor.h"
 #include "PreampCardEditor.h"
 #include "VSTCardEditor.h"
@@ -21,6 +22,8 @@ IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QStr
 		return new PreampCardEditor(PreampCardEditor::parseGain(parameters));
 	if (normalizedCommand == QStringLiteral("channel"))
 		return new ChannelCardEditor(parameters);
+	if (normalizedCommand == QStringLiteral("device"))
+		return new DeviceCardEditor(filterTable, parameters);
 	if (normalizedCommand == QStringLiteral("include"))
 		return new IncludeCardEditor(filterTable, parameters);
 	if (normalizedCommand == QStringLiteral("vstplugin"))

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -20,6 +20,7 @@
 #include "Editor/import/ImportManifest.h"
 #include "Editor/widgets/FilterCardModel.h"
 #include "Editor/widgets/cards/ChannelSelectionModel.h"
+#include "Editor/widgets/cards/DeviceSelectionModel.h"
 #include "UpdateChecker/UpdateInfoFormatter.h"
 #include "UpdateChecker/VelopackUpdateInfo.h"
 
@@ -419,6 +420,76 @@ int main(int argc, char** argv)
 		model.load("", surround51);
 		expectTrue(model.addCustom("sub"), "SUB through addCustom is accepted");
 		expectEqual(model.serialize(), "LFE", "SUB resolves to the device's LFE chip");
+	}
+
+	{
+		// DeviceSelectionModel serialization identity: for equivalent device
+		// selections the in-place chip editor must write the same bytes the
+		// legacy change-button dialog produced - "all", or each selected
+		// device's device string joined with "; " in list order (output
+		// devices first, then input). Matching runs through the shared
+		// DeviceCommand codec, the same one the engine uses, so a chip is
+		// pre-selected exactly when the engine would match that device.
+		auto dev = [](const QString& deviceString, const QString& name, bool installed, bool isInput) {
+			DeviceEntry e;
+			e.deviceString = deviceString;
+			e.name = name;
+			e.installed = installed;
+			e.isInput = isInput;
+			return e;
+		};
+		const QString devSpeakers = "Speakers Realtek HD Audio {0.0.0.00000000}.{aaaaaaaa-1111-2222-3333-444444444444}";
+		const QString devHeadphones = "Headphones Realtek HD Audio {0.0.0.00000000}.{bbbbbbbb-1111-2222-3333-444444444444}";
+		const QString devDigital = "Digital Output Realtek HD Audio {0.0.0.00000000}.{cccccccc-1111-2222-3333-444444444444}";
+		const QString devMic = "Microphone Realtek HD Audio {0.0.1.00000000}.{dddddddd-1111-2222-3333-444444444444}";
+		const QList<DeviceEntry> devices = {
+			dev(devSpeakers, "Speakers", true, false),
+			dev(devHeadphones, "Headphones", true, false),
+			dev(devDigital, "Digital Output", false, false),
+			dev(devMic, "Microphone", true, true),
+		};
+
+		DeviceSelectionModel model;
+
+		// The literal lowercase "all" line is the all-devices state, like the
+		// dialog's "All devices" choice: it round-trips to "all" and marks no
+		// individual chip selected.
+		model.load("all", devices);
+		expectTrue(model.allSelected(), "literal 'all' sets the all-devices state");
+		expectEqual(model.serialize(), "all", "all-devices serializes back as 'all'");
+
+		// An empty parameter is not the all state and selects nothing.
+		model.load("", devices);
+		expectFalse(model.allSelected(), "empty parameter is not the all state");
+		expectEqual(model.serialize(), "", "no selection serializes empty");
+
+		// A full device-string pattern pre-selects exactly that endpoint and
+		// round-trips byte-for-byte, GUID included.
+		model.load(devSpeakers, devices);
+		expectFalse(model.allSelected(), "a specific device is not the all state");
+		expectEqual(model.serialize(), devSpeakers, "single device round-trips verbatim");
+
+		// A bare word matches as a case-insensitive substring (DeviceCommand
+		// semantics) and is rewritten to the matched device's full string.
+		model.load("headphones", devices);
+		expectEqual(model.serialize(), devHeadphones, "word pattern selects and canonicalizes to the device string");
+
+		// Multiple patterns, written input-first, serialize in list order
+		// (output devices first, then input) joined with "; ".
+		model.load(devMic + "; " + devSpeakers, devices);
+		expectEqual(model.serialize(), devSpeakers + "; " + devMic, "multiple devices serialize in list order");
+
+		// toggle() flips one chip and keeps canonical list order.
+		model.load(devSpeakers, devices);
+		model.toggle(devHeadphones);
+		expectEqual(model.serialize(), devSpeakers + "; " + devHeadphones, "toggling on adds a chip in list order");
+		model.toggle(devSpeakers);
+		expectEqual(model.serialize(), devHeadphones, "toggling off removes the token");
+
+		// "All devices" wins over individual selections, like the dialog.
+		model.load(devSpeakers, devices);
+		model.setAllSelected(true);
+		expectEqual(model.serialize(), "all", "All overrides individual selections");
 	}
 
 	harness.report();

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -120,7 +120,10 @@
     <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\cards\ChannelSelectionModel.cpp" />
+    <ClCompile Include="..\..\Editor\widgets\cards\DeviceSelectionModel.cpp" />
     <ClCompile Include="..\..\filters\BiQuadCommand.cpp" />
+    <ClCompile Include="..\..\filters\DeviceCommand.cpp" />
+    <ClCompile Include="..\..\helpers\StringHelper.cpp" />
     <ClCompile Include="..\..\filters\ChannelCommand.cpp" />
     <ClCompile Include="..\..\filters\FilterFactoryRegistry.cpp" />
     <ClCompile Include="..\..\UpdateChecker\UpdateInfoFormatter.cpp" />
@@ -133,7 +136,10 @@
     <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
     <ClInclude Include="..\..\Editor\widgets\cards\ChannelSelectionModel.h" />
+    <ClInclude Include="..\..\Editor\widgets\cards\DeviceSelectionModel.h" />
     <ClInclude Include="..\..\filters\BiQuad.h" />
+    <ClInclude Include="..\..\filters\DeviceCommand.h" />
+    <ClInclude Include="..\..\helpers\StringHelper.h" />
     <ClInclude Include="..\..\filters\BiQuadCommand.h" />
     <ClInclude Include="..\..\filters\ChannelCommand.h" />
     <ClInclude Include="..\..\filters\FilterFactoryRegistry.h" />


### PR DESCRIPTION
## What

The `Device:` filter card row now picks endpoints **in place**, the same way the Channel card was reworked. Previously, choosing which playback/capture devices a `Device:` line applies to meant opening a separate modal dialog, reading a device tree, ticking boxes, and coming back. The card body now shows the choice directly:

- one checkable chip per endpoint (`objectName "DeviceChip"`),
- an **"All devices"** chip for the `all` state,
- endpoints that do **not** have the APO installed kept behind a **"Show all (+N)"** reveal so machines with many idle endpoints don't fill the card.

## Why

This was the second clunky "go into a separate settings panel and fetch it back" flow in the card UI (the Channel filter was the first, already fixed). The Device row had the same friction plus a native Windows device tree that ignored the skin entirely.

## How

- **`DeviceSelectionModel`** (pure Qt Core, so it is unit-testable) maps the line's parameters onto a chip list and serializes back. Matching runs through the shared **`DeviceCommand`** codec (the same one the engine uses), and `serialize()` is **byte-identical** with the legacy `DeviceFilterGUIDialog::getPattern()` output: `all`, or each selected device's device string joined with `"; "` in list order (output devices first, then input).
- **`DeviceCardEditor`** (`IFilterGUI`) builds the chips from `FilterTable::getOutputDevices()/getInputDevices()`. It reuses the Channel card's safety rule: the "All devices" and "Show all" controls are persistent at flow indices 0/1, and `reloadChips()` only ever rebuilds the chips after them, so a chip can never delete the control whose `toggled` signal triggered the rebuild.
- A trimmed canonical Qt **`FlowLayout`** wraps the chips (and skips hidden widgets).
- The chips are plain checkable `QToolButton`s, so each skin's existing `QToolButton` QSS dresses them — no native tree.

The legacy `DeviceFilterGUI`/dialog path is left intact for the LegacyRows render mode; this only adds the modern in-card editor.

## Verification

- **`EditorLogicTests`**: added a `DeviceSelectionModel` block (all / empty / full-device-string round-trip / case-insensitive word match / multi-select list ordering / toggle / "All" override). Built Release x64 and ran: **113 checks pass, exit 0**.
- **Skin gallery** (offscreen): added a `device` row; re-rendered all skins → **280 PNGs, exit 0** (the harness fails on any horizontal overflow), confirming the card is skin-styled (studio/precision-minimal/soft/rack/matrix, dark+light) and never overflows.
- `git diff --check` clean.

## Scope / follow-up

This is **Phase 1** (in-card, inline) of the Device filter redesign. **Phase 2** — bespoke per-skin Device card designs (like the per-skin Copy renderers) — is a deliberate follow-up and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)