### PR TITLE
ci: self-check skin gallery shot count instead of hard-coding it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1066,9 +1066,13 @@ jobs:
         }
         $pngs = @(Get-ChildItem $outDir -Filter *.png)
         Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # 5 skins x 2 modes x (8 rows x 3 states + 3 picker states + toolbar + titlebar + menubar + menu)
-        if ($pngs.Count -ne 310) {
-          Write-Error "Expected 310 gallery PNGs, got $($pngs.Count)"
+        # SkinGallery self-checks the shot count (skins x 2 modes x (rows x 3 +
+        # fixed chrome)) and exits non-zero on any mismatch, so the exit-code
+        # check above already catches a missing or extra shot. Adding a gallery
+        # row no longer needs a hard-coded count here; just guard against an
+        # empty run.
+        if ($pngs.Count -lt 1) {
+          Write-Error "Gallery produced no PNGs"
           exit 1
         }
 

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -53,6 +53,16 @@ QList<GalleryRow> galleryRows()
 	};
 }
 
+// renderSkin() renders, per skin and per mode: every gallery row in
+// kStatesPerRow states (normal + hover from renderStates(commented=false), and
+// disabled from renderStates(commented=true)), plus kExtraShotsPerSkinMode fixed
+// chrome shots (picker x3, toolbar, titlebar, menubar, menu). run() multiplies
+// these by skins x 2 modes to self-check the output count, so adding a gallery
+// row needs no external count to be updated. Keep both constants in step with
+// renderStates()/renderSkin() if the state set or chrome shots change.
+constexpr int kStatesPerRow = 3;
+constexpr int kExtraShotsPerSkinMode = 7;
+
 // Faithful chrome replica of MainWindow's toolbar: same object names, same
 // widget train, dummy data where the real one reads devices. The gallery
 // judges chrome, not data, and constructing the real toolbar would drag in
@@ -382,6 +392,20 @@ int run(const QStringList& arguments)
 	{
 		failures += renderSkin(outDir, skinId.trimmed(), true);
 		failures += renderSkin(outDir, skinId.trimmed(), false);
+	}
+
+	// Self-check the shot count so a silently dropped skin, row or state fails
+	// the run even when every attempted grab succeeded. galleryRows() drives the
+	// row term, so adding a gallery row updates this expectation automatically
+	// and no external (build.yml) count needs to be touched.
+	const int perSkinMode = static_cast<int>(galleryRows().size()) * kStatesPerRow + kExtraShotsPerSkinMode;
+	const int expected = static_cast<int>(skinIds.size()) * 2 * perSkinMode;
+	const int actual = static_cast<int>(outDir.entryList(QStringList{QStringLiteral("*.png")}, QDir::Files).size());
+	if (actual != expected)
+	{
+		qWarning("SkinGallery: expected %d shots (%d skins x 2 modes x (%d rows x %d + %d extras)), wrote %d",
+			expected, static_cast<int>(skinIds.size()), static_cast<int>(galleryRows().size()), kStatesPerRow, kExtraShotsPerSkinMode, actual);
+		failures++;
 	}
 
 	// --skin-gallery is a headless one-shot: by this point every screenshot has


### PR DESCRIPTION
## Summary

Makes the skin-gallery CI check maintenance-free. build.yml used to compare the rendered PNG count against a hard-coded number (280, then 310), so adding a gallery row needed a manual count bump — which is exactly what broke #130's first CI run.

Now `SkinGallery::run` derives the expected count from `galleryRows().size()` (rows x 3 states + fixed per-skin-mode chrome) times skins x 2 modes, and fails the run on any mismatch. Adding a gallery row updates the expectation automatically; `build.yml` only checks the exit code and guards against an empty output dir.

## Verification

Built the Editor and ran the gallery offscreen locally: 310 shots rendered and the self-check passes (exit 0, no warning). The constants `kStatesPerRow` and `kExtraShotsPerSkinMode` are documented next to `galleryRows()` so a future change to the state set or chrome shots is a one-line update in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)