### PR TITLE
fix(engine): order the reconfiguration handoff to the audio thread (ARM64)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,11 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- ARM64에서 재생 중 설정을 다시 읽을 때 오디오 스레드가 아직 완성되지 않은 필터
+  설정을 받을 수 있던 메모리 가시성 경합을 고쳤습니다. 로더가 새 설정을 실시간
+  스레드에 release/acquire 플래그로 게시하도록 바꿔, 오디오 스레드가 구성이 보이기
+  전에 그것을 읽지 않습니다. x86/x64 빌드는 영향이 없습니다(메모리 모델이 이미 이
+  순서를 보장합니다). ([#124])
 - Device 필터 행에서 장치를 카드 안에서 바로 고릅니다. `Device:` 줄이 어떤 재생·
   녹음 장치에 적용될지 정할 때 더는 별도 다이얼로그를 열지 않습니다. 카드 본문에
   장치마다 체크 가능한 칩과 'All devices' 칩이 나오고, APO가 설치되지 않은 장치는
@@ -450,4 +455,5 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
+[#124]: https://github.com/115dkk/EqualizerAPO-XT/pull/124
 [#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Fixed a memory-visibility data race on ARM64 where reloading the config during
+  playback could hand the audio thread a partially-constructed filter
+  configuration. The loader now publishes the new configuration to the real-time
+  thread through a release/acquire flag, so the audio thread never reads it
+  before its construction is visible. x86/x64 builds are unaffected (their memory
+  model already ordered this). ([#124])
 - Device filter rows now pick endpoints inline. Choosing which playback or
   capture devices a `Device:` line applies to no longer opens a separate
   dialog: the card body shows one checkable chip per endpoint plus an "All
@@ -480,4 +486,5 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#107]: https://github.com/115dkk/EqualizerAPO-XT/pull/107
 [#108]: https://github.com/115dkk/EqualizerAPO-XT/pull/108
 [#118]: https://github.com/115dkk/EqualizerAPO-XT/pull/118
+[#124]: https://github.com/115dkk/EqualizerAPO-XT/pull/124
 [#120]: https://github.com/115dkk/EqualizerAPO-XT/pull/120

--- a/FilterEngine.h
+++ b/FilterEngine.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <memory>
 #include <unordered_set>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -122,6 +123,16 @@ private:
 	FilterConfigurationPtr currentConfig;
 	FilterConfigurationPtr nextConfig;
 	FilterConfigurationPtr previousConfig;
+	// Publication flag for the nextConfig worker->RT handoff. The notification
+	// worker builds a FilterConfiguration and stores it into nextConfig under
+	// loadMutex; the real-time process() thread reads nextConfig lock-free. As
+	// nextConfig is a plain unique_ptr, on a weakly-ordered CPU (ARM64) the RT
+	// thread could see the new pointer before the configuration's construction is
+	// visible. This atomic carries the release(worker)/acquire(RT) edge: the RT
+	// dereferences nextConfig only after acquire-loading true here. On x86/x64
+	// (TSO) it lowers to plain loads/stores, so the existing platforms are
+	// unaffected.
+	std::atomic<bool> nextConfigReady{ false };
 
 	unsigned transitionCounter;
 	unsigned transitionLength = 0;

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -112,7 +112,12 @@ void FilterEngine::loadConfig(const wstring& customPath)
 	if (!currentConfig)
 		currentConfig = move(config);
 	else
+	{
 		nextConfig = move(config);
+		// Release: publish the fully-constructed FilterConfiguration to the RT
+		// thread. Pairs with the acquire loads in process()/finishTransitionIfReady.
+		nextConfigReady.store(true, std::memory_order_release);
+	}
 }
 
 void FilterEngine::loadConfigFile(const wstring& path)

--- a/engine/FilterEngine.Process.cpp
+++ b/engine/FilterEngine.Process.cpp
@@ -115,7 +115,7 @@ void FilterEngine::process(float* output, float* input, unsigned frameCount)
 	PerfScope _eapo_total("FilterEngine::process(float interleaved)");
 	MxcsrFtzDazGuard _mxcsrGuard;
 
-	if (currentConfig->isEmpty() && !nextConfig)
+	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
 		// Bypass mode: if no filters are active, just copy input to output if necessary.
 		if (realChannelCount == outputChannelCount && input != output) {
@@ -135,7 +135,7 @@ void FilterEngine::process(float* output, float* input, unsigned frameCount)
 		currentConfig->process(frameCount);
 	}
 
-	if (nextConfig)
+	if (nextConfigReady.load(std::memory_order_acquire))
 	{
 		{
 			PerfScope _ps("FilterConfiguration::readFloatInterleaved(next)");
@@ -163,7 +163,7 @@ void FilterEngine::process(float** output, float** input, unsigned frameCount)
 	PerfScope _eapo_total("FilterEngine::process(float planar)");
 	MxcsrFtzDazGuard _mxcsrGuard;
 
-	if (currentConfig->isEmpty() && !nextConfig)
+	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
 		// Bypass mode
 		if (realChannelCount == outputChannelCount && input != output) {
@@ -185,7 +185,7 @@ void FilterEngine::process(float** output, float** input, unsigned frameCount)
 		currentConfig->process(frameCount);
 	}
 
-	if (nextConfig)
+	if (nextConfigReady.load(std::memory_order_acquire))
 	{
 		{
 			PerfScope _ps("FilterConfiguration::readFloatPlanar(next)");
@@ -213,7 +213,7 @@ void FilterEngine::process(double* output, double* input, unsigned frameCount)
 	PerfScope _eapo_total("FilterEngine::process(double interleaved)");
 	MxcsrFtzDazGuard _mxcsrGuard;
 
-	if (currentConfig->isEmpty() && !nextConfig)
+	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
 		// Bypass mode: if no filters are active, just copy input to output if necessary.
 		if (realChannelCount == outputChannelCount && input != output) {
@@ -231,7 +231,7 @@ void FilterEngine::process(double* output, double* input, unsigned frameCount)
 		currentConfig->process(frameCount);
 	}
 
-	if (nextConfig)
+	if (nextConfigReady.load(std::memory_order_acquire))
 	{
 		{
 			PerfScope _ps("FilterConfiguration::read(interleaved)");
@@ -259,7 +259,7 @@ void FilterEngine::process(double** output, double** input, unsigned frameCount)
 	PerfScope _eapo_total("FilterEngine::process(double planar)");
 	MxcsrFtzDazGuard _mxcsrGuard;
 
-	if (currentConfig->isEmpty() && !nextConfig)
+	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
 		// Bypass mode
 		if (realChannelCount == outputChannelCount && input != output) {
@@ -278,7 +278,7 @@ void FilterEngine::process(double** output, double** input, unsigned frameCount)
 		currentConfig->process(frameCount);
 	}
 
-	if (nextConfig)
+	if (nextConfigReady.load(std::memory_order_acquire))
 	{
 		{
 			PerfScope _ps("FilterConfiguration::read(planar)");

--- a/engine/FilterEngine.Runtime.cpp
+++ b/engine/FilterEngine.Runtime.cpp
@@ -138,6 +138,7 @@ void FilterEngine::cleanupConfigurations()
 {
 	currentConfig.reset();
 	nextConfig.reset();
+	nextConfigReady.store(false, std::memory_order_relaxed);
 	previousConfig.reset();
 }
 
@@ -163,10 +164,15 @@ void FilterEngine::releaseLoadPermit()
 
 void FilterEngine::finishTransitionIfReady()
 {
-	if (nextConfig && transitionCounter >= transitionLength)
+	// Acquire: pairs with the release store in loadConfig so the dereference of
+	// nextConfig below observes the fully-constructed configuration on ARM64.
+	if (nextConfigReady.load(std::memory_order_acquire) && transitionCounter >= transitionLength)
 	{
 		previousConfig = move(currentConfig);
 		currentConfig = move(nextConfig);
+		// Cleared before releaseLoadPermit(); the permit mutex then publishes this
+		// to the worker, which cannot store a new nextConfig until it reacquires.
+		nextConfigReady.store(false, std::memory_order_relaxed);
 		transitionCounter = 0;
 		releaseLoadPermit();
 	}


### PR DESCRIPTION
## Summary

The third finding from the real-time-path security audit: an ARM64-only memory-visibility data race in the runtime reconfiguration handoff.

The notification worker builds a `FilterConfiguration` and stores it into `nextConfig` (under `loadMutex`) while the real-time `process()` thread reads `nextConfig` lock-free. `nextConfig` is a plain `unique_ptr`, and the `loadPermit` handshake only prevents the worker from overwriting an unconsumed config; it does not order the worker's *construct-then-publish* against the RT thread's *first read* of the new pointer. On a weakly-ordered CPU (ARM64) the RT thread could observe the new pointer before the configuration's member writes are visible and dereference a partially-constructed object. x86/x64's strong (TSO) ordering masked this.

The fix carries the handoff on a new `std::atomic<bool> nextConfigReady`: the worker release-stores it after assigning `nextConfig`, and `process()` / `finishTransitionIfReady` acquire-load it before dereferencing `nextConfig`. The flag tracks `nextConfig` 1:1 (set on publish, cleared on promotion and in `cleanupConfigurations`).

## Impact
- **ARM64**: gains the required acquire/release (`ldar`/`stlr`) barriers, so a config reload during playback can no longer surface a partially-constructed configuration to the audio thread.
- **x86/x64**: `atomic<bool>` lowers to plain loads/stores under TSO, so behaviour is unchanged.

## Verification (local, x64)
- `Common.vcxproj /t:Rebuild` (v145) — clean.
- `HybridConvTests` — all suites pass.
- `AudioRegressionTests --variant avx2` (verify mode) — **9/9 pass**, byte-identical (maxAbsError 0) at the −120 dB tolerance, confirming the synchronization addition does not change engine output.
- The ARM64 build, cppcheck gate, and the full 6-variant matrix run in CI.

Follow-up promised in #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
