### PR TITLE
test: cover the ConfigFileCodec seam and share the parser extension roster

### DIFF
--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -371,6 +371,7 @@
     <ClInclude Include="parser\LogicalOperators.h" />
     <ClInclude Include="parser\RegexFunctions.h" />
     <ClInclude Include="parser\RegistryFunctions.h" />
+    <ClInclude Include="parser\ParserExtensions.h" />
     <ClInclude Include="parser\StringOperators.h" />
     <ClInclude Include="VoicemeeterAPOInfo.h" />
     <ClInclude Include="stdafx.h" />
@@ -452,6 +453,7 @@
     <ClCompile Include="IFilter.cpp" />
     <ClCompile Include="libHybridConv-0.1.1\libHybridConv_eapo.cpp" />
     <ClCompile Include="parser\LogicalOperators.cpp" />
+    <ClCompile Include="parser\ParserExtensions.cpp" />
     <ClCompile Include="parser\RegexFunctions.cpp" />
     <ClCompile Include="parser\RegistryFunctions.cpp" />
     <ClCompile Include="parser\StringOperators.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -173,6 +173,9 @@
     <ClInclude Include="parser\RegistryFunctions.h">
       <Filter>parser</Filter>
     </ClInclude>
+    <ClInclude Include="parser\ParserExtensions.h">
+      <Filter>parser</Filter>
+    </ClInclude>
     <ClInclude Include="parser\StringOperators.h">
       <Filter>parser</Filter>
     </ClInclude>
@@ -363,6 +366,9 @@
     </ClCompile>
     <ClCompile Include="libHybridConv-0.1.1\libHybridConv_eapo.cpp">
       <Filter>libHybridConv-0.1.1</Filter>
+    </ClCompile>
+    <ClCompile Include="parser\ParserExtensions.cpp">
+      <Filter>parser</Filter>
     </ClCompile>
     <ClCompile Include="parser\RegexFunctions.cpp">
       <Filter>parser</Filter>

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -153,6 +153,7 @@ SOURCES += main.cpp\
 	../filters/IncludeFilterFactory.cpp \
 	../filters/ChannelFilter.cpp \
 	../filters/ConvolutionFilter.cpp \
+	../parser/ParserExtensions.cpp \
 	../parser/RegexFunctions.cpp \
 	../parser/RegistryFunctions.cpp \
 	../parser/StringOperators.cpp \
@@ -363,6 +364,7 @@ HEADERS  += \
 	../filters/ConvolutionFilter.h \
 	../parser/RegexFunctions.h \
 	../parser/RegistryFunctions.h \
+	../parser/ParserExtensions.h \
 	../parser/StringOperators.h \
 	AnalysisThread.h \
 	widgets/ExponentialSpinBox.h \

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -14,6 +14,7 @@
 #include <QTemporaryDir>
 #include <QTextStream>
 
+#include "Editor/ConfigFileCodec.h"
 #include "Editor/helpers/ConvolutionPathHelper.h"
 #include "Editor/import/ConfigDependencyScanner.h"
 #include "Editor/import/ImportExecutor.h"
@@ -710,6 +711,32 @@ int main(int argc, char** argv)
 		model.setFactorText(0, "0.5");
 		model.addTrace(2, 1);
 		expectEqual(formatted(model.assignments()), "L=1*0+1*1 R=1*2", "fixed mode keeps every factor at unity");
+	}
+
+	{
+		// ConfigFileCodec::decodeLines/encodeLines were extracted expressly as
+		// an independently testable seam but had no tests. (audit #146 TD031)
+		QList<QString> mixed = ConfigFileCodec::decodeLines(std::string("Preamp: -6 dB\r\nInclude: a.txt\nlast"));
+		expectEqual((int)mixed.size(), 3, "decodeLines splits CRLF and LF terminated lines");
+		expectEqual(mixed[0], "Preamp: -6 dB", "decodeLines strips the trailing CR");
+		expectEqual(mixed[2], "last", "decodeLines keeps the final unterminated line");
+
+		QList<QString> unicode = ConfigFileCodec::decodeLines(std::string("# caf\xC3\xA9"));
+		expectEqual(unicode[0], QString::fromUtf8("# caf\xC3\xA9"), "decodeLines decodes valid UTF-8");
+
+		// 0xE9 alone is invalid UTF-8, so the system-ANSI fallback must engage.
+		// The decoded glyph depends on the machine's CP_ACP (e.g. CP1252 vs
+		// CP949), so only the line structure is asserted, not the character.
+		QList<QString> fallback = ConfigFileCodec::decodeLines(std::string("caf\xE9\r\nnext"));
+		expectEqual((int)fallback.size(), 2, "ANSI fallback still yields one entry per line");
+		expectEqual(fallback[1], "next", "ANSI fallback preserves the following line");
+
+		QByteArray encoded = ConfigFileCodec::encodeLines(QList<QString>() << "a" << QString::fromUtf8("caf\xC3\xA9"));
+		expectEqual(QString::fromUtf8(encoded), QString::fromUtf8("a\r\ncaf\xC3\xA9"), "encodeLines joins with CRLF, UTF-8, no trailing newline");
+
+		QList<QString> roundTrip = ConfigFileCodec::decodeLines(std::string(encoded.constData(), (size_t)encoded.size()));
+		expectEqual((int)roundTrip.size(), 2, "encodeLines output decodes back to the same line count");
+		expectEqual(roundTrip[1], QString::fromUtf8("caf\xC3\xA9"), "decode(encode(lines)) round-trips non-ASCII text");
 	}
 
 	harness.report();

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -115,6 +115,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="EditorLogicTests.cpp" />
+    <ClCompile Include="..\..\Editor\ConfigFileCodec.cpp" />
     <ClCompile Include="..\..\Editor\helpers\ConvolutionPathHelper.cpp" />
     <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp" />
     <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp" />

--- a/Tests/HybridConvTests/ParserTests.cpp
+++ b/Tests/HybridConvTests/ParserTests.cpp
@@ -23,9 +23,7 @@
 #include <mpPackageStr.h>
 #include <mpPackageMatrix.h>
 
-#include "parser/RegexFunctions.h"
-#include "parser/StringOperators.h"
-#include "parser/LogicalOperators.h"
+#include "parser/ParserExtensions.h"
 #include "Tests/TestHarness.h"
 
 using std::wstring;
@@ -56,12 +54,10 @@ void configureParser(ParserX& parser)
 	parser.AddPackage(PackageStr::Instance());
 	parser.AddPackage(PackageMatrix::Instance());
 
-	parser.DefineFun(new RegexSearchFunction());
-	parser.DefineFun(new RegexReplaceFunction());
-
-	parser.RemoveOprt(L"+");
-	parser.DefineOprt(new AddOperator());
-	parser.DefineInfixOprt(new NotOperator());
+	// Same engine-free roster as ExpressionFilterFactory::initialize; the
+	// engine-bound registrations (readRegString etc.) stay engine-only.
+	// (audit #146 TD021)
+	registerEngineFreeParserExtensions(parser);
 }
 
 double evalFloat(ParserX& parser, const wstring& expr)

--- a/filters/ExpressionFilterFactory.cpp
+++ b/filters/ExpressionFilterFactory.cpp
@@ -22,10 +22,8 @@
 
 #include "helpers/LogHelper.h"
 #include "helpers/StringHelper.h"
-#include "parser/RegexFunctions.h"
+#include "parser/ParserExtensions.h"
 #include "parser/RegistryFunctions.h"
-#include "parser/StringOperators.h"
-#include "parser/LogicalOperators.h"
 #include "FilterEngine.h"
 #include "filters/FilterFactoryRegistry.h"
 #include "ExpressionCommand.h"
@@ -46,12 +44,10 @@ void ExpressionFilterFactory::initialize(FilterEngine* engine)
 
 	parser->DefineFun(new ReadRegStringFunction(engine));
 	parser->DefineFun(new ReadRegDWORDFunction(engine));
-	parser->DefineFun(new RegexSearchFunction());
-	parser->DefineFun(new RegexReplaceFunction());
 
-	parser->RemoveOprt(L"+");
-	parser->DefineOprt(new AddOperator());
-	parser->DefineInfixOprt(new NotOperator());
+	// Engine-free extensions (regex functions, '+', '!') live in one shared
+	// roster so the parser tests register exactly the same set. (audit #146 TD021)
+	registerEngineFreeParserExtensions(*parser);
 }
 
 vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)

--- a/parser/ParserExtensions.cpp
+++ b/parser/ParserExtensions.cpp
@@ -1,0 +1,36 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2014  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "stdafx.h"
+#include <mpParser.h>
+
+#include "RegexFunctions.h"
+#include "StringOperators.h"
+#include "LogicalOperators.h"
+#include "ParserExtensions.h"
+
+void registerEngineFreeParserExtensions(mup::ParserX& parser)
+{
+	parser.DefineFun(new RegexSearchFunction());
+	parser.DefineFun(new RegexReplaceFunction());
+
+	parser.RemoveOprt(L"+");
+	parser.DefineOprt(new AddOperator());
+	parser.DefineInfixOprt(new NotOperator());
+}

--- a/parser/ParserExtensions.h
+++ b/parser/ParserExtensions.h
@@ -1,0 +1,31 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2014  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+namespace mup {
+class ParserX;
+}
+
+// Registers the muparserx extensions that need no FilterEngine: the regex
+// functions, the string-aware '+' AddOperator, and the '!' NotOperator.
+// ExpressionFilterFactory::initialize and the parser tests share this roster
+// so a new engine-free extension cannot silently miss one of them.
+// (audit #146 TD021)
+void registerEngineFreeParserExtensions(mup::ParserX& parser);


### PR DESCRIPTION
감사 이슈 #146의 테스트 부채 2건(TD031, TD021)을 반영합니다.

- ConfigFileCodec을 EditorLogicTests에 컴파일해 decodeLines/encodeLines를 검증합니다. CRLF/LF 분리, CR 제거, UTF-8 해석, 유효하지 않은 UTF-8의 시스템 ANSI 폴백(코드페이지 의존이라 구조만 단언), 왕복 인코딩까지 9개 체크가 늘었습니다(161→170).
- 엔진 불요 muparserx 확장(정규식 함수, '+', '!')을 registerEngineFreeParserExtensions()로 추출해 ExpressionFilterFactory와 ParserTests가 같은 로스터를 쓰게 했습니다. 엔진 종속 등록(readRegString 등)은 엔진 쪽에만 남습니다.

세 테스트 스위트 전체 통과, 변경 파일 cppcheck 2.21.0 깨끗입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)