### PR TITLE
docs: sync four drifted docs with the build and release reality

### DIFF
--- a/docs/ConvolutionRegressionTests.md
+++ b/docs/ConvolutionRegressionTests.md
@@ -25,8 +25,11 @@ Build the common library, build the test executable, then run it:
 Expected output:
 
 ```text
-HybridConvTests passed
+HybridConvTests passed (<N> checks)
 ```
+
+`<N>` is the number of assertions that passed (`Tests/TestHarness.h`). It
+grows whenever a suite adds checks, so do not match it exactly.
 
 The test project copies `libfftw3.dll` and `sndfile.dll` from the configured
 dependency folders into its output directory.
@@ -34,4 +37,8 @@ dependency folders into its output directory.
 ## CI
 
 GitHub Actions builds `Tests\HybridConvTests\HybridConvTests.vcxproj` for each
-SIMD matrix entry and runs the executable after the non-Qt projects finish.
+SIMD matrix entry. It runs the executable after the non-Qt projects finish,
+but only for variants whose `RunnerCanExecute` flag is true in
+`.github/simd-variants.psd1`. GitHub-hosted x64 runners do not guarantee
+AVX-512 or AVX10.1 at runtime, so the `avx512` and `avx10_1` binaries are
+built but not executed in CI.

--- a/docs/LocalDependencySetup.md
+++ b/docs/LocalDependencySetup.md
@@ -62,11 +62,11 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\
 mkdir build-Editor-x64
 cd build-Editor-x64
 ..\Qt\bin\lrelease.exe ..\Editor\Editor.pro
-..\Qt\bin\qmake.exe ..\Editor\Editor.pro -r "CONFIG+=release" "QMAKE_CXXFLAGS-=/arch:AVX2" "QMAKE_CXXFLAGS+=/arch:AVX2"
+..\Qt\bin\qmake.exe ..\Editor\Editor.pro -r "CONFIG+=release" "EAPO_UPDATE_CHANNEL=x64-avx2" "EAPO_SIMD_FLAGS=/arch:AVX2"
 nmake /NOLOGO
 ```
 
-`DeviceSelector`와 `UpdateChecker`도 같은 방식으로 빌드합니다. 빌드 뒤에는 다음처럼 Qt 런타임을 배치합니다.
+`DeviceSelector`와 `UpdateChecker`도 같은 방식으로 빌드합니다. 세 `.pro` 파일 모두 x64 빌드에서 `EAPO_SIMD_FLAGS`(또는 SSE2 기준선의 `EAPO_SIMD_BASELINE=1`)가 없으면 qmake가 `error()`로 실패합니다. 변형별 플래그와 채널 값은 `.github/simd-variants.psd1`을 기준으로 합니다. 빌드 뒤에는 다음처럼 Qt 런타임을 배치합니다.
 
 ```powershell
 & .\Qt\bin\windeployqt.exe .\build-Editor-x64\release\Editor.exe --release --no-opengl-sw

--- a/docs/OptimizationNotes.md
+++ b/docs/OptimizationNotes.md
@@ -6,7 +6,7 @@
 
 - C/C++ 소스와 헤더 285개, 약 3만 줄을 확인했습니다.
 - 주요 대상은 오디오 처리 경로, 필터 구현, VST 처리, 설정 파싱, Qt 도구, 빌드 파일입니다.
-- 빌드 파일은 `EqualizerAPO.sln`, 각 `.vcxproj`, Qt `.pro`, NSIS `.nsi`, GitHub Actions 파일을 기준으로 확인했습니다.
+- 빌드 파일은 `EqualizerAPO.sln`, 각 `.vcxproj`, Qt `.pro`, GitHub Actions 파일을 기준으로 확인했습니다.
 
 ## 완료한 작업
 

--- a/docs/SimdBuildMatrix.md
+++ b/docs/SimdBuildMatrix.md
@@ -5,14 +5,22 @@ runtime-dispatching one universal x64 binary.
 
 ## CI Variants
 
-| Matrix name | Platform | SIMD variant | MSBuild instruction set | Qt flag | Dependency release assets | Installer artifact |
+| Matrix name | Platform | SIMD variant | MSBuild instruction set | Qt flag | Dependency release assets | Update channel |
 | --- | --- | --- | --- | --- | --- | --- |
-| `windows-x64-sse2` | `x64` | `sse2` | `NotSet` | none | vcpkg `fftw3[sse2,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `EqualizerAPO_Setup-x64-sse2` |
-| `windows-x64-avx` | `x64` | `avx` | `AdvancedVectorExtensions` | `/arch:AVX` | vcpkg `fftw3[avx,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `EqualizerAPO_Setup-x64-avx` |
-| `windows-x64-avx2` | `x64` | `avx2` | `AdvancedVectorExtensions2` | `/arch:AVX2` | `*-x64-avx2` | `EqualizerAPO_Setup-x64-avx2` |
-| `windows-x64-avx512` | `x64` | `avx512` | `AdvancedVectorExtensions512` | `/arch:AVX512` | `*-x64-avx512` | `EqualizerAPO_Setup-x64-avx512` |
-| `windows-x64-avx10_1` | `x64` | `avx10_1` | `AdvancedVectorExtensions101` | `/arch:AVX10.1` | `*-x64-avx10` | `EqualizerAPO_Setup-x64-avx10_1` |
-| `windows-arm64` | `ARM64` | `neon` | none | none | `*-arm64` | `EqualizerAPO_Setup-arm64` |
+| `windows-x64-sse2` | `x64` | `sse2` | `NotSet` | none | vcpkg `fftw3[sse2,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `x64-sse2` |
+| `windows-x64-avx` | `x64` | `avx` | `AdvancedVectorExtensions` | `/arch:AVX` | vcpkg `fftw3[avx,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `x64-avx` |
+| `windows-x64-avx2` | `x64` | `avx2` | `AdvancedVectorExtensions2` | `/arch:AVX2` | `*-x64-avx2` | `x64-avx2` |
+| `windows-x64-avx512` | `x64` | `avx512` | `AdvancedVectorExtensions512` | `/arch:AVX512` | `*-x64-avx512` | `x64-avx512` |
+| `windows-x64-avx10_1` | `x64` | `avx10_1` | `AdvancedVectorExtensions101` | `/arch:AVX10.1` | `*-x64-avx10` | `x64-avx10-1` |
+| `windows-arm64` | `ARM64` | `neon` | none | none | `*-arm64` | `arm64-neon` |
+
+The per-variant facts above are defined once in `.github/simd-variants.psd1`.
+Each variant ships as a Velopack package whose `packId` is
+`EqualizerAPO-XT-<channel>`. Velopack appends `-<channel>-Setup.exe`, so the
+release Setup asset is named `EqualizerAPO-XT-<channel>-<channel>-Setup.exe`
+(for example `EqualizerAPO-XT-arm64-neon-arm64-neon-Setup.exe`). The
+channel-less `EqualizerAPO-XT-Setup.exe` on the same release is the
+auto-detect installer described in `docs/AutoDetectInstaller.md`.
 
 ## Runtime Compatibility
 


### PR DESCRIPTION
감사 이슈 #146의 문서 표류 4건(TD042 문서 절반, TD043, TD044, TD045)을 반영합니다.

- SimdBuildMatrix.md의 설치 파일명 열을 실제 자산명 규칙(`EqualizerAPO-XT-<channel>-<channel>-Setup.exe`, v2.8.0 릴리스 자산으로 실측 확인)과 업데이트 채널 기준으로 교체. 감사가 제안한 `EqualizerAPO-XT-<channel>-Setup.exe` 단일 채널 표기는 실물과 달라 채택하지 않았습니다.
- OptimizationNotes.md의 제거된 NSIS `.nsi` 언급 삭제.
- ConvolutionRegressionTests.md에 `(N checks)` 출력 형식과 RunnerCanExecute 실행 게이트 반영.
- LocalDependencySetup.md의 qmake 명령이 .pro의 error() 게이트에 걸리던 것을 CI와 같은 플래그로 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)