### PR TITLE
fix(editor): pick the MultiConvolution output channel from a dropdown

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,11 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- MultiConvolution 카드가 출력 채널을 자유 입력 상자 대신, 그 위치에 존재하는
+  채널의 드롭다운에서 고르게 바뀌었습니다. 이 필터는 여러 입력을 한 채널(BRIR의
+  한쪽 귀)로 합치므로 출력은 거의 항상 이미 쓰이는 실제 채널입니다. 그래서 카드가
+  그 채널들을 제시하고, 가상·커스텀 이름은 여전히 직접 입력할 수 있습니다. 레거시
+  행 편집기도 같은 선택기를 씁니다. ([#135])
 - 2.5.0에 망가진 채로 나간 MultiConvolution 필터의 Editor UI를 고쳤습니다. 삽입
   메뉴에서 기존 '고급 필터' 그룹에 들어가지 않고 번역이 없는 'Advanced filters'
   그룹으로 따로 떴습니다. 픽커는 필터를 번역된 카테고리 이름으로 묶는데, 새
@@ -533,3 +538,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129
 [#130]: https://github.com/115dkk/EqualizerAPO-XT/pull/130
 [#132]: https://github.com/115dkk/EqualizerAPO-XT/pull/132
+[#135]: https://github.com/115dkk/EqualizerAPO-XT/pull/135

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -12,7 +12,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
   채널의 드롭다운에서 고르게 바뀌었습니다. 이 필터는 여러 입력을 한 채널(BRIR의
   한쪽 귀)로 합치므로 출력은 거의 항상 이미 쓰이는 실제 채널입니다. 그래서 카드가
   그 채널들을 제시하고, 가상·커스텀 이름은 여전히 직접 입력할 수 있습니다. 레거시
-  행 편집기도 같은 선택기를 씁니다. ([#135])
+  행 편집기도 같은 선택기를 씁니다. ([#136])
 - 2.5.0에 망가진 채로 나간 MultiConvolution 필터의 Editor UI를 고쳤습니다. 삽입
   메뉴에서 기존 '고급 필터' 그룹에 들어가지 않고 번역이 없는 'Advanced filters'
   그룹으로 따로 떴습니다. 픽커는 필터를 번역된 카테고리 이름으로 묶는데, 새
@@ -538,4 +538,4 @@ TheFireKahuna 트리 위에서 포크를 시작한 버전입니다.
 [#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129
 [#130]: https://github.com/115dkk/EqualizerAPO-XT/pull/130
 [#132]: https://github.com/115dkk/EqualizerAPO-XT/pull/132
-[#135]: https://github.com/115dkk/EqualizerAPO-XT/pull/135
+[#136]: https://github.com/115dkk/EqualizerAPO-XT/pull/136

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
   The filter sums several inputs into one channel (one ear of a BRIR), so its
   output is almost always a channel that is already in play; the card presents
   those and still lets you type a custom or virtual channel name. The legacy row
-  editor gets the same picker. ([#135])
+  editor gets the same picker. ([#136])
 - Fixed the MultiConvolution filter's Editor UI, which shipped broken in 2.5.0.
   In the Insert menu it appeared under its own untranslated "Advanced filters"
   group instead of joining the existing one: the picker groups filters by their
@@ -586,4 +586,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129
 [#130]: https://github.com/115dkk/EqualizerAPO-XT/pull/130
 [#132]: https://github.com/115dkk/EqualizerAPO-XT/pull/132
-[#135]: https://github.com/115dkk/EqualizerAPO-XT/pull/135
+[#136]: https://github.com/115dkk/EqualizerAPO-XT/pull/136

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- The MultiConvolution card now picks the output channel from a dropdown of the
+  channels that exist at that point in the config, instead of a free-text box.
+  The filter sums several inputs into one channel (one ear of a BRIR), so its
+  output is almost always a channel that is already in play; the card presents
+  those and still lets you type a custom or virtual channel name. The legacy row
+  editor gets the same picker. ([#135])
 - Fixed the MultiConvolution filter's Editor UI, which shipped broken in 2.5.0.
   In the Insert menu it appeared under its own untranslated "Advanced filters"
   group instead of joining the existing one: the picker groups filters by their
@@ -580,3 +586,4 @@ Fork bootstrap on top of TheFireKahuna's tree.
 [#129]: https://github.com/115dkk/EqualizerAPO-XT/pull/129
 [#130]: https://github.com/115dkk/EqualizerAPO-XT/pull/130
 [#132]: https://github.com/115dkk/EqualizerAPO-XT/pull/132
+[#135]: https://github.com/115dkk/EqualizerAPO-XT/pull/135

--- a/Editor/guis/MultiConvolutionFilterGUI.cpp
+++ b/Editor/guis/MultiConvolutionFilterGUI.cpp
@@ -18,10 +18,12 @@
 
 #include "MultiConvolutionFilterGUI.h"
 
+#include <QComboBox>
 #include <QFileDialog>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QSignalBlocker>
 #include <QToolButton>
 
 #include "filters/MultiConvolutionCommand.h"
@@ -33,11 +35,15 @@ MultiConvolutionFilterGUI::MultiConvolutionFilterGUI(const QString& configPath, 
 	layout->setContentsMargins(0, 0, 0, 0);
 
 	layout->addWidget(new QLabel(tr("Output channel:"), this));
-	channelEdit = new QLineEdit(outputChannel.trimmed(), this);
-	channelEdit->setMaximumWidth(80);
-	channelEdit->setToolTip(tr("Output channel the summed convolution is written to"));
-	connect(channelEdit, SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
-	layout->addWidget(channelEdit);
+	channelCombo = new QComboBox(this);
+	channelCombo->setEditable(true);
+	channelCombo->setInsertPolicy(QComboBox::NoInsert);
+	channelCombo->setMinimumWidth(90);
+	channelCombo->setToolTip(tr("Output channel the summed convolution is written to"));
+	channelCombo->setCurrentText(outputChannel.trimmed());
+	connect(channelCombo, SIGNAL(activated(int)), this, SIGNAL(updateModel()));
+	connect(channelCombo->lineEdit(), SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
+	layout->addWidget(channelCombo);
 
 	layout->addWidget(new QLabel(tr("Impulse response:"), this));
 	pathEdit = new QLineEdit(path.trimmed(), this);
@@ -56,9 +62,21 @@ void MultiConvolutionFilterGUI::store(QString& command, QString& parameters)
 	command = QStringLiteral("MultiConvolution");
 
 	MultiConvolutionCommand cmd;
-	cmd.outputChannel = channelEdit->text().trimmed().toStdWString();
+	cmd.outputChannel = channelCombo->currentText().trimmed().toStdWString();
 	cmd.path = pathEdit->text().toStdWString();
 	parameters = QString::fromStdWString(cmd.serialize());
+}
+
+void MultiConvolutionFilterGUI::configureChannels(std::vector<std::wstring>& channelNames)
+{
+	// Present the channels in scope at this row as the output options, matching
+	// the modern card editor; the combo stays editable for custom channels.
+	const QString current = channelCombo->currentText();
+	const QSignalBlocker blocker(channelCombo);
+	channelCombo->clear();
+	for (const std::wstring& name : channelNames)
+		channelCombo->addItem(QString::fromStdWString(name));
+	channelCombo->setCurrentText(current);
 }
 
 void MultiConvolutionFilterGUI::selectFile()

--- a/Editor/guis/MultiConvolutionFilterGUI.h
+++ b/Editor/guis/MultiConvolutionFilterGUI.h
@@ -20,6 +20,7 @@
 
 #include "Editor/IFilterGUI.h"
 
+class QComboBox;
 class QLineEdit;
 
 // Legacy (frozen-fallback) row GUI for a "MultiConvolution:" line. Deliberately
@@ -35,12 +36,13 @@ public:
 	MultiConvolutionFilterGUI(const QString& configPath, const QString& outputChannel, const QString& path);
 
 	void store(QString& command, QString& parameters) override;
+	void configureChannels(std::vector<std::wstring>& channelNames) override;
 
 private slots:
 	void selectFile();
 
 private:
 	QString configPath;
-	QLineEdit* channelEdit;
+	QComboBox* channelCombo;
 	QLineEdit* pathEdit;
 };

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include <QColor>
+#include <QComboBox>
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -28,6 +29,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QSignalBlocker>
 #include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
@@ -71,16 +73,21 @@ MultiConvolutionCardEditor::MultiConvolutionCardEditor(FilterTable* filterTable,
 	fileGlyph->setPixmap(GUIHelper::tintedIcon(QStringLiteral(":/icons/modern/waveform.svg"), glyphColor, 20).pixmap(GUIHelper::scale(QSize(20, 20))));
 	layout->addWidget(fileGlyph, 0, Qt::AlignVCenter);
 
-	// Output channel that the summed convolution is written to. Kept narrow: a
-	// channel name is a short token (L, R, or a custom upper-case name).
-	channelEdit = new QLineEdit(this);
-	channelEdit->setObjectName(QStringLiteral("MultiConvolutionCardChannel"));
-	channelEdit->setText(outputChannel.trimmed());
-	channelEdit->setPlaceholderText(tr("Out ch"));
-	channelEdit->setToolTip(tr("Output channel the summed convolution is written to"));
-	channelEdit->setMaximumWidth(GUIHelper::scale(QSize(72, 0)).width());
-	connect(channelEdit, SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
-	layout->addWidget(channelEdit, 0, Qt::AlignTop);
+	// Output channel the summed convolution is written to. An editable combo:
+	// configureChannels() fills it with the channels that exist at this row so
+	// the user picks the target ("which ear") from the real channels instead of
+	// typing one, while a custom/virtual channel name can still be typed in.
+	channelCombo = new QComboBox(this);
+	channelCombo->setObjectName(QStringLiteral("MultiConvolutionCardChannel"));
+	channelCombo->setEditable(true);
+	channelCombo->setInsertPolicy(QComboBox::NoInsert);
+	channelCombo->setToolTip(tr("Output channel the summed convolution is written to"));
+	channelCombo->lineEdit()->setPlaceholderText(tr("Out ch"));
+	channelCombo->setCurrentText(outputChannel.trimmed());
+	channelCombo->setMaximumWidth(GUIHelper::scale(QSize(96, 0)).width());
+	connect(channelCombo, SIGNAL(activated(int)), this, SIGNAL(updateModel()));
+	connect(channelCombo->lineEdit(), SIGNAL(editingFinished()), this, SIGNAL(updateModel()));
+	layout->addWidget(channelCombo, 0, Qt::AlignTop);
 
 	QWidget* pathBlock = new QWidget(this);
 	QVBoxLayout* pathLayout = new QVBoxLayout(pathBlock);
@@ -136,9 +143,22 @@ void MultiConvolutionCardEditor::store(QString& command, QString& parameters)
 	command = QStringLiteral("MultiConvolution");
 
 	MultiConvolutionCommand cmd;
-	cmd.outputChannel = channelEdit->text().trimmed().toStdWString();
+	cmd.outputChannel = channelCombo->currentText().trimmed().toStdWString();
 	cmd.path = pathEdit->text().toStdWString();
 	parameters = QString::fromStdWString(cmd.serialize());
+}
+
+void MultiConvolutionCardEditor::configureChannels(std::vector<std::wstring>& channelNames)
+{
+	// Repopulate the output options with the channels in scope at this row while
+	// keeping whatever is currently entered/selected. The combo stays editable,
+	// so a custom output channel that is not in the list survives as typed text.
+	const QString current = channelCombo->currentText();
+	const QSignalBlocker blocker(channelCombo);
+	channelCombo->clear();
+	for (const std::wstring& name : channelNames)
+		channelCombo->addItem(QString::fromStdWString(name));
+	channelCombo->setCurrentText(current);
 }
 
 void MultiConvolutionCardEditor::chooseFile()

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.h
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.h
@@ -21,6 +21,7 @@
 #include "Editor/IFilterGUI.h"
 
 class FilterTable;
+class QComboBox;
 class QLabel;
 class QLineEdit;
 class QToolButton;
@@ -38,6 +39,9 @@ public:
 	MultiConvolutionCardEditor(FilterTable* filterTable, const QString& outputChannel, const QString& path, QWidget* parent = nullptr);
 
 	void store(QString& command, QString& parameters) override;
+	// Offer the channels that exist at this row as the output options, so the
+	// user picks the target channel instead of typing it.
+	void configureChannels(std::vector<std::wstring>& channelNames) override;
 
 private slots:
 	void chooseFile();
@@ -50,7 +54,7 @@ private:
 	void updateFileInfo();
 
 	FilterTable* filterTable = nullptr;
-	QLineEdit* channelEdit = nullptr;
+	QComboBox* channelCombo = nullptr;
 	QLineEdit* pathEdit = nullptr;
 	QLabel* infoLabel = nullptr;
 	QLabel* statusLabel = nullptr;


### PR DESCRIPTION
## Problem

The MultiConvolution card (and the legacy row) asked the user to **type** the output channel into a free-text box. That is poor UX: this filter is the primitive "sum several inputs into one channel" — one ear of a BRIR — so its output is almost always a channel that already exists at that point in the config, not an arbitrary name. Typing it also made the relationship between the preceding `Channel:` selection (inputs) and this output unclear.

## Change

Replace the output-channel `QLineEdit` with an **editable `QComboBox`** and override `configureChannels()` — the same hook `ChannelCardEditor` and `CopyFilterGUI` already use — to populate it with the channels in scope at that row (`FilterTable::propagateChannels()` → `configureChannels`). The user now **picks** the target channel from the real channels; a custom/virtual name can still be typed (editable, `NoInsert`). Applied to both `MultiConvolutionCardEditor` (modern card) and `MultiConvolutionFilterGUI` (legacy row).

Serialization is unchanged: `currentText()` feeds the same `MultiConvolutionCommand::serialize()`, so written lines stay byte-identical for the same selection. `EditorLogicTests` exercises `FilterCardModel::describeLine` (header parsing) only, unaffected.

## Verification

Wiring confirmed against the proven `ChannelCardEditor` path (`item->gui->configureChannels` in `FilterTable.Model.cpp`); full Editor compile/link rides on CI. `fix:` → REVISION bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)