### PR TITLE
ci: dedup provisioning helpers and pin the remaining supply-chain inputs

### DIFF
--- a/.github/scripts/Get-VersionPart.ps1
+++ b/.github/scripts/Get-VersionPart.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+    Defines Get-VersionPart: reads one numeric component (MAJOR / MINOR /
+    REVISION) out of version.h.
+
+.DESCRIPTION
+    Dot-source this file, then call the function with the #define name:
+
+      . .\.github\scripts\Get-VersionPart.ps1
+      $major = Get-VersionPart "MAJOR"
+
+    version.h is resolved relative to the current directory (the repository
+    root in CI). Shared by the version-bump and create-release jobs in
+    .github/workflows/build.yml, so the version.h parsing is written exactly
+    once.
+#>
+function Get-VersionPart {
+  param([string]$Name)
+
+  $line = Select-String -Path version.h -Pattern "^\s*#define\s+$Name\s+(\d+)" | Select-Object -First 1
+  if (-not $line) {
+    throw "Could not find version part: $Name"
+  }
+  return $line.Matches[0].Groups[1].Value
+}

--- a/.github/scripts/Import-VsDevEnvironment.ps1
+++ b/.github/scripts/Import-VsDevEnvironment.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Defines Import-VsDevEnvironment: locates Visual Studio via vswhere and
+    imports the VsDevCmd.bat environment into the current PowerShell session.
+
+.DESCRIPTION
+    Dot-source this file, then call the function with the target architecture:
+
+      . .\.github\scripts\Import-VsDevEnvironment.ps1
+      Import-VsDevEnvironment "x64"   # or "arm64"
+
+    Shared by .github/workflows/build.yml (the vcpkg dependency build and the
+    Qt qmake/nmake build steps) and setup-build.ps1, so the vswhere/VsDevCmd
+    lookup is written exactly once.
+#>
+function Import-VsDevEnvironment {
+  param([string]$Arch)
+
+  $vswherePath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+  if (-not (Test-Path $vswherePath)) {
+    throw "vswhere.exe not found at $vswherePath"
+  }
+
+  $vsInstallPath = & $vswherePath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -latest
+  if (-not $vsInstallPath) {
+    $vsInstallPath = & $vswherePath -products * -requires Microsoft.Component.MSBuild -property installationPath -latest
+  }
+  if (-not $vsInstallPath) {
+    throw "Visual Studio installation not found"
+  }
+
+  $devCmdPath = Join-Path $vsInstallPath "Common7\Tools\VsDevCmd.bat"
+  if (-not (Test-Path $devCmdPath)) {
+    throw "VsDevCmd.bat not found at $devCmdPath"
+  }
+
+  Write-Host "Configuring MSVC environment for $Arch"
+  $environment = cmd /c "`"$devCmdPath`" -arch=$Arch -no_logo >nul && set"
+  if ($LASTEXITCODE -ne 0) {
+    throw "VsDevCmd.bat failed for architecture $Arch"
+  }
+
+  foreach ($line in $environment) {
+    if ($line -match "^(.*?)=(.*)$") {
+      Set-Item -Path "Env:$($matches[1])" -Value $matches[2]
+    }
+  }
+
+  Write-Host "Configured MSVC target: $env:VSCMD_ARG_TGT_ARCH"
+}

--- a/.github/scripts/New-BuildMatrix.ps1
+++ b/.github/scripts/New-BuildMatrix.ps1
@@ -8,6 +8,12 @@
     { name: [...], include: [...] }. Pull requests build only the Primary
     variant; pushes and manual dispatches build the full set.
 
+    Also writes an output named `runner_executable_variants`: a JSON array of
+    the x64 Simd names whose binaries GitHub-hosted runners can execute at
+    runtime (RunnerCanExecute). The cross-variant-compare job hands it to
+    Tests/AudioRegressionTests/scripts/cross_variant_compare.py so the audio
+    gating list is derived from the manifest instead of being hard-coded.
+
     Runs on the ubuntu prepare-matrix job (pwsh), and locally for inspection:
       pwsh .github/scripts/New-BuildMatrix.ps1 -EventName push
 #>
@@ -73,6 +79,17 @@ $matrix = [ordered]@{
 $json = $matrix | ConvertTo-Json -Compress -Depth 5
 Write-Host "Build matrix ($EventName): $json"
 
+# Cross-variant audio comparison gates only on the x64 variants the hosted
+# runner is guaranteed to execute (RunnerCanExecute); ARM64 output is captured
+# for inspection but not diffed. Derived from the full manifest (not the
+# PR-filtered $include) because the comparison job never runs on pull requests.
+$compareVariants = @($manifest.Variants |
+  Where-Object { $_.Platform -eq 'x64' -and $_.RunnerCanExecute } |
+  ForEach-Object { $_.Simd })
+$compareJson = ConvertTo-Json -InputObject $compareVariants -Compress
+Write-Host "Runner-executable x64 variants: $compareJson"
+
 if ($env:GITHUB_OUTPUT) {
   "matrix=$json" >> $env:GITHUB_OUTPUT
+  "runner_executable_variants=$compareJson" >> $env:GITHUB_OUTPUT
 }

--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -37,6 +37,9 @@ $ChannelTable = [ordered]@{
 # Fail loudly if the manifest's channel set drifts from this table, so a new or
 # renamed variant cannot ship with missing download guidance. The manifest sits two
 # levels up from this script (.github/scripts/ -> .github/simd-variants.psd1).
+# $manifestChannels is reused below to author the Verification variant list from
+# the manifest instead of hard-coding it here.
+$manifestChannels = @()
 $manifestPath = Join-Path $PSScriptRoot "..\simd-variants.psd1"
 if (Test-Path $manifestPath) {
   $manifestChannels = @((Import-PowerShellDataFile -Path $manifestPath).Variants | ForEach-Object { $_.Channel })
@@ -326,7 +329,21 @@ if ($previousRelease -and $compare) {
 [void]$lines.Add("")
 [void]$lines.Add("## Verification")
 [void]$lines.Add("")
-[void]$lines.Add("The linked workflow builds x64 SSE2 baseline, x64 AVX, x64 AVX2, x64 AVX-512, x64 AVX10.1, and ARM64 installers. It runs EditorLogicTests on every build variant and runs HybridConvTests where the GitHub-hosted runner can execute the target instruction set.")
+
+# The variant list comes from simd-variants.psd1 so this sentence cannot drift
+# from what CI actually builds; the test-suite list mirrors the build.yml steps.
+$builtVariantsPhrase = if ($manifestChannels.Count -gt 0) {
+  $channelNames = @($manifestChannels | ForEach-Object { "``$_``" })
+  $channelList = if ($channelNames.Count -gt 1) {
+    (($channelNames | Select-Object -SkipLast 1) -join ", ") + ", and " + $channelNames[-1]
+  } else {
+    $channelNames[0]
+  }
+  "installers for the $channelList channels"
+} else {
+  "installers for every SIMD/architecture channel"
+}
+[void]$lines.Add("The linked workflow builds $builtVariantsPhrase. It runs EditorLogicTests on every build variant, and runs HybridConvTests, EngineOrchestrationTests, and AudioRegressionTests (plus a cross-variant output comparison) where the GitHub-hosted runner can execute the target instruction set.")
 [void]$lines.Add("")
 [void]$lines.Add("Release page: [$Tag]($releaseUrl)")
 

--- a/.github/simd-variants.psd1
+++ b/.github/simd-variants.psd1
@@ -44,19 +44,22 @@
 #                 downloaded (x64 sse2 / avx only).
 #     RunnerCanExecute  $true when GitHub-hosted runners can execute this variant's
 #                 binaries at runtime. avx512/avx10_1 stay $false: CI builds and
-#                 ships them but skips their runtime test steps. (The gating list in
-#                 Tests/AudioRegressionTests/scripts/cross_variant_compare.py is
-#                 hardcoded separately and currently matches the executable x64
-#                 variants; it does not read this flag.)
+#                 ships them but skips their runtime test steps. The cross-variant
+#                 audio gating list (x64 variants with this flag) is derived from
+#                 here by New-BuildMatrix.ps1 and handed to
+#                 Tests/AudioRegressionTests/scripts/cross_variant_compare.py via
+#                 the RUNNER_EXECUTABLE_VARIANTS env var in build.yml.
 #     Primary     $true on exactly one variant. The primary variant is the only one
 #                 pull requests build, and it seeds the audio regression reference
 #                 set when Tests/AudioRegressionTests/references is empty.
 #
 #   Shared = pinned tags/versions that are NOT per-variant:
 #     VelopackLibcVersion  velopack/velopack release tag for velopack_libc_<v>.zip.
+#     VelopackLibcSha256   SHA-256 of that zip; bumped together with the version.
 #     Vst3Tag              steinbergmedia/vst3_pluginterfaces git tag/ref.
 #     HighwayTag           google/highway git tag/ref.
 #     TclapTag             TheFireKahuna/tclap git tag/ref.
+#     VcpkgCommit          microsoft/vcpkg commit for the sse2/avx vcpkg builds.
 #
 #   DependencyReleases = supply-chain pins for the prebuilt binary dependencies.
 #     Keyed by GitHub repository. CI and setup-build.ps1 download from
@@ -159,12 +162,19 @@
         # velopack_libc ships as a single cross-platform zip attached to the
         # velopack/velopack release. The asset name is velopack_libc_<version>.zip.
         VelopackLibcVersion = '1.1.1'
+        # SHA-256 of velopack_libc_<VelopackLibcVersion>.zip, verified like the
+        # DependencyReleases assets below. Bump together with VelopackLibcVersion.
+        VelopackLibcSha256  = '7b77d378226e4c5b110565dbe1c718cc91eadbf0c4be8b8e6af9ed8ea6202cb1'
         # steinbergmedia/vst3_pluginterfaces — pinned to the first MIT-licensed tag.
         Vst3Tag             = 'v3.8.0_build_66'
         # google/highway — header-only portable SIMD.
         HighwayTag          = '1.4.0'
         # TheFireKahuna/tclap — header-only CLI parser (tag 1.2.5 = fork HEAD).
         TclapTag            = '1.2.5'
+        # microsoft/vcpkg — commit the sse2/avx dependency builds (FFTW,
+        # libsndfile) check out. Pinned so a moving vcpkg HEAD cannot silently
+        # change the portfiles those builds compile from; bump deliberately.
+        VcpkgCommit         = 'd87340acc46bdeda386037b38aca30136e667e47'
     }
 
     DependencyReleases = @{

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,12 +70,8 @@ jobs:
       run: |
         $ErrorActionPreference = "Stop"
 
-        function Get-VersionPart {
-          param([string]$Name)
-          $line = Select-String -Path version.h -Pattern "^\s*#define\s+$Name\s+(\d+)" | Select-Object -First 1
-          if (-not $line) { throw "Could not find version part: $Name" }
-          return $line.Matches[0].Groups[1].Value
-        }
+        # Canonical version.h reader, shared with the create-release job.
+        . .\.github\scripts\Get-VersionPart.ps1
 
         git diff --quiet -- version.h
         $diffExit = $LASTEXITCODE
@@ -117,6 +113,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
+      # JSON array of the x64 variants hosted runners can execute at runtime
+      # (Platform x64 + RunnerCanExecute in the manifest). Consumed by the
+      # cross-variant-compare job so its gating list cannot drift from the
+      # manifest.
+      runner_executable_variants: ${{ steps.gen.outputs.runner_executable_variants }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -280,39 +281,9 @@ jobs:
       run: |
         $ErrorActionPreference = "Stop"
 
-        function Import-VsDevEnvironment {
-          param([string]$Arch)
-
-          $vswherePath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswherePath)) {
-            throw "vswhere.exe not found at $vswherePath"
-          }
-
-          $vsInstallPath = & $vswherePath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -latest
-          if (-not $vsInstallPath) {
-            $vsInstallPath = & $vswherePath -products * -requires Microsoft.Component.MSBuild -property installationPath -latest
-          }
-          if (-not $vsInstallPath) {
-            throw "Visual Studio installation not found"
-          }
-
-          $devCmdPath = Join-Path $vsInstallPath "Common7\Tools\VsDevCmd.bat"
-          if (-not (Test-Path $devCmdPath)) {
-            throw "VsDevCmd.bat not found at $devCmdPath"
-          }
-
-          Write-Host "Configuring MSVC environment for $Arch"
-          $environment = cmd /c "`"$devCmdPath`" -arch=$Arch -no_logo >nul && set"
-          if ($LASTEXITCODE -ne 0) {
-            throw "VsDevCmd.bat failed for architecture $Arch"
-          }
-
-          foreach ($line in $environment) {
-            if ($line -match "^(.*?)=(.*)$") {
-              Set-Item -Path "Env:$($matches[1])" -Value $matches[2]
-            }
-          }
-        }
+        # Canonical vswhere/VsDevCmd import, shared with the Qt build step below
+        # and setup-build.ps1.
+        . .\.github\scripts\Import-VsDevEnvironment.ps1
 
         function Copy-RequiredFile {
           param(
@@ -825,45 +796,9 @@ jobs:
     - name: Build Qt Applications
       shell: pwsh
       run: |
-        function Import-VsDevEnvironment {
-          param([string]$Arch)
-
-          $vswherePath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswherePath)) {
-            Write-Error "vswhere.exe not found at $vswherePath"
-            exit 1
-          }
-
-          $vsInstallPath = & $vswherePath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -latest
-          if (-not $vsInstallPath) {
-            $vsInstallPath = & $vswherePath -products * -requires Microsoft.Component.MSBuild -property installationPath -latest
-          }
-          if (-not $vsInstallPath) {
-            Write-Error "Visual Studio installation not found"
-            exit 1
-          }
-
-          $devCmdPath = Join-Path $vsInstallPath "Common7\Tools\VsDevCmd.bat"
-          if (-not (Test-Path $devCmdPath)) {
-            Write-Error "VsDevCmd.bat not found at $devCmdPath"
-            exit 1
-          }
-
-          Write-Host "Configuring MSVC environment for $Arch"
-          $environment = cmd /c "`"$devCmdPath`" -arch=$Arch -no_logo >nul && set"
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "VsDevCmd.bat failed for architecture $Arch"
-            exit $LASTEXITCODE
-          }
-
-          foreach ($line in $environment) {
-            if ($line -match "^(.*?)=(.*)$") {
-              Set-Item -Path "Env:$($matches[1])" -Value $matches[2]
-            }
-          }
-
-          Write-Host "Configured MSVC target: $env:VSCMD_ARG_TGT_ARCH"
-        }
+        # Canonical vswhere/VsDevCmd import, shared with the vcpkg dependency
+        # build step above and setup-build.ps1.
+        . .\.github\scripts\Import-VsDevEnvironment.ps1
 
         Import-VsDevEnvironment "${{ matrix.msvcdevplatform }}"
 
@@ -1340,7 +1275,7 @@ jobs:
         retention-days: 30
 
   cross-variant-compare:
-    needs: build
+    needs: [build, prepare-matrix]
     runs-on: ubuntu-latest
     # The PR pipeline only builds AVX2, so there is nothing to compare
     # across variants. The always() guard matters on workflow_dispatch runs:
@@ -1363,6 +1298,11 @@ jobs:
       run: python3 -m pip install --quiet numpy
 
     - name: Compare SIMD variants
+      env:
+        # Gating variant list derived from .github/simd-variants.psd1 by
+        # New-BuildMatrix.ps1; the script falls back to its hard-coded list
+        # (with a warning) only when this variable is absent.
+        RUNNER_EXECUTABLE_VARIANTS: ${{ needs.prepare-matrix.outputs.runner_executable_variants }}
       run: python3 Tests/AudioRegressionTests/scripts/cross_variant_compare.py
 
   create-release:
@@ -1398,15 +1338,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        function Get-VersionPart {
-          param([string]$Name)
-
-          $line = Select-String -Path version.h -Pattern "^\s*#define\s+$Name\s+(\d+)" | Select-Object -First 1
-          if (-not $line) {
-            throw "Could not find version part: $Name"
-          }
-          return $line.Matches[0].Groups[1].Value
-        }
+        # Canonical version.h reader, shared with the version-bump job.
+        . .\.github\scripts\Get-VersionPart.ps1
 
         $major = Get-VersionPart "MAJOR"
         $minor = Get-VersionPart "MINOR"

--- a/Tests/AudioRegressionTests/scripts/cross_variant_compare.py
+++ b/Tests/AudioRegressionTests/scripts/cross_variant_compare.py
@@ -6,21 +6,30 @@ Downloaded audio-regression-output-* artifacts each contain the raw
 float-interleaved outputs of every test case for a single SIMD variant
 under <variant>/<case>.raw.
 
-This script compares every pair of variants we list in VARIANTS, case by
-case, and fails (non-zero exit) if any pair drifts beyond TOLERANCE_DB.
+This script compares every pair of gating variants, case by case, and
+fails (non-zero exit) if any pair drifts beyond TOLERANCE_DB.
 We intentionally limit comparisons to variants that GitHub-hosted x64
 runners are guaranteed to execute correctly. ARM64 and AVX-512/AVX10.1
 output is captured for inspection but is not part of the gating diff
 because the hosted runner may not actually execute those code paths.
+
+The gating variant list is derived from .github/simd-variants.psd1 (the
+x64 variants with RunnerCanExecute) by .github/scripts/New-BuildMatrix.ps1
+and passed in through the RUNNER_EXECUTABLE_VARIANTS environment variable
+(a JSON array; see the cross-variant-compare job in build.yml). When the
+variable is absent (e.g. a local run), the script falls back to
+FALLBACK_VARIANTS with a warning.
 """
 
+import json
 import os
 import sys
 
 import numpy as np
 
 ARTIFACT_ROOT = "artifacts"
-VARIANTS = ["sse2", "avx", "avx2"]
+# Fallback only; the authoritative list comes from RUNNER_EXECUTABLE_VARIANTS.
+FALLBACK_VARIANTS = ["sse2", "avx", "avx2"]
 TOLERANCE_DB = -120.0
 CASES = [
     "preamp_minus6",
@@ -50,6 +59,28 @@ def compare(a: np.ndarray, b: np.ndarray):
     return max_err <= tol, max_err, int(diff.argmax()), rmse
 
 
+def resolve_variants() -> list:
+    raw = os.environ.get("RUNNER_EXECUTABLE_VARIANTS", "").strip()
+    if not raw:
+        print(
+            "WARNING: RUNNER_EXECUTABLE_VARIANTS is not set; falling back to the "
+            f"hard-coded variant list {FALLBACK_VARIANTS}. In CI this list is "
+            "derived from .github/simd-variants.psd1 by New-BuildMatrix.ps1."
+        )
+        return FALLBACK_VARIANTS
+    variants = json.loads(raw)
+    if (
+        not isinstance(variants, list)
+        or not variants
+        or not all(isinstance(v, str) and v for v in variants)
+    ):
+        raise ValueError(
+            "RUNNER_EXECUTABLE_VARIANTS must be a non-empty JSON array of "
+            f"variant names, got: {raw!r}"
+        )
+    return variants
+
+
 def variant_dir(variant: str) -> str:
     artifact_dir = os.path.join(ARTIFACT_ROOT, f"audio-regression-output-{variant}")
     candidates = [
@@ -63,11 +94,12 @@ def variant_dir(variant: str) -> str:
 
 
 def main() -> int:
-    pairs = [(VARIANTS[i], VARIANTS[j]) for i in range(len(VARIANTS)) for j in range(i + 1, len(VARIANTS))]
-    print(f"Cross-variant compare: tolerance={TOLERANCE_DB} dBFS, variants={VARIANTS}")
+    variants = resolve_variants()
+    pairs = [(variants[i], variants[j]) for i in range(len(variants)) for j in range(i + 1, len(variants))]
+    print(f"Cross-variant compare: tolerance={TOLERANCE_DB} dBFS, variants={variants}")
 
-    dirs = {v: variant_dir(v) for v in VARIANTS}
-    missing = [v for v in VARIANTS if not os.path.isdir(dirs[v])]
+    dirs = {v: variant_dir(v) for v in variants}
+    missing = [v for v in variants if not os.path.isdir(dirs[v])]
     if missing:
         for variant in missing:
             print(f"ERROR: missing variant output directory for {variant}: {dirs[variant]}")

--- a/reformat.bat
+++ b/reformat.bat
@@ -1,7 +1,7 @@
 @echo off
 cd %~dp0
 for /r %%f in (*.cpp *.h) do (
-	(Echo "%%f" | FIND /I "\build-" 1>NUL) || (Echo "%%f" | FIND /I "\resource.h" 1>NUL) || (Echo "%%f" | FIND /I "\libHybridConv-0.1.1\" 1>NUL) || (Echo "%%f" | FIND /I "\helpers\aeffectx.h" 1>NUL) || (Echo "%%f" | FIND /I "\helpers\UncaughtExceptions.h" 1>NUL) || (Echo "%%f" | FIND /I "\VoicemeeterClient\VoicemeeterRemote.h" 1>NUL)  || (
+	(Echo "%%f" | FIND /I "\build-" 1>NUL) || (Echo "%%f" | FIND /I "\deps\" 1>NUL) || (Echo "%%f" | FIND /I "\Qt\" 1>NUL) || (Echo "%%f" | FIND /I "\resource.h" 1>NUL) || (Echo "%%f" | FIND /I "\libHybridConv-0.1.1\" 1>NUL) || (Echo "%%f" | FIND /I "\helpers\aeffectx.h" 1>NUL) || (Echo "%%f" | FIND /I "\helpers\UncaughtExceptions.h" 1>NUL) || (Echo "%%f" | FIND /I "\VoicemeeterClient\VoicemeeterRemote.h" 1>NUL)  || (
 		uncrustify -c uncrustify.cfg -l CPP --replace --no-backup "%%f"
     )
 )

--- a/setup-build.ps1
+++ b/setup-build.ps1
@@ -90,9 +90,12 @@ $downloads = @(
     @{
         # Velopack C/C++ runtime (Velopack.h + import libs + DLLs for every platform).
         # Always fetched regardless of SIMD variant; the Editor links it for auto-update.
+        # Not covered by DependencyReleases (the URL is release-tag based already), so
+        # its SHA-256 pin rides on the download entry itself.
         Repo        = "velopack/velopack"
         Asset       = "velopack_libc_$velopackLibcVersion.zip"
         Url         = "https://github.com/velopack/velopack/releases/download/$velopackLibcVersion/velopack_libc_$velopackLibcVersion.zip"
+        Sha256      = $simdManifest.Shared.VelopackLibcSha256
         Destination = Join-Path $depsDir "velopack_libc"
     }
 )
@@ -135,8 +138,10 @@ foreach ($dl in $downloads) {
         }
     }
 
-    if ($pin) {
-        $expected = $pin.Sha256[$dl.Asset]
+    if ($pin -or $dl.Sha256) {
+        # DependencyReleases pins are per-asset; velopack_libc carries its pin on
+        # the download entry (Shared.VelopackLibcSha256 in simd-variants.psd1).
+        $expected = if ($dl.Sha256) { $dl.Sha256 } else { $pin.Sha256[$dl.Asset] }
         if (-not $expected) {
             throw "No pinned SHA-256 for $($dl.Asset) in simd-variants.psd1"
         }
@@ -157,25 +162,25 @@ foreach ($dl in $downloads) {
 if ($usesVcpkg) {
     Write-Host "`n  Building lower-SIMD dependencies via vcpkg..."
 
-    # Import VS dev environment
-    $vswherePath = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-    $vsInstallPath = & $vswherePath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -latest
-    if (-not $vsInstallPath) {
-        $vsInstallPath = & $vswherePath -products * -requires Microsoft.Component.MSBuild -property installationPath -latest
-    }
-    $devCmdPath = Join-Path $vsInstallPath "Common7\Tools\VsDevCmd.bat"
-    $environment = cmd /c "`"$devCmdPath`" -arch=x64 -no_logo >nul && set"
-    foreach ($line in $environment) {
-        if ($line -match "^(.*?)=(.*)$") {
-            Set-Item -Path "Env:$($matches[1])" -Value $matches[2]
-        }
-    }
+    # Import VS dev environment (canonical helper shared with build.yml)
+    . (Join-Path $workspace ".github\scripts\Import-VsDevEnvironment.ps1")
+    Import-VsDevEnvironment "x64"
 
     $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
     if (-not $vcpkgRoot -or -not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
         $vcpkgRoot = Join-Path $workspace "vcpkg"
         if (-not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
+            # Pin vcpkg to the manifest commit: cloning a moving HEAD would let the
+            # portfiles (and thus the FFTW/libsndfile binaries built here) change
+            # without a reviewed diff in simd-variants.psd1. --depth 1 keeps the
+            # clone small; the pinned commit is fetched by SHA and checked out.
+            $vcpkgCommit = $simdManifest.Shared.VcpkgCommit
             git clone --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
+            if ($LASTEXITCODE -ne 0) { throw "Failed to clone vcpkg" }
+            git -C $vcpkgRoot fetch --depth 1 origin $vcpkgCommit
+            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch pinned vcpkg commit $vcpkgCommit" }
+            git -C $vcpkgRoot checkout --detach $vcpkgCommit
+            if ($LASTEXITCODE -ne 0) { throw "Failed to check out pinned vcpkg commit $vcpkgCommit" }
             & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
         }
     }
@@ -379,6 +384,21 @@ if (-not $SkipQt) {
 
 if ($allOk) {
     Write-Host "`n=== Setup Complete ===" -ForegroundColor Green
+
+    # The .pro files fail with error() when an x64 build passes neither
+    # EAPO_SIMD_FLAGS nor EAPO_SIMD_BASELINE, so the printed qmake line must
+    # carry the same variant arguments CI passes (build.yml "Build Qt
+    # Applications"): the update channel plus the variant's /arch flag, or the
+    # explicit baseline marker for sse2. ARM64 passes no SIMD argument.
+    $qmakeVariantArgs = "`"EAPO_UPDATE_CHANNEL=$($variantEntry.Channel)`""
+    if ($Platform -eq "x64") {
+        if ($variantEntry.QtArchFlag) {
+            $qmakeVariantArgs += " `"EAPO_SIMD_FLAGS=$($variantEntry.QtArchFlag)`""
+        } else {
+            $qmakeVariantArgs += " `"EAPO_SIMD_BASELINE=1`""
+        }
+    }
+
     Write-Host @"
 
 To build the project, open a VS Developer Command Prompt and run:
@@ -397,12 +417,15 @@ To build the project, open a VS Developer Command Prompt and run:
   `$env:QT_ROOT          = "$qtRoot"
 
   # Build core projects with MSBuild
-  msbuild EqualizerAPO.sln /p:Configuration=Release /p:Platform=x64
+  msbuild EqualizerAPO.sln /p:Configuration=Release /p:Platform=$Platform
 
-  # Build Qt apps with qmake
-  cd build-Editor
-  qmake ..\Editor\Editor.pro -r CONFIG+=release
+  # Build Qt apps with qmake (run lrelease first: nmake stalls without the .qm files)
+  mkdir build-Editor-$Platform; cd build-Editor-$Platform
+  lrelease ..\Editor\Editor.pro
+  qmake ..\Editor\Editor.pro -r "CONFIG+=release" $qmakeVariantArgs
   nmake
+
+  # DeviceSelector and UpdateChecker build the same way from their .pro files.
 "@
 } else {
     Write-Host "`n=== Setup Incomplete ===" -ForegroundColor Red


### PR DESCRIPTION
감사 이슈 #146의 빌드 글루 8건(TD014, TD016, TD034, TD037, TD038, TD042 스크립트 절반, TD047, TD048)을 반영합니다.

- Import-VsDevEnvironment 3중복(그중 setup-build.ps1 사본은 오류 검사가 전혀 없었음)과 Get-VersionPart 2중복을 .github/scripts로 승격해 dot-source합니다. 성공 경로 동작은 동일하고, setup-build.ps1 쪽은 실패를 조용히 지나치던 것이 명시적 실패로 바뀝니다.
- vcpkg 클론을 simd-variants.psd1의 커밋 핀으로 고정하고, velopack_libc zip에 SHA-256 핀을 추가합니다(다른 바이너리 의존성과 같은 검증 경로).
- cross-variant-compare의 게이팅 변형 목록을 New-BuildMatrix.ps1이 manifest에서 뽑아 env로 전달합니다(두 번째 하드코딩 목록 제거, 부재 시 경고와 함께 기존 목록으로 폴백).
- New-ReleaseNotes의 Verification 문단을 manifest 기반으로 생성하고 실제 실행되는 4개 테스트 스위트를 모두 명시합니다.
- setup-build.ps1의 마무리 안내가 .pro error() 게이트를 통과하는 qmake 명령을 출력합니다.
- reformat.bat이 deps/와 Qt/를 제외합니다.

로컬 검증은 PSParser 구문 검사, psd1 Import, build.yml YAML 파싱, Test-VariantSync, Pester 18/18, py_compile, New-BuildMatrix 실행(기존 목록과 바이트 동일 출력 확인) 등이 있습니다. version-bump job의 dot-source 관례는 같은 job의 Bump-Version.ps1 호출로 이미 검증되어 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)