### PR TITLE
docs(changelog): file the Unreleased entry under v2.7.1

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.7.1 (2026-07-03)
 
 - Signal Matrix 필터 픽커가 마우스 아래의 항목·카테고리를 하이라이트하지
   않던 문제를 고쳤습니다. 호버 예고광이 보드 위에서 약 3.5% 밝기 차로

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.7.1 — 2026-07-03
 
 - Fixed the Signal Matrix filter picker not highlighting the entry or
   category under the mouse. The hover pre-light was painted at roughly 3.5%


### PR DESCRIPTION
Moves the matrix picker hover fix entry ([#142]) under a dated `v2.7.1` section in `CHANGELOG.md` and `CHANGELOG.ko.md`, matching the release published at https://github.com/115dkk/EqualizerAPO-XT/releases/tag/v2.7.1.

Docs-only; no version bump.

[#142]: https://github.com/115dkk/EqualizerAPO-XT/pull/142

🤖 Generated with [Claude Code](https://claude.com/claude-code)