### PR TITLE
fix(engine): close the audit #146 runtime robustness findings

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,21 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- Windows 오디오 엔진의 크래시 경로를 고쳤습니다. 설정을 하나도 싣지 못한
+  상태(예: `ConfigPath` 레지스트리 값을 읽을 수 없는 경우)에서 처리 루틴이
+  audiodg.exe 안에서 null 구성을 역참조해 시스템 오디오가 죽었는데, 이제
+  소리를 그대로 통과시킵니다.
+  ([#150](https://github.com/115dkk/EqualizerAPO-XT/pull/150))
+- `MultiConvolution`이 `Convolution`과 임펄스 응답 캐시를 공유합니다. 설정을
+  다시 읽을 때 BRIR 파일 전체를 디스크에서 재독취하지 않고 해석된 IR을
+  재사용합니다.
+  ([#150](https://github.com/115dkk/EqualizerAPO-XT/pull/150))
+- VST 플러그인 준비 단계가 메모리 부족을 견딥니다. 버퍼 할당이 실패하면
+  오디오 서비스를 죽이는 대신 소리를 그대로 통과시킵니다.
+  ([#150](https://github.com/115dkk/EqualizerAPO-XT/pull/150))
+
 ## v2.8.0 (2026-07-03)
 
 - 주석과 Stage 행이 진짜 카드가 되었습니다. 메모 줄은 카드 안에서 바로

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- Fixed a crash path inside the Windows audio engine: if EqualizerAPO could
+  not load any configuration (for example an unreadable `ConfigPath` registry
+  value), processing dereferenced a null configuration inside audiodg.exe and
+  killed system audio. Audio now passes through unchanged instead.
+  ([#150](https://github.com/115dkk/EqualizerAPO-XT/pull/150))
+- `MultiConvolution` now shares the impulse-response cache with `Convolution`:
+  a configuration reload reuses the decoded IR instead of re-reading every
+  BRIR file from disk.
+  ([#150](https://github.com/115dkk/EqualizerAPO-XT/pull/150))
+- VST plugin setup survives out-of-memory conditions: a failed buffer
+  allocation now degrades to passing audio through instead of crashing the
+  audio service.
+  ([#150](https://github.com/115dkk/EqualizerAPO-XT/pull/150))
+
 ## v2.8.0 — 2026-07-03
 
 - Comment and Stage rows became real cards. A note line gets an in-place

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -315,6 +315,7 @@
     <ClInclude Include="filters\ConvolutionFilter.h" />
     <ClInclude Include="filters\ConvolutionFilePath.h" />
     <ClInclude Include="filters\ConvolutionFilterFactory.h" />
+    <ClInclude Include="filters\IrCache.h" />
     <ClInclude Include="filters\MultiConvolutionCommand.h" />
     <ClInclude Include="filters\MultiConvolutionFilter.h" />
     <ClInclude Include="filters\MultiConvolutionFilterFactory.h" />
@@ -400,6 +401,7 @@
     <ClCompile Include="filters\ConvolutionFilter.cpp" />
     <ClCompile Include="filters\ConvolutionFilePath.cpp" />
     <ClCompile Include="filters\ConvolutionFilterFactory.cpp" />
+    <ClCompile Include="filters\IrCache.cpp" />
     <ClCompile Include="filters\MultiConvolutionCommand.cpp" />
     <ClCompile Include="filters\MultiConvolutionFilter.cpp" />
     <ClCompile Include="filters\MultiConvolutionFilterFactory.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClInclude Include="filters\ConvolutionFilterFactory.h">
       <Filter>filters</Filter>
     </ClInclude>
+    <ClInclude Include="filters\IrCache.h">
+      <Filter>filters</Filter>
+    </ClInclude>
     <ClInclude Include="filters\CopyFilter.h">
       <Filter>filters</Filter>
     </ClInclude>
@@ -233,6 +236,9 @@
       <Filter>filters</Filter>
     </ClCompile>
     <ClCompile Include="filters\ConvolutionFilterFactory.cpp">
+      <Filter>filters</Filter>
+    </ClCompile>
+    <ClCompile Include="filters\IrCache.cpp">
       <Filter>filters</Filter>
     </ClCompile>
     <ClCompile Include="filters\CopyFilter.cpp">

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -153,6 +153,7 @@ SOURCES += main.cpp\
 	../filters/IncludeFilterFactory.cpp \
 	../filters/ChannelFilter.cpp \
 	../filters/ConvolutionFilter.cpp \
+	../filters/IrCache.cpp \
 	../parser/RegexFunctions.cpp \
 	../parser/RegistryFunctions.cpp \
 	../parser/StringOperators.cpp \
@@ -361,6 +362,7 @@ HEADERS  += \
 	../filters/ChannelFilter.h \
 	../filters/ConvolutionCommand.h \
 	../filters/ConvolutionFilter.h \
+	../filters/IrCache.h \
 	../parser/RegexFunctions.h \
 	../parser/RegistryFunctions.h \
 	../parser/StringOperators.h \

--- a/FilterEngine.h
+++ b/FilterEngine.h
@@ -71,6 +71,10 @@ public:
 	unsigned getChannelMask() const {return channelMask;}
 	float getSampleRate() const {return sampleRate;}
 	unsigned getMaxFrameCount() const {return maxFrameCount;}
+	// Crossfade length in samples for a configuration swap, set by initialize().
+	// Exposed so tests exercise the real value instead of re-deriving the
+	// sampleRate / 100 formula. (audit #146 TD033)
+	unsigned getTransitionLength() const {return transitionLength;}
 	mup::ParserX* getParser() {return parser.get();}
 	// Returns true if the active configuration (or any transition target) carries
 	// state across blocks or has a tail. Used by the APO to skip processing on

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -373,7 +373,6 @@ void testRealBrirCrossfeed(test::Harness& harness)
 void testConfigSwapCrossfades(test::Harness& harness)
 {
 	const unsigned sampleRate = 48000;
-	const unsigned transitionLength = sampleRate / 100; // matches FilterEngine::initialize
 	const unsigned blockFrames = 120;
 
 	std::wstring configA = writeConfig(harness, L"transition_a.txt", "Preamp: -6.0206 dB\n");
@@ -381,6 +380,10 @@ void testConfigSwapCrossfades(test::Harness& harness)
 
 	FilterEngine engine;
 	initializeEngine(engine, sampleRate, 2, 480, configA);
+
+	// The engine's real crossfade length; do not re-derive its formula here.
+	const unsigned transitionLength = engine.getTransitionLength();
+	harness.expect(transitionLength > 0, "engine reported no transition length after initialize");
 
 	// Settle on config A.
 	std::vector<float> settled = processDcBlock(engine, 1.0f, 1.0f, 480);
@@ -426,6 +429,42 @@ void testConfigSwapCrossfades(test::Harness& harness)
 	harness.expect(std::fabs(finalRight - target) < 1e-4f, "right channel did not converge to the new config gain");
 }
 
+// process() can arrive before initialize(), and initialize() can finish
+// without loading any configuration (unreadable ConfigPath and no custom
+// path). Both leave currentConfig null; every overload must pass audio
+// through instead of dereferencing it inside audiodg.exe. (audit #146 TD026)
+void testProcessWithoutConfigurationDoesNotCrash(test::Harness& harness)
+{
+	FilterEngine engine;
+
+	const unsigned frames = 16;
+	std::vector<float> inputF((size_t)2 * frames, 0.25f);
+	std::vector<float> outputF((size_t)2 * frames, -1.0f);
+	engine.process(outputF.data(), inputF.data(), frames);
+
+	std::vector<double> inputD((size_t)2 * frames, 0.25);
+	std::vector<double> outputD((size_t)2 * frames, -1.0);
+	engine.process(outputD.data(), inputD.data(), frames);
+
+	std::vector<float> planarFIn((size_t)2 * frames, 0.25f);
+	std::vector<float> planarFOut((size_t)2 * frames, -1.0f);
+	float* inF[2] = {planarFIn.data(), planarFIn.data() + frames};
+	float* outF[2] = {planarFOut.data(), planarFOut.data() + frames};
+	engine.process(outF, inF, frames);
+
+	std::vector<double> planarDIn((size_t)2 * frames, 0.25);
+	std::vector<double> planarDOut((size_t)2 * frames, -1.0);
+	double* inD[2] = {planarDIn.data(), planarDIn.data() + frames};
+	double* outD[2] = {planarDOut.data(), planarDOut.data() + frames};
+	engine.process(outD, inD, frames);
+
+	// Reaching this line is the point: no null dereference. Before
+	// initialize() the channel counts are zero, so the bypass copies nothing
+	// and the output buffers stay untouched.
+	harness.expect(outputF[0] == -1.0f && outputD[0] == -1.0 && planarFOut[0] == -1.0f && planarDOut[0] == -1.0,
+		"process() without a configuration wrote output despite zero channel counts");
+}
+
 } // namespace
 
 int main()
@@ -434,6 +473,7 @@ int main()
 
 	test::Harness harness("EngineOrchestrationTests");
 
+	testProcessWithoutConfigurationDoesNotCrash(harness);
 	testChannelSelectorRouting(harness);
 	testCopySwapsChannels(harness);
 	testMultiConvolutionIgnoresChannelSelection(harness);

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -166,6 +166,12 @@ void FilterEngine::loadConfigFile(const wstring& path)
 				vector<IFilter*> newFilters;
 				try
 				{
+					// A factory that throws after constructing some filters leaks
+					// those IFilter*s: partial results live inside the factory and
+					// cannot be reclaimed here. The leak is bounded by config-reload
+					// frequency and accepted; factories that allocate more than
+					// trivially should own partials via a scope guard before
+					// returning. (audit #146 TD030)
 					newFilters = factory->createFilter(path, key, value);
 				}
 				catch (const exception& e)

--- a/engine/FilterEngine.Process.cpp
+++ b/engine/FilterEngine.Process.cpp
@@ -115,6 +115,18 @@ void FilterEngine::process(float* output, float* input, unsigned frameCount)
 	PerfScope _eapo_total("FilterEngine::process(float interleaved)");
 	MxcsrFtzDazGuard _mxcsrGuard;
 
+	if (currentConfig == nullptr)
+	{
+		// initialize() can finish without loading any configuration (unreadable
+		// ConfigPath with no custom path, or an empty path value), and the APO
+		// can call process() before initialize(). Treat both like the
+		// empty-config bypass below instead of dereferencing null. (audit #146 TD026)
+		if (realChannelCount == outputChannelCount && input != output) {
+			std::copy_n(input, outputChannelCount * frameCount, output);
+		}
+		return;
+	}
+
 	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
 		// Bypass mode: if no filters are active, just copy input to output if necessary.
@@ -162,6 +174,16 @@ void FilterEngine::process(float** output, float** input, unsigned frameCount)
 {
 	PerfScope _eapo_total("FilterEngine::process(float planar)");
 	MxcsrFtzDazGuard _mxcsrGuard;
+
+	if (currentConfig == nullptr)
+	{
+		// Null configuration: see the float-interleaved overload. (audit #146 TD026)
+		if (realChannelCount == outputChannelCount && input != output) {
+			for (unsigned c = 0; c < realChannelCount; c++)
+				std::copy_n(input[c], frameCount, output[c]);
+		}
+		return;
+	}
 
 	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
@@ -213,6 +235,15 @@ void FilterEngine::process(double* output, double* input, unsigned frameCount)
 	PerfScope _eapo_total("FilterEngine::process(double interleaved)");
 	MxcsrFtzDazGuard _mxcsrGuard;
 
+	if (currentConfig == nullptr)
+	{
+		// Null configuration: see the float-interleaved overload. (audit #146 TD026)
+		if (realChannelCount == outputChannelCount && input != output) {
+			std::copy_n(input, outputChannelCount * frameCount, output);
+		}
+		return;
+	}
+
 	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
 		// Bypass mode: if no filters are active, just copy input to output if necessary.
@@ -258,6 +289,16 @@ void FilterEngine::process(double** output, double** input, unsigned frameCount)
 {
 	PerfScope _eapo_total("FilterEngine::process(double planar)");
 	MxcsrFtzDazGuard _mxcsrGuard;
+
+	if (currentConfig == nullptr)
+	{
+		// Null configuration: see the float-interleaved overload. (audit #146 TD026)
+		if (realChannelCount == outputChannelCount && input != output) {
+			for (unsigned c = 0; c < realChannelCount; c++)
+				std::copy_n(input[c], frameCount, output[c]);
+		}
+		return;
+	}
 
 	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{

--- a/engine/FilterEngine.Runtime.cpp
+++ b/engine/FilterEngine.Runtime.cpp
@@ -204,8 +204,18 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 	HANDLE handles[3] = {engine->shutdownEvent->get(), notificationHandle, registryEvent.get()};
 	while (true)
 	{
+		// watchRegistryKeys is cleared and refilled under loadMutex whenever a
+		// configuration loads (loadConfig can run on the APO thread for a device
+		// format change while this thread is between waits). Snapshot it under
+		// the same mutex instead of iterating the live set. (audit #146 TD027)
+		vector<wstring> watchedKeys;
+		{
+			lock_guard<mutex> lock(engine->loadMutex);
+			watchedKeys.assign(engine->watchRegistryKeys.begin(), engine->watchRegistryKeys.end());
+		}
+
 		vector<HKEY> keyHandles;
-		for (auto it = engine->watchRegistryKeys.begin(); it != engine->watchRegistryKeys.end(); it++)
+		for (auto it = watchedKeys.begin(); it != watchedKeys.end(); it++)
 		{
 			try
 			{

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -21,13 +21,8 @@
 #include <atomic>
 #include <cmath>
 #include <memory>
-#include <mutex>
-#include <unordered_map>
-#include <climits>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
 #include <fftw3.h>
 
 #include "helpers/LogHelper.h"
@@ -35,167 +30,14 @@
 #include "ConvolutionFilter.h"
 #include "helpers/PerfProfile.h"
 
-using std::abs;
 using std::vector;
 using std::wstring;
 
-// Decoded impulse-response PCM, shared between ConvolutionFilter instances that
-// reference the same IR. Defined at global scope (not in the anonymous namespace)
-// so ConvolutionFilter can forward-declare it and hold a std::shared_ptr member.
-struct IrCacheEntry
-{
-	unsigned channels = 0;
-	unsigned frames = 0;
-	// Channel-major IR samples; each inner vector has `frames` elements.
-	std::vector<std::vector<double>> buffers;
-};
+// The IR intake (libsndfile read, hardening, deinterleave) and the weak-ptr
+// cache live in IrCache.cpp, shared with MultiConvolutionFilter. (audit #146 TD001)
 
 namespace
 {
-	// Cache of decoded impulse-response PCM, keyed by path + mtime + sample rate.
-	// Lets a config reload (or a second ConvolutionFilter using the same IR) skip
-	// the libsndfile read + interleave-to-planar pass. File I/O and the
-	// per-channel reshuffle dominate ConvolutionFilter initialization for large
-	// IRs.
-	//
-	// The cache holds *weak* references: each live ConvolutionFilter keeps a
-	// shared_ptr to its IrCacheEntry, so the entry survives exactly as long as some
-	// filter still uses it. Once the last filter referencing an IR is destroyed the
-	// entry is freed, which bounds cache memory to the current config's working set
-	// and stops a long-lived process from accumulating every IR it ever loaded.
-	struct IrCacheKey
-	{
-		std::wstring path;
-		unsigned long long mtime = 0;
-		int sampleRate = 0;
-
-		bool operator==(const IrCacheKey& o) const
-		{
-			return sampleRate == o.sampleRate && mtime == o.mtime && path == o.path;
-		}
-	};
-
-	struct IrCacheKeyHash
-	{
-		size_t operator()(const IrCacheKey& k) const noexcept
-		{
-			size_t h = std::hash<std::wstring>{}(k.path);
-			h ^= std::hash<unsigned long long>{}(k.mtime) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-			h ^= std::hash<int>{}(k.sampleRate) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
-			return h;
-		}
-	};
-
-	std::mutex& irCacheMutex()
-	{
-		static std::mutex m;
-		return m;
-	}
-
-	std::unordered_map<IrCacheKey, std::weak_ptr<const IrCacheEntry>, IrCacheKeyHash>& irCache()
-	{
-		static std::unordered_map<IrCacheKey, std::weak_ptr<const IrCacheEntry>, IrCacheKeyHash> c;
-		return c;
-	}
-
-	unsigned long long getMtime(const std::wstring& path)
-	{
-		WIN32_FILE_ATTRIBUTE_DATA attrs;
-		if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attrs))
-			return 0;
-		return (static_cast<unsigned long long>(attrs.ftLastWriteTime.dwHighDateTime) << 32)
-			| attrs.ftLastWriteTime.dwLowDateTime;
-	}
-
-	std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, double sampleRate)
-	{
-		const int sampleRateKey = static_cast<int>(sampleRate);
-		IrCacheKey key{ filename, getMtime(filename), sampleRateKey };
-
-		{
-			std::lock_guard<std::mutex> lock(irCacheMutex());
-			auto it = irCache().find(key);
-			if (it != irCache().end())
-			{
-				if (auto entry = it->second.lock())
-					return entry;
-				// Weak reference expired (last filter using it was destroyed);
-				// drop the dead slot and fall through to reload.
-				irCache().erase(it);
-			}
-		}
-
-		SF_INFO info{};
-		SNDFILE* in = sf_wchar_open(filename.c_str(), SFM_READ, &info);
-		if (in == nullptr)
-		{
-			LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(in));
-			return nullptr;
-		}
-		if (abs(sampleRate - info.samplerate) > 1.0)
-		{
-			LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
-			sf_close(in);
-			return nullptr;
-		}
-
-		// Reject impulse responses with no usable audio before they reach the
-		// convolution setup. A 0-frame IR makes hcInitSingle dereference an empty
-		// filter-pointer array (crash); channels == 0 divides by zero in the
-		// channel map; and frames > INT_MAX would wrap negative when cast to int.
-		// All three are reachable from a user-writable config plus a crafted IR.
-		if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX)
-		{
-			LogFStatic(L"Impulse response has no usable audio (frames=%lld, channels=%d); ignoring %s",
-				static_cast<long long>(info.frames), info.channels, filename.c_str());
-			sf_close(in);
-			return nullptr;
-		}
-
-		const unsigned channels = static_cast<unsigned>(info.channels);
-		const unsigned frames = static_cast<unsigned>(info.frames);
-		std::vector<double> interleaved(static_cast<size_t>(frames) * channels);
-		sf_count_t numRead = 0;
-		while (numRead < info.frames)
-		{
-			sf_count_t got = sf_readf_double(in, interleaved.data() + numRead * channels, info.frames - numRead);
-			if (got <= 0)
-				break; // truncated or unreadable file: stop instead of spinning forever
-			numRead += got;
-		}
-		sf_close(in);
-
-		auto entry = std::make_shared<IrCacheEntry>();
-		entry->channels = channels;
-		entry->frames = frames;
-		entry->buffers.resize(channels);
-		for (unsigned c = 0; c < channels; ++c)
-		{
-			entry->buffers[c].resize(frames);
-			double* dst = entry->buffers[c].data();
-			const double* src = interleaved.data() + c;
-			for (unsigned i = 0; i < frames; ++i)
-				dst[i] = src[i * channels];
-		}
-
-		{
-			std::lock_guard<std::mutex> lock(irCacheMutex());
-			// Prune slots whose entries have been freed so the map does not keep
-			// accumulating dead keys as IRs come and go across config reloads.
-			for (auto it = irCache().begin(); it != irCache().end();)
-			{
-				if (it->second.expired())
-					it = irCache().erase(it);
-				else
-					++it;
-			}
-			// store_or_replace: a concurrent loader may have inserted the same key
-			// (possibly now expired); overwrite with our live weak reference.
-			irCache()[std::move(key)] = entry;
-		}
-		return entry;
-	}
-
 	// Running total of process() calls that took the frameCount-mismatch mute path,
 	// across all ConvolutionFilter instances. The mute is otherwise silent after the
 	// first log, so this makes the condition observable (logged in cleanup()). The
@@ -203,20 +45,7 @@ namespace
 	std::atomic<unsigned long long> muteCallCount{ 0 };
 }
 
-void HConvSingleArray::reset()
-{
-	if (ptr != nullptr)
-	{
-		for (unsigned i = 0; i < channelCount; i++)
-			hcCloseSingle(&ptr[i]);
-
-		MemoryHelper::free(ptr);
-		ptr = nullptr;
-	}
-}
-
 ConvolutionFilter::ConvolutionFilter(const wstring& filename)
-	: filters(channelCount)
 {
 	this->filename = filename;
 	filterFrameCount = 0;
@@ -324,7 +153,7 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 		LogF(L"ConvolutionFilter: could not allocate %u filter slots", channelCount);
 		return;
 	}
-	filters = allocated;
+	filters.adopt(allocated, channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		// hcInitSingle reads the IR samples during planning but does not retain

--- a/filters/ConvolutionFilter.h
+++ b/filters/ConvolutionFilter.h
@@ -23,59 +23,7 @@
 #include <memory>
 
 #include "IFilter.h"
-#include "libHybridConv-0.1.1/libHybridConv_eapo.h"
-
-struct IrCacheEntry;
-
-// RAII owner for the per-channel HConvSingle array. The array is a single block
-// allocated with MemoryHelper::alloc(sizeof(HConvSingle) * channelCount) and must
-// be torn down by closing every channel filter (hcCloseSingle) before freeing the
-// block. Wrapping it makes that teardown automatic and idempotent. The holder keeps
-// a reference to the owner's channelCount so it knows how many channel filters to
-// close; the count is read at teardown time, after the owner has set it. The type
-// stays a thin handle around HConvSingle*: it converts to the raw pointer and is
-// assignable from one so existing call sites (filters[i], &filters[i],
-// filters = MemoryHelper::alloc(...), filters == nullptr) keep their exact meaning.
-class HConvSingleArray
-{
-public:
-	explicit HConvSingleArray(const unsigned& channelCount)
-		: ptr(nullptr), channelCount(channelCount) {}
-	~HConvSingleArray() { reset(); }
-
-	HConvSingleArray(const HConvSingleArray&) = delete;
-	HConvSingleArray& operator=(const HConvSingleArray&) = delete;
-
-	// Take ownership of a freshly allocated block (or nullptr). Any previously held
-	// block is torn down first using the same close-then-free sequence.
-	HConvSingleArray& operator=(HConvSingle* newPtr)
-	{
-		if (newPtr != ptr)
-			reset();
-		ptr = newPtr;
-		return *this;
-	}
-
-	HConvSingleArray& operator=(std::nullptr_t)
-	{
-		reset();
-		return *this;
-	}
-
-	HConvSingle& operator[](unsigned i) const { return ptr[i]; }
-	// Implicit decay to the raw pointer keeps every existing use of `filters`
-	// (filters[i], &filters[i], filters == nullptr, hcInitSingle(&filters[i], ...))
-	// byte-for-byte identical to the former raw HConvSingle* member.
-	operator HConvSingle*() const { return ptr; }
-
-	// Close every channel filter, then free the block. Mirrors the legacy
-	// cleanup() sequence exactly (hcCloseSingle loop, then MemoryHelper::free).
-	void reset();
-
-private:
-	HConvSingle* ptr;
-	const unsigned& channelCount;
-};
+#include "IrCache.h"
 
 #pragma AVRT_VTABLES_BEGIN
 class ConvolutionFilter : public IFilter
@@ -91,8 +39,6 @@ protected:
 	virtual void initializeFilters(unsigned frameCount);
 	float sampleRate = 0.0f;
 	unsigned channelCount = 0;
-	// Declared after channelCount: the holder binds a reference to channelCount in
-	// the initializer list, so channelCount must be constructed first.
 	HConvSingleArray filters;
 	// Keeps the cached impulse response alive for this filter's lifetime. The
 	// process-wide cache only holds weak references, so this is what pins the IR

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -173,7 +173,15 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 	}
 
 	fftw_make_planner_thread_safe();
-	filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	if (allocated == nullptr)
+	{
+		// alloc returns nullptr on failure; stay inert (filters is null from
+		// cleanup(), process() then no-ops) instead of dereferencing it.
+		LogF(L"GraphicEQFilter: could not allocate %u filter slots", channelCount);
+		return;
+	}
+	filters.adopt(allocated, channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		hcInitSingle(&filters[i], const_cast<double*>(cached->ir.data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);

--- a/filters/IncludeFilterFactory.cpp
+++ b/filters/IncludeFilterFactory.cpp
@@ -64,11 +64,9 @@ vector<IFilter*> IncludeFilterFactory::createFilter(const wstring& configPath, w
 		if (PathIsRelativeW(value.c_str()))
 		{
 			wchar_t filePath[MAX_PATH];
-			configPath._Copy_s(filePath, sizeof(filePath) / sizeof(wchar_t), MAX_PATH);
-			if (configPath.size() < MAX_PATH)
-				filePath[configPath.size()] = L'\0';
-			else
-				filePath[MAX_PATH - 1] = L'\0';
+			// Standard copy + truncate; _Copy_s is an MSVC-internal helper. (audit #146 TD025)
+			const size_t copyLength = configPath.copy(filePath, MAX_PATH - 1);
+			filePath[copyLength] = L'\0';
 			PathRemoveFileSpecW(filePath);
 			PathAppendW(filePath, value.c_str());
 			includePath = filePath;

--- a/filters/IrCache.cpp
+++ b/filters/IrCache.cpp
@@ -1,0 +1,195 @@
+/*
+	This file is part of EqualizerAPO, a system-wide equalizer.
+	Copyright (C) 2015  Jonas Thedering
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License along
+	with this program; if not, write to the Free Software Foundation, Inc.,
+	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+#include <cmath>
+#include <climits>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#include <sndfile.h>
+
+#include "helpers/LogHelper.h"
+#include "helpers/MemoryHelper.h"
+#include "IrCache.h"
+
+using std::abs;
+
+namespace
+{
+	// Cache of decoded impulse-response PCM, keyed by path + mtime + sample rate.
+	// Lets a config reload (or a second filter using the same IR) skip the
+	// libsndfile read + interleave-to-planar pass. File I/O and the per-channel
+	// reshuffle dominate convolution filter initialization for large IRs.
+	//
+	// The cache holds *weak* references: each live filter keeps a shared_ptr to
+	// its IrCacheEntry, so the entry survives exactly as long as some filter
+	// still uses it. Once the last filter referencing an IR is destroyed the
+	// entry is freed, which bounds cache memory to the current config's working
+	// set and stops a long-lived process from accumulating every IR it ever
+	// loaded.
+	struct IrCacheKey
+	{
+		std::wstring path;
+		unsigned long long mtime = 0;
+		int sampleRate = 0;
+
+		bool operator==(const IrCacheKey& o) const
+		{
+			return sampleRate == o.sampleRate && mtime == o.mtime && path == o.path;
+		}
+	};
+
+	struct IrCacheKeyHash
+	{
+		size_t operator()(const IrCacheKey& k) const noexcept
+		{
+			size_t h = std::hash<std::wstring>{}(k.path);
+			h ^= std::hash<unsigned long long>{}(k.mtime) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(k.sampleRate) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+			return h;
+		}
+	};
+
+	std::mutex& irCacheMutex()
+	{
+		static std::mutex m;
+		return m;
+	}
+
+	std::unordered_map<IrCacheKey, std::weak_ptr<const IrCacheEntry>, IrCacheKeyHash>& irCache()
+	{
+		static std::unordered_map<IrCacheKey, std::weak_ptr<const IrCacheEntry>, IrCacheKeyHash> c;
+		return c;
+	}
+
+	unsigned long long getMtime(const std::wstring& path)
+	{
+		WIN32_FILE_ATTRIBUTE_DATA attrs;
+		if (!GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attrs))
+			return 0;
+		return (static_cast<unsigned long long>(attrs.ftLastWriteTime.dwHighDateTime) << 32)
+			| attrs.ftLastWriteTime.dwLowDateTime;
+	}
+}
+
+std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, double sampleRate)
+{
+	const int sampleRateKey = static_cast<int>(sampleRate);
+	IrCacheKey key{ filename, getMtime(filename), sampleRateKey };
+
+	{
+		std::lock_guard<std::mutex> lock(irCacheMutex());
+		auto it = irCache().find(key);
+		if (it != irCache().end())
+		{
+			if (auto entry = it->second.lock())
+				return entry;
+			// Weak reference expired (last filter using it was destroyed);
+			// drop the dead slot and fall through to reload.
+			irCache().erase(it);
+		}
+	}
+
+	SF_INFO info{};
+	SNDFILE* in = sf_wchar_open(filename.c_str(), SFM_READ, &info);
+	if (in == nullptr)
+	{
+		LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(in));
+		return nullptr;
+	}
+	if (abs(sampleRate - info.samplerate) > 1.0)
+	{
+		LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
+		sf_close(in);
+		return nullptr;
+	}
+
+	// Reject impulse responses with no usable audio before they reach the
+	// convolution setup. A 0-frame IR makes hcInitSingle dereference an empty
+	// filter-pointer array (crash); channels == 0 divides by zero in the
+	// channel map; and frames > INT_MAX would wrap negative when cast to int.
+	// All three are reachable from a user-writable config plus a crafted IR.
+	if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX)
+	{
+		LogFStatic(L"Impulse response has no usable audio (frames=%lld, channels=%d); ignoring %s",
+			static_cast<long long>(info.frames), info.channels, filename.c_str());
+		sf_close(in);
+		return nullptr;
+	}
+
+	const unsigned channels = static_cast<unsigned>(info.channels);
+	const unsigned frames = static_cast<unsigned>(info.frames);
+	std::vector<double> interleaved(static_cast<size_t>(frames) * channels);
+	sf_count_t numRead = 0;
+	while (numRead < info.frames)
+	{
+		sf_count_t got = sf_readf_double(in, interleaved.data() + numRead * channels, info.frames - numRead);
+		if (got <= 0)
+			break; // truncated or unreadable file: stop instead of spinning forever
+		numRead += got;
+	}
+	sf_close(in);
+
+	auto entry = std::make_shared<IrCacheEntry>();
+	entry->channels = channels;
+	entry->frames = frames;
+	entry->buffers.resize(channels);
+	for (unsigned c = 0; c < channels; ++c)
+	{
+		entry->buffers[c].resize(frames);
+		double* dst = entry->buffers[c].data();
+		const double* src = interleaved.data() + c;
+		for (unsigned i = 0; i < frames; ++i)
+			dst[i] = src[i * channels];
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(irCacheMutex());
+		// Prune slots whose entries have been freed so the map does not keep
+		// accumulating dead keys as IRs come and go across config reloads.
+		for (auto it = irCache().begin(); it != irCache().end();)
+		{
+			if (it->second.expired())
+				it = irCache().erase(it);
+			else
+				++it;
+		}
+		// store_or_replace: a concurrent loader may have inserted the same key
+		// (possibly now expired); overwrite with our live weak reference.
+		irCache()[std::move(key)] = entry;
+	}
+	return entry;
+}
+
+void HConvSingleArray::reset()
+{
+	if (ptr != nullptr)
+	{
+		for (unsigned i = 0; i < count; i++)
+			hcCloseSingle(&ptr[i]);
+
+		MemoryHelper::free(ptr);
+		ptr = nullptr;
+	}
+	count = 0;
+}

--- a/filters/IrCache.h
+++ b/filters/IrCache.h
@@ -1,0 +1,98 @@
+/*
+	This file is part of EqualizerAPO, a system-wide equalizer.
+	Copyright (C) 2015  Jonas Thedering
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License along
+	with this program; if not, write to the Free Software Foundation, Inc.,
+	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "libHybridConv-0.1.1/libHybridConv_eapo.h"
+
+// Decoded impulse-response PCM, shared between filters that reference the same
+// IR file. Each live filter keeps a shared_ptr to its entry; the process-wide
+// cache (IrCache.cpp) holds only weak references, so an entry survives exactly
+// as long as some filter still uses it.
+struct IrCacheEntry
+{
+	unsigned channels = 0;
+	unsigned frames = 0;
+	// Channel-major IR samples; each inner vector has `frames` elements.
+	std::vector<std::vector<double>> buffers;
+};
+
+// Loads the impulse response at `filename` (or returns the cached copy, keyed
+// by path + mtime + sample rate), validated against the device sample rate.
+// Returns nullptr and logs when the file is unreadable, the sample rate does
+// not match, or the file has no usable audio (0 frames / 0 channels /
+// frames > INT_MAX). One implementation shared by ConvolutionFilter and
+// MultiConvolutionFilter so the intake hardening and the cache cannot
+// diverge between them. (audit #146 TD001)
+std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, double sampleRate);
+
+// RAII owner for a flat HConvSingle array. The array is a single block
+// allocated with MemoryHelper::alloc(sizeof(HConvSingle) * count) and must be
+// torn down by closing every element (hcCloseSingle) before freeing the block.
+// Wrapping it makes that teardown automatic and idempotent. The element count
+// is stored by value at adopt() time (audit #146 TD023 replaced the previous
+// reference-to-owner-member binding, which depended on member declaration
+// order). The type stays a thin handle around HConvSingle*: it converts to the
+// raw pointer, so existing call sites (filters[i], &filters[i],
+// filters == nullptr) keep their exact meaning.
+class HConvSingleArray
+{
+public:
+	HConvSingleArray() = default;
+	~HConvSingleArray() { reset(); }
+
+	HConvSingleArray(const HConvSingleArray&) = delete;
+	HConvSingleArray& operator=(const HConvSingleArray&) = delete;
+
+	// Take ownership of a freshly allocated block holding `newCount` elements.
+	// Any previously held block is torn down first using the same
+	// close-then-free sequence.
+	void adopt(HConvSingle* newPtr, unsigned newCount)
+	{
+		if (newPtr != ptr)
+			reset();
+		ptr = newPtr;
+		count = newCount;
+	}
+
+	HConvSingleArray& operator=(std::nullptr_t)
+	{
+		reset();
+		return *this;
+	}
+
+	HConvSingle& operator[](unsigned i) const { return ptr[i]; }
+	// Implicit decay to the raw pointer keeps every existing use of `filters`
+	// (filters[i], &filters[i], filters == nullptr, hcInitSingle(&filters[i], ...))
+	// byte-for-byte identical to a raw HConvSingle* member.
+	operator HConvSingle*() const { return ptr; }
+
+	// Close every element, then free the block. Mirrors the legacy cleanup()
+	// sequence exactly (hcCloseSingle loop, then MemoryHelper::free).
+	void reset();
+
+private:
+	HConvSingle* ptr = nullptr;
+	unsigned count = 0;
+};

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -18,13 +18,9 @@
 
 #include "stdafx.h"
 #include <algorithm>
-#include <cmath>
-#include <climits>
 #include <cstring>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
 #include <fftw3.h>
 
 #include "helpers/ChannelHelper.h"
@@ -32,7 +28,6 @@
 #include "helpers/MemoryHelper.h"
 #include "MultiConvolutionFilter.h"
 
-using std::abs;
 using std::find;
 using std::vector;
 using std::wstring;
@@ -43,7 +38,6 @@ MultiConvolutionFilter::MultiConvolutionFilter(const vector<MultiConvolutionComm
 	this->filename = filename;
 	sampleRate = 0.0f;
 	filterFrameCount = 0;
-	filters = nullptr;
 	unitCount = 0;
 }
 
@@ -84,46 +78,16 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		plans[i].inputChannel = channelIndex;
 	}
 
-	SF_INFO info{};
-	SNDFILE* in = sf_wchar_open(filename.c_str(), SFM_READ, &info);
-	if (in == nullptr)
-	{
-		LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(in));
+	// Shared IR intake + cache (IrCache.cpp): validates the file, deinterleaves
+	// to channel-major buffers, and lets a config reload (or another filter on
+	// the same IR) skip the disk read entirely. (audit #146 TD001)
+	auto ir = loadIrCached(filename, sampleRate);
+	if (!ir)
 		return outChannelNames;
-	}
-	if (abs(sampleRate - info.samplerate) > 1.0)
-	{
-		LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
-		sf_close(in);
-		return outChannelNames;
-	}
-	if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX)
-	{
-		LogFStatic(L"Impulse response has no usable audio (frames=%lld, channels=%d); ignoring %s",
-			static_cast<long long>(info.frames), info.channels, filename.c_str());
-		sf_close(in);
-		return outChannelNames;
-	}
+	irEntry = ir;
 
-	const unsigned irChannels = (unsigned)info.channels;
-	const unsigned irFrames = (unsigned)info.frames;
-	vector<double> interleaved((size_t)irFrames * irChannels);
-	sf_count_t numRead = 0;
-	while (numRead < info.frames)
-	{
-		sf_count_t got = sf_readf_double(in, interleaved.data() + numRead * irChannels, info.frames - numRead);
-		if (got <= 0)
-			break;
-		numRead += got;
-	}
-	sf_close(in);
-
-	// Deinterleave into channel-major IR buffers so each convolution reads a
-	// contiguous per-channel impulse response.
-	vector<vector<double>> irBuffers(irChannels, vector<double>(irFrames));
-	for (unsigned c = 0; c < irChannels; c++)
-		for (unsigned f = 0; f < irFrames; f++)
-			irBuffers[c][f] = interleaved[(size_t)f * irChannels + c];
+	const unsigned irChannels = ir->channels;
+	const unsigned irFrames = ir->frames;
 
 	// Expand each mapping to its participating IR channels. The simple form
 	// (empty list) means every channel of the file; explicit references beyond
@@ -158,8 +122,8 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		return outChannelNames;
 
 	fftw_make_planner_thread_safe();
-	filters = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * totalUnits);
-	if (filters == nullptr)
+	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * totalUnits);
+	if (allocated == nullptr)
 	{
 		LogF(L"MultiConvolutionFilter: could not allocate %u convolution units", totalUnits);
 		return outChannelNames;
@@ -172,11 +136,14 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		plans[i].firstUnit = next;
 		for (unsigned c : perMapping[i])
 		{
-			hcInitSingle(&filters[next], irBuffers[c].data(), (int)irFrames, (int)maxFrameCount, 1);
+			// hcInitSingle reads the IR samples during planning but does not
+			// retain the pointer, so the shared cache buffer is safe to feed.
+			hcInitSingle(&allocated[next], const_cast<double*>(ir->buffers[c].data()), (int)irFrames, (int)maxFrameCount, 1);
 			next++;
 		}
 		plans[i].unitCount = next - plans[i].firstUnit;
 	}
+	filters.adopt(allocated, next);
 	unitCount = next;
 	filterFrameCount = maxFrameCount;
 
@@ -219,13 +186,12 @@ void MultiConvolutionFilter::process(double** output, double** input, unsigned f
 
 void MultiConvolutionFilter::cleanup()
 {
-	if (filters != nullptr)
-	{
-		for (unsigned u = 0; u < unitCount; u++)
-			hcCloseSingle(&filters[u]);
-		MemoryHelper::free(filters);
-		filters = nullptr;
-	}
+	// HConvSingleArray::reset() runs the close-then-free sequence that used to
+	// be spelled out here. (audit #146 TD002)
+	filters = nullptr;
+	// Release this filter's hold on the cached IR; the weak-ptr cache frees the
+	// entry once the last user drops it.
+	irEntry.reset();
 	unitCount = 0;
 	plans.clear();
 	tempBuffer.clear();

--- a/filters/MultiConvolutionFilter.h
+++ b/filters/MultiConvolutionFilter.h
@@ -18,12 +18,13 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "IFilter.h"
+#include "IrCache.h"
 #include "MultiConvolutionCommand.h"
-#include "libHybridConv-0.1.1/libHybridConv_eapo.h"
 
 // Multi-input synthesis convolution ("다중 합성 컨볼루션"). Unlike the 1:1
 // ConvolutionFilter, this filter convolves each mapping target's own
@@ -71,9 +72,14 @@ private:
 	std::vector<MappingPlan> plans;
 
 	// One convolution state per (mapping, impulse-response channel) pair, laid
-	// out mapping by mapping; plans[] holds the per-mapping ranges.
-	HConvSingle* filters;
+	// out mapping by mapping; plans[] holds the per-mapping ranges. The holder
+	// runs the close-then-free teardown that cleanup() used to spell out by
+	// hand. (audit #146 TD002)
+	HConvSingleArray filters;
 	unsigned unitCount;
+	// Pins the cached impulse response for this filter's lifetime; the
+	// process-wide cache holds only weak references. (audit #146 TD001)
+	std::shared_ptr<const IrCacheEntry> irEntry;
 	// Scratch buffer for one unit's convolution result before it is summed into
 	// the mapping's output. Sized in initialize() so process() never allocates
 	// on the audio thread.

--- a/filters/VSTPluginFilter.cpp
+++ b/filters/VSTPluginFilter.cpp
@@ -44,7 +44,17 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 
 	skipProcessing = false;
 
+	// MemoryHelper::alloc returns nullptr on failure (and logs the size). Every
+	// result below is checked, mirroring DelayFilter's hardening: on failure the
+	// filter degrades to skipProcessing (process() passes audio through) with the
+	// already-built state left consistent for cleanup(). (audit #146 TD022)
 	void* mem = MemoryHelper::alloc(sizeof(VSTPluginInstance));
+	if (mem == nullptr)
+	{
+		LogF(L"The VST plugin %s could not allocate its host instance; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		return channelNames;
+	}
 	VSTPluginInstance* firstEffect = new(mem) VSTPluginInstance(library, 2);
 	if (!firstEffect->initialize())
 	{
@@ -64,10 +74,28 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	// round up
 	effectCount = (channelCount + (effectChannelCount - 1)) / effectChannelCount;
 	effects = (VSTPluginInstance**)MemoryHelper::alloc(effectCount * sizeof(VSTPluginInstance*));
+	if (effects == nullptr)
+	{
+		LogF(L"The VST plugin %s could not allocate its instance table; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		effectCount = 0;
+		firstEffect->~VSTPluginInstance();
+		MemoryHelper::free(firstEffect);
+		return channelNames;
+	}
 	effects[0] = firstEffect;
 	for (unsigned i = 1; i < effectCount; i++)
 	{
 		mem = MemoryHelper::alloc(sizeof(VSTPluginInstance));
+		if (mem == nullptr)
+		{
+			LogF(L"The VST plugin %s could not allocate instance %u; passing audio through.", libPath.c_str(), i);
+			skipProcessing = true;
+			// cleanup() tears down exactly [0, effectCount); entries past i were
+			// never constructed.
+			effectCount = i;
+			return channelNames;
+		}
 		effects[i] = new(mem) VSTPluginInstance(library, 2);
 		if (!effects[i]->initialize() && !skipProcessing)
 		{
@@ -81,19 +109,47 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	// 2 times for input and output
 	emptyChannelCount = 2 * (effectCount * effectChannelCount - channelCount);
 	emptyChannels = (double**)MemoryHelper::alloc(emptyChannelCount * sizeof(double*));
+	if (emptyChannels == nullptr && emptyChannelCount > 0)
+	{
+		LogF(L"The VST plugin %s could not allocate padding channels; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		emptyChannelCount = 0;
+		return channelNames;
+	}
 	for (unsigned i = 0; i < emptyChannelCount; i++)
 	{
 		emptyChannels[i] = static_cast<double*>(MemoryHelper::alloc(maxFrameCount * sizeof *emptyChannels[i]));
+		if (emptyChannels[i] == nullptr)
+		{
+			LogF(L"The VST plugin %s could not allocate padding channel %u; passing audio through.", libPath.c_str(), i);
+			skipProcessing = true;
+			// Entries past i are uninitialized; shrink the count so cleanup()
+			// frees only what was built.
+			emptyChannelCount = i;
+			return channelNames;
+		}
 		std::fill_n(emptyChannels[i], maxFrameCount, 0.0);
 	}
 
 	inputArray = (double**)MemoryHelper::alloc(firstEffect->numInputs() * sizeof(double*));
 	outputArray = (double**)MemoryHelper::alloc(firstEffect->numOutputs() * sizeof(double*));
+	if (inputArray == nullptr || outputArray == nullptr)
+	{
+		LogF(L"The VST plugin %s could not allocate its bus arrays; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		return channelNames;
+	}
 
 	// Allocate float buffers for conversion
 	if (firstEffect->numInputs() > 0) {
 		floatInputs = (float**)MemoryHelper::alloc(firstEffect->numInputs() * sizeof(float*));
 		_floatInputBuffer = static_cast<float*>(MemoryHelper::alloc(firstEffect->numInputs() * maxFrameCount * sizeof *_floatInputBuffer));
+		if (floatInputs == nullptr || _floatInputBuffer == nullptr)
+		{
+			LogF(L"The VST plugin %s could not allocate float input buffers; passing audio through.", libPath.c_str());
+			skipProcessing = true;
+			return channelNames;
+		}
 		for (int i = 0; i < firstEffect->numInputs(); ++i) {
 			floatInputs[i] = _floatInputBuffer + i * maxFrameCount;
 		}
@@ -102,6 +158,12 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	if (firstEffect->numOutputs() > 0) {
 		floatOutputs = (float**)MemoryHelper::alloc(firstEffect->numOutputs() * sizeof(float*));
 		_floatOutputBuffer = static_cast<float*>(MemoryHelper::alloc(firstEffect->numOutputs() * maxFrameCount * sizeof *_floatOutputBuffer));
+		if (floatOutputs == nullptr || _floatOutputBuffer == nullptr)
+		{
+			LogF(L"The VST plugin %s could not allocate float output buffers; passing audio through.", libPath.c_str());
+			skipProcessing = true;
+			return channelNames;
+		}
 		for (int i = 0; i < firstEffect->numOutputs(); ++i) {
 			floatOutputs[i] = _floatOutputBuffer + i * maxFrameCount;
 		}
@@ -112,12 +174,39 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	if (delayBufferLength > 0)
 	{
 		delayBuffers = (double**)MemoryHelper::alloc(channelCount * sizeof(double*));
+		if (delayBuffers == nullptr)
+		{
+			LogF(L"The VST plugin %s could not allocate delay buffers; passing audio through.", libPath.c_str());
+			skipProcessing = true;
+			delayBufferLength = 0;
+			return channelNames;
+		}
 		for (unsigned i = 0; i < channelCount; i++)
 		{
 			delayBuffers[i] = static_cast<double*>(MemoryHelper::alloc(delayBufferLength * sizeof *delayBuffers[i]));
+			if (delayBuffers[i] == nullptr)
+			{
+				LogF(L"The VST plugin %s could not allocate delay buffer %u; passing audio through.", libPath.c_str(), i);
+				skipProcessing = true;
+				// cleanup() walks all channelCount entries; free what was built
+				// and drop the array so it never reads the uninitialized tail.
+				for (unsigned j = 0; j < i; j++)
+					MemoryHelper::free(delayBuffers[j]);
+				MemoryHelper::free(delayBuffers);
+				delayBuffers = nullptr;
+				delayBufferLength = 0;
+				return channelNames;
+			}
 			std::fill_n(delayBuffers[i], delayBufferLength, 0.0);
 		}
 		delayTempBuffer = static_cast<double*>(MemoryHelper::alloc(maxFrameCount * sizeof *delayTempBuffer));
+		if (delayTempBuffer == nullptr)
+		{
+			LogF(L"The VST plugin %s could not allocate its delay scratch buffer; passing audio through.", libPath.c_str());
+			skipProcessing = true;
+			delayBufferLength = 0;
+			return channelNames;
+		}
 		delayBufferOffset = 0;
 	}
 

--- a/helpers/LogHelper.cpp
+++ b/helpers/LogHelper.cpp
@@ -19,6 +19,7 @@
 
 #include "stdafx.h"
 #include <cstdarg>
+#include <mutex>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
@@ -28,34 +29,47 @@
 using std::log;
 using std::wstring;
 
-bool LogHelper::initialized = false;
+std::atomic<bool> LogHelper::initialized{false};
 wstring LogHelper::logPath;
-bool LogHelper::enableTrace = false;
+std::atomic<bool> LogHelper::enableTrace{false};
 FILE* LogHelper::presetFP = nullptr;
 bool LogHelper::compact = false;
 bool LogHelper::useConsoleColors = false;
 
 void LogHelper::log(const char* file, int line, const void* caller, bool trace, const wchar_t* format, ...)
 {
-	if (!initialized)
+	// Two first-loggers used to race on writing logPath (a std::wstring) while
+	// the other read it. Double-checked init under a mutex; the release store
+	// pairs with the acquire load so later loggers see logPath. (audit #146 TD028)
+	if (!initialized.load(std::memory_order_acquire))
 	{
-		// Do not try to initialize again, even in case of error
-		initialized = true;
-
-		wchar_t temp[255];
-		GetTempPathW(sizeof(temp) / sizeof(wchar_t), temp);
-
-		logPath = temp;
-		logPath += L"EqualizerAPO.log";
-
-		try
+		static std::mutex initMutex;
+		std::lock_guard<std::mutex> lock(initMutex);
+		if (!initialized.load(std::memory_order_relaxed))
 		{
-			if (RegistryHelper::readValue(APP_REGPATH, L"EnableTrace") != L"false")
-				enableTrace = true;
-		}
-		catch (const RegistryException& e)
-		{
-			LogFStatic(L"%s", e.getMessage());
+			wchar_t temp[255];
+			GetTempPathW(sizeof(temp) / sizeof(wchar_t), temp);
+
+			logPath = temp;
+			logPath += L"EqualizerAPO.log";
+
+			// Publish before the registry probe, and do not try to initialize
+			// again even in case of error: the catch below logs through
+			// LogFStatic, which re-enters log() on this thread and must take
+			// the fast path (logPath is set) instead of deadlocking here.
+			initialized.store(true, std::memory_order_release);
+
+			try
+			{
+				if (RegistryHelper::readValue(APP_REGPATH, L"EnableTrace") != L"false")
+					enableTrace = true;
+			}
+			catch (const RegistryException& e)
+			{
+				// getMessage() returns a std::wstring; passing it through
+				// varargs is undefined behavior. (audit #146 TD024)
+				LogFStatic(L"%s", e.getMessage().c_str());
+			}
 		}
 	}
 

--- a/helpers/LogHelper.h
+++ b/helpers/LogHelper.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <cstdio>
 
@@ -35,9 +36,13 @@ public:
 	static void set(FILE* fp, bool enableTrace, bool compact, bool useConsoleColors);
 
 private:
-	static bool initialized;
+	// First log() call may race between RT, worker, and GUI threads: the
+	// acquire load on `initialized` publishes `logPath` written under the init
+	// mutex in log(). reset()/set() stay single-threaded test/tool helpers.
+	// (audit #146 TD028)
+	static std::atomic<bool> initialized;
 	static std::wstring logPath;
-	static bool enableTrace;
+	static std::atomic<bool> enableTrace;
 	static FILE* presetFP;
 	static bool compact;
 	static bool useConsoleColors;

--- a/helpers/VSTPluginInstance.cpp
+++ b/helpers/VSTPluginInstance.cpp
@@ -413,13 +413,6 @@ void VSTPluginInstance::setSizeWindowFunc(std::function<void(int, int)> func)
 	sizeWindowFunc = func;
 }
 
-bool VSTPluginInstance::getEditorSize(int* width, int* height)
-{
-	(void)width;
-	(void)height;
-	return false;
-}
-
 void VSTPluginInstance::onSizeWindow(int w, int h)
 {
 	if (vst3EditorHostWindow != NULL)

--- a/helpers/VSTPluginInstance.h
+++ b/helpers/VSTPluginInstance.h
@@ -77,7 +77,6 @@ public:
 
 	void setSizeWindowFunc(std::function<void(int, int)> func);
 	void onSizeWindow(int w, int h);
-	bool getEditorSize(int* width, int* height);
 
 private:
 	class VST3HostContext;


### PR DESCRIPTION
감사 이슈 #146의 런타임/견고성 발견 12건을 반영합니다. 자세한 발견별 내역은 커밋 메시지에 있습니다.

- **TD026(High):** initialize()가 구성을 못 싣고 끝난 상태(레지스트리 ConfigPath 불가 + custom path 없음, 또는 initialize 전 호출)에서 process() 4개 오버로드 전부가 null currentConfig를 역참조해 audiodg.exe를 죽이던 경로에 빈 구성 우회 가드를 넣었습니다. EngineOrchestrationTests에 회귀 테스트를 추가했고, 가드 없는 기존 Common.lib에서는 이 테스트가 실제로 세그폴트합니다(버그 실재 확인).
- **TD001/TD002/TD023:** IR 인테이크와 weak-ptr 캐시를 filters/IrCache.{h,cpp}로 추출해 MultiConvolution도 캐시를 쓰게 했습니다(리로드마다 BRIR 전체 재독취 제거). 수동 teardown은 RAII 홀더로 대체, 홀더는 참조 대신 값으로 카운트를 보관합니다.
- **TD022/TD027/TD028/TD024/TD025/TD030/TD033/TD010:** VST 필터 할당 하드닝(+감사가 놓친 GraphicEQFilter 동형 사례), 레지스트리 감시 셋 스냅숏, LogHelper 초기화 경쟁 수정, varargs UB 수정, _Copy_s 대체, 경계 있는 누수 문서화, 크로스페이드 길이 getter, 죽은 스텁 삭제.

로컬 검증은 HybridConvTests(MultiConvolution 3421 체크 포함), EngineOrchestrationTests(493 체크, 신규 테스트 포함), EditorLogicTests 전체 통과와 변경 파일 cppcheck 2.21.0 깨끗입니다.

머지 순서상 이 PR은 감사 반영 PR들 중 마지막에 머지합니다(fix: 릴리스가 전체 매트릭스로 나머지 no-bump PR까지 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)