### PR TITLE
docs(readme): add a wiki pointer near the top of the README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -6,6 +6,8 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 
 이 포크는 [equalizer-apo-64](https://github.com/chebum/equalizer-apo-64)의 double 정밀도 작업과, 그 뒤를 이은 TheFireKahuna의 Equalizer APO 포크들의 SIMD/빌드 작업을 이어받았습니다.
 
+설정 방법이 궁금하다면 [GitHub Wiki](https://github.com/115dkk/EqualizerAPO-XT/wiki)를 보십시오. 설치 안내와 모든 필터 명령을 다루는 [설정 레퍼런스](https://github.com/115dkk/EqualizerAPO-XT/wiki/Korean-Configuration-reference)가 영어판과 한국어판으로 있습니다.
+
 ## 프로젝트 현황
 
 포크가 처음 목표로 잡았던 작업은 모두 끝났습니다. 컨볼루션 꼬리가 끊기던 버그를 고쳤고, 엔진 코드를 리팩토링해 회귀 테스트로 보호했으며, Editor UI를 새로 만들었고, SIMD 지원을 정리했습니다. 릴리스는 자동 업데이트가 되는 Velopack 패키지로 나갑니다. 포크 이후의 전체 이력은 [CHANGELOG.ko.md](CHANGELOG.ko.md)에 있습니다.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ EqualizerAPO-XT is an active fork of [Equalizer APO 1.4.2](https://sourceforge.n
 
 This fork builds on earlier double-precision work from [equalizer-apo-64](https://github.com/chebum/equalizer-apo-64) and later SIMD/build work from TheFireKahuna's Equalizer APO forks.
 
+Looking to configure it? The [GitHub Wiki](https://github.com/115dkk/EqualizerAPO-XT/wiki) has installation help and a full [configuration reference](https://github.com/115dkk/EqualizerAPO-XT/wiki/Configuration-reference) for every filter command, in English and Korean.
+
 ## Project Status
 
 The original fork goals are complete: the convolution tail bug is fixed, the engine code was refactored and put under regression tests, the Editor UI was rebuilt, SIMD support was consolidated, and releases ship as Velopack packages with automatic updates. The full history since the fork is in [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
Adds a short wiki pointer right after the intro paragraphs in both `README.md` and `README.ko.md`, linking the [GitHub Wiki](https://github.com/115dkk/EqualizerAPO-XT/wiki) home and the configuration reference ([English](https://github.com/115dkk/EqualizerAPO-XT/wiki/Configuration-reference) / [Korean](https://github.com/115dkk/EqualizerAPO-XT/wiki/Korean-Configuration-reference)).

The existing wiki link lived only in the Documentation section lower down; this surfaces it above the fold and points straight at the per-filter command docs (where MultiConvolution was just documented). Docs-only (`docs:`), so no version bump or release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)