### PR TITLE
fix(editor): render text with FreeType grayscale AA instead of ClearType

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,15 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 이제 Editor가 텍스트를 Windows ClearType 대신 FreeType의 그레이스케일
+  안티앨리어싱으로 그립니다. 번들된 한글 폰트(Pretendard)는 CFF/OpenType
+  글꼴이라, ClearType가 서브픽셀 색 번짐을 넣어 보통 밀도의 모니터에서 흐릿하게
+  보였습니다. 고해상도 화면(예: 4K 150%)은 픽셀이 촘촘해 이 번짐을 가렸고,
+  그래서 해상도가 낮은 화면에서만 흐림이 드러났습니다. Editor를 Qt의 FreeType
+  폰트 엔진으로 바꿔 색 번짐을 없애고, 모니터가 달라도 글자가 일관되게 나옵니다.
+  장치 선택기와 업데이트 확인 도구는 그대로입니다. 시스템 폰트를 쓰는데
+  ClearType에서 깔끔하게 나오기 때문입니다. 예전 ClearType 렌더링으로 되돌리려면
+  환경 변수 QT_QPA_PLATFORM을 `windows`로 설정하면 됩니다. ([#129])
 - 2.3.0에 들어간 Editor 번역을 다듬었습니다. 채널 구성의 'From device' 항목이
   한국어·독일어·중국어에서 장치 설정을 따른다는 뜻으로 자연스러워졌고(전에는 말이
   잘린 느낌이었습니다), 프랑스어에 영어로 남아 있던 'VST plugin'을 번역했으며,
@@ -497,3 +506,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#125]: https://github.com/115dkk/EqualizerAPO-XT/pull/125
 [#126]: https://github.com/115dkk/EqualizerAPO-XT/pull/126
 [#128]: https://github.com/115dkk/EqualizerAPO-XT/pull/128
+[#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- The Editor now renders text with FreeType's grayscale antialiasing instead of
+  Windows ClearType. The bundled Korean font (Pretendard) is a CFF/OpenType face,
+  which ClearType draws with subpixel colour fringing that looks blurry on
+  ordinary-density monitors; high-DPI panels (4K at 150%, say) packed enough
+  pixels to hide it, so the blur only showed on lower-resolution screens.
+  Switching the Editor to Qt's FreeType font engine removes the fringing and
+  keeps text consistent from monitor to monitor. The device selector and update
+  checker are unchanged: they use the system font, which ClearType renders
+  cleanly. To go back to the old ClearType rendering, set the QT_QPA_PLATFORM
+  environment variable to `windows`. ([#129])
 - Polished the Editor translations that shipped in 2.3.0. The channel
   configuration's "From device" option now reads as following the device's
   configuration in Korean, German and Chinese (it previously looked like a
@@ -540,3 +550,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#125]: https://github.com/115dkk/EqualizerAPO-XT/pull/125
 [#126]: https://github.com/115dkk/EqualizerAPO-XT/pull/126
 [#128]: https://github.com/115dkk/EqualizerAPO-XT/pull/128
+[#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -379,6 +379,19 @@ int main(int argc, char* argv[])
 		}
 	}
 
+	// Font rendering: force Qt's FreeType font engine on Windows instead of the
+	// default DirectWrite/GDI ClearType subpixel rasteriser. The bundled
+	// Pretendard ships as CFF/OTF, which ClearType renders with subpixel colour
+	// fringing that reads as blur on low-PPI monitors. High-DPI panels pack
+	// enough pixels to hide it (the UI looks crisp at 4K/150%) but a 1080p
+	// screen shows it plainly. FreeType uses grayscale antialiasing plus its own
+	// CFF hinting, which stays consistent across monitors regardless of DPI.
+	// Only set it when no platform is chosen externally, so the offscreen
+	// gallery / CI (QT_QPA_PLATFORM=offscreen) still win and a user can opt back
+	// into the default ClearType engine with QT_QPA_PLATFORM=windows.
+	if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
+		qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
+
 	// High-DPI: let Qt scale the whole UI by the monitor's device pixel ratio.
 	// The editor used to disable Qt scaling (QT_ENABLE_HIGHDPI_SCALING=0) and
 	// only hand-scale a few widget sizes through GUIHelper::scale, so on a 4K /


### PR DESCRIPTION
## What

Switch the Editor's text rendering from Windows ClearType (DirectWrite/GDI subpixel) to Qt's **FreeType** font engine, so the bundled Korean font (Pretendard) stops looking blurry on ordinary-density monitors.

## Why

Pretendard ships as a **CFF/OpenType** face. Windows ClearType draws CFF outlines with subpixel colour fringing that reads as blur. The effect is DPI-dependent: a high-DPI panel (4K at 150%) packs enough pixels to hide it, so the UI looks crisp there, while a low-PPI 1080p screen shows the blur plainly. This matches the reported symptom exactly (sharp on 4K/150%, blurry on a low-resolution monitor regardless of scale), which rules out fractional-DPI scaling and points at ClearType subpixel rendering.

FreeType uses grayscale antialiasing plus its own CFF hinting, which is consistent across monitors regardless of DPI.

## How

In `Editor/main.cpp`, before `QApplication` is constructed:

```cpp
if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
    qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
```

The guard means an externally chosen platform still wins, so the offscreen skin gallery / CI (`QT_QPA_PLATFORM=offscreen`) are unaffected, and a user can opt back into the default ClearType engine with `QT_QPA_PLATFORM=windows`.

## Scope

**Editor only, on purpose.** DeviceSelector and UpdateChecker render the *system* font (not Pretendard), which ClearType draws cleanly, so they stay on the default engine. Forcing FreeType there would change their (currently fine) look without fixing anything.

## Verification

- **Compile/link:** rides on CI (the full Editor link fails locally only due to the known `/GL`+LTCG toolchain issue). The `qputenv`/`qEnvironmentVariableIsEmpty` call resolves unambiguously to the `QByteArrayView` overload in Qt 6.10.
- **Deployment:** relies on Qt's bundled FreeType support being compiled into the Windows platform plugin (it is, in the official binaries). If the engine were unavailable the plugin falls back rather than failing to start.
- **Visual (the real test):** please run the PR's AVX2 build artifact on the low-PPI monitor and confirm (a) the blur is gone and (b) no skin's card layout clips text from the slightly different FreeType metrics. Merge releases to users, so let's confirm the rendering before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)