### PR TITLE
ci: run biweekly audit on Fable 5 xhigh with Opus fallback blocked

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -269,10 +269,19 @@ jobs:
         run: |
           unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 
+          # Fable 5's safety classifiers can silently re-run a flagged
+          # request on Opus 4.8 and keep the session there. Restricting
+          # availableModels to Fable 5 blocks that fallback target, so a
+          # flagged request ends with an explicit refusal error instead of
+          # a quiet model switch (and no Opus tokens are spent). See
+          # code.claude.com/docs/en/model-config, "Automatic model
+          # fallback" and "Restrict model selection". Availability-based
+          # fallback is opt-in (--fallback-model) and stays unset.
           set +e
           claude \
-            --model claude-opus-4-8 \
-            --effort max \
+            --model claude-fable-5 \
+            --effort xhigh \
+            --settings '{"availableModels": ["claude-fable-5"]}' \
             --permission-mode auto \
             --max-turns 100 \
             -p "


### PR DESCRIPTION
## 요약

격주 감사(biweekly-audit.yml)의 Claude 호출을 변경합니다.

- `--model claude-opus-4-8` → `--model claude-fable-5` (이슈 본문 표기 "Model: Fable 5"와 실제 호출이 어긋나 있던 것을 해소)
- `--effort max` → `--effort xhigh`
- `--settings '{"availableModels": ["claude-fable-5"]}'` 추가 — Fable 5의 안전 분류기가 플래그된 요청을 Opus 4.8로 조용히 재라우팅하는 자동 폴백을 차단합니다. 허용 목록에서 폴백 대상이 제외되면 폴백이 실행되지 않고 명시적 거부 오류로 끝난다고 문서에 명시되어 있습니다(code.claude.com/docs/en/model-config, "Automatic model fallback" / "Restrict model selection"). 가용성 기반 폴백(`--fallback-model`)은 opt-in이므로 계속 미설정입니다.

이슈 #135는 Opus 4.8로 수행된 회차 + 이후 코드 대폭 변경(v2.8.0)으로 처분 없이 닫았고, 머지 후 workflow_dispatch로 감사를 1회 수동 실행합니다.

버전 무변경(`ci:`) 커밋입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)