### PR TITLE
refactor(editor): one row-GUI selection path and shared build glue

### DIFF
--- a/DeviceSelector/DeviceSelector.pro
+++ b/DeviceSelector/DeviceSelector.pro
@@ -59,35 +59,16 @@ LIBS += Kernel32.lib version.lib Shlwapi.lib authz.lib user32.lib advapi32.lib c
 
 # Include Common.lib
 LIBS += Common.lib
+include($$PWD/../common.pri)
 contains(QT_ARCH, arm64) {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../ARM64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../ARM64/Release"
-	}
-} else:!isEmpty(EAPO_SIMD_FLAGS) {
-	QMAKE_CXXFLAGS += $$EAPO_SIMD_FLAGS
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../x64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../x64/Release"
-	}
-} else:equals(EAPO_SIMD_BASELINE, 1) {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../x64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../x64/Release"
-	}
+	EAPO_COMMON_ARCH = ARM64
 } else {
-	# A non-ARM64 build that passes no SIMD selection used to fall back to /arch:AVX2
-	# while still labelling the binary with whatever EAPO_UPDATE_CHANNEL it was given.
-	# That silently mislabels a misconfigured local build as AVX2. Fail loudly instead;
-	# the documented local + CI command passes EAPO_SIMD_FLAGS and EAPO_UPDATE_CHANNEL
-	# (e.g. EAPO_SIMD_FLAGS=/arch:AVX2 EAPO_UPDATE_CHANNEL=x64-avx2).
-	error("EAPO_SIMD_FLAGS must be set for x64 builds (e.g. EAPO_SIMD_FLAGS=/arch:AVX2), or pass EAPO_SIMD_BASELINE=1 for the SSE2 baseline. Also set EAPO_UPDATE_CHANNEL to the matching channel (e.g. x64-avx2). See .github/simd-variants.psd1 for the variant/channel map.")
+	EAPO_COMMON_ARCH = x64
+}
+build_pass:CONFIG(debug, debug|release) {
+	QMAKE_LIBDIR += "../$$EAPO_COMMON_ARCH/Debug"
+} else {
+	QMAKE_LIBDIR += "../$$EAPO_COMMON_ARCH/Release"
 }
 
 # UAC: Require Administrator

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -546,21 +546,8 @@ build_pass:CONFIG(debug, debug|release) {
 	LIBS += muparserx.lib
 }
 
-contains(QT_ARCH, arm64) {
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
-} else:!isEmpty(EAPO_SIMD_FLAGS) {
-	QMAKE_CXXFLAGS += $$EAPO_SIMD_FLAGS
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
-} else:equals(EAPO_SIMD_BASELINE, 1) {
-	QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
-} else {
-	# A non-ARM64 build that passes no SIMD selection used to fall back to /arch:AVX2
-	# while still labelling the binary with whatever EAPO_UPDATE_CHANNEL it was given.
-	# That silently mislabels a misconfigured local build as AVX2. Fail loudly instead;
-	# the documented local + CI command passes EAPO_SIMD_FLAGS and EAPO_UPDATE_CHANNEL
-	# (e.g. EAPO_SIMD_FLAGS=/arch:AVX2 EAPO_UPDATE_CHANNEL=x64-avx2).
-	error("EAPO_SIMD_FLAGS must be set for x64 builds (e.g. EAPO_SIMD_FLAGS=/arch:AVX2), or pass EAPO_SIMD_BASELINE=1 for the SSE2 baseline. Also set EAPO_UPDATE_CHANNEL to the matching channel (e.g. x64-avx2). See .github/simd-variants.psd1 for the variant/channel map.")
-}
+include($$PWD/../common.pri)
+QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 
 # Include Common.lib
 LIBS += Common.lib

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -164,61 +164,7 @@ void FilterTable::updateGuis()
 	int row = 0;
 	for (Item* item : items)
 	{
-		QString line = item->text;
-		IFilterGUI* gui = nullptr;
-		int pos = line.indexOf(':');
-		// A pure comment has no "command: parameters" shape (with or without an
-		// inner colon), so it never reaches the factories below. In card mode it
-		// still gets a real editor; the legacy path stays frozen (raw row).
-		if (renderMode == ModernCards && FilterCardModel::isPureCommentLine(line))
-		{
-			gui = new CommentCardEditor(line);
-		}
-		else if (pos != -1)
-		{
-			QString key = line.mid(0, pos);
-			QString value = line.mid(pos + 1);
-
-			// allow to use indentation
-			key = key.trimmed();
-			QString factoryKey = key;
-			QString factoryValue = value;
-
-			for (IFilterGUIFactory* factory : factories)
-			{
-				gui = factory->createFilterGUI(factoryKey, factoryValue);
-
-				if (gui != nullptr || factoryKey == "")
-					break;
-			}
-
-			if (gui != nullptr)
-			{
-				bool usingCardEditor = false;
-				if (renderMode == ModernCards)
-				{
-					// factoryKey is the command after CommentFilterGUIFactory strips a leading '#',
-					// so both "Include: a.txt" and "# Include: a.txt" reach the card factory with
-					// the same key. Without this, only the active line would receive the modern
-					// card editor and the commented line would fall back to the legacy GUI.
-					IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
-					if (cardGui != nullptr)
-					{
-						delete gui;
-						gui = cardGui;
-						usingCardEditor = true;
-					}
-				}
-
-				// In Modern Cards we skip the legacy CommentFilterGUI decorator on
-				// purpose: the card row already owns the enable/disable affordance
-				// and a second power toolbar inside the body editor only produces
-				// rules that disagree with the card header.
-				if (!usingCardEditor && renderMode != ModernCards)
-					for (IFilterGUIFactory* factory : factories)
-						gui = factory->decorateFilterGUI(gui);
-			}
-		}
+		IFilterGUI* gui = createRowGui(item->text);
 
 		// ModernCards (FilterCardRow) is the canonical filter-list UI; LegacyRows
 		// (FilterTableRow) is a frozen fallback that must not be extended. New
@@ -272,6 +218,74 @@ void FilterTable::updateGuis()
 	update();
 }
 
+IFilterGUI* FilterTable::createRowGui(const QString& line)
+{
+	// A pure comment has no "command: parameters" shape (with or without an
+	// inner colon), so it never reaches the factories below. In card mode it
+	// still gets a real editor; the legacy path stays frozen (raw row).
+	if (renderMode == ModernCards && FilterCardModel::isPureCommentLine(line))
+		return new CommentCardEditor(line);
+
+	int pos = line.indexOf(':');
+	if (pos == -1)
+		return nullptr;
+
+	// allow to use indentation
+	QString factoryKey = line.mid(0, pos).trimmed();
+	QString factoryValue = line.mid(pos + 1);
+
+	if (renderMode == ModernCards)
+	{
+		// Card editors take precedence, so ask them before running the legacy
+		// chain: constructing a legacy GUI only to replace and delete it parsed
+		// VSTPlugin state twice per rebuild. Safe to short-circuit because the
+		// card-covered factories keep no per-row state in createFilterGUI (their
+		// state is set in initialize()/startOfFile()). Commented lines ("# ...")
+		// do not match here and fall through to the chain, where
+		// CommentFilterGUIFactory strips the '#'; the post-chain lookup below
+		// then gives them the same card editor as their active form.
+		// (audit #146 TD004)
+		IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
+		if (cardGui != nullptr)
+			return cardGui;
+	}
+
+	IFilterGUI* gui = nullptr;
+	for (IFilterGUIFactory* factory : factories)
+	{
+		gui = factory->createFilterGUI(factoryKey, factoryValue);
+		if (gui != nullptr || factoryKey == "")
+			break;
+	}
+
+	if (gui == nullptr)
+		return nullptr;
+
+	if (renderMode == ModernCards)
+	{
+		// factoryKey is the command after CommentFilterGUIFactory strips a
+		// leading '#', so "# Include: a.txt" reaches the card factory with the
+		// same key as "Include: a.txt". Without this, only the active line
+		// would receive the modern card editor and the commented line would
+		// fall back to the legacy GUI.
+		IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
+		if (cardGui != nullptr)
+		{
+			delete gui;
+			return cardGui;
+		}
+		// In Modern Cards we skip the legacy CommentFilterGUI decorator on
+		// purpose: the card row already owns the enable/disable affordance
+		// and a second power toolbar inside the body editor only produces
+		// rules that disagree with the card header.
+		return gui;
+	}
+
+	for (IFilterGUIFactory* factory : factories)
+		gui = factory->decorateFilterGUI(gui);
+	return gui;
+}
+
 void FilterTable::updateSingleRowGui(Item* item)
 {
 	int rowIndex = items.indexOf(item);
@@ -298,48 +312,12 @@ void FilterTable::updateSingleRowGui(Item* item)
 	gridLayout->removeWidget(oldRow);
 	oldRow->deleteLater();
 
-	// Reparse the line and rebuild the GUI exactly the way updateGuis() does,
-	// using the same factory chain. Factory startOfFile/endOfFile is skipped
-	// intentionally: a single in-place edit (enabled toggle) does not change
-	// the surrounding file's structural context, so the include/depth state
-	// the factories track stays valid.
-	QString line = item->text;
-	IFilterGUI* gui = nullptr;
-	int colonPos = line.indexOf(':');
-	if (colonPos != -1)
-	{
-		QString key = line.mid(0, colonPos).trimmed();
-		QString value = line.mid(colonPos + 1);
-
-		QString factoryKey = key;
-		QString factoryValue = value;
-		for (IFilterGUIFactory* factory : factories)
-		{
-			gui = factory->createFilterGUI(factoryKey, factoryValue);
-			if (gui != nullptr || factoryKey == "")
-				break;
-		}
-
-		if (gui != nullptr)
-		{
-			bool usingCardEditor = false;
-			if (renderMode == ModernCards)
-			{
-				IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
-				if (cardGui != nullptr)
-				{
-					delete gui;
-					gui = cardGui;
-					usingCardEditor = true;
-				}
-			}
-			// Same decorator gating as updateGuis(): Modern Cards owns power UI
-			// in the card header, no additional CommentFilterGUI toolbar inside.
-			if (!usingCardEditor && renderMode != ModernCards)
-				for (IFilterGUIFactory* factory : factories)
-					gui = factory->decorateFilterGUI(gui);
-		}
-	}
+	// Rebuild the GUI through the same selection policy as updateGuis().
+	// Factory startOfFile/endOfFile is skipped intentionally: a single
+	// in-place edit (enabled toggle) does not change the surrounding file's
+	// structural context, so the include/depth state the factories track
+	// stays valid.
+	IFilterGUI* gui = createRowGui(item->text);
 
 	QVector<int> rowDepths = FilterCardModel::calculateDepths(getLines());
 	int depth = rowIndex < rowDepths.size() ? rowDepths[rowIndex] : 0;

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -36,6 +36,7 @@
 #include "IFilterGUIFactory.h"
 
 class MainWindow;
+class QMimeData;
 
 // FilterTable's implementation is split across several translation units (all
 // listed in Editor.pro SOURCES). When looking for a method, check the matching
@@ -166,6 +167,14 @@ private:
 	QRectF rowRect(int row);
 	void disableWheelForWidgets();
 	void updateRowWidgets();
+	// The single row-GUI selection policy (pure-comment card, card-first
+	// lookup, legacy factory chain, card override for commented lines,
+	// decorator gating). Shared by updateGuis() and updateSingleRowGui() so
+	// policy edits happen once. (audit #146 TD005)
+	IFilterGUI* createRowGui(const QString& line);
+	// Inserts the mime data's lines at dropRow and makes them the selection.
+	// Shared by paste() and dropEvent(). (audit #146 TD006)
+	void insertLinesFromMimeData(const QMimeData* mimeData, int dropRow);
 
 	MainWindow* mainWindow;
 	QScrollArea* scrollArea;

--- a/Editor/FilterTableParts/FilterTable.Clipboard.cpp
+++ b/Editor/FilterTableParts/FilterTable.Clipboard.cpp
@@ -99,33 +99,38 @@ void FilterTable::paste()
 			}
 		}
 
-		QString text = mimeData->text();
-		QStringList textLines = text.split("\n");
-		QList<QVariantMap> prefsList;
-		const FilterTableMimeData* filterTableMimeData = qobject_cast<const FilterTableMimeData*>(mimeData);
-		if (filterTableMimeData != nullptr)
-			prefsList = filterTableMimeData->getPrefsList();
-
-		selected.clear();
-		focused = nullptr;
-		selectionStart = nullptr;
-		for (int i = 0; i < textLines.size(); i++)
-		{
-			QString line = textLines[i];
-			Item* item = new Item(line);
-			if (i < prefsList.size())
-				item->prefs = prefsList[i];
-			selected.insert(item);
-			items.insert(dropRow++, item);
-			if (focused == nullptr)
-			{
-				focused = item;
-				selectionStart = item;
-			}
-		}
+		insertLinesFromMimeData(mimeData, dropRow);
 
 		emit linesChanged();
 		updateGuis();
+	}
+}
+
+void FilterTable::insertLinesFromMimeData(const QMimeData* mimeData, int dropRow)
+{
+	QString text = mimeData->text();
+	QStringList textLines = text.split("\n");
+	QList<QVariantMap> prefsList;
+	const FilterTableMimeData* filterTableMimeData = qobject_cast<const FilterTableMimeData*>(mimeData);
+	if (filterTableMimeData != nullptr)
+		prefsList = filterTableMimeData->getPrefsList();
+
+	selected.clear();
+	focused = nullptr;
+	selectionStart = nullptr;
+	for (int i = 0; i < textLines.size(); i++)
+	{
+		QString line = textLines[i];
+		Item* item = new Item(line);
+		if (i < prefsList.size())
+			item->prefs = prefsList[i];
+		selected.insert(item);
+		items.insert(dropRow++, item);
+		if (focused == nullptr)
+		{
+			focused = item;
+			selectionStart = item;
+		}
 	}
 }
 

--- a/Editor/FilterTableParts/FilterTable.DragDrop.cpp
+++ b/Editor/FilterTableParts/FilterTable.DragDrop.cpp
@@ -108,34 +108,11 @@ void FilterTable::dropEvent(QDropEvent* event)
 		else
 			event->setDropAction(Qt::MoveAction);
 
-		QString text = mimeData->text();
-		QStringList textLines = text.split("\n");
-		QList<QVariantMap> prefsList;
-		const FilterTableMimeData* filterTableMimeData = qobject_cast<const FilterTableMimeData*>(mimeData);
-		if (filterTableMimeData != nullptr)
-			prefsList = filterTableMimeData->getPrefsList();
-
 		int dropRow = rowForPos(event->pos(), true);
 		if (dropRow == -1)
 			dropRow = items.size();
 
-		selected.clear();
-		focused = nullptr;
-		selectionStart = nullptr;
-		for (int i = 0; i < textLines.size(); i++)
-		{
-			QString line = textLines[i];
-			Item* item = new Item(line);
-			if (i < prefsList.size())
-				item->prefs = prefsList[i];
-			selected.insert(item);
-			items.insert(dropRow++, item);
-			if (focused == nullptr)
-			{
-				focused = item;
-				selectionStart = item;
-			}
-		}
+		insertLinesFromMimeData(mimeData, dropRow);
 		event->accept();
 
 		if (!internalDrag)

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -51,7 +51,7 @@ class TitleBar;
 //   MainWindow.cpp                             - ctor/dtor, shared setup, doChecks
 //   MainWindowParts/MainWindow.Analysis.cpp    - instant mode + analysis panel
 //   MainWindowParts/MainWindow.Device.cpp      - device/channel selection + tabs
-//   MainWindowParts/MainWindow.Edit.cpp        - cut/copy/paste/undo edit actions
+//   MainWindowParts/MainWindow.Edit.cpp        - cut/copy/paste edit actions
 //   MainWindowParts/MainWindow.FileActions.cpp - open/save/recent menu actions
 //   MainWindowParts/MainWindow.FileIO.cpp      - config load/save
 //   MainWindowParts/MainWindow.Frame.cpp       - custom window chrome / title bar

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -54,6 +54,7 @@
 #include "helpers/ApoRegistration.h"
 #include "helpers/RegistryHelper.h"
 #include "helpers/VelopackBootstrap.h"
+#include "version.h"
 #include "Editor/helpers/CrashHandler.h"
 #include "Editor/helpers/GUIHelper.h"
 
@@ -536,7 +537,7 @@ int main(int argc, char* argv[])
 #ifdef EAPO_UPDATE_CHANNEL
 				channel = EAPO_UPDATE_CHANNEL;
 #endif
-				VelopackBootstrap::startBackgroundDownload("https://github.com/115dkk/EqualizerAPO-XT", channel);
+				VelopackBootstrap::startBackgroundDownload(EAPO_REPO_URL, channel);
 			});
 		}
 

--- a/Installer/AutoInstaller.cpp
+++ b/Installer/AutoInstaller.cpp
@@ -37,6 +37,8 @@
 #include <intrin.h>      // __cpuid, __cpuidex, _xgetbv
 #include <string>
 
+#include "../version.h"
+
 #pragma comment(lib, "winhttp.lib")
 #pragma comment(lib, "bcrypt.lib")
 #pragma comment(lib, "ole32.lib")
@@ -48,7 +50,7 @@ namespace
 // the in-app updater (Editor/main.cpp).
 const wchar_t* kRepoOwner = L"115dkk";
 const wchar_t* kRepoName = L"EqualizerAPO-XT";
-const wchar_t* kReleasesPage = L"https://github.com/115dkk/EqualizerAPO-XT/releases/latest";
+const wchar_t* kReleasesPage = EAPO_REPO_URL_W L"/releases/latest";
 const wchar_t* kUserAgent = L"EqualizerAPO-XT-Setup";
 
 // Checksums asset that CI publishes to every release, one sha256sum-style

--- a/UpdateChecker/UpdateChecker.pro
+++ b/UpdateChecker/UpdateChecker.pro
@@ -62,35 +62,16 @@ LIBS += -lSecur32 -ltaskschd Kernel32.lib version.lib oleaut32.lib Shlwapi.lib u
 
 # Include Common.lib
 LIBS += Common.lib
+include($$PWD/../common.pri)
 contains(QT_ARCH, arm64) {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../ARM64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../ARM64/Release"
-	}
-} else:!isEmpty(EAPO_SIMD_FLAGS) {
-	QMAKE_CXXFLAGS += $$EAPO_SIMD_FLAGS
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../x64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../x64/Release"
-	}
-} else:equals(EAPO_SIMD_BASELINE, 1) {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../x64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../x64/Release"
-	}
+	EAPO_COMMON_ARCH = ARM64
 } else {
-	# A non-ARM64 build that passes no SIMD selection used to fall back to /arch:AVX2
-	# while still labelling the binary with whatever EAPO_UPDATE_CHANNEL it was given.
-	# That silently mislabels a misconfigured local build as AVX2. Fail loudly instead;
-	# the documented local + CI command passes EAPO_SIMD_FLAGS and EAPO_UPDATE_CHANNEL
-	# (e.g. EAPO_SIMD_FLAGS=/arch:AVX2 EAPO_UPDATE_CHANNEL=x64-avx2).
-	error("EAPO_SIMD_FLAGS must be set for x64 builds (e.g. EAPO_SIMD_FLAGS=/arch:AVX2), or pass EAPO_SIMD_BASELINE=1 for the SSE2 baseline. Also set EAPO_UPDATE_CHANNEL to the matching channel (e.g. x64-avx2). See .github/simd-variants.psd1 for the variant/channel map.")
+	EAPO_COMMON_ARCH = x64
+}
+build_pass:CONFIG(debug, debug|release) {
+	QMAKE_LIBDIR += "../$$EAPO_COMMON_ARCH/Debug"
+} else {
+	QMAKE_LIBDIR += "../$$EAPO_COMMON_ARCH/Release"
 }
 
 RC_FILE = UpdateChecker.rc

--- a/UpdateChecker/main.cpp
+++ b/UpdateChecker/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 		version += QString(".%0").arg(REVISION);
 
 	QString channel = VelopackUpdateInfo::defaultChannel();
-	QString url = VelopackUpdateInfo::githubLatestReleaseUrl("115dkk/EqualizerAPO-XT");
+	QString url = VelopackUpdateInfo::githubLatestReleaseUrl(EAPO_REPO_SLUG);
 	QString skipVersion;
 	if (autoMode)
 	{

--- a/common.pri
+++ b/common.pri
@@ -1,0 +1,20 @@
+# Shared qmake fragment for the three Qt apps (Editor, DeviceSelector,
+# UpdateChecker). The SIMD flag selection and its misconfiguration gate used
+# to be pasted into each .pro, so every change had to be made three times.
+# QMAKE_LIBDIR stays in each .pro: the Editor links the dependency lib
+# directories directly while the satellite apps link the MSBuild output tree.
+# (audit #146 TD012)
+contains(QT_ARCH, arm64) {
+	# ARM64 builds take NEON without an /arch switch.
+} else:!isEmpty(EAPO_SIMD_FLAGS) {
+	QMAKE_CXXFLAGS += $$EAPO_SIMD_FLAGS
+} else:equals(EAPO_SIMD_BASELINE, 1) {
+	# SSE2 baseline: the MSVC x64 default, no /arch switch.
+} else {
+	# A non-ARM64 build that passes no SIMD selection used to fall back to /arch:AVX2
+	# while still labelling the binary with whatever EAPO_UPDATE_CHANNEL it was given.
+	# That silently mislabels a misconfigured local build as AVX2. Fail loudly instead;
+	# the documented local + CI command passes EAPO_SIMD_FLAGS and EAPO_UPDATE_CHANNEL
+	# (e.g. EAPO_SIMD_FLAGS=/arch:AVX2 EAPO_UPDATE_CHANNEL=x64-avx2).
+	error("EAPO_SIMD_FLAGS must be set for x64 builds (e.g. EAPO_SIMD_FLAGS=/arch:AVX2), or pass EAPO_SIMD_BASELINE=1 for the SSE2 baseline. Also set EAPO_UPDATE_CHANNEL to the matching channel (e.g. x64-avx2). See .github/simd-variants.psd1 for the variant/channel map.")
+}

--- a/version.h
+++ b/version.h
@@ -1,3 +1,11 @@
 #define MAJOR 2
 #define MINOR 8
 #define REVISION 0
+
+// Canonical GitHub repository for release and update URLs, consumed by the
+// Editor's Velopack bootstrap, the UpdateChecker, and the auto-detect
+// installer so the location is written down once. (audit #146 TD017)
+#define EAPO_REPO_SLUG "115dkk/EqualizerAPO-XT"
+#define EAPO_REPO_URL "https://github.com/" EAPO_REPO_SLUG
+#define EAPO_REPO_SLUG_W L"115dkk/EqualizerAPO-XT"
+#define EAPO_REPO_URL_W L"https://github.com/" EAPO_REPO_SLUG_W


### PR DESCRIPTION
감사 이슈 #146의 Editor·빌드 글루 6건(TD004, TD005, TD006, TD012, TD017, TD046)을 반영합니다.

- updateGuis()와 updateSingleRowGui()에 이중화돼 있던 행 GUI 선택 정책을 createRowGui() 하나로 합쳤습니다. 단일 행 경로가 순수 주석 행에 카드 에디터를 만들지 않던 잠복 불일치도 이 통합으로 함께 사라집니다(TD005).
- 카드 모드에서 카드 팩토리를 레거시 체인보다 먼저 조회해, 활성 VSTPlugin 행이 리빌드마다 플러그인 상태를 두 번 파싱하던 낭비를 없앴습니다. 카드가 담당하는 레거시 팩토리 8종 모두 createFilterGUI에 행간 상태가 없음을 확인하고 적용했습니다(TD004).
- paste()/dropEvent()의 붙여넣기 루프를 공유 헬퍼로 추출했습니다(TD006).
- 저장소 슬러그/URL을 version.h 상수로 만들어 Editor, UpdateChecker, AutoInstaller(감사가 놓친 세 번째 사이트)가 함께 씁니다(TD017).
- 세 .pro에 삼중화돼 있던 qmake SIMD 게이트를 common.pri로 승격했습니다. QMAKE_LIBDIR은 앱별로 다른 페이로드라 각자 유지합니다(TD012).
- MainWindow 부분 파일 색인의 존재하지 않는 undo 언급을 지웠습니다(TD046).

TD003(카드 에디터 자기등록)은 TD005 이후 if-체인 조회 지점이 하나뿐이라 실익이 줄어 후속으로 보류했습니다.

검증은 새 common.pri 경유 Editor qmake+nmake 빌드, EditorLogicTests 161 체크, studio 스킨 갤러리 자기 검사(122샷), 변경 파일 cppcheck 2.21.0 깨끗입니다. 위성 앱 빌드는 PR CI가 검증합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)