### PR TITLE
ci: migrate GitHub Actions off the deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -121,7 +121,7 @@ jobs:
       # Checkout (for the diagnosis script) + a snapshot directory.
       # -----------------------------------------------------------------------
       - name: Checkout (for the diagnosis script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare snapshot directory
         shell: pwsh
@@ -131,11 +131,21 @@ jobs:
           "SNAP_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "Snapshots will be written to $dir"
 
-      # signtool lives in the Windows SDK; ilammy/msvc-dev-cmd puts it on PATH.
-      - name: Add MSVC / SDK tools (signtool) to PATH
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
+      # signtool lives in the Windows SDK. Resolve it directly instead of
+      # ilammy/msvc-dev-cmd, whose latest release (v1.13.0) still runs on the
+      # deprecated Node.js 20 runtime. This step is pure PowerShell (no Node
+      # action), so it survives GitHub's Node 20 removal. Only signtool is
+      # needed here (not the full MSVC toolchain), so a direct SDK lookup is
+      # enough; the newest installed SDK build is preferred.
+      - name: Add signtool (Windows SDK) to PATH
+        shell: pwsh
+        run: |
+          $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $signtool) { throw "signtool.exe not found in the Windows SDK" }
+          $dir = Split-Path $signtool.FullName
+          Write-Host "Found signtool at $($signtool.FullName)"
+          Add-Content -Path $env:GITHUB_PATH -Value $dir
 
       # -----------------------------------------------------------------------
       # STEP 1: Install Scream as a REAL active virtual render endpoint.
@@ -1027,7 +1037,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Upload snapshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: audio-live-snapshots
           path: ${{ env.SNAP_DIR }}/**

--- a/.github/workflows/audio-uninstall-repro.yml
+++ b/.github/workflows/audio-uninstall-repro.yml
@@ -117,7 +117,7 @@ jobs:
       # Setup: a place to keep the snapshots, and a tiny snapshot helper.
       # -----------------------------------------------------------------------
       - name: Checkout (for the diagnosis script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare snapshot directory
         shell: pwsh
@@ -574,7 +574,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Upload snapshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: audio-uninstall-snapshots
           path: ${{ env.SNAP_DIR }}/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1226,7 +1226,7 @@ jobs:
     # against the same version developers run locally.
     - name: Cache cppcheck
       id: cache-cppcheck
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/cppcheck-install
         key: cppcheck-2.21.0-${{ runner.os }}


### PR DESCRIPTION
## Why

GitHub is removing the **Node.js 20** action runtime. The `actions/cache@v4` step in `build.yml` was flagged by the deprecation annotation on #126, and a sweep found a few more node20 actions in the dispatch-only repro workflows. This bumps every action to a node24-capable version so CI keeps working past the removal.

## Changes

- `actions/cache@v4` → **`@v6`** (cppcheck cache, `build.yml`) — the flagged one.
- `actions/checkout@v4` → **`@v6`** and `actions/upload-artifact@v4` → **`@v7`** in `audio-live-repro.yml` and `audio-uninstall-repro.yml`, matching what the main pipeline already uses.
- `ilammy/msvc-dev-cmd@v1` (node20; latest v1.13.0 is still node20, no node24 release) → replaced with a **pure-PowerShell step** that resolves `signtool` from the Windows SDK and adds it to `PATH`. That workflow only used the action for `signtool`, not the full MSVC toolchain.

After this, the only remaining "low" version is `microsoft/setup-msbuild@v3`, which already targets node24 (verified against its `action.yml`). No node20 actions remain.

## Validation

- All five workflow YAML files parse.
- The `actions/cache@v6` change is exercised by this PR's `cppcheck` job.
- `audio-live-repro` / `audio-uninstall-repro` are `workflow_dispatch`-only, so PR CI does not run them — the `signtool` replacement should be confirmed by one manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
