### PR TITLE
feat(filters): add MultiConvolution filter for BRIR crossfeed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1066,9 +1066,9 @@ jobs:
         }
         $pngs = @(Get-ChildItem $outDir -Filter *.png)
         Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # 5 skins x 2 modes x (7 rows x 3 states + 3 picker states + toolbar + titlebar + menubar + menu)
-        if ($pngs.Count -ne 280) {
-          Write-Error "Expected 280 gallery PNGs, got $($pngs.Count)"
+        # 5 skins x 2 modes x (8 rows x 3 states + 3 picker states + toolbar + titlebar + menubar + menu)
+        if ($pngs.Count -ne 310) {
+          Write-Error "Expected 310 gallery PNGs, got $($pngs.Count)"
           exit 1
         }
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,19 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- BRIR(Binaural Room Impulse Response) 재생을 위한 MultiConvolution 필터를
+  추가했습니다. 기존 Convolution 필터는 각 채널을 제자리에서 자신의 임펄스
+  응답과만 컨볼루션합니다. 그래서 스테레오 IR을 걸어도 한쪽 입력을 반대쪽
+  출력 채널로 보낼 수 없었고, BRIR에 필요한 크로스피드(한쪽 가상 스피커의
+  소리가 반대쪽 귀에도 도달하는 성분)가 사라졌습니다. MultiConvolution은
+  선택한 여러 입력 채널을 하나의 다채널 IR 파일에서 대응하는 채널과 각각
+  컨볼루션한 뒤 그 결과를 합산해 하나의 출력 채널로 보내므로, 이 크로스피드가
+  살아 있습니다. config 문법은 `MultiConvolution: <출력 채널> <다채널 IR
+  경로>`이며, 첫 토큰이 출력 채널이고 나머지가 IR 경로입니다. 완전한 양 귀
+  BRIR을 구성하려면 입력을 복제하는 Copy와 함께 이 필터 두 개(귀마다 하나씩)가
+  있어야 합니다. Editor에는 현대적인 카드 에디터(출력 채널 입력란, 파일
+  선택이 붙은 IR 경로 입력란, 5종 스킨 모두 지원)와 레거시 행 위젯을 함께
+  추가했습니다. ([#130])
 - 이제 Editor가 텍스트를 Windows ClearType 대신 FreeType의 그레이스케일
   안티앨리어싱으로 그립니다. 번들된 한글 폰트(Pretendard)는 CFF/OpenType
   글꼴이라, ClearType가 서브픽셀 색 번짐을 넣어 보통 밀도의 모니터에서 흐릿하게
@@ -507,3 +520,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#126]: https://github.com/115dkk/EqualizerAPO-XT/pull/126
 [#128]: https://github.com/115dkk/EqualizerAPO-XT/pull/128
 [#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129
+[#130]: https://github.com/115dkk/EqualizerAPO-XT/pull/130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Added a MultiConvolution filter for BRIR (Binaural Room Impulse Response)
+  playback. The existing Convolution filter only convolves each channel with
+  its own in-place impulse response, so a stereo IR could not route one input
+  into the other output channel; that collapses the crossfeed a BRIR needs
+  (sound from one virtual speaker reaching the opposite ear). MultiConvolution
+  convolves several selected input channels against the matching channels of
+  one multichannel IR file and sums the results into a single output channel,
+  so crossfeed survives. Config syntax is `MultiConvolution: <output channel>
+  <multichannel IR path>`, where the first token names the output channel and
+  the rest of the line is the IR path; a full binaural BRIR needs two of these
+  filters plus a Copy to duplicate the input, one MultiConvolution per ear. The
+  Editor gained both a modern card editor (output channel field, IR path field
+  with a file picker, supported by all five skins) and a legacy row widget for
+  this filter. ([#130])
 - The Editor now renders text with FreeType's grayscale antialiasing instead of
   Windows ClearType. The bundled Korean font (Pretendard) is a CFF/OpenType face,
   which ClearType draws with subpixel colour fringing that looks blurry on
@@ -551,3 +565,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#126]: https://github.com/115dkk/EqualizerAPO-XT/pull/126
 [#128]: https://github.com/115dkk/EqualizerAPO-XT/pull/128
 [#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129
+[#130]: https://github.com/115dkk/EqualizerAPO-XT/pull/130

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -315,6 +315,9 @@
     <ClInclude Include="filters\ConvolutionFilter.h" />
     <ClInclude Include="filters\ConvolutionFilePath.h" />
     <ClInclude Include="filters\ConvolutionFilterFactory.h" />
+    <ClInclude Include="filters\MultiConvolutionCommand.h" />
+    <ClInclude Include="filters\MultiConvolutionFilter.h" />
+    <ClInclude Include="filters\MultiConvolutionFilterFactory.h" />
     <ClInclude Include="filters\CopyFilter.h" />
     <ClInclude Include="filters\CopyFilterFactory.h" />
     <ClInclude Include="filters\DelayCommand.h" />
@@ -397,6 +400,9 @@
     <ClCompile Include="filters\ConvolutionFilter.cpp" />
     <ClCompile Include="filters\ConvolutionFilePath.cpp" />
     <ClCompile Include="filters\ConvolutionFilterFactory.cpp" />
+    <ClCompile Include="filters\MultiConvolutionCommand.cpp" />
+    <ClCompile Include="filters\MultiConvolutionFilter.cpp" />
+    <ClCompile Include="filters\MultiConvolutionFilterFactory.cpp" />
     <ClCompile Include="filters\CopyFilter.cpp" />
     <ClCompile Include="filters\CopyFilterFactory.cpp" />
     <ClCompile Include="filters\DelayCommand.cpp" />

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -109,6 +109,8 @@ SOURCES += main.cpp\
 	widgets/CompactToolBar.cpp \
 	guis/ConvolutionFilterGUIFactory.cpp \
 	guis/ConvolutionFilterGUI.cpp \
+	guis/MultiConvolutionFilterGUIFactory.cpp \
+	guis/MultiConvolutionFilterGUI.cpp \
 	helpers/ConvolutionPathHelper.cpp \
 	helpers/DisableWheelFilter.cpp \
 	widgets/EscapableLineEdit.cpp \
@@ -201,6 +203,7 @@ SOURCES += main.cpp\
 	widgets/cards/ChannelCardEditor.cpp \
 	widgets/cards/ChannelSelectionModel.cpp \
 	widgets/cards/ConvolutionCardEditor.cpp \
+	widgets/cards/MultiConvolutionCardEditor.cpp \
 	widgets/cards/DeviceCardEditor.cpp \
 	widgets/cards/DeviceSelectionModel.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \
@@ -311,6 +314,8 @@ HEADERS  += \
 	widgets/CompactToolBar.h \
 	guis/ConvolutionFilterGUIFactory.h \
 	guis/ConvolutionFilterGUI.h \
+	guis/MultiConvolutionFilterGUIFactory.h \
+	guis/MultiConvolutionFilterGUI.h \
 	helpers/ConvolutionPathHelper.h \
 	helpers/DisableWheelFilter.h \
 	widgets/EscapableLineEdit.h \
@@ -389,6 +394,7 @@ HEADERS  += \
 	widgets/cards/ChannelCardEditor.h \
 	widgets/cards/ChannelSelectionModel.h \
 	widgets/cards/ConvolutionCardEditor.h \
+	widgets/cards/MultiConvolutionCardEditor.h \
 	widgets/cards/DeviceCardEditor.h \
 	widgets/cards/DeviceSelectionModel.h \
 	widgets/cards/FilterCardEditorFactory.h \

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -48,7 +48,8 @@ QList<GalleryRow> galleryRows()
 		{ QStringLiteral("include"), QStringLiteral("Include: example.txt") },
 		{ QStringLiteral("vst"), QStringLiteral("VSTPlugin: Library example.dll") },
 		{ QStringLiteral("device"), QStringLiteral("Device: all") },
-		{ QStringLiteral("copy_empty"), QStringLiteral("Copy:") }
+		{ QStringLiteral("copy_empty"), QStringLiteral("Copy:") },
+		{ QStringLiteral("multiconvolution"), QStringLiteral("MultiConvolution: L brir.wav") }
 	};
 }
 

--- a/Editor/guis/MultiConvolutionFilterGUI.cpp
+++ b/Editor/guis/MultiConvolutionFilterGUI.cpp
@@ -1,0 +1,73 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "MultiConvolutionFilterGUI.h"
+
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QToolButton>
+
+#include "filters/MultiConvolutionCommand.h"
+
+MultiConvolutionFilterGUI::MultiConvolutionFilterGUI(const QString& configPath, const QString& outputChannel, const QString& path)
+	: configPath(configPath)
+{
+	QHBoxLayout* layout = new QHBoxLayout(this);
+	layout->setContentsMargins(0, 0, 0, 0);
+
+	layout->addWidget(new QLabel(tr("Output channel:"), this));
+	channelEdit = new QLineEdit(outputChannel.trimmed(), this);
+	channelEdit->setMaximumWidth(80);
+	channelEdit->setToolTip(tr("Output channel the summed convolution is written to"));
+	connect(channelEdit, SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
+	layout->addWidget(channelEdit);
+
+	layout->addWidget(new QLabel(tr("Impulse response:"), this));
+	pathEdit = new QLineEdit(path.trimmed(), this);
+	connect(pathEdit, SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
+	layout->addWidget(pathEdit, 1);
+
+	QToolButton* selectButton = new QToolButton(this);
+	selectButton->setText(QStringLiteral("..."));
+	selectButton->setToolTip(tr("Select impulse response file"));
+	connect(selectButton, SIGNAL(clicked()), this, SLOT(selectFile()));
+	layout->addWidget(selectButton);
+}
+
+void MultiConvolutionFilterGUI::store(QString& command, QString& parameters)
+{
+	command = QStringLiteral("MultiConvolution");
+
+	MultiConvolutionCommand cmd;
+	cmd.outputChannel = channelEdit->text().trimmed().toStdWString();
+	cmd.path = pathEdit->text().toStdWString();
+	parameters = QString::fromStdWString(cmd.serialize());
+}
+
+void MultiConvolutionFilterGUI::selectFile()
+{
+	QString file = QFileDialog::getOpenFileName(this, tr("Select impulse response file"), configPath,
+			tr("Impulse response (*.wav *.flac *.ogg)"));
+	if (!file.isEmpty())
+	{
+		pathEdit->setText(file);
+		emit updateModel();
+	}
+}

--- a/Editor/guis/MultiConvolutionFilterGUI.h
+++ b/Editor/guis/MultiConvolutionFilterGUI.h
@@ -1,0 +1,46 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "Editor/IFilterGUI.h"
+
+class QLineEdit;
+
+// Legacy (frozen-fallback) row GUI for a "MultiConvolution:" line. Deliberately
+// minimal, built in code rather than from a .ui: an output-channel field and an
+// impulse-response path field with a file picker. The modern card editor
+// (widgets/cards/MultiConvolutionCardEditor) is the canonical UI; this exists so
+// the LegacyRows render mode still edits the line.
+class MultiConvolutionFilterGUI : public IFilterGUI
+{
+	Q_OBJECT
+
+public:
+	MultiConvolutionFilterGUI(const QString& configPath, const QString& outputChannel, const QString& path);
+
+	void store(QString& command, QString& parameters) override;
+
+private slots:
+	void selectFile();
+
+private:
+	QString configPath;
+	QLineEdit* channelEdit;
+	QLineEdit* pathEdit;
+};

--- a/Editor/guis/MultiConvolutionFilterGUIFactory.cpp
+++ b/Editor/guis/MultiConvolutionFilterGUIFactory.cpp
@@ -1,0 +1,52 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "filters/MultiConvolutionCommand.h"
+#include "MultiConvolutionFilterGUI.h"
+#include "MultiConvolutionFilterGUIFactory.h"
+#include "../FilterGUIFactoryRegistry.h"
+
+// Shares the Convolution order: it runs in the same processing-filter slot and
+// is told apart by its command keyword, so a "MultiConvolution:" line falls
+// through the Convolution factory (whose parse rejects it) to this one.
+REGISTER_FILTER_GUI_FACTORY(FilterGUIFactoryOrder::Convolution, MultiConvolutionFilterGUIFactory)
+
+MultiConvolutionFilterGUIFactory::MultiConvolutionFilterGUIFactory()
+{
+}
+
+QList<FilterTemplate> MultiConvolutionFilterGUIFactory::createFilterTemplates()
+{
+	QList<FilterTemplate> list;
+	list.append(FilterTemplate(tr("MultiConvolution (BRIR / multi-input synthesis convolution)"), "MultiConvolution:", QStringList(tr("Advanced filters"))));
+	return list;
+}
+
+void MultiConvolutionFilterGUIFactory::startOfFile(const QString& configPath)
+{
+	this->configPath = configPath;
+}
+
+IFilterGUI* MultiConvolutionFilterGUIFactory::createFilterGUI(QString& command, QString& parameters)
+{
+	MultiConvolutionCommand cmd;
+	if (MultiConvolutionCommand::parse(command.toStdWString(), parameters.toStdWString(), cmd))
+		return new MultiConvolutionFilterGUI(configPath, QString::fromStdWString(cmd.outputChannel), QString::fromStdWString(cmd.path));
+
+	return nullptr;
+}

--- a/Editor/guis/MultiConvolutionFilterGUIFactory.h
+++ b/Editor/guis/MultiConvolutionFilterGUIFactory.h
@@ -1,0 +1,36 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "Editor/IFilterGUIFactory.h"
+
+class MultiConvolutionFilterGUIFactory : public IFilterGUIFactory
+{
+	Q_OBJECT
+public:
+	explicit MultiConvolutionFilterGUIFactory();
+
+	QList<FilterTemplate> createFilterTemplates() override;
+
+	void startOfFile(const QString& configPath) override;
+	IFilterGUI* createFilterGUI(QString& command, QString& parameters) override;
+
+private:
+	QString configPath;
+};

--- a/Editor/widgets/cards/FilterCardEditorFactory.cpp
+++ b/Editor/widgets/cards/FilterCardEditorFactory.cpp
@@ -7,11 +7,13 @@
 #include "Editor/IFilterGUI.h"
 #include "ChannelCardEditor.h"
 #include "ConvolutionCardEditor.h"
+#include "MultiConvolutionCardEditor.h"
 #include "DeviceCardEditor.h"
 #include "IncludeCardEditor.h"
 #include "PreampCardEditor.h"
 #include "VSTCardEditor.h"
 #include "filters/ConvolutionCommand.h"
+#include "filters/MultiConvolutionCommand.h"
 #include "filters/VSTPluginFilter.h"
 #include "filters/VSTPluginFilterFactory.h"
 #include "helpers/VSTPluginLibrary.h"
@@ -35,6 +37,13 @@ IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QStr
 		ConvolutionCommand cmd;
 		ConvolutionCommand::parse(command.trimmed().toStdWString(), parameters.toStdWString(), cmd);
 		return new ConvolutionCardEditor(filterTable, QString::fromStdWString(cmd.path));
+	}
+	if (normalizedCommand == QStringLiteral("multiconvolution"))
+	{
+		// MultiConvolutionCommand owns the "<output channel> <path>" grammar.
+		MultiConvolutionCommand cmd;
+		MultiConvolutionCommand::parse(command.trimmed().toStdWString(), parameters.toStdWString(), cmd);
+		return new MultiConvolutionCardEditor(filterTable, QString::fromStdWString(cmd.outputChannel), QString::fromStdWString(cmd.path));
 	}
 	if (normalizedCommand == QStringLiteral("vstplugin"))
 	{

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
@@ -1,0 +1,310 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "MultiConvolutionCardEditor.h"
+
+#include <memory>
+
+#include <QColor>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QStyle>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#include <sndfile.h>
+
+#include "AbstractAPOInfo.h"
+#include "Editor/FilterTable.h"
+#include "Editor/SkinManager.h"
+#include "Editor/skins/ISkin.h"
+#include "Editor/helpers/ConvolutionPathHelper.h"
+#include "Editor/helpers/GUIHelper.h"
+#include "Editor/import/ConfigDependencyScanner.h"
+#include "Editor/import/ImportDialog.h"
+#include "Editor/import/ImportExecutor.h"
+#include "filters/MultiConvolutionCommand.h"
+#include "helpers/RegistryHelper.h"
+
+MultiConvolutionCardEditor::MultiConvolutionCardEditor(FilterTable* filterTable, const QString& outputChannel, const QString& path, QWidget* parent)
+	: IFilterGUI(parent), filterTable(filterTable)
+{
+	setObjectName(QStringLiteral("MultiConvolutionCardEditor"));
+
+	QHBoxLayout* layout = new QHBoxLayout(this);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->setSpacing(10);
+
+	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const QColor glyphColor(tokens.mutedText);
+	const QColor actionColor(tokens.text);
+
+	QLabel* fileGlyph = new QLabel(this);
+	// Reuse the Include glyph identity so every skin's transparent-glyph rule
+	// already applies; the artwork is the same impulse-response trace the
+	// single-input convolution card uses.
+	fileGlyph->setObjectName(QStringLiteral("IncludeCardGlyph"));
+	fileGlyph->setPixmap(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/waveform.svg"), glyphColor, 20).pixmap(GUIHelper::scale(QSize(20, 20))));
+	layout->addWidget(fileGlyph, 0, Qt::AlignVCenter);
+
+	// Output channel that the summed convolution is written to. Kept narrow: a
+	// channel name is a short token (L, R, or a custom upper-case name).
+	channelEdit = new QLineEdit(this);
+	channelEdit->setObjectName(QStringLiteral("MultiConvolutionCardChannel"));
+	channelEdit->setText(outputChannel.trimmed());
+	channelEdit->setPlaceholderText(tr("Out ch"));
+	channelEdit->setToolTip(tr("Output channel the summed convolution is written to"));
+	channelEdit->setMaximumWidth(GUIHelper::scale(QSize(72, 0)).width());
+	connect(channelEdit, SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
+	layout->addWidget(channelEdit, 0, Qt::AlignTop);
+
+	QWidget* pathBlock = new QWidget(this);
+	QVBoxLayout* pathLayout = new QVBoxLayout(pathBlock);
+	pathLayout->setContentsMargins(0, 0, 0, 0);
+	pathLayout->setSpacing(5);
+
+	pathEdit = new QLineEdit(pathBlock);
+	pathEdit->setObjectName(QStringLiteral("IncludeCardPath"));
+	pathEdit->setText(path.trimmed());
+	pathEdit->setPlaceholderText(tr("Multi-channel impulse response file"));
+	connect(pathEdit, SIGNAL(editingFinished()), this, SLOT(pathEdited()));
+	pathLayout->addWidget(pathEdit);
+
+	infoLabel = new QLabel(pathBlock);
+	infoLabel->setObjectName(QStringLiteral("ConvolutionCardInfo"));
+	infoLabel->setStyleSheet(QStringLiteral("color: %1;").arg(glyphColor.name()));
+	pathLayout->addWidget(infoLabel);
+
+	statusLabel = new QLabel(pathBlock);
+	statusLabel->setObjectName(QStringLiteral("IncludeCardStatus"));
+	statusLabel->setWordWrap(true);
+	pathLayout->addWidget(statusLabel);
+
+	layout->addWidget(pathBlock, 1);
+
+	chooseButton = new QToolButton(this);
+	chooseButton->setObjectName(QStringLiteral("FilterCardIconButton"));
+	chooseButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/folder-open.svg"), actionColor, 18));
+	chooseButton->setToolTip(tr("Select impulse response file"));
+	connect(chooseButton, SIGNAL(clicked()), this, SLOT(chooseFile()));
+	layout->addWidget(chooseButton, 0, Qt::AlignTop);
+
+	importButton = new QToolButton(this);
+	importButton->setObjectName(QStringLiteral("FilterCardIconButton"));
+	importButton->setIcon(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/import.svg"), actionColor, 18));
+	importButton->setToolTip(tr("Copy this file into the config directory"));
+	importButton->setVisible(false);
+	connect(importButton, SIGNAL(clicked()), this, SLOT(importToConfig()));
+	layout->addWidget(importButton, 0, Qt::AlignTop);
+
+	// Let the active skin decorate this body. It shares the convolution row type
+	// so a skin that styles convolution cards covers this one too.
+	CommandRowInfo rowInfo;
+	rowInfo.type = QStringLiteral("convolution");
+	rowInfo.command = QStringLiteral("multiconvolution");
+	SkinManager::instance()->prepareCommandRow(rowInfo, nullptr, nullptr, this);
+
+	updateFileInfo();
+}
+
+void MultiConvolutionCardEditor::store(QString& command, QString& parameters)
+{
+	command = QStringLiteral("MultiConvolution");
+
+	MultiConvolutionCommand cmd;
+	cmd.outputChannel = channelEdit->text().trimmed().toStdWString();
+	cmd.path = pathEdit->text().toStdWString();
+	parameters = QString::fromStdWString(cmd.serialize());
+}
+
+void MultiConvolutionCardEditor::chooseFile()
+{
+	if (filterTable == nullptr)
+		return;
+
+	const QString configPath = filterTable->getConfigPath();
+	const QString current = pathEdit->text();
+	const QString currentAbsolute = ConvolutionPathHelper::absolutePathForConfig(configPath, current);
+	QFileInfo startInfo(currentAbsolute.isEmpty() ? configPath : currentAbsolute);
+
+	QFileDialog dialog(this, tr("Select impulse response file"), startInfo.absolutePath(), QStringLiteral("*.wav *.flac *.ogg"));
+	dialog.setFileMode(QFileDialog::ExistingFile);
+	dialog.setNameFilter(tr("Impulse response (*.wav *.flac *.ogg)"));
+	if (!current.isEmpty())
+		dialog.selectFile(startInfo.fileName());
+	if (dialog.exec() == QDialog::Accepted)
+	{
+		const QString selected = dialog.selectedFiles().first();
+		pathEdit->setText(ConvolutionPathHelper::displayPathForSelection(configPath, selected));
+		updateFileInfo();
+		emit updateModel();
+	}
+}
+
+void MultiConvolutionCardEditor::pathEdited()
+{
+	updateFileInfo();
+	emit updateModel();
+}
+
+void MultiConvolutionCardEditor::importToConfig()
+{
+	if (filterTable == nullptr)
+		return;
+
+	const QString source = resolvedAbsolutePath();
+	if (source.isEmpty() || !QFileInfo::exists(source))
+		return;
+
+	const QString configDir = QFileInfo(filterTable->getConfigPath()).absolutePath();
+
+	EqAPO::Import::ImportManifest manifest = EqAPO::Import::ConfigDependencyScanner::scan(source, configDir);
+	if (manifest.items.isEmpty())
+	{
+		QMessageBox::warning(this, tr("Import"), tr("Nothing to import: %1").arg(manifest.warnings.join('\n')));
+		return;
+	}
+
+	EqAPO::Import::ImportDialog dialog(manifest, configDir, this);
+	if (dialog.exec() != QDialog::Accepted)
+		return;
+
+	EqAPO::Import::ExecutionResult result = EqAPO::Import::ImportExecutor::execute(manifest, configDir);
+	if (!result.success)
+	{
+		QMessageBox::warning(this, tr("Import"),
+			tr("Some files could not be copied:\n%1").arg(result.errors.join('\n')));
+		return;
+	}
+
+	pathEdit->setText(QDir::toNativeSeparators(manifest.rootDest));
+	updateFileInfo();
+	emit updateModel();
+}
+
+QString MultiConvolutionCardEditor::resolvedAbsolutePath() const
+{
+	if (filterTable == nullptr)
+		return QString();
+
+	return ConvolutionPathHelper::absolutePathForConfig(filterTable->getConfigPath(), pathEdit->text());
+}
+
+unsigned MultiConvolutionCardEditor::currentDeviceSampleRate() const
+{
+	if (filterTable == nullptr)
+		return 0;
+
+	std::shared_ptr<AbstractAPOInfo> device = filterTable->getSelectedDevice();
+	return device != nullptr ? device->getSampleRate() : 0;
+}
+
+void MultiConvolutionCardEditor::updateFileInfo()
+{
+	QString info;
+	QString error;
+	QString warning;
+	bool offerImport = false;
+
+	const QString path = pathEdit->text();
+	if (path.isEmpty())
+	{
+		error = tr("No file selected");
+	}
+	else
+	{
+		const QString absolute = resolvedAbsolutePath();
+		QFileInfo fileInfo(absolute);
+		if (absolute.isEmpty() || !fileInfo.exists())
+		{
+			error = tr("File not found");
+		}
+		else
+		{
+			const QString nativeAbsolute = QDir::toNativeSeparators(fileInfo.absoluteFilePath());
+
+			SF_INFO sfInfo = {};
+			SNDFILE* file = sf_wchar_open(nativeAbsolute.toStdWString().c_str(), SFM_READ, &sfInfo);
+			if (file == nullptr)
+			{
+				error = tr("Unsupported file format");
+			}
+			else
+			{
+				const int sampleRate = sfInfo.samplerate;
+				const double lengthMs = sampleRate > 0 ? sfInfo.frames * 1000.0 / sampleRate : 0.0;
+				// A multi-channel readout: the channel count matters here because it
+				// must match the number of selected input channels.
+				info = tr("%1 ms · %2 samples · %3 Hz · %4 ch")
+					.arg(QString::number(lengthMs, 'f', 1))
+					.arg(static_cast<qlonglong>(sfInfo.frames))
+					.arg(sampleRate)
+					.arg(sfInfo.channels);
+				sf_close(file);
+
+				const unsigned deviceRate = currentDeviceSampleRate();
+				if (deviceRate != 0 && static_cast<unsigned>(sampleRate) != deviceRate)
+					warning = tr("Sample rate does not match the device (%1 Hz)").arg(deviceRate);
+			}
+
+			ACCESS_MASK mask = GENERIC_READ;
+			try
+			{
+				mask = RegistryHelper::getFileAccessForUser(nativeAbsolute.toStdWString(), SECURITY_LOCAL_SERVICE_RID);
+			}
+			catch (const RegistryException&)
+			{
+			}
+			const bool readableByService = (mask & GENERIC_READ) == GENERIC_READ || (mask & FILE_GENERIC_READ) == FILE_GENERIC_READ;
+
+			if (!readableByService)
+			{
+				error = tr("Not readable by the audio service.\nClick the import button to copy it into the config directory.");
+				offerImport = true;
+			}
+			else if (!info.isEmpty())
+			{
+				const QString configDir = QDir::cleanPath(QFileInfo(filterTable->getConfigPath()).absolutePath());
+				const QString fileDir = QDir::cleanPath(fileInfo.absolutePath());
+				if (!configDir.isEmpty() && !fileDir.startsWith(configDir, Qt::CaseInsensitive))
+					offerImport = true;
+			}
+		}
+	}
+
+	const QString statusText = !error.isEmpty() ? error : warning;
+	statusLabel->setVisible(!statusText.isEmpty());
+	statusLabel->setText(statusText);
+	statusLabel->setProperty("severity", error.isEmpty() ? QStringLiteral("warning") : QStringLiteral("critical"));
+	statusLabel->style()->unpolish(statusLabel);
+	statusLabel->style()->polish(statusLabel);
+
+	infoLabel->setVisible(!info.isEmpty());
+	infoLabel->setText(info);
+
+	importButton->setVisible(offerImport);
+}

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.h
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "Editor/IFilterGUI.h"
+
+class FilterTable;
+class QLabel;
+class QLineEdit;
+class QToolButton;
+
+// Modern card body for a "MultiConvolution:" line. It is the card-mode
+// counterpart of the legacy guis/MultiConvolutionFilterGUI and reuses
+// ConvolutionCardEditor's impulse-response path block (file picker, length/rate
+// readout, import affordance), adding a small field for the single output
+// channel that the summed convolution is written to.
+class MultiConvolutionCardEditor : public IFilterGUI
+{
+	Q_OBJECT
+
+public:
+	MultiConvolutionCardEditor(FilterTable* filterTable, const QString& outputChannel, const QString& path, QWidget* parent = nullptr);
+
+	void store(QString& command, QString& parameters) override;
+
+private slots:
+	void chooseFile();
+	void pathEdited();
+	void importToConfig();
+
+private:
+	QString resolvedAbsolutePath() const;
+	unsigned currentDeviceSampleRate() const;
+	void updateFileInfo();
+
+	FilterTable* filterTable = nullptr;
+	QLineEdit* channelEdit = nullptr;
+	QLineEdit* pathEdit = nullptr;
+	QLabel* infoLabel = nullptr;
+	QLabel* statusLabel = nullptr;
+	QToolButton* chooseButton = nullptr;
+	QToolButton* importButton = nullptr;
+};

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,6 +19,7 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 
 - 오디오를 내부에서 double 정밀도로 처리해 복잡한 필터 체인에서도 정밀도를 잃지 않습니다.
 - Convolution, GraphicEQ, 파라메트릭 EQ, VST2/VST3와 기존 Equalizer APO 필터를 지원합니다.
+- BRIR(Binaural Room Impulse Response) 재생을 위한 MultiConvolution 필터가 있습니다. 여러 입력 채널을 하나의 다채널 임펄스 응답과 각각 컨볼루션한 뒤 합산해 하나의 출력으로 보내므로, 채널을 제자리에서만 처리하는 기존 Convolution 필터와 달리 BRIR에 필요한 크로스피드가 살아 있습니다.
 - Steinberg VST3 SDK(MIT 라이선스 pluginterfaces)로 VST3를 네이티브 호스팅하며, 플러그인이 지원하면 64비트(double)로 처리합니다.
 - SIMD 커널은 [Google Highway](https://github.com/google/highway)로 한 번만 작성해 변형별로 컴파일합니다. x64는 SSE2, AVX, AVX2, AVX-512, AVX10.1, ARM64는 NEON입니다.
 - Qt Editor를 현대화했습니다. 카드 기반 필터 UI와 행 chrome·노브 렌더링·Copy 라우팅 렌더러까지 서로 다른 5종 스킨([docs/skin-integration-report.md](docs/skin-integration-report.md)), 내장 폰트, 고해상도(High-DPI) 대응이 들어 있습니다.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Current work areas:
 
 - Double-precision internal audio processing for complex filter chains.
 - Convolution, GraphicEQ, parametric EQ, VST2/VST3, and standard Equalizer APO filter support.
+- MultiConvolution filter for BRIR (Binaural Room Impulse Response) playback: it convolves several input channels against one multichannel impulse response and sums them into a single output, so the crossfeed a BRIR needs survives, unlike the in-place Convolution filter.
 - Native VST3 hosting through the Steinberg VST3 SDK (MIT-licensed pluginterfaces), with 64-bit (double) processing where the plug-in supports it.
 - Portable SIMD kernels written once with [Google Highway](https://github.com/google/highway) and compiled per variant: SSE2, AVX, AVX2, AVX-512, and AVX10.1 on x64, NEON on ARM64.
 - Modernized Qt Editor: card-based filter UI and five fully differentiated visual skins — each with its own row chrome, knob rendering, and Copy routing renderer ([docs/skin-integration-report.md](docs/skin-integration-report.md)) — plus embedded fonts and high-DPI scaling.

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -21,6 +22,8 @@
 #endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#include <sndfile.h>
 
 #include "FilterEngine.h"
 #include "helpers/LogHelper.h"
@@ -91,6 +94,44 @@ std::vector<float> processDcBlock(FilterEngine& engine, float left, float right,
 	return output;
 }
 
+// Narrows a wide string to the active code page. Temp paths and config text are
+// ASCII in these tests; this avoids the wchar_t->char narrowing warning (C4244)
+// that the std::string(begin, end) shortcut raises.
+std::string toNarrow(const std::wstring& w)
+{
+	if (w.empty())
+		return std::string();
+	int len = WideCharToMultiByte(CP_ACP, 0, w.data(), (int)w.size(), nullptr, 0, nullptr, nullptr);
+	std::string s((size_t)len, '\0');
+	WideCharToMultiByte(CP_ACP, 0, w.data(), (int)w.size(), &s[0], len, nullptr, nullptr);
+	return s;
+}
+
+// Writes a 2-channel delta impulse response (each channel passes its input
+// straight through) to the temp dir so a MultiConvolution line has a real file
+// to load. Registered for cleanup like the configs.
+std::wstring writeStereoDeltaIr(test::Harness& harness, const std::wstring& fileName)
+{
+	std::wstring path = testDirectory() + L"\\" + fileName;
+	const int frames = 16;
+	std::vector<double> interleaved((size_t)frames * 2, 0.0);
+	interleaved[0] = 1.0; // channel 0, first sample
+	interleaved[1] = 1.0; // channel 1, first sample
+
+	SF_INFO info = {};
+	info.samplerate = 48000;
+	info.channels = 2;
+	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
+	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_WRITE, &info);
+	if (file == nullptr)
+		harness.fail("could not write stereo delta IR");
+	sf_writef_double(file, interleaved.data(), frames);
+	sf_close(file);
+
+	writtenConfigFiles().push_back(path);
+	return path;
+}
+
 // A Channel selector must route the following filter to the named channel
 // only. This pins down the channel-name -> channel-index resolution in
 // FilterEngine::addFilters.
@@ -128,6 +169,202 @@ void testCopySwapsChannels(test::Harness& harness)
 	float right = output[(size_t)478 * 2 + 1];
 	harness.expect(std::fabs(left - 0.25f) < 1e-6f, "Copy did not route R into L");
 	harness.expect(std::fabs(right - 0.75f) < 1e-6f, "Copy did not route L into R");
+}
+
+// MultiConvolution must convolve every selected input with its own channel of a
+// single multi-channel IR and SUM them into one output channel. With a stereo
+// delta IR (pass-through) and inputs L=0.3, R=0.5, the "L" output becomes their
+// sum 0.8, while R (not a filter output) passes through unchanged. This is the
+// end-to-end check that both inputs are folded in, not just one.
+void testMultiConvolutionSumsSelectedInputs(test::Harness& harness)
+{
+	std::wstring irPath = writeStereoDeltaIr(harness, L"mc_delta.wav");
+	std::string irNarrow = toNarrow(irPath);
+
+	std::wstring config = writeConfig(harness, L"multiconv.txt",
+			"Channel: L R\n"
+			"MultiConvolution: L \"" + irNarrow + "\"\n");
+
+	FilterEngine engine;
+	initializeEngine(engine, 48000, 2, 480, config);
+
+	std::vector<float> output = processDcBlock(engine, 0.3f, 0.5f, 480);
+	float left = output[(size_t)478 * 2 + 0];
+	float right = output[(size_t)478 * 2 + 1];
+	harness.expect(std::fabs(left - 0.8f) < 1e-3f, "L must be the summed convolution of both selected inputs");
+	harness.expect(std::fabs(right - 0.5f) < 1e-3f, "R must pass through unchanged (it is not the filter's output)");
+}
+
+// Reads a stereo IR file into two channel-major buffers. Fails the harness if
+// the file is missing or not stereo.
+void readStereoIr(test::Harness& harness, const std::wstring& path, std::vector<double>& ch0, std::vector<double>& ch1)
+{
+	SF_INFO info = {};
+	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_READ, &info);
+	if (file == nullptr)
+		harness.fail("could not open BRIR IR file");
+	if (info.channels != 2)
+		harness.fail("BRIR IR file is not stereo");
+	std::vector<double> interleaved((size_t)info.frames * info.channels);
+	sf_readf_double(file, interleaved.data(), info.frames);
+	sf_close(file);
+	ch0.resize((size_t)info.frames);
+	ch1.resize((size_t)info.frames);
+	for (sf_count_t i = 0; i < info.frames; i++)
+	{
+		ch0[(size_t)i] = interleaved[(size_t)i * 2 + 0];
+		ch1[(size_t)i] = interleaved[(size_t)i * 2 + 1];
+	}
+}
+
+// Writes two channel-major buffers as a stereo double WAV, registered for cleanup.
+void writeStereoIr(const std::wstring& path, const std::vector<double>& ch0, const std::vector<double>& ch1)
+{
+	size_t frames = std::min(ch0.size(), ch1.size());
+	std::vector<double> interleaved(frames * 2);
+	for (size_t i = 0; i < frames; i++)
+	{
+		interleaved[i * 2 + 0] = ch0[i];
+		interleaved[i * 2 + 1] = ch1[i];
+	}
+	SF_INFO info = {};
+	info.samplerate = 48000;
+	info.channels = 2;
+	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
+	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_WRITE, &info);
+	sf_writef_double(file, interleaved.data(), (sf_count_t)frames);
+	sf_close(file);
+	writtenConfigFiles().push_back(path);
+}
+
+// Drives a single unit impulse on the LEFT input through the engine and returns
+// the accumulated L and R outputs across enough blocks to capture the full IR.
+void processLeftImpulse(FilterEngine& engine, unsigned frames, unsigned blocks, std::vector<float>& outL, std::vector<float>& outR)
+{
+	outL.clear();
+	outR.clear();
+	for (unsigned b = 0; b < blocks; b++)
+	{
+		std::vector<float> input((size_t)frames * 2, 0.0f);
+		std::vector<float> output((size_t)frames * 2, 0.0f);
+		if (b == 0)
+			input[0] = 1.0f; // left channel, first sample
+		engine.process(output.data(), input.data(), frames);
+		for (unsigned i = 0; i < frames; i++)
+		{
+			outL.push_back(output[(size_t)i * 2 + 0]);
+			outR.push_back(output[(size_t)i * 2 + 1]);
+		}
+	}
+}
+
+// Peak magnitude and its sample index in a signal.
+void peakOf(const std::vector<float>& sig, double& peak, size_t& pos)
+{
+	peak = 0.0;
+	pos = 0;
+	for (size_t i = 0; i < sig.size(); i++)
+	{
+		double a = std::fabs((double)sig[i]);
+		if (a > peak) { peak = a; pos = i; }
+	}
+}
+
+double energyOf(const std::vector<float>& sig)
+{
+	double e = 0.0;
+	for (float s : sig)
+		e += (double)s * (double)s;
+	return e;
+}
+
+// Diagnostic: with a real BRIR set, MultiConvolution must produce genuine
+// crossfeed (a left-only impulse reaches the RIGHT ear), whereas the 1:1
+// ConvolutionFilter cannot (its right output stays silent for right-input = 0).
+// Runs only when EAPO_XT_BRIR_DIR points at a folder holding Thead400FL.wav and
+// Thead400FR.wav (both stereo, [left-ear, right-ear]); otherwise it skips so CI
+// stays green without the data files.
+void testRealBrirCrossfeed(test::Harness& harness)
+{
+	wchar_t* dirBuf = nullptr;
+	size_t dirLen = 0;
+	_wdupenv_s(&dirBuf, &dirLen, L"EAPO_XT_BRIR_DIR");
+	if (dirBuf == nullptr)
+	{
+		std::printf("  [skip] testRealBrirCrossfeed: set EAPO_XT_BRIR_DIR to the BRIR folder to run it\n");
+		return;
+	}
+	std::wstring dir(dirBuf);
+	free(dirBuf);
+
+	std::wstring flPath = dir + L"\\Thead400FL.wav";
+	std::wstring frPath = dir + L"\\Thead400FR.wav";
+
+	std::vector<double> flL, flR, frL, frR;
+	readStereoIr(harness, flPath, flL, flR); // FL: ch0 = L-ear, ch1 = R-ear
+	readStereoIr(harness, frPath, frL, frR); // FR: ch0 = L-ear, ch1 = R-ear
+
+	// Ear-based IRs: Lear = both speakers -> left ear, Rear = both -> right ear.
+	std::wstring lear = testDirectory() + L"\\Lear.wav";
+	std::wstring rear = testDirectory() + L"\\Rear.wav";
+	writeStereoIr(lear, flL, frL);
+	writeStereoIr(rear, flR, frR);
+
+	const unsigned frames = 480;
+	const unsigned blocks = 80; // 38400 samples > IR length
+
+	// Config A: full BRIR via two MultiConvolution filters.
+	// Custom channel names must be upper-case: the "Channel:" command upper-cases
+	// its selectors (ChannelCommand::parse), while "Copy:" keeps the target case
+	// as written, so a mixed-case name would never match. SO/SE are private
+	// scratch channels holding the original L/R before the ears overwrite L/R.
+	std::string cfgA =
+			"Copy: SO=L SE=R\n"
+			"Channel: SO SE\n"
+			"MultiConvolution: L \"" + toNarrow(lear) + "\"\n"
+			"Channel: SO SE\n"
+			"MultiConvolution: R \"" + toNarrow(rear) + "\"\n";
+	std::wstring cfgAPath = writeConfig(harness, L"brir_multi.txt", cfgA);
+
+	FilterEngine engineA;
+	initializeEngine(engineA, 48000, 2, frames, cfgAPath);
+	std::vector<float> aL, aR;
+	processLeftImpulse(engineA, frames, blocks, aL, aR);
+
+	double aLpeak, aRpeak; size_t aLpos, aRpos;
+	peakOf(aL, aLpeak, aLpos);
+	peakOf(aR, aRpeak, aRpos);
+	double aRenergy = energyOf(aR);
+	std::printf("  [BRIR] MultiConvolution  L-ear peak=%.4f@%zu  R-ear(crossfeed) peak=%.4f@%zu energy=%.5f\n",
+			aLpeak, aLpos, aRpeak, aRpos, aRenergy);
+
+	// Config B: the old 1:1 ConvolutionFilter on the same stereo FL IR.
+	std::string cfgB =
+			"Channel: L R\n"
+			"Convolution: \"" + toNarrow(flPath) + "\"\n";
+	std::wstring cfgBPath = writeConfig(harness, L"brir_1to1.txt", cfgB);
+
+	FilterEngine engineB;
+	initializeEngine(engineB, 48000, 2, frames, cfgBPath);
+	std::vector<float> bL, bR;
+	processLeftImpulse(engineB, frames, blocks, bL, bR);
+
+	double bLpeak, bRpeak; size_t bLpos, bRpos;
+	peakOf(bL, bLpeak, bLpos);
+	peakOf(bR, bRpeak, bRpos);
+	double bRenergy = energyOf(bR);
+	std::printf("  [BRIR] 1:1 Convolution   L-ear peak=%.4f@%zu  R-ear peak=%.4f@%zu energy=%.5f\n",
+			bLpeak, bLpos, bRpeak, bRpos, bRenergy);
+
+	// MultiConvolution must deliver crossfeed to the right ear...
+	harness.expect(aRenergy > 1e-6, "MultiConvolution BRIR produced no crossfeed to the right ear");
+	// ...matching the left speaker's contralateral response (FL right-ear channel,
+	// peak ~0.0188 around sample 184).
+	harness.expect(std::fabs(aRpeak - 0.0188) < 5e-3, "right-ear crossfeed peak does not match the contralateral IR");
+	harness.expect(aRpos > 120 && aRpos < 260, "right-ear crossfeed peak is not at the expected contralateral delay");
+	// The 1:1 path leaves the right ear essentially silent (no crossfeed).
+	harness.expect(bRenergy < 1e-6, "1:1 Convolution unexpectedly produced right-ear output");
+	harness.expect(aRenergy > bRenergy * 1000.0, "MultiConvolution crossfeed is not dramatically larger than the 1:1 path");
 }
 
 // Loading a new config while processing must crossfade smoothly from the old
@@ -200,7 +437,9 @@ int main()
 
 	testChannelSelectorRouting(harness);
 	testCopySwapsChannels(harness);
+	testMultiConvolutionSumsSelectedInputs(harness);
 	testConfigSwapCrossfades(harness);
+	testRealBrirCrossfeed(harness);
 
 	removeTestDirectory();
 	harness.report();

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -43,6 +43,7 @@ void runVSTPluginCommandTests();
 void runVstHostTests();
 void runParserTests();
 void runParserPreampTests();
+void runMultiConvolutionTests();
 
 using std::string;
 using std::vector;
@@ -253,6 +254,7 @@ int main()
 	runVstHostTests();
 	runParserTests();
 	runParserPreampTests();
+	runMultiConvolutionTests();
 
 	harness.report();
 	return 0;

--- a/Tests/HybridConvTests/HybridConvTests.vcxproj
+++ b/Tests/HybridConvTests/HybridConvTests.vcxproj
@@ -247,6 +247,7 @@ if exist "$(MSBuildThisFileDirectory)..\TestVst2Plugin\$(Platform)\$(Configurati
     <ClCompile Include="ChannelCommandTests.cpp" />
     <ClCompile Include="CommonLogicTests.cpp" />
     <ClCompile Include="ConvolutionCommandTests.cpp" />
+    <ClCompile Include="MultiConvolutionTests.cpp" />
     <ClCompile Include="CopyCommandTests.cpp" />
     <ClCompile Include="DelayCommandTests.cpp" />
     <ClCompile Include="DeviceCommandTests.cpp" />

--- a/Tests/HybridConvTests/MultiConvolutionTests.cpp
+++ b/Tests/HybridConvTests/MultiConvolutionTests.cpp
@@ -1,0 +1,185 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	Unit tests for the multi-input synthesis convolution filter
+	(MultiConvolutionFilter): several input channels convolved with a single
+	multi-channel impulse response and summed into one output channel.
+*/
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#define WIN32_LEAN_AND_MEAN
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#include <windows.h>
+#include <sndfile.h>
+
+#include "filters/MultiConvolutionCommand.h"
+#include "filters/MultiConvolutionFilter.h"
+#include "Tests/TestHarness.h"
+
+using std::vector;
+using std::wstring;
+
+namespace
+{
+constexpr int frameLength = 480;
+constexpr int sampleRate = 48000;
+constexpr double tolerance = 1.0e-8;
+
+test::Harness harness("MultiConvolutionTests");
+
+// Writes a multi-channel impulse response to a temporary WAV. channels[c] holds
+// the samples of IR channel c; all channels must have the same length.
+wstring createMultiChannelIr(const vector<vector<double>>& channels)
+{
+	const unsigned numCh = (unsigned)channels.size();
+	const unsigned frames = (unsigned)channels[0].size();
+	vector<double> interleaved((size_t)frames * numCh);
+	for (unsigned f = 0; f < frames; f++)
+		for (unsigned c = 0; c < numCh; c++)
+			interleaved[(size_t)f * numCh + c] = channels[c][f];
+
+	wchar_t tempPath[MAX_PATH] = {};
+	wchar_t tempFile[MAX_PATH] = {};
+	if (GetTempPathW(MAX_PATH, tempPath) == 0)
+		harness.fail("GetTempPathW failed");
+	if (GetTempFileNameW(tempPath, L"mc", 0, tempFile) == 0)
+		harness.fail("GetTempFileNameW failed");
+
+	wstring filename = tempFile;
+	DeleteFileW(filename.c_str());
+	filename += L".wav";
+
+	SF_INFO info = {};
+	info.samplerate = sampleRate;
+	info.channels = (int)numCh;
+	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
+
+	SNDFILE* file = sf_wchar_open(filename.c_str(), SFM_WRITE, &info);
+	if (file == nullptr)
+		harness.fail("could not create temporary impulse response file");
+	sf_writef_double(file, interleaved.data(), (sf_count_t)frames);
+	sf_close(file);
+
+	return filename;
+}
+
+// First tracer bullet: two selected inputs, each convolved with a delta impulse
+// response (pass-through), must be summed into the single output channel. With
+// L = 0.3 and R = 0.5 the output is 0.8 everywhere. This is exactly the routing
+// the 1:1 ConvolutionFilter cannot do (it would leave the two inputs separate).
+void assertTwoInputsSumIntoOneOutput()
+{
+	vector<double> delta(frameLength, 0.0);
+	delta[0] = 1.0;
+	wstring irFile = createMultiChannelIr({delta, delta});
+
+	MultiConvolutionFilter filter(L"Mixed", irFile);
+	vector<wstring> inChannels = {L"L", L"R"};
+	vector<wstring> outChannels = filter.initialize((float)sampleRate, frameLength, inChannels);
+	DeleteFileW(irFile.c_str());
+
+	harness.expectEqual(outChannels.size(), (size_t)1, "filter should declare exactly one output channel");
+	harness.expectTrue(!outChannels.empty() && outChannels[0] == L"Mixed", "output channel should be named Mixed");
+
+	vector<double> inL(frameLength, 0.3);
+	vector<double> inR(frameLength, 0.5);
+	vector<double> out(frameLength, 0.0);
+	double* input[] = {inL.data(), inR.data()};
+	double* output[] = {out.data()};
+	filter.process(output, input, frameLength);
+
+	for (int f = 0; f < frameLength; f++)
+		harness.expectTrue(fabs(out[f] - 0.8) <= tolerance, "two inputs should be summed into one output");
+}
+
+// Second slice: each input must be convolved with its OWN IR channel. Distinct
+// IR gains (2x on channel 0, 3x on channel 1) with distinct inputs (0.1, 0.2)
+// give 0.1*2 + 0.2*3 = 0.8; a swapped pairing would give 0.7. The delta test
+// above cannot catch a swap because two identical deltas hide it.
+void assertEachInputPairsWithItsOwnIrChannel()
+{
+	vector<double> ir0(frameLength, 0.0);
+	ir0[0] = 2.0;
+	vector<double> ir1(frameLength, 0.0);
+	ir1[0] = 3.0;
+	wstring irFile = createMultiChannelIr({ir0, ir1});
+
+	MultiConvolutionFilter filter(L"Mixed", irFile);
+	vector<wstring> inChannels = {L"L", L"R"};
+	filter.initialize((float)sampleRate, frameLength, inChannels);
+	DeleteFileW(irFile.c_str());
+
+	vector<double> inL(frameLength, 0.1);
+	vector<double> inR(frameLength, 0.2);
+	vector<double> out(frameLength, 0.0);
+	double* input[] = {inL.data(), inR.data()};
+	double* output[] = {out.data()};
+	filter.process(output, input, frameLength);
+
+	for (int f = 0; f < frameLength; f++)
+		harness.expectTrue(fabs(out[f] - 0.8) <= tolerance, "each input must pair with its own IR channel");
+}
+
+// Third slice: the "MultiConvolution:" config line parses into an output channel
+// and an IR path. The channel is the first token; the rest (trimmed) is the path
+// and keeps its inner spaces. A non-matching command or a line without a path is
+// rejected.
+void assertCommandParsesChannelAndPath()
+{
+	MultiConvolutionCommand cmd;
+	harness.expectTrue(MultiConvolutionCommand::parse(L"MultiConvolution", L"Mixed room.wav", cmd), "valid MultiConvolution line parses");
+	harness.expectTrue(cmd.outputChannel == L"Mixed", "output channel is the first token");
+	harness.expectTrue(cmd.path == L"room.wav", "IR path is the remainder");
+
+	MultiConvolutionCommand spaced;
+	harness.expectTrue(MultiConvolutionCommand::parse(L"MultiConvolution", L"LeftEar sub dir\\room ir.wav", spaced), "path with inner spaces parses");
+	harness.expectTrue(spaced.outputChannel == L"LeftEar", "channel stops at the first space");
+	harness.expectTrue(spaced.path == L"sub dir\\room ir.wav", "path keeps inner spaces");
+
+	MultiConvolutionCommand rejected;
+	harness.expectFalse(MultiConvolutionCommand::parse(L"Convolution", L"Mixed room.wav", rejected), "a non-MultiConvolution command is rejected");
+	harness.expectFalse(MultiConvolutionCommand::parse(L"MultiConvolution", L"OnlyChannel", rejected), "a line without an IR path is rejected");
+}
+
+// serialize -> parse round trip is stable, so the Editor can write the line and
+// read it back unchanged (the card and the engine share this one codec).
+void assertCommandSerializeRoundTrips()
+{
+	struct Case
+	{
+		const wchar_t* channel;
+		const wchar_t* path;
+	};
+	const Case cases[] = {
+		{L"Mixed", L"room.wav"},
+		{L"LeftEar", L"sub dir\\room ir.wav"},
+		{L"R", L"%USERPROFILE%\\ir.wav"},
+	};
+
+	for (const Case& c : cases)
+	{
+		MultiConvolutionCommand first;
+		first.outputChannel = c.channel;
+		first.path = c.path;
+		wstring serialized = first.serialize();
+
+		MultiConvolutionCommand second;
+		harness.expectTrue(MultiConvolutionCommand::parse(L"MultiConvolution", serialized, second), "serialized line re-parses");
+		harness.expectTrue(second.outputChannel == first.outputChannel, "channel round-trips");
+		harness.expectTrue(second.path == first.path, "path round-trips");
+		harness.expectTrue(second.serialize() == serialized, "second serialization is identical");
+	}
+}
+} // namespace
+
+void runMultiConvolutionTests()
+{
+	assertTwoInputsSumIntoOneOutput();
+	assertEachInputPairsWithItsOwnIrChannel();
+	assertCommandParsesChannelAndPath();
+	assertCommandSerializeRoundTrips();
+	harness.report();
+}

--- a/filters/MultiConvolutionCommand.cpp
+++ b/filters/MultiConvolutionCommand.cpp
@@ -1,0 +1,50 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+
+#include "MultiConvolutionCommand.h"
+
+#include "helpers/StringHelper.h"
+
+const std::wstring& MultiConvolutionCommand::serialize() const
+{
+	serialized = outputChannel + L" " + path;
+	return serialized;
+}
+
+bool MultiConvolutionCommand::parse(const std::wstring& command, const std::wstring& parameters, MultiConvolutionCommand& out)
+{
+	if (command != L"MultiConvolution")
+		return false;
+
+	// The output channel is the first whitespace-delimited token; the remainder
+	// (trimmed) is the IR path. A line with no space separates nothing, so there
+	// is no path and the line is rejected.
+	std::wstring trimmed = StringHelper::trim(parameters);
+	size_t space = trimmed.find_first_of(L" \t");
+	if (space == std::wstring::npos)
+		return false;
+
+	out.outputChannel = trimmed.substr(0, space);
+	out.path = StringHelper::trim(trimmed.substr(space + 1));
+	if (out.outputChannel.empty() || out.path.empty())
+		return false;
+
+	return true;
+}

--- a/filters/MultiConvolutionCommand.h
+++ b/filters/MultiConvolutionCommand.h
@@ -1,0 +1,49 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+
+// Single owner of the "MultiConvolution:" config-line grammar, shared by the
+// engine factory and the Editor GUI. The line names one output channel followed
+// by a single multi-channel impulse response path:
+//
+//   MultiConvolution: <outputChannel> <impulse response path>
+//
+// The output channel is the first whitespace-delimited token; everything after
+// the first space (trimmed) is the path, so paths may contain inner spaces just
+// like the "Convolution:" grammar. Quotes and environment variables are left in
+// the path for ConvolutionFilePath::resolve to handle.
+struct MultiConvolutionCommand
+{
+	std::wstring outputChannel;
+	std::wstring path;
+
+	// Canonical parameter string: "<outputChannel> <path>".
+	const std::wstring& serialize() const;
+
+	// Returns true only when command is "MultiConvolution" and the parameters
+	// carry both an output channel and a non-empty path. A line with just a
+	// channel (no path) is rejected, unlike the single-field Convolution grammar.
+	static bool parse(const std::wstring& command, const std::wstring& parameters, MultiConvolutionCommand& out);
+
+private:
+	// serialize() returns a reference, so the composed string is cached here.
+	mutable std::wstring serialized;
+};

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -1,0 +1,179 @@
+﻿/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+#include <cmath>
+#include <climits>
+#include <cstring>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#include <sndfile.h>
+#include <fftw3.h>
+
+#include "helpers/LogHelper.h"
+#include "helpers/MemoryHelper.h"
+#include "MultiConvolutionFilter.h"
+
+using std::abs;
+using std::vector;
+using std::wstring;
+
+MultiConvolutionFilter::MultiConvolutionFilter(const wstring& outputChannel, const wstring& filename)
+{
+	this->outputChannel = outputChannel;
+	this->filename = filename;
+	sampleRate = 0.0f;
+	inputChannelCount = 0;
+	filterFrameCount = 0;
+	filters = nullptr;
+}
+
+MultiConvolutionFilter::~MultiConvolutionFilter()
+{
+	cleanup();
+}
+
+vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned maxFrameCount, vector<wstring> channelNames)
+{
+	cleanup();
+
+	this->sampleRate = sampleRate;
+	inputChannelCount = (unsigned)channelNames.size();
+	filterFrameCount = 0;
+
+	// The output channel is declared regardless of whether the IR loads, so a
+	// bad path degrades to a silent output channel instead of vanishing (which
+	// would shift every following channel selection).
+	vector<wstring> outChannelNames = {outputChannel};
+
+	if (inputChannelCount == 0)
+		return outChannelNames;
+
+	SF_INFO info{};
+	SNDFILE* in = sf_wchar_open(filename.c_str(), SFM_READ, &info);
+	if (in == nullptr)
+	{
+		LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(in));
+		return outChannelNames;
+	}
+	if (abs(sampleRate - info.samplerate) > 1.0)
+	{
+		LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
+		sf_close(in);
+		return outChannelNames;
+	}
+	if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX)
+	{
+		LogFStatic(L"Impulse response has no usable audio (frames=%lld, channels=%d); ignoring %s",
+			static_cast<long long>(info.frames), info.channels, filename.c_str());
+		sf_close(in);
+		return outChannelNames;
+	}
+
+	const unsigned irChannels = (unsigned)info.channels;
+	const unsigned irFrames = (unsigned)info.frames;
+	vector<double> interleaved((size_t)irFrames * irChannels);
+	sf_count_t numRead = 0;
+	while (numRead < info.frames)
+	{
+		sf_count_t got = sf_readf_double(in, interleaved.data() + numRead * irChannels, info.frames - numRead);
+		if (got <= 0)
+			break;
+		numRead += got;
+	}
+	sf_close(in);
+
+	// Deinterleave into channel-major IR buffers so each convolution reads a
+	// contiguous per-channel impulse response.
+	vector<vector<double>> irBuffers(irChannels, vector<double>(irFrames));
+	for (unsigned c = 0; c < irChannels; c++)
+		for (unsigned f = 0; f < irFrames; f++)
+			irBuffers[c][f] = interleaved[(size_t)f * irChannels + c];
+
+	fftw_make_planner_thread_safe();
+	filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * inputChannelCount);
+	if (filters == nullptr)
+	{
+		LogF(L"MultiConvolutionFilter: could not allocate %u filter slots", inputChannelCount);
+		return outChannelNames;
+	}
+
+	tempBuffers.assign(inputChannelCount, vector<double>(maxFrameCount, 0.0));
+	for (unsigned i = 0; i < inputChannelCount; i++)
+	{
+		// Input i pairs with IR channel (i mod irChannels): an exact match when
+		// the IR channel count equals the selected input count, and a sensible
+		// wrap (e.g. a mono IR applied to every input) otherwise.
+		vector<double>& src = irBuffers[i % irChannels];
+		hcInitSingle(&filters[i], src.data(), (int)irFrames, (int)maxFrameCount, 1);
+	}
+	filterFrameCount = maxFrameCount;
+
+	return outChannelNames;
+}
+
+#pragma AVRT_CODE_BEGIN
+void MultiConvolutionFilter::process(double** output, double** input, unsigned frameCount)
+{
+	if (frameCount == 0)
+		return;
+
+	// No usable IR (bad path / sample-rate mismatch): emit silence on the output
+	// channel rather than leaving it uninitialized.
+	if (filters == nullptr)
+	{
+		memset(output[0], 0, sizeof(double) * frameCount);
+		return;
+	}
+
+	// libHybridConv fixes its block length at hcInitSingle time. A frameCount that
+	// differs from the initialized value cannot be fed to hcProcessSingle, so mute
+	// this block instead (matches ConvolutionFilter's real-time-safe behaviour).
+	if (frameCount != filterFrameCount)
+	{
+		memset(output[0], 0, sizeof(double) * frameCount);
+		return;
+	}
+
+	// Convolve each selected input with its paired IR channel and sum the results
+	// into the single output channel.
+	memset(output[0], 0, sizeof(double) * frameCount);
+	for (unsigned i = 0; i < inputChannelCount; i++)
+	{
+		hcPutSingle(&filters[i], input[i]);
+		hcProcessSingle(&filters[i]);
+		hcGetSingle(&filters[i], tempBuffers[i].data());
+		for (unsigned f = 0; f < frameCount; f++)
+			output[0][f] += tempBuffers[i][f];
+	}
+}
+#pragma AVRT_CODE_END
+
+void MultiConvolutionFilter::cleanup()
+{
+	if (filters != nullptr)
+	{
+		for (unsigned i = 0; i < inputChannelCount; i++)
+			hcCloseSingle(&filters[i]);
+		MemoryHelper::free(filters);
+		filters = nullptr;
+	}
+	tempBuffers.clear();
+	filterFrameCount = 0;
+}

--- a/filters/MultiConvolutionFilter.h
+++ b/filters/MultiConvolutionFilter.h
@@ -1,0 +1,62 @@
+﻿/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "IFilter.h"
+#include "libHybridConv-0.1.1/libHybridConv_eapo.h"
+
+// Multi-input synthesis convolution ("다중 합성 컨볼루션"). Unlike the 1:1
+// ConvolutionFilter, this filter reads every selected input channel, convolves
+// each with the corresponding channel of a single multi-channel impulse
+// response, sums the results, and writes them to one output channel. It is the
+// building block for BRIR/crossfeed setups where one ear's output is the sum of
+// several speaker signals, each passed through its own impulse response.
+//
+// getInPlace() is false because the output channel differs from the inputs, so
+// the engine hands us separate input/output buffers.
+#pragma AVRT_VTABLES_BEGIN
+class MultiConvolutionFilter : public IFilter
+{
+public:
+	MultiConvolutionFilter(const std::wstring& outputChannel, const std::wstring& filename);
+	virtual ~MultiConvolutionFilter();
+	bool getInPlace() override {return false;}
+	std::vector<std::wstring> initialize(float sampleRate, unsigned maxFrameCount, std::vector<std::wstring> channelNames) override;
+	void process(double** output, double** input, unsigned frameCount) override;
+
+private:
+	void cleanup();
+
+	std::wstring outputChannel;
+	std::wstring filename;
+	float sampleRate;
+	unsigned inputChannelCount;
+	unsigned filterFrameCount;
+	// One convolution state per input channel; filters[i] convolves input i with
+	// impulse-response channel (i modulo IR channel count).
+	HConvSingle* filters;
+	// Per-input scratch buffer for one channel's convolution result before it is
+	// summed into the single output. Sized in initialize() so process() never
+	// allocates on the audio thread.
+	std::vector<std::vector<double>> tempBuffers;
+};
+#pragma AVRT_VTABLES_END

--- a/filters/MultiConvolutionFilterFactory.cpp
+++ b/filters/MultiConvolutionFilterFactory.cpp
@@ -1,0 +1,47 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+
+#include "helpers/MemoryHelper.h"
+#include "MultiConvolutionCommand.h"
+#include "ConvolutionFilePath.h"
+#include "MultiConvolutionFilter.h"
+#include "filters/FilterFactoryRegistry.h"
+#include "MultiConvolutionFilterFactory.h"
+
+// Shares the Convolution priority: it runs in the same processing-filter stage
+// and is told apart from "Convolution" by its command keyword.
+REGISTER_FILTER_FACTORY(FilterFactoryPriority::Convolution, MultiConvolutionFilterFactory, false, L"MultiConvolution")
+
+using std::vector;
+using std::wstring;
+
+vector<IFilter*> MultiConvolutionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+{
+	MultiConvolutionCommand cmd;
+	if (!MultiConvolutionCommand::parse(command, parameters, cmd))
+		return vector<IFilter*>(0);
+
+	wstring absolutePath = ConvolutionFilePath::resolve(configPath, cmd.path);
+	if (absolutePath.empty())
+		return vector<IFilter*>(0);
+
+	MultiConvolutionFilter* filter = MemoryHelper::construct<MultiConvolutionFilter>(cmd.outputChannel, absolutePath);
+	return vector<IFilter*>(1, filter);
+}

--- a/filters/MultiConvolutionFilterFactory.h
+++ b/filters/MultiConvolutionFilterFactory.h
@@ -1,0 +1,30 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <string>
+
+#include "IFilterFactory.h"
+#include "IFilter.h"
+
+class MultiConvolutionFilterFactory : public IFilterFactory
+{
+public:
+	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+};


### PR DESCRIPTION
## Summary

Adds a **MultiConvolution** filter for BRIR (Binaural Room Impulse Response) playback. It convolves each selected input channel with the matching channel of a single multi-channel impulse response and sums them into one output channel. The 1:1 `ConvolutionFilter` is in-place per-channel and cannot route inputs across outputs, so a stereo IR loses the BRIR crossfeed (one speaker's sound reaching the opposite ear); MultiConvolution fills that gap.

## Changes

- **Engine:** `MultiConvolutionFilter`, `MultiConvolutionCommand`, `MultiConvolutionFilterFactory`
- **Config:** `MultiConvolution: <output channel> <multi-channel IR>`
- **Editor:** modern card editor (all five skins) + legacy row GUI
- **Tests:** HybridConvTests (sum routing, per-channel IR pairing, parse + serialize round-trip); EngineOrchestrationTests (engine integration + an env-gated real-BRIR crossfeed diagnostic)
- **Docs:** CHANGELOG + README (EN/KO)

## Verification

Built and tested locally (VS 2022 v143, AVX2). With a real BRIR set, a left-only impulse produces the contralateral response in the right ear (crossfeed peak ~0.0188 @ sample 184, matching the IR), whereas the 1:1 path leaves the right ear silent. The Editor card renders correctly across all five skins (offscreen gallery).

Full two-ear BRIR example (custom channel names must be upper-case, since \`Channel:\` upper-cases its selectors):

    Copy: SO=L SE=R
    Channel: SO SE
    MultiConvolution: L Lear.wav
    Channel: SO SE
    MultiConvolution: R Rear.wav

🤖 Generated with [Claude Code](https://claude.com/claude-code)