### PR TITLE
docs(changelog): file the Unreleased entries under v2.6.0

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.6.0 (2026-07-02)
 
 - 파일 참조 행(Include·Convolution·MultiConvolution·VST 플러그인)을 스킨별
   참조 카드로 다시 만들었습니다. 다섯 스킨이 같은 사실(대상의 이름이 1차,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.6.0 — 2026-07-02
 
 - Reworked the file-reference rows (Include, Convolution, MultiConvolution,
   VST plugin) as per-skin reference cards. Every skin now presents the same


### PR DESCRIPTION
Moves the four Unreleased entries (AR2 per-skin reference cards, pictogram set, rack faceplate fixes, 460-shot gallery — all [#137]) under a dated `v2.6.0` section in both `CHANGELOG.md` and `CHANGELOG.ko.md`, matching the release published at https://github.com/115dkk/EqualizerAPO-XT/releases/tag/v2.6.0.

Docs-only; no version bump.

[#137]: https://github.com/115dkk/EqualizerAPO-XT/pull/137

🤖 Generated with [Claude Code](https://claude.com/claude-code)