### PR TITLE
docs(changelog): file the Unreleased entries under v2.8.0

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.8.0 (2026-07-03)
 
 - 주석과 Stage 행이 진짜 카드가 되었습니다. 메모 줄은 카드 안에서 바로
   편집하고(주석 행이 정의상 비활성이라 어느 스킨에서도 본문이 잠겨 있던

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.8.0 — 2026-07-03
 
 - Comment and Stage rows became real cards. A note line gets an in-place
   editor (and stays editable even though a comment row counts as disabled -


### PR DESCRIPTION
PR #141이 v2.8.0으로 릴리스되어, CHANGELOG(en/ko)의 Unreleased 절을 v2.8.0 절로 옮깁니다. 내용 변경은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)