### PR TITLE
feat(editor): give each skin its own Device card grammar (Phase 2)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,12 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 이제 각 스킨이 Device 필터 카드를 단순히 색만 바꾼 칩이 아니라 스킨 고유의 문법으로
+  그립니다. 카드 안 장치 칩을 스킨마다 다시 칠해, 장치 선택 화면만 봐도 스킨이 구분됩니다.
+  studio는 유리 계기 셀, minimal은 평면 터미널 블록, soft는 둥근 캡슐, rack은 상태 램프가
+  달린 각인 래칭 스위치('All devices' 마스터는 녹색, 개별 라우트는 앰버로 켜지고 녹음
+  장치는 함몰된 입력 우물로 읽힘), matrix는 점등되는 보드 셀입니다. 순수 스킨별 QSS이고
+  장치 선택 동작은 그대로입니다. ([#122])
 - Device 필터 행에서 장치를 카드 안에서 바로 고릅니다. `Device:` 줄이 어떤 재생·
   녹음 장치에 적용될지 정할 때 더는 별도 다이얼로그를 열지 않습니다. 카드 본문에
   장치마다 체크 가능한 칩과 'All devices' 칩이 나오고, APO가 설치되지 않은 장치는
@@ -451,3 +457,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
 [#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120
+[#122]: https://github.com/115dkk/EqualizerAPO-XT/pull/122

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Each skin now draws the Device filter card in its own visual grammar, not just
+  recolored chips. The in-card device chips are restyled per skin so the device
+  picker alone tells skins apart: studio glass readout cells, minimal flat
+  terminal blocks, soft rounded capsules, rack engraved latching switches with
+  status lamps (the "All devices" master lights green while individual routes
+  light amber, and capture endpoints read as recessed input wells), and matrix
+  lit board cells. Pure per-skin QSS; device selection behaviour is unchanged.
+  ([#122])
 - Device filter rows now pick endpoints inline. Choosing which playback or
   capture devices a `Device:` line applies to no longer opens a separate
   dialog: the card body shows one checkable chip per endpoint plus an "All
@@ -481,3 +489,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
 [#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120
+[#122]: https://github.com/115dkk/EqualizerAPO-XT/pull/122

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -1183,3 +1183,126 @@ QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
     border-color: @DANGER@;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* ===== Device picker: routing endpoints as crosspoint cells =====
+   The Device card lists every audio endpoint as a sunken board cell - a
+   destination the configuration patches into (the toolbar device-readout and
+   picker entry-cell grammar). Engaging a cell engages a crosspoint: accent
+   fill + 1px accent rule, the picker's engaged-entry treatment. Endpoint
+   direction (playback/capture) is NOT colour-coded: colour stays rationed for
+   state, the way the type badge reads from mono code, not hue (the tooltip
+   already carries Playback/Capture). A device with no APO installed is a
+   cancelled departure - dashed rule + muted ink, never a traffic-light colour,
+   still posted on the board and still clickable. Compact cells (no min-width)
+   so the wrapping row never overflows. */
+QToolButton#DeviceChip {
+    background: @GRAPH@;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px;
+    min-height: 20px;
+}
+/* Capture endpoint: an identical board cell to a playback endpoint. Direction
+   is type, and type is never a colour here (rationing). Declared before the
+   :hover/:checked rules so those still win on a capture chip. */
+QToolButton#DeviceChip[deviceInput="true"] {
+    background: @GRAPH@;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+}
+/* "All devices" = the master cell that engages every endpoint at once. Same
+   sunken cell and engage grammar, but an uppercase board caption marks it as a
+   command, not a named endpoint. Before :hover/:checked so they pre-light it. */
+QToolButton#DeviceChip[allDevices="true"] {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+}
+/* Hover = crosspoint pre-light: the rule lights accent and a faint accent wash
+   enters the cell, well below the engaged fill (picker entry hover, M1). */
+QToolButton#DeviceChip:hover {
+    color: @TEXT@;
+    border-color: @ACCENT@;
+    background: rgba(34, 211, 238, 0.10);
+}
+/* Checked = engaged crosspoint: accent fill + 1px accent rule lit the cell. */
+QToolButton#DeviceChip:checked {
+    background: rgba(34, 211, 238, 0.26);
+    border: 1px solid @ACCENT@;
+    color: @TEXT@;
+}
+QToolButton#DeviceChip:checked:hover {
+    background: rgba(34, 211, 238, 0.32);
+}
+/* APO-not-installed endpoint = cancelled departure: dashed rule, muted ink,
+   still on the board and still engageable once revealed. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    color: @MUTED@;
+    border: 1px dashed @BORDER@;
+}
+QToolButton#DeviceChip[deviceInstalled="false"]:hover {
+    color: @TEXT@;
+    border-color: @ACCENT@;
+    background: rgba(34, 211, 238, 0.08);
+}
+/* A revealed, not-installed endpoint that is still engaged: the dashed rule
+   keeps the cancelled mark while accent ink + a faint accent wash show the
+   crosspoint is held. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    color: @ACCENT@;
+    border: 1px dashed @ACCENT@;
+    background: rgba(34, 211, 238, 0.16);
+}
+/* The master cell engaged: accent fill + rule, uppercase caption from base. */
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    color: @TEXT@;
+    background: rgba(34, 211, 238, 0.26);
+    border: 1px solid @ACCENT@;
+}
+/* While "All devices" is engaged, every endpoint cell is inert: cancelled
+   grammar (dashed rule + dead muted ink), colour dropped - disabled speaks in
+   form, not colour. Placed last so it overrides the not-installed and engaged
+   rules: when the master wins, the whole catalog reads cancelled. */
+QToolButton#DeviceChip:disabled {
+    color: #4A6470;
+    background: #0A1014;
+    border: 1px dashed #1A2933;
+}
+QToolButton#DeviceChip:checked:disabled {
+    color: #4A6470;
+    background: #0A1014;
+    border: 1px dashed #1A2933;
+}
+/* The reveal control is not an endpoint: a transparent mono caption cell whose
+   hidden-count readout ("+N") sits apart from the sunken endpoint cells. Hover
+   pre-lights; the revealed (checked) state lights its rule accent. */
+QToolButton#DeviceChipMore {
+    background: transparent;
+    color: @MUTED@;
+    border: 1px solid transparent;
+    border-radius: 0;
+    padding: 2px 8px;
+    min-height: 20px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QToolButton#DeviceChipMore:hover {
+    color: @TEXT@;
+    background: rgba(34, 211, 238, 0.08);
+    border-color: @BORDER@;
+}
+QToolButton#DeviceChipMore:checked {
+    color: @TEXT@;
+    border: 1px solid @ACCENT@;
+}
+QToolButton#DeviceChipMore:disabled {
+    color: #4A6470;
+    border: 1px dashed #1A2933;
+}

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -1179,3 +1179,128 @@ QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
     border-color: @DANGER@;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* ===== Device picker: routing endpoints as crosspoint cells =====
+   The Device card lists every audio endpoint as a board cell - a destination
+   the configuration patches into (the toolbar device-readout and picker
+   entry-cell grammar). Engaging a cell engages a crosspoint: accent fill + 1px
+   accent rule, the picker's engaged-entry treatment. Endpoint direction
+   (playback/capture) is NOT colour-coded: colour stays rationed for state, the
+   way the type badge reads from mono code, not hue (the tooltip carries
+   Playback/Capture). A device with no APO installed is a cancelled departure -
+   dashed rule + muted ink, never a traffic-light colour, still posted on the
+   board and still clickable. On the light board graph == card, so the cell
+   rides on the brightest surface (#FFFFFF) with its 1px rule, the same
+   construction the row coordinate cell (FilterCardNumber) uses. Compact cells
+   (no min-width) so the wrapping row never overflows. */
+QToolButton#DeviceChip {
+    background: #FFFFFF;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+    border-radius: 0;
+    padding: 2px 8px;
+    min-height: 20px;
+}
+/* Capture endpoint: an identical board cell to a playback endpoint. Direction
+   is type, and type is never a colour here (rationing). Declared before the
+   :hover/:checked rules so those still win on a capture chip. */
+QToolButton#DeviceChip[deviceInput="true"] {
+    background: #FFFFFF;
+    color: @TEXT@;
+    border: 1px solid @BORDER@;
+}
+/* "All devices" = the master cell that engages every endpoint at once. Same
+   cell and engage grammar, but an uppercase board caption marks it as a
+   command, not a named endpoint. Before :hover/:checked so they pre-light it. */
+QToolButton#DeviceChip[allDevices="true"] {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+}
+/* Hover = crosspoint pre-light: the rule lights accent and a faint accent wash
+   enters the cell, well below the engaged fill (picker entry hover, M1). */
+QToolButton#DeviceChip:hover {
+    color: @TEXT@;
+    border-color: @ACCENT@;
+    background: rgba(0, 142, 170, 0.08);
+}
+/* Checked = engaged crosspoint: accent fill + 1px accent rule lit the cell. */
+QToolButton#DeviceChip:checked {
+    background: rgba(0, 142, 170, 0.16);
+    border: 1px solid @ACCENT@;
+    color: @TEXT@;
+}
+QToolButton#DeviceChip:checked:hover {
+    background: rgba(0, 142, 170, 0.22);
+}
+/* APO-not-installed endpoint = cancelled departure: dashed rule, muted ink,
+   still on the board and still engageable once revealed. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    color: @MUTED@;
+    border: 1px dashed @BORDER@;
+}
+QToolButton#DeviceChip[deviceInstalled="false"]:hover {
+    color: @TEXT@;
+    border-color: @ACCENT@;
+    background: rgba(0, 142, 170, 0.06);
+}
+/* A revealed, not-installed endpoint that is still engaged: the dashed rule
+   keeps the cancelled mark while accent ink + a faint accent wash show the
+   crosspoint is held. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    color: @ACCENT@;
+    border: 1px dashed @ACCENT@;
+    background: rgba(0, 142, 170, 0.10);
+}
+/* The master cell engaged: accent fill + rule, uppercase caption from base. */
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    color: @TEXT@;
+    background: rgba(0, 142, 170, 0.16);
+    border: 1px solid @ACCENT@;
+}
+/* While "All devices" is engaged, every endpoint cell is inert: cancelled
+   grammar (dashed rule + dead muted ink), colour dropped - disabled speaks in
+   form, not colour. Placed last so it overrides the not-installed and engaged
+   rules: when the master wins, the whole catalog reads cancelled. */
+QToolButton#DeviceChip:disabled {
+    color: #9DB4BD;
+    background: #EDF2F4;
+    border: 1px dashed #D4E2E8;
+}
+QToolButton#DeviceChip:checked:disabled {
+    color: #9DB4BD;
+    background: #EDF2F4;
+    border: 1px dashed #D4E2E8;
+}
+/* The reveal control is not an endpoint: a transparent mono caption cell whose
+   hidden-count readout ("+N") sits apart from the endpoint cells. Hover
+   pre-lights; the revealed (checked) state lights its rule accent. */
+QToolButton#DeviceChipMore {
+    background: transparent;
+    color: @MUTED@;
+    border: 1px solid transparent;
+    border-radius: 0;
+    padding: 2px 8px;
+    min-height: 20px;
+    font-family: "@MONO@", "Consolas", "Malgun Gothic", monospace;
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+QToolButton#DeviceChipMore:hover {
+    color: @TEXT@;
+    background: rgba(0, 142, 170, 0.06);
+    border-color: @BORDER@;
+}
+QToolButton#DeviceChipMore:checked {
+    color: @TEXT@;
+    border: 1px solid @ACCENT@;
+}
+QToolButton#DeviceChipMore:disabled {
+    color: #9DB4BD;
+    border: 1px dashed #D4E2E8;
+}

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -523,3 +523,88 @@ QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
 QToolButton#TitleBarClose:hover, QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* ====================================================================
+   Device picker (minimal, dark): an endpoint manifest on the console.
+   Each chip is a mono token in a 1px hairline box; selection is the
+   inverted block (ink and ground swap), the picker's blunt-cursor
+   grammar - never a new fill colour, never the accent (no chip state is
+   an active drag/entry). Kind rides line/letter, not hue: not-installed
+   endpoints print in a dashed hairline at secondary ink, capture devices
+   lean italic. "All devices" is the uppercase mode line; "Show all (+N)"
+   is a quiet meta-command with the picker's counter grammar. State keeps
+   to the value ladder: rest=card, hover=cardHover (+1), disabled=surface
+   (-1). Compact so a row of endpoints never overflows the card. */
+QWidget#DeviceCardEditor { background: transparent; }
+
+/* Resting chip: a bare boxed mono token. */
+QToolButton#DeviceChip {
+    background: @CARD@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 0;
+    padding: 2px 8px; min-height: 20px;
+    font-size: 9pt;
+}
+/* Hover: exactly one background-value step up. That is the whole grammar. */
+QToolButton#DeviceChip:hover { background: @CARD_HOVER@; }
+/* Selected: the inverted block - ink and ground trade places (identical to
+   MinimalFilterPicker's selection and the toolbar's pressed cursor). */
+QToolButton#DeviceChip:checked {
+    background: @TEXT@; color: @BG@; border: 1px solid @TEXT@;
+}
+/* Selection outranks hover: the block stays inverted under the cursor. */
+QToolButton#DeviceChip:checked:hover { background: @TEXT@; color: @BG@; }
+/* Disabled (every device chip while "All devices" rules): drop one step
+   below rest onto the surface and fall to secondary ink - a greyed, inert
+   line that cannot take the cursor. */
+QToolButton#DeviceChip:disabled {
+    background: @SURFACE@; color: @MUTED@; border: 1px solid @BORDER@;
+}
+
+/* Not-installed endpoint: no APO on it yet, so the box is a dashed hairline
+   and the label drops to secondary ink (importance = brightness). Still a
+   selectable token, just printed lighter. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    color: @MUTED@; border: 1px dashed @BORDER@;
+}
+/* Selecting one still inverts; the block reclaims a solid edge so the dashes
+   never read through the cursor. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    background: @TEXT@; color: @BG@; border: 1px solid @TEXT@;
+}
+QToolButton#DeviceChip[deviceInstalled="false"]:disabled {
+    background: @SURFACE@; color: @MUTED@; border: 1px dashed @BORDER@;
+}
+
+/* Capture (input) device: the same token leaning italic - a kind tag carried
+   by letter shape, not by a colour the meter skins would use. font-style
+   only, so it survives every other state untouched. */
+QToolButton#DeviceChip[deviceInput="true"] { font-style: italic; }
+
+/* "All devices": a mode, not a device name. Uppercase, letter-spaced - the
+   mode line that switches the whole card. Selecting it inverts like any other
+   line; while it rules, the device tokens beside it grey out and this block
+   stays lit. */
+QToolButton#DeviceChip[allDevices="true"] {
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+    font-style: normal;
+}
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    background: @TEXT@; color: @BG@; border: 1px solid @TEXT@;
+}
+
+/* Reveal toggle: a meta-command line, not a chip. Bare secondary type with a
+   (+N) count (the picker's "22/22" counter grammar). Hover climbs one step;
+   while it is showing everything ("Show fewer") the ink lifts to body
+   brightness. The accent stays reserved for active controls, so it is absent. */
+QToolButton#DeviceChipMore {
+    background: transparent; color: @MUTED@;
+    border: 1px solid transparent; border-radius: 0;
+    padding: 2px 8px; min-height: 20px;
+    font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QToolButton#DeviceChipMore:hover { background: @CARD_HOVER@; color: @TEXT@; }
+QToolButton#DeviceChipMore:checked { background: @CARD@; color: @TEXT@; }
+QToolButton#DeviceChipMore:disabled { background: transparent; color: @MUTED@; }

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -468,3 +468,80 @@ QToolButton#TitleBarMin:pressed, QToolButton#TitleBarMax:pressed {
 QToolButton#TitleBarClose:hover, QToolButton#TitleBarClose:pressed {
     background: @DANGER@;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* ====================================================================
+   Device picker (minimal, light): the same endpoint manifest, printed on
+   paper. Identical grammar to the dark sheet - boxed mono tokens, an
+   inverted block (black on white) for the chosen endpoint, dashed/italic
+   for kind, an uppercase mode line for "All devices". The only deliberate
+   divergence: this palette has surface == card == #FFFFFF, so "disabled =
+   one step below rest" cannot land on surface; it drops to @BG@ (#F6F6F3),
+   the nearest darker step on the paper, plus secondary ink. */
+QWidget#DeviceCardEditor { background: transparent; }
+
+/* Resting chip: a bare boxed mono token. */
+QToolButton#DeviceChip {
+    background: @CARD@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 0;
+    padding: 2px 8px; min-height: 20px;
+    font-size: 9pt;
+}
+/* Hover: exactly one value step (one step darker on the paper). */
+QToolButton#DeviceChip:hover { background: @CARD_HOVER@; }
+/* Selected: the inverted block - black ink ground, paper-coloured glyphs
+   (the printed cursor; identical to MinimalFilterPicker's selection). */
+QToolButton#DeviceChip:checked {
+    background: @TEXT@; color: @BG@; border: 1px solid @TEXT@;
+}
+/* Selection outranks hover: the block stays inverted under the cursor. */
+QToolButton#DeviceChip:checked:hover { background: @TEXT@; color: @BG@; }
+/* Disabled (every device chip while "All devices" rules): drop to @BG@ (a
+   step below the white card) and fall to secondary ink - a greyed, inert
+   line. */
+QToolButton#DeviceChip:disabled {
+    background: @BG@; color: @MUTED@; border: 1px solid @BORDER@;
+}
+
+/* Not-installed endpoint: no APO on it yet - dashed hairline box and
+   secondary ink (importance = brightness). Still selectable, printed lighter. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    color: @MUTED@; border: 1px dashed @BORDER@;
+}
+/* Selecting one still inverts; the block reclaims a solid edge so the dashes
+   never read through the cursor. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    background: @TEXT@; color: @BG@; border: 1px solid @TEXT@;
+}
+QToolButton#DeviceChip[deviceInstalled="false"]:disabled {
+    background: @BG@; color: @MUTED@; border: 1px dashed @BORDER@;
+}
+
+/* Capture (input) device: the same token leaning italic - a kind tag carried
+   by letter shape, not by a colour the meter skins would use. */
+QToolButton#DeviceChip[deviceInput="true"] { font-style: italic; }
+
+/* "All devices": the uppercase, letter-spaced mode line that switches the
+   whole card. Selecting it inverts like any other line. */
+QToolButton#DeviceChip[allDevices="true"] {
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+    font-style: normal;
+}
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    background: @TEXT@; color: @BG@; border: 1px solid @TEXT@;
+}
+
+/* Reveal toggle: a meta-command line with a (+N) count (the picker's counter
+   grammar). Hover sinks one step on the paper; while it shows everything the
+   ink lifts to body brightness. Accent reserved for active controls, absent. */
+QToolButton#DeviceChipMore {
+    background: transparent; color: @MUTED@;
+    border: 1px solid transparent; border-radius: 0;
+    padding: 2px 8px; min-height: 20px;
+    font-size: 9pt; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+QToolButton#DeviceChipMore:hover { background: @CARD_HOVER@; color: @TEXT@; }
+QToolButton#DeviceChipMore:checked { background: @CARD@; color: @TEXT@; }
+QToolButton#DeviceChipMore:disabled { background: transparent; color: @MUTED@; }

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -552,3 +552,151 @@ QToolButton#TitleBarClose:pressed {
         stop:0 #8A2E1E, stop:1 #4A180D);
     border-color: @DANGER@; border-top-color: #3A130A;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* Device card: the OUTPUT ROUTING switch bank. Each chip is a latching
+   faceplate switch cap (machined gradient, lit top bevel, shadowed base,
+   engraved uppercase label). State is a lamp: engaged = warm backlit cap +
+   amber border (invariant 4, the picker's lit-slot grammar). Depth carries
+   type (invariant 3): playback = raised switch, capture = recessed well,
+   unwired endpoint = flat blank. Compact padding so the FlowLayout never
+   overflows horizontally.
+
+   CASCADE NOTE (read before editing): the type attributes
+   [deviceInput="true"] and [deviceInstalled="false"] each score the same Qt
+   specificity (0x111) as the bare state pseudo-classes :hover and :checked.
+   On a tie Qt takes the later rule, so a type rule placed after :checked would
+   MASK the lamp. Every state that must survive on a typed chip is therefore
+   authored as an explicit combined selector (0x121, or 0x131 with two pseudo)
+   so it wins by specificity regardless of source order. Do not collapse these
+   back into the bare pseudo rules. */
+QWidget#DeviceCardEditor { background: transparent; }
+
+/* Base = a raised playback switch cap. */
+QToolButton#DeviceChip {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2C333A, stop:1 #1B2126);
+    color: @TEXT@;
+    border: 1px solid #11161A; border-top-color: #3E474F;
+    border-radius: 2px;
+    padding: 3px 9px; min-height: 20px;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 0.5px;
+}
+/* Hover (bare): the faceplate edge warms amber, gloss rises one step. */
+QToolButton#DeviceChip:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #343C44, stop:1 #20272D);
+    border: 1px solid @ACCENT@; border-top-color: #3E474F;
+    color: #F2DDB4;
+}
+/* Engaged (bare playback switch): the amber routing lamp lights. */
+QToolButton#DeviceChip:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #4A3A1C, stop:1 #2E2410);
+    border: 1px solid @ACCENT@; border-top-color: #6E521E;
+    color: #FFE9C8;
+}
+
+/* Capture device = recessed input well: shadowed top, lit lower lip. This is
+   the AT-REST face; its state lamps are restored by the combined rules below. */
+QToolButton#DeviceChip[deviceInput="true"] {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #1B2126, stop:1 #2A3036);
+    border: 1px solid #11161A; border-top-color: #0C1013; border-bottom-color: #3E474F;
+    color: #BDB7A9;
+}
+/* Unwired endpoint (APO not installed) = flat blank position, recedes (R5). */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    background: #181D21;
+    border: 1px solid #11161A; border-top-color: #11161A;
+    color: #6E685C;
+}
+
+/* Hover on a capture well (0x121): the type base would otherwise mask the bare
+   :hover, so warm the well's amber edge explicitly while keeping the recessed
+   orientation (dark top, lit lower lip). */
+QToolButton#DeviceChip[deviceInput="true"]:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #20272D, stop:1 #2E363C);
+    border: 1px solid @ACCENT@; border-top-color: #0C1013; border-bottom-color: #3E474F;
+    color: #F2DDB4;
+}
+/* Hover on a blank position (0x121): a blank still warms its amber edge so the
+   bank's hover grammar is uniform; it stays flat (no top bevel). */
+QToolButton#DeviceChip[deviceInstalled="false"]:hover {
+    background: #1E242A;
+    border: 1px solid @ACCENT@; border-top-color: #11161A;
+    color: #8C8678;
+}
+
+/* Engaged capture well (0x121) — THE LAMP FIX. A routed input well lights the
+   SAME amber lamp as a routed playback switch (a routed switch is a routed
+   switch, invariant 4). Identical fill/border to the bare :checked so capture
+   and playback are indistinguishable once engaged; the well's depth read its
+   type only at rest. Beats both :checked and [deviceInput="true"] (0x111). */
+QToolButton#DeviceChip[deviceInput="true"]:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #4A3A1C, stop:1 #2E2410);
+    border: 1px solid @ACCENT@; border-top-color: #6E521E;
+    color: #FFE9C8;
+}
+/* Routed offline device (0x121): amber lamp on the darker blank metal. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #3A2F18, stop:1 #241B0E);
+    border: 1px solid @ACCENT@; border-top-color: #5C440F;
+    color: #F2DDB4;
+}
+/* Master BUS-ENABLE engaged (0x121): the green bus lamp, never amber. */
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #16352A, stop:1 #0F2A20);
+    border: 1px solid @ACCENT2@; border-top-color: #1E5A44;
+    color: #BFF0D8;
+}
+
+/* Powered down (bank disabled while ALL is on): dark film, lamp off. The
+   powering-down is type-blind - a well and a blank go dark identically,
+   because a powered-down unit shows no part-type colour. */
+QToolButton#DeviceChip:disabled {
+    background: #171B1F;
+    border: 1px solid #22282D; border-top-color: #22282D;
+    color: #4E4A40;
+}
+/* Routed but powered down (0x121): faint warm memory of the lamp, no glow. */
+QToolButton#DeviceChip:checked:disabled {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2A2417, stop:1 #211C12);
+    border: 1px solid #6B4A10; border-top-color: #6B4A10;
+    color: #7A6A45;
+}
+/* Capture/blank powered down (0x121): the type base would otherwise mask the
+   bare :disabled and keep the well/blank colour lit, so collapse them to the
+   same dark film. */
+QToolButton#DeviceChip[deviceInput="true"]:disabled,
+QToolButton#DeviceChip[deviceInstalled="false"]:disabled {
+    background: #171B1F;
+    border: 1px solid #22282D; border-top-color: #22282D;
+    color: #4E4A40;
+}
+/* Routed capture/blank powered down (0x131): same faint warm memory as any
+   routed switch that loses power. Beats [deviceInput]:checked,
+   :checked:disabled and [deviceInput]:disabled (all 0x121). */
+QToolButton#DeviceChip[deviceInput="true"]:checked:disabled,
+QToolButton#DeviceChip[deviceInstalled="false"]:checked:disabled {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #2A2417, stop:1 #211C12);
+    border: 1px solid #6B4A10; border-top-color: #6B4A10;
+    color: #7A6A45;
+}
+
+/* Reveal latch: a subordinate service latch; open (:checked) sits pressed in.
+   It carries no device type properties, so the bare pseudo rules are safe. */
+QToolButton#DeviceChipMore {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #262C32, stop:1 #1A1F23);
+    color: @MUTED@;
+    border: 1px solid #11161A; border-top-color: #333A41;
+    border-radius: 2px;
+    padding: 3px 9px; min-height: 20px;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 0.5px;
+}
+QToolButton#DeviceChipMore:hover { border-color: @ACCENT@; border-top-color: #333A41; color: #E0D6BC; }
+QToolButton#DeviceChipMore:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #14181C, stop:1 #20262B);
+    border: 1px solid #11161A; border-top-color: #0C1013;
+    color: @TEXT@;
+}
+QToolButton#DeviceChipMore:disabled { background: #171B1F; border-color: #22282D; color: #4E4A40; }

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -554,3 +554,147 @@ QToolButton#TitleBarClose:pressed {
         stop:0 #A83A26, stop:1 #7A2415);
     border-color: #6B1D10; border-top-color: #581808;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* Device card: the OUTPUT ROUTING switch bank (cream/aluminium). Same
+   switch-bank grammar on the light faceplate: raised machined caps with a
+   white top bevel, engraved uppercase labels, amber lamp on engage, green
+   master bus, recessed input wells, flat blank positions, powered-down film.
+   Compact padding so the FlowLayout never overflows horizontally.
+
+   CASCADE NOTE (read before editing): the type attributes
+   [deviceInput="true"] and [deviceInstalled="false"] each score the same Qt
+   specificity (0x111) as the bare state pseudo-classes :hover and :checked. On
+   a tie Qt takes the later rule, so a type rule placed after :checked would
+   MASK the lamp. Every state that must survive on a typed chip is authored as
+   an explicit combined selector (0x121, or 0x131 with two pseudo) so it wins
+   by specificity regardless of source order. Do not collapse these back into
+   the bare pseudo rules. */
+QWidget#DeviceCardEditor { background: transparent; }
+
+/* Base = a raised playback switch cap. */
+QToolButton#DeviceChip {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #E6DECC);
+    color: @TEXT@;
+    border: 1px solid #AFA288; border-top-color: #FFFFFF;
+    border-radius: 2px;
+    padding: 3px 9px; min-height: 20px;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 0.5px;
+}
+/* Hover (bare): the faceplate edge warms amber, gloss rises one step. */
+QToolButton#DeviceChip:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FFFFFF, stop:1 #F0E8D6);
+    border: 1px solid @ACCENT@; border-top-color: #FFFFFF;
+    color: #7A4A05;
+}
+/* Engaged (bare playback switch): the amber routing lamp lights. */
+QToolButton#DeviceChip:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FBE9C2, stop:1 #E8C887);
+    border: 1px solid @ACCENT@; border-top-color: #FFF3D8;
+    color: #4A2E00;
+}
+
+/* Capture device = recessed input well: shadowed top, lit lower lip. AT-REST
+   face; its state lamps are restored by the combined rules below. */
+QToolButton#DeviceChip[deviceInput="true"] {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #E6DECC, stop:1 #FFFFFF);
+    border: 1px solid #AFA288; border-top-color: #B8AC92; border-bottom-color: #FFFFFF;
+    color: #3A352C;
+}
+/* Unwired endpoint (APO not installed) = flat blank position, recedes. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    background: #EFEADD;
+    border: 1px solid #C4BBA6; border-top-color: #C4BBA6;
+    color: #9A917F;
+}
+
+/* Hover on a capture well (0x121): warm the well's amber edge explicitly while
+   keeping the recessed orientation (dark top, lit lower lip). */
+QToolButton#DeviceChip[deviceInput="true"]:hover {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #F0E8D6, stop:1 #FFFFFF);
+    border: 1px solid @ACCENT@; border-top-color: #B8AC92; border-bottom-color: #FFFFFF;
+    color: #7A4A05;
+}
+/* Hover on a blank position (0x121): a blank still warms its amber edge so the
+   bank's hover grammar is uniform; it stays flat (no top bevel). */
+QToolButton#DeviceChip[deviceInstalled="false"]:hover {
+    background: #F4EFE2;
+    border: 1px solid @ACCENT@; border-top-color: #C4BBA6;
+    color: #7E7565;
+}
+
+/* Engaged capture well (0x121) — THE LAMP FIX. A routed input well lights the
+   SAME amber lamp as a routed playback switch (invariant 4). Identical
+   fill/border to the bare :checked so capture and playback are
+   indistinguishable once engaged. Beats both :checked and
+   [deviceInput="true"] (0x111). */
+QToolButton#DeviceChip[deviceInput="true"]:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #FBE9C2, stop:1 #E8C887);
+    border: 1px solid @ACCENT@; border-top-color: #FFF3D8;
+    color: #4A2E00;
+}
+/* Routed offline device (0x121): amber lamp on the darker blank base. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #F2DEAE, stop:1 #E8CE92);
+    border: 1px solid @ACCENT@; border-top-color: #FBEBC4;
+    color: #5C3A00;
+}
+/* Master BUS-ENABLE engaged (0x121): the green bus lamp, never amber. */
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #CDEBDD, stop:1 #B6E0C8);
+    border: 1px solid @ACCENT2@; border-top-color: #DFF3E8;
+    color: #0C3A28;
+}
+
+/* Powered down (bank disabled while ALL is on): dim film, lamp off. Type-blind:
+   a well and a blank dim identically, because a powered-down unit shows no
+   part-type colour. */
+QToolButton#DeviceChip:disabled {
+    background: #E2DCCE;
+    border: 1px solid #C9C0AC; border-top-color: #C9C0AC;
+    color: #A99F8E;
+}
+/* Routed but powered down (0x121): faint warm memory of the lamp, no glow. */
+QToolButton#DeviceChip:checked:disabled {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #EFE3C6, stop:1 #E6D6B2);
+    border: 1px solid #C49A4A; border-top-color: #C49A4A;
+    color: #9A7A3A;
+}
+/* Capture/blank powered down (0x121): collapse to the same dim film so the
+   type base cannot keep the well/blank colour lit on a powered-down unit. */
+QToolButton#DeviceChip[deviceInput="true"]:disabled,
+QToolButton#DeviceChip[deviceInstalled="false"]:disabled {
+    background: #E2DCCE;
+    border: 1px solid #C9C0AC; border-top-color: #C9C0AC;
+    color: #A99F8E;
+}
+/* Routed capture/blank powered down (0x131): same faint warm memory as any
+   routed switch that loses power. Beats [deviceInput]:checked,
+   :checked:disabled and [deviceInput]:disabled (all 0x121). */
+QToolButton#DeviceChip[deviceInput="true"]:checked:disabled,
+QToolButton#DeviceChip[deviceInstalled="false"]:checked:disabled {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #EFE3C6, stop:1 #E6D6B2);
+    border: 1px solid #C49A4A; border-top-color: #C49A4A;
+    color: #9A7A3A;
+}
+
+/* Reveal latch: a subordinate service latch; open (:checked) sits pressed in.
+   It carries no device type properties, so the bare pseudo rules are safe. */
+QToolButton#DeviceChipMore {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #F6F1E6, stop:1 #E6DECC);
+    color: @MUTED@;
+    border: 1px solid #C4BBA6; border-top-color: #FFFFFF;
+    border-radius: 2px;
+    padding: 3px 9px; min-height: 20px;
+    font-weight: 700; font-size: 8pt;
+    text-transform: uppercase; letter-spacing: 0.5px;
+}
+QToolButton#DeviceChipMore:hover { border-color: @ACCENT@; border-top-color: #FFFFFF; color: #5C3A00; }
+QToolButton#DeviceChipMore:checked {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #D8CFBB, stop:1 #EFE8D8);
+    border: 1px solid #AFA288; border-top-color: #B8AC92;
+    color: @TEXT@;
+}
+QToolButton#DeviceChipMore:disabled { background: #E2DCCE; border-color: #C9C0AC; color: #A99F8E; }

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -486,3 +486,101 @@ QToolButton#TitleBarClose:pressed {
     border: 1px solid rgba(245, 158, 11, 0.46);
     border-radius: 12px;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* Device picker (DeviceCardEditor): the multi-select toggle group of a
+   consumer settings app. Chips are stadium pills; ON is an accent pastel
+   fill, OFF is a quiet sunken pill (the "off track"). Elevation is faked the
+   constitutional way - sunken at rest, exactly one value step up on hover -
+   never a shadow, and the value step matches soft's own sunken element (the
+   value scrub well: @SURFACE_SUNKEN@ -> @SURFACE@). Colour stays the single
+   @ACCENT@ and means only "on": capture and playback chips fill the same
+   way, and the Capture/Playback + APO-installed distinction rides in the
+   tooltip instead of a second hue (soft.md:59 reserves accent2 for the
+   bipolar knob's cut side only). Disabled and not-installed endpoints become
+   the "sleeping slot": a dashed pill sunk into the window background, an
+   empty slot and never an alarm. Compact paddings keep the wrapping row
+   clear of the gallery's overflow check. */
+QWidget#DeviceCardEditor { background: transparent; }
+
+/* OFF chip: a calm pill one value step below the body tray, the very light
+   1px border standing in for a shadow. */
+QToolButton#DeviceChip {
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 16px;
+    padding: 4px 12px; min-height: 22px; font-weight: 500;
+}
+/* Hover lifts exactly one value step (sunken -> surface, the value scrub
+   well's step), with a quiet accent hint on the edge - no shadow, no jump. */
+QToolButton#DeviceChip:hover {
+    background: @SURFACE@; border: 1px solid rgba(59, 130, 246, 0.40);
+}
+/* ON: the accent pastel fill of a switched-on toggle, deep warm ink kept on
+   it (no low-contrast white-on-pastel). Capture chips fill identically -
+   colour means only "on" here. */
+QToolButton#DeviceChip:checked {
+    background: rgba(59, 130, 246, 0.28); color: @TEXT@;
+    border: 1px solid @ACCENT@; font-weight: 600;
+}
+QToolButton#DeviceChip:checked:hover { background: rgba(59, 130, 246, 0.36); }
+
+/* Not installed: a sleeping slot. Sinks into the window background behind a
+   dashed outline, muted text - an empty slot, not a warning. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    background: @BG@; color: @MUTED@;
+    border: 1px dashed @BORDER@;
+}
+/* Sleeping but selected (the saved config still names it): the dashed slot
+   keeps a faint accent wash so the choice stays legible. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    background: rgba(59, 130, 246, 0.14); color: @TEXT@;
+    border: 1px dashed rgba(59, 130, 246, 0.55);
+}
+
+/* Disabled (All devices is on): every chip sleeps the same calm way. */
+QToolButton#DeviceChip:disabled {
+    background: @BG@; color: rgba(179, 171, 157, 0.45);
+    border: 1px dashed @BORDER@;
+}
+/* A sleeping chip that was selected keeps a faint trace of its fill. */
+QToolButton#DeviceChip:disabled:checked {
+    background: rgba(59, 130, 246, 0.12); color: rgba(179, 171, 157, 0.65);
+    border: 1px dashed rgba(59, 130, 246, 0.40);
+}
+
+/* "All devices": the master toggle. It sits at the SAME elevation as the
+   other OFF chips (hierarchy comes from weight and the deeper ON pastel, not
+   from a value step - soft.md:35). ON it wears the deepest accent pastel and
+   the rest fall asleep. */
+QToolButton#DeviceChip[allDevices="true"] {
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px solid @BORDER@; font-weight: 600;
+}
+QToolButton#DeviceChip[allDevices="true"]:hover {
+    background: @SURFACE@; border: 1px solid rgba(59, 130, 246, 0.40);
+}
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    background: rgba(59, 130, 246, 0.32); color: @TEXT@;
+    border: 1px solid @ACCENT@;
+}
+
+/* Reveal toggle ("Show all (+N)" / "Show fewer"): a quiet, secondary control
+   - a dashed pill in the muted face, never competing with the device chips. */
+QToolButton#DeviceChipMore {
+    background: transparent; color: @MUTED@;
+    border: 1px dashed @BORDER@; border-radius: 16px;
+    padding: 4px 12px; min-height: 22px; font-weight: 500;
+}
+QToolButton#DeviceChipMore:hover {
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px dashed rgba(59, 130, 246, 0.45);
+}
+QToolButton#DeviceChipMore:checked {
+    background: rgba(59, 130, 246, 0.14); color: @TEXT@;
+    border: 1px solid rgba(59, 130, 246, 0.45);
+}
+QToolButton#DeviceChipMore:disabled {
+    background: transparent; color: rgba(179, 171, 157, 0.40);
+    border: 1px dashed @BORDER@;
+}

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -486,3 +486,99 @@ QToolButton#TitleBarClose:pressed {
     border: 1px solid rgba(245, 158, 11, 0.50);
     border-radius: 12px;
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* Device picker (DeviceCardEditor): the multi-select toggle group of a
+   consumer settings app. Chips are stadium pills; ON is an accent pastel
+   fill, OFF is a quiet sunken cream pill held by the beige border. Elevation
+   is faked the constitutional way - sunken at rest, exactly one value step up
+   on hover - never a shadow; the step matches soft's own sunken element (the
+   value scrub well: @SURFACE_SUNKEN@ -> @CARD@, the near-white the light
+   ramp treats as one step). Colour stays the single @ACCENT@ and means only
+   "on": capture and playback chips fill the same way, and the
+   Capture/Playback + APO-installed distinction rides in the tooltip instead
+   of a second hue (soft.md:59 reserves accent2 for the bipolar knob's cut
+   side only). Disabled and not-installed endpoints become the "sleeping
+   slot": a dashed pill sunk into the cream window background, an empty slot
+   and never an alarm. Compact paddings keep the wrapping row clear of the
+   gallery's overflow check. */
+QWidget#DeviceCardEditor { background: transparent; }
+
+/* OFF chip: a calm pill on the sunken cream, the very light 1px beige border
+   standing in for a shadow. */
+QToolButton#DeviceChip {
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px solid @BORDER@; border-radius: 16px;
+    padding: 4px 12px; min-height: 22px; font-weight: 500;
+}
+/* Hover lifts exactly one value step to white, matching the value scrub
+   well's light step (@SURFACE_SUNKEN@ -> @CARD@), with a quiet accent hint. */
+QToolButton#DeviceChip:hover {
+    background: @CARD@; border: 1px solid rgba(59, 130, 246, 0.35);
+}
+/* ON: the accent pastel fill of a switched-on toggle. Capture chips fill
+   identically - colour means only "on" here. */
+QToolButton#DeviceChip:checked {
+    background: rgba(59, 130, 246, 0.16); color: @TEXT@;
+    border: 1px solid @ACCENT@; font-weight: 600;
+}
+QToolButton#DeviceChip:checked:hover { background: rgba(59, 130, 246, 0.22); }
+
+/* Not installed: a sleeping slot. Sinks into the cream background behind a
+   dashed outline, muted text - an empty slot, not a warning. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    background: @BG@; color: @MUTED@;
+    border: 1px dashed @BORDER@;
+}
+/* Sleeping but selected: a faint accent wash keeps the choice legible. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked {
+    background: rgba(59, 130, 246, 0.10); color: @TEXT@;
+    border: 1px dashed rgba(59, 130, 246, 0.45);
+}
+
+/* Disabled (All devices is on): every chip sleeps the same calm way. */
+QToolButton#DeviceChip:disabled {
+    background: @BG@; color: rgba(120, 111, 103, 0.45);
+    border: 1px dashed @BORDER@;
+}
+/* A sleeping chip that was selected keeps a faint trace of its fill. */
+QToolButton#DeviceChip:disabled:checked {
+    background: rgba(59, 130, 246, 0.10); color: rgba(120, 111, 103, 0.70);
+    border: 1px dashed rgba(59, 130, 246, 0.35);
+}
+
+/* "All devices": the master toggle. It sits at the SAME elevation as the
+   other OFF chips (hierarchy comes from weight and the deeper ON pastel, not
+   from a value step - soft.md:35). ON it wears the deepest accent pastel. */
+QToolButton#DeviceChip[allDevices="true"] {
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px solid @BORDER@; font-weight: 600;
+}
+QToolButton#DeviceChip[allDevices="true"]:hover {
+    background: @CARD@; border: 1px solid rgba(59, 130, 246, 0.35);
+}
+QToolButton#DeviceChip[allDevices="true"]:checked {
+    background: rgba(59, 130, 246, 0.20); color: @TEXT@;
+    border: 1px solid @ACCENT@;
+}
+
+/* Reveal toggle ("Show all (+N)" / "Show fewer"): a quiet, secondary control
+   - a dashed pill in the muted face. */
+QToolButton#DeviceChipMore {
+    background: transparent; color: @MUTED@;
+    border: 1px dashed @BORDER@; border-radius: 16px;
+    padding: 4px 12px; min-height: 22px; font-weight: 500;
+}
+QToolButton#DeviceChipMore:hover {
+    background: @SURFACE_SUNKEN@; color: @TEXT@;
+    border: 1px dashed rgba(59, 130, 246, 0.45);
+}
+QToolButton#DeviceChipMore:checked {
+    background: rgba(59, 130, 246, 0.12); color: @TEXT@;
+    border: 1px solid rgba(59, 130, 246, 0.45);
+}
+QToolButton#DeviceChipMore:disabled {
+    background: transparent; color: rgba(120, 111, 103, 0.40);
+    border: 1px dashed @BORDER@;
+}

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -1124,3 +1124,134 @@ QToolButton#TitleBarClose:pressed {
     background: qradialgradient(cx:0.5, cy:0.55, radius:0.7, fx:0.5, fy:0.55,
         stop:0 rgba(239, 68, 68, 0.64), stop:0.6 rgba(239, 68, 68, 0.26), stop:1 rgba(239, 68, 68, 0));
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* ===== Device picker - chips are lit glass patches =====
+   Each chip is a raised glass patch (the type-badge "lit glass chip"
+   grammar): unlit quiet glass at rest, lit from within when signal flows to
+   that endpoint, and hover pools accent light under the cursor (the picker's
+   "light pooling under the cursor"), faked with a radial gradient. Playback
+   vs capture is NOT carried by the chip - constitution rule 4 (studio.md:50)
+   reserves luminance/depth for STATE (rest/hover/selected/off), and the
+   colour semantics (studio.md:72) keep a command's *kind* in its border
+   material, never in the fill or silhouette. So every device chip wears one
+   raised-glass silhouette and the tooltip (Playback/Capture) names the
+   direction. A device row already carries a DEFAULT-BLUE signal lamp
+   (paintCardChrome else branch), so every chip lights with that one blue -
+   never a second hue in the row (rule 1, studio.md:163). Not-installed = a
+   deader pane, dimmed never warned. Disabled (every chip while "All devices"
+   rules) = switched off. The interactive states are pinned to :enabled so a
+   lit chip can never out-rank :disabled. Compact: no min-width, small
+   padding, 8px glass round. */
+QWidget#DeviceCardEditor {
+    background: transparent;
+}
+
+QToolButton#DeviceChip {
+    background: rgba(255, 255, 255, 0.03);
+    color: @MUTED@;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-top-color: rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    padding: 4px 10px;
+    font-size: 9pt;
+}
+
+/* APO not installed: a deader pane. The endpoint cannot carry signal yet, so
+   it recedes - fainter ink, fainter glass. No warning colour. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    color: rgba(145, 160, 186, 0.55);
+    background: rgba(255, 255, 255, 0.02);
+    border-color: rgba(255, 255, 255, 0.05);
+}
+
+/* Selected = the chip lights from within: accent ink, a translucent accent
+   fill, an accent border with a lit reflection edge. Signal flows here. The
+   alpha runs one notch above the static type badge (0.15/0.42) because this
+   is a clickable chip carrying an S4 hover/selected ladder a badge does not. */
+QToolButton#DeviceChip:checked:enabled {
+    background: rgba(91, 140, 255, 0.20);
+    color: @TEXT@;
+    border: 1px solid rgba(91, 140, 255, 0.55);
+    border-top-color: rgba(123, 162, 255, 0.85);
+}
+/* Selected but not-installed: still lit (the user meant it) one step dimmer -
+   the glass is alive yet the endpoint stays dark. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked:enabled {
+    background: rgba(91, 140, 255, 0.13);
+    color: @TEXT@;
+    border: 1px solid rgba(91, 140, 255, 0.40);
+    border-top-color: rgba(123, 162, 255, 0.55);
+}
+
+/* Hover on an unlit chip pools accent light under the cursor. */
+QToolButton#DeviceChip:!checked:hover:enabled {
+    background: qradialgradient(cx:0.5, cy:1.05, radius:0.9, fx:0.5, fy:1.05,
+        stop:0 rgba(91, 140, 255, 0.22), stop:0.45 rgba(91, 140, 255, 0.09), stop:1 rgba(91, 140, 255, 0));
+    color: @TEXT@;
+    border-color: rgba(91, 140, 255, 0.45);
+    border-top-color: rgba(123, 162, 255, 0.50);
+}
+/* An already-lit chip just turns the light up one step (S4 ladder). */
+QToolButton#DeviceChip:checked:hover:enabled {
+    background: rgba(91, 140, 255, 0.28);
+    border-color: rgba(91, 140, 255, 0.75);
+}
+
+/* "All devices" master chip. Unlit it is an ordinary chip; lit it shines a
+   STRONGER blue than a single selected chip - "every endpoint" said with
+   luminance, not a second hue (rule 4: state is light intensity). One alpha
+   step hotter fill (0.30 vs the single chip's 0.20) plus a brighter blue
+   border and top-edge, so it reads as more light - never a colour shift. It
+   stays single-colour blue, sharing the row's blue signal lamp (rule 1,
+   studio.md:163). */
+QToolButton#DeviceChip[allDevices="true"]:checked:enabled {
+    background: rgba(91, 140, 255, 0.30);
+    color: @TEXT@;
+    border: 1px solid rgba(91, 140, 255, 0.70);
+    border-top-color: rgba(123, 162, 255, 0.95);
+}
+QToolButton#DeviceChip[allDevices="true"]:checked:hover:enabled {
+    background: rgba(91, 140, 255, 0.38);
+    border: 1px solid rgba(91, 140, 255, 0.90);
+    border-top-color: rgba(123, 162, 255, 1.0);
+}
+
+/* Disabled = switched off. The light is simply out: no fill, faint ink and
+   border, no warning colour. */
+QToolButton#DeviceChip:disabled {
+    background: rgba(255, 255, 255, 0.02);
+    color: rgba(145, 160, 186, 0.38);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-top-color: rgba(255, 255, 255, 0.05);
+}
+
+/* The reveal toggle is a view control, not a value, so it stays the quietest
+   glass strip (the paramSelector idiom): muted ink, faint border, ink and
+   border lighting only under the cursor. It never floods like a device chip. */
+QToolButton#DeviceChipMore {
+    background: transparent;
+    color: @MUTED@;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-top-color: rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    padding: 4px 10px;
+    font-size: 9pt;
+}
+QToolButton#DeviceChipMore:hover:enabled {
+    color: @TEXT@;
+    background: rgba(91, 140, 255, 0.10);
+    border-color: rgba(91, 140, 255, 0.45);
+    border-top-color: rgba(91, 140, 255, 0.45);
+}
+QToolButton#DeviceChipMore:checked:enabled {
+    color: @TEXT@;
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.10);
+}
+QToolButton#DeviceChipMore:disabled {
+    color: rgba(145, 160, 186, 0.38);
+    border-color: rgba(255, 255, 255, 0.05);
+    border-top-color: rgba(255, 255, 255, 0.05);
+}

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -756,3 +756,124 @@ QToolButton#TitleBarClose:pressed {
     background: qradialgradient(cx:0.5, cy:0.55, radius:0.7, fx:0.5, fy:0.55,
         stop:0 rgba(239, 68, 68, 0.58), stop:0.6 rgba(239, 68, 68, 0.22), stop:1 rgba(239, 68, 68, 0));
 }
+
+
+/* ===== Phase 2: Device card (skin-specific) ===== */
+/* ===== Device picker - chips are lit glass patches =====
+   Same grammar as the dark sheet: every device chip is a single raised glass
+   patch that lights from within when signal flows to that endpoint. Playback
+   vs capture is NOT carried by the chip (constitution rule 4 reserves
+   luminance/depth for state; the colour semantics keep a command's kind in
+   its border material, not its fill or silhouette) - the tooltip
+   (Playback/Capture) names the direction. A device row already carries a
+   DEFAULT-BLUE signal lamp, so every chip lights with that one blue, never a
+   second hue in the row (rule 1). White glass cannot get brighter, so
+   selection leans on a slightly stronger accent fill + accent border and the
+   depth comes from edge shading (S2). Not-installed = a deader pane, dimmed
+   never warned. Disabled = switched off. Interactive states pinned to
+   :enabled. Compact. */
+QWidget#DeviceCardEditor {
+    background: transparent;
+}
+
+QToolButton#DeviceChip {
+    background: rgba(24, 32, 51, 0.03);
+    color: @MUTED@;
+    border: 1px solid rgba(24, 32, 51, 0.10);
+    border-top-color: rgba(255, 255, 255, 0.85);
+    border-radius: 8px;
+    padding: 4px 10px;
+    font-size: 9pt;
+}
+
+/* APO not installed: a deader pane - fainter ink, fainter glass. */
+QToolButton#DeviceChip[deviceInstalled="false"] {
+    color: rgba(93, 106, 132, 0.55);
+    background: rgba(24, 32, 51, 0.02);
+    border-color: rgba(24, 32, 51, 0.06);
+}
+
+/* Selected = lit from within: accent fill (one notch stronger than dark since
+   white cannot brighten, and one notch above the static type badge's 0.10
+   because this clickable chip carries an S4 hover/selected ladder), accent
+   border, white reflection edge. */
+QToolButton#DeviceChip:checked:enabled {
+    background: rgba(47, 107, 255, 0.16);
+    color: @TEXT@;
+    border: 1px solid rgba(47, 107, 255, 0.55);
+    border-top-color: rgba(255, 255, 255, 0.95);
+}
+/* Selected but not-installed: still lit, one step dimmer. */
+QToolButton#DeviceChip[deviceInstalled="false"]:checked:enabled {
+    background: rgba(47, 107, 255, 0.10);
+    color: @TEXT@;
+    border: 1px solid rgba(47, 107, 255, 0.40);
+    border-top-color: rgba(255, 255, 255, 0.85);
+}
+
+/* Hover on an unlit chip pools accent light under the cursor. */
+QToolButton#DeviceChip:!checked:hover:enabled {
+    background: qradialgradient(cx:0.5, cy:1.05, radius:0.9, fx:0.5, fy:1.05,
+        stop:0 rgba(47, 107, 255, 0.16), stop:0.45 rgba(47, 107, 255, 0.07), stop:1 rgba(47, 107, 255, 0));
+    color: @TEXT@;
+    border-color: rgba(47, 107, 255, 0.50);
+    border-top-color: rgba(255, 255, 255, 0.95);
+}
+/* An already-lit chip turns the light up one step (S4 ladder). */
+QToolButton#DeviceChip:checked:hover:enabled {
+    background: rgba(47, 107, 255, 0.24);
+    border-color: rgba(47, 107, 255, 0.75);
+}
+
+/* "All devices" master chip. Lit, it shines a STRONGER blue than a single
+   selected chip - "every endpoint" said with luminance, not a second hue
+   (rule 4). White glass cannot brighten, so the stronger light is a hotter
+   accent fill (0.26 vs the single chip's 0.16) and a deeper accent border. It
+   stays single-colour blue, sharing the row's blue lamp (rule 1). */
+QToolButton#DeviceChip[allDevices="true"]:checked:enabled {
+    background: rgba(47, 107, 255, 0.26);
+    color: @TEXT@;
+    border: 1px solid rgba(47, 107, 255, 0.70);
+    border-top-color: rgba(255, 255, 255, 1.0);
+}
+QToolButton#DeviceChip[allDevices="true"]:checked:hover:enabled {
+    background: rgba(47, 107, 255, 0.34);
+    border: 1px solid rgba(47, 107, 255, 0.90);
+    border-top-color: rgba(255, 255, 255, 1.0);
+}
+
+/* Disabled = switched off: no fill, faint ink and border, no warning colour. */
+QToolButton#DeviceChip:disabled {
+    background: rgba(24, 32, 51, 0.02);
+    color: rgba(93, 106, 132, 0.45);
+    border: 1px solid rgba(24, 32, 51, 0.05);
+    border-top-color: rgba(24, 32, 51, 0.05);
+}
+
+/* The reveal toggle is a view control, not a value: the quietest glass strip
+   (the paramSelector idiom), lighting only under the cursor. */
+QToolButton#DeviceChipMore {
+    background: transparent;
+    color: @MUTED@;
+    border: 1px solid rgba(24, 32, 51, 0.10);
+    border-top-color: rgba(255, 255, 255, 0.85);
+    border-radius: 8px;
+    padding: 4px 10px;
+    font-size: 9pt;
+}
+QToolButton#DeviceChipMore:hover:enabled {
+    color: @TEXT@;
+    background: rgba(47, 107, 255, 0.08);
+    border-color: rgba(47, 107, 255, 0.50);
+    border-top-color: rgba(47, 107, 255, 0.50);
+}
+QToolButton#DeviceChipMore:checked:enabled {
+    color: @TEXT@;
+    background: rgba(24, 32, 51, 0.04);
+    border-color: rgba(24, 32, 51, 0.14);
+}
+QToolButton#DeviceChipMore:disabled {
+    color: rgba(93, 106, 132, 0.45);
+    border-color: rgba(24, 32, 51, 0.05);
+    border-top-color: rgba(24, 32, 51, 0.05);
+}


### PR DESCRIPTION
Phase 2 of the Device card redesign. Phase 1 (#120, merged) put the device picker in-card with generic chips; this gives those chips **each skin's own visual grammar** so the device picker alone identifies the skin. Tracking issue: #121.

## What changed

Pure per-skin QSS appended to each `<skin>_{dark,light}.qss` (minimal uses the legacy `precision_*.qss`). **No C++ change** — `DeviceSelectionModel` and the written `Device:` line are untouched; only `QToolButton#DeviceChip`/`#DeviceChipMore` styling differs per skin.

- **studio** — cool glass-panel readout cells, hairline rules
- **minimal** — flat monospace terminal blocks, no depth
- **soft** — rounded softly-shadowed pastel capsules
- **rack** — engraved latching switch caps with status lamps: the "All devices" master lights **accent2 green**, individual routes light **amber**, capture endpoints read as **recessed input wells**, not-installed endpoints as flat blanks. Depth carries playback/capture; colour lives only in lamps (constitution invariants 3 & 4)
- **matrix** — lit board cells on the signal grid

## How it was produced

Isolated per-skin designers + a 3-reviewer adversarial gate each (the Phase 2 Workflow: 5 designers, 15 reviewers, common-agent patch on 1 refuse, isolated rewrite on 2+). rack additionally ran a **dedicated single-skin review round** (3 reviewers, loop until unanimous accept) that caught a real Qt QSS specificity tie — `[deviceInput="true"]` (0x111) was masking `:checked` (0x111), so a routed capture device would have shown **no lit lamp**; fixed with explicit combined selectors (0x121).

## Verification

- Clean Editor build (qrc re-embeds the QSS).
- Offscreen gallery renders all 5 skins × dark/light with **no horizontal overflow** (exit 0).
- **Non-interference gate**: the 250 non-device gallery PNGs are **byte-identical** to before; only the 30 device PNGs change. The styling is fully isolated to device rows.

## Scope / review gate

**Please hold — do not merge yet.** Like the AR1/AR2 design rounds, this is gated on human pixel-review (see the before/after gallery on #121).

Known follow-ups (not in this PR):
- The offscreen gallery's synthetic `FilterTable` has no device list, so the renders show only the styled **"All devices"** chip, not a full multi-device card (playback switches / capture wells / blanks). Those need a real device list or a mock added to the harness.
- A short device-card clause should be added to each `docs/skins/<skin>.md` constitution to record the agreed grammar (the rationale is captured in the design artifacts for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)