### PR TITLE
fix(security): harden DLL search path and real-time audio path (security audit)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,14 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- Windows 쪽 보안 감사에서 나온 항목 몇 가지를 고쳤습니다. 장치 선택기와 업데이트
+  확인 도구가 Qt 플러그인을 작업 디렉터리 기준이 아니라 실행 파일이 있는 폴더에서
+  불러오도록 바꿔, 권한이 높은 장치 선택기로 코드를 실행시킬 수 있던 DLL 검색 순서
+  하이재킹을 막았습니다. 실시간 오디오 엔진에서는 잘못된 설정으로 오디오 서비스가
+  죽지 않게 했습니다. 범위를 벗어난 `Delay:` 값은 상한을 두고 버퍼 할당 실패를
+  확인하며(실패하면 소리를 지연 없이 그대로 통과), 프레임이 없거나 채널이 없거나
+  길이가 비정상인 `Convolution:` 임펄스 응답은 처리 전에 거부해 빈 버퍼를
+  참조하거나 무한 루프에 빠지지 않게 했습니다. ([#123])
 - Device 필터 행에서 장치를 카드 안에서 바로 고릅니다. `Device:` 줄이 어떤 재생·
   녹음 장치에 적용될지 정할 때 더는 별도 다이얼로그를 열지 않습니다. 카드 본문에
   장치마다 체크 가능한 칩과 'All devices' 칩이 나오고, APO가 설치되지 않은 장치는
@@ -450,4 +458,5 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
+[#123]: https://github.com/115dkk/EqualizerAPO-XT/pull/123
 [#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Hardened several security-audit findings on the Windows-facing surface. The
+  Device Selector and Update Checker now load their Qt plugins from the
+  executable's own folder instead of a path relative to the current working
+  directory, closing a DLL search-order hijack that could run code with the
+  elevated Device Selector's privileges. In the real-time audio engine a
+  malformed config can no longer crash the audio service: an out-of-range
+  `Delay:` value is clamped and its ring buffers are allocation-checked (audio
+  passes through undelayed if allocation fails), and a `Convolution:` impulse
+  response with no frames, no channels, or an implausible length is rejected
+  before processing instead of dereferencing an empty buffer or spinning
+  forever. ([#123])
 - Device filter rows now pick endpoints inline. Choosing which playback or
   capture devices a `Device:` line applies to no longer opens a separate
   dialog: the card body shows one checkable chip per endpoint plus an "All
@@ -480,4 +491,5 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
+[#123]: https://github.com/115dkk/EqualizerAPO-XT/pull/123
 [#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120

--- a/DeviceSelector/main.cpp
+++ b/DeviceSelector/main.cpp
@@ -27,11 +27,47 @@
 #include "ReceiveThread.h"
 #include "DeviceSelector.h"
 
+namespace
+{
+// addLibraryPath() resolves a relative path against the current working
+// directory, not the executable directory. DeviceSelector runs elevated
+// (requireAdministrator), so a relative "qt" plugin path let a caller that
+// controls the working directory plant a Qt plugin DLL that the QApplication
+// constructor would then load into this elevated process. Anchor the plugin
+// search to the executable's own directory instead (mirrors Editor/main.cpp).
+std::wstring executableDirectory()
+{
+	wchar_t buffer[MAX_PATH];
+	DWORD length = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+	if (length == 0)
+		return std::wstring();
+	std::wstring path(buffer, length);
+	size_t slash = path.find_last_of(L"\\/");
+	if (slash == std::wstring::npos)
+		return path;
+	return path.substr(0, slash);
+}
+
+void addExecutableRelativePluginPath()
+{
+	std::wstring pluginDir = executableDirectory();
+	if (!pluginDir.empty())
+	{
+		pluginDir += L"\\qt";
+		QCoreApplication::addLibraryPath(QString::fromStdWString(pluginDir));
+	}
+	else
+	{
+		QCoreApplication::addLibraryPath(QStringLiteral("qt"));
+	}
+}
+}
+
 int main(int argc, char* argv[])
 {
 	int result = 0;
 
-	QCoreApplication::addLibraryPath("qt");
+	addExecutableRelativePluginPath();
 
 	QApplication app(argc, argv);
 	if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)

--- a/UpdateChecker/main.cpp
+++ b/UpdateChecker/main.cpp
@@ -30,14 +30,55 @@
 #include "VelopackUpdateInfo.h"
 #include "version.h"
 
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
 
 
 QByteArray readUpdateUrl(QNetworkAccessManager& manager, const QString& url, bool autoMode, bool* ok, QString* errorMessage);
 void showFailureMessage(QString message, QString title);
 
+namespace
+{
+// addLibraryPath() resolves a relative path against the current working
+// directory, not the executable directory. Anchor the Qt plugin search to the
+// executable's own directory so the loaded platform/style/tls plugin DLLs come
+// from the install folder regardless of the working directory (mirrors
+// Editor/main.cpp; hardens the same relative-"qt" pattern as DeviceSelector).
+std::wstring executableDirectory()
+{
+	wchar_t buffer[MAX_PATH];
+	DWORD length = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+	if (length == 0)
+		return std::wstring();
+	std::wstring path(buffer, length);
+	size_t slash = path.find_last_of(L"\\/");
+	if (slash == std::wstring::npos)
+		return path;
+	return path.substr(0, slash);
+}
+
+void addExecutableRelativePluginPath()
+{
+	std::wstring pluginDir = executableDirectory();
+	if (!pluginDir.empty())
+	{
+		pluginDir += L"\\qt";
+		QCoreApplication::addLibraryPath(QString::fromStdWString(pluginDir));
+	}
+	else
+	{
+		QCoreApplication::addLibraryPath(QStringLiteral("qt"));
+	}
+}
+}
+
 int main(int argc, char* argv[])
 {
-	QCoreApplication::addLibraryPath("qt");
+	addExecutableRelativePluginPath();
 
 	QApplication app(argc, argv);
 	if (QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)

--- a/engine/FilterEngine.Runtime.cpp
+++ b/engine/FilterEngine.Runtime.cpp
@@ -88,7 +88,21 @@ void FilterEngine::addFilters(const vector<IFilter*>& filters)
 			for (vector<wstring>::iterator it2 = currentChannelNames.begin(); it2 != currentChannelNames.end(); it2++)
 			{
 				vector<wstring>::iterator pos = find(allChannelNames.begin(), allChannelNames.end(), *it2);
-				filterInfo->inChannels[c++] = pos - allChannelNames.begin();
+				if (pos == allChannelNames.end())
+				{
+					// Defensive: every currentChannelNames entry should already be in
+					// allChannelNames (seeded from it, or a filter's own subset). If that
+					// invariant is ever broken, append the name instead of storing a
+					// one-past-the-end index that process() would read out of bounds; the
+					// appended channel reads the zero-filled virtual range (silence).
+					// Mirrors the outChannels handling below.
+					filterInfo->inChannels[c++] = allChannelNames.size();
+					allChannelNames.push_back(*it2);
+				}
+				else
+				{
+					filterInfo->inChannels[c++] = pos - allChannelNames.begin();
+				}
 			}
 		}
 

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <climits>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
@@ -138,12 +139,30 @@ namespace
 			return nullptr;
 		}
 
+		// Reject impulse responses with no usable audio before they reach the
+		// convolution setup. A 0-frame IR makes hcInitSingle dereference an empty
+		// filter-pointer array (crash); channels == 0 divides by zero in the
+		// channel map; and frames > INT_MAX would wrap negative when cast to int.
+		// All three are reachable from a user-writable config plus a crafted IR.
+		if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX)
+		{
+			LogFStatic(L"Impulse response has no usable audio (frames=%lld, channels=%d); ignoring %s",
+				static_cast<long long>(info.frames), info.channels, filename.c_str());
+			sf_close(in);
+			return nullptr;
+		}
+
 		const unsigned channels = static_cast<unsigned>(info.channels);
 		const unsigned frames = static_cast<unsigned>(info.frames);
 		std::vector<double> interleaved(static_cast<size_t>(frames) * channels);
 		sf_count_t numRead = 0;
 		while (numRead < info.frames)
-			numRead += sf_readf_double(in, interleaved.data() + numRead * channels, info.frames - numRead);
+		{
+			sf_count_t got = sf_readf_double(in, interleaved.data() + numRead * channels, info.frames - numRead);
+			if (got <= 0)
+				break; // truncated or unreadable file: stop instead of spinning forever
+			numRead += got;
+		}
 		sf_close(in);
 
 		auto entry = std::make_shared<IrCacheEntry>();
@@ -297,7 +316,15 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 		filename.c_str(), ir->channels, ir->frames);
 
 	fftw_make_planner_thread_safe();
-	filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	if (allocated == nullptr)
+	{
+		// alloc returns nullptr on failure; bail to the inert state (filters stays
+		// null from cleanup(), process() then no-ops) rather than dereferencing it.
+		LogF(L"ConvolutionFilter: could not allocate %u filter slots", channelCount);
+		return;
+	}
+	filters = allocated;
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		// hcInitSingle reads the IR samples during planning but does not retain

--- a/filters/DelayFilter.cpp
+++ b/filters/DelayFilter.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 
 #include "helpers/MemoryHelper.h"
+#include "helpers/LogHelper.h"
 #include "DelayFilter.h"
 #include "helpers/PerfProfile.h"
 
@@ -38,22 +39,57 @@ DelayFilter::~DelayFilter()
 	cleanup();
 }
 
+// Upper bound on the per-channel delay ring buffer. A config Delay value is
+// attacker-influenceable (the config directory is user-writable) and otherwise
+// unbounded. Casting a huge or non-finite double to unsigned is undefined
+// behaviour, and an unbounded length asks for a multi-gigabyte allocation that
+// crashes audiodg. 32 Mi doubles per channel (256 MiB, ~700 s at 48 kHz) is far
+// beyond any real delay line, so clamping here never affects legitimate use.
+static const double kMaxDelaySamples = 32.0 * 1024.0 * 1024.0;
+
 vector<wstring> DelayFilter::initialize(float sampleRate, unsigned maxFrameCount, vector<wstring> channelNames)
 {
 	cleanup();
 
 	channelCount = (unsigned)channelNames.size();
 
-	if (isMs)
-		bufferLength = (unsigned)(sampleRate * delay / 1000.0 + 0.5);
-	else
-		bufferLength = (unsigned)(delay + 0.5);
+	double samples = isMs ? (static_cast<double>(sampleRate) * delay / 1000.0) : delay;
+	samples = std::floor(samples + 0.5);
+	if (!(samples >= 1.0))
+		samples = 1.0;
+	if (samples > kMaxDelaySamples)
+	{
+		LogFStatic(L"Delay length %.0f samples exceeds the %.0f sample cap; clamping", samples, kMaxDelaySamples);
+		samples = kMaxDelaySamples;
+	}
+	bufferLength = static_cast<unsigned>(samples);
 
+	// MemoryHelper::alloc returns nullptr on failure. Check every result: a
+	// failed allocation here used to be dereferenced immediately, turning an
+	// out-of-memory request (reachable from a config Delay value) into a crash.
+	// On failure leave buffers == nullptr; process() then passes audio through
+	// undelayed instead of touching a null ring buffer.
 	buffers = (double**)MemoryHelper::alloc(sizeof(double*) * channelCount);
+	if (buffers == nullptr)
+	{
+		LogFStatic(L"Delay pointer-array allocation failed (%u channels); passing audio through", channelCount);
+		bufferOffset = 0;
+		return channelNames;
+	}
 
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		buffers[i] = static_cast<double*>(MemoryHelper::alloc(sizeof *buffers[i] * bufferLength));
+		if (buffers[i] == nullptr)
+		{
+			LogFStatic(L"Delay buffer allocation failed (%u samples); passing audio through", bufferLength);
+			for (unsigned j = 0; j < i; j++)
+				MemoryHelper::free(buffers[j]);
+			MemoryHelper::free(buffers);
+			buffers = nullptr;
+			bufferOffset = 0;
+			return channelNames;
+		}
 		std::fill_n(buffers[i], bufferLength, 0.0);
 	}
 
@@ -66,6 +102,15 @@ vector<wstring> DelayFilter::initialize(float sampleRate, unsigned maxFrameCount
 void DelayFilter::process(double** output, double** input, unsigned frameCount)
 {
 	PerfScope _ps("DelayFilter::process");
+	if (buffers == nullptr)
+	{
+		// Allocation failed at initialize(): pass audio through undelayed rather
+		// than dereferencing a null ring buffer.
+		for (unsigned i = 0; i < channelCount; i++)
+			if (output[i] != input[i])
+				std::copy_n(input[i], frameCount, output[i]);
+		return;
+	}
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		double* inputChannel = input[i];


### PR DESCRIPTION
## Summary

Fixes from the two security audits of the Win-API-facing surface. Everything here is local (no remote vector): one privilege-escalation finding plus three config-triggerable DoS findings.

### HIGH — local privilege escalation (DLL search-order hijack)
`DeviceSelector.exe` runs elevated (`requireAdministrator`) but called `addLibraryPath("qt")` with a working-directory-relative path before constructing `QApplication`. A caller that controls the CWD could plant a Qt platform/style/tls plugin DLL that the `QApplication` constructor loads into the elevated process (CWE-427), escalating a standard user to administrator. The plugin search is now anchored to the executable directory, mirroring the existing `Editor/main.cpp` fix. The same relative-`"qt"` pattern in the non-elevated `UpdateChecker` is hardened for consistency.

### MEDIUM — config-triggerable crashes in the real-time audio path
The config directory is user-writable, so config values drive C / raw-pointer code in `audiodg.exe` (LocalService):
- **DelayFilter**: an unbounded `Delay:` value invoked undefined behaviour in a `double`→`unsigned` cast and dereferenced a failed multi-gigabyte allocation. The length is now clamped and every ring-buffer allocation is null-checked; on failure the filter passes audio through undelayed.
- **ConvolutionFilter**: a 0-frame / 0-channel / `> INT_MAX`-frame impulse response crashed `hcInitSingle` (empty pointer-array dereference), and a truncated IR could spin the read loop forever. The IR is now validated up front, the read loop is bounded, and the filter-slot allocation is null-checked.
- **FilterEngine::addFilters** (defensive): an unknown input-channel name now appends to `allChannelNames` instead of storing a one-past-the-end index, mirroring the existing output-channel handling, so the invariant can no longer silently become an out-of-bounds read.

No controllable memory corruption / RCE was found in the real-time path; these are crash-class (DoS) fixes plus the one EoP fix.

## Verification (local)
- `Common.vcxproj /t:Rebuild` (v145) — clean (only the pre-existing muparserx C4267 warning).
- `HybridConvTests` — all suites pass, including the convolution round-trip and the Delay command tests, confirming the new IR guard and delay clamp do not alter valid inputs.
- `DeviceSelector` + `UpdateChecker` qmake/nmake — build and link clean.
- The cppcheck zero-baseline gate, `AudioRegressionTests` (−120 dB), `EditorLogicTests`, and the 6-variant build matrix run in CI.

## Not included (follow-up)
The ARM64-only `nextConfig` publication memory-visibility race (lock-free publish vs. RT-thread read) is a separate, more delicate concurrency change and will be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
