### PR TITLE
docs(changelog): file the Unreleased entries under v2.8.1

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.8.1 (2026-07-03)
 
 - Windows 오디오 엔진의 크래시 경로를 고쳤습니다. 설정을 하나도 싣지 못한
   상태(예: `ConfigPath` 레지스트리 값을 읽을 수 없는 경우)에서 처리 루틴이

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.8.1 — 2026-07-03
 
 - Fixed a crash path inside the Windows audio engine: if EqualizerAPO could
   not load any configuration (for example an unreadable `ConfigPath` registry


### PR DESCRIPTION
v2.8.1 릴리스가 만들어졌으므로 CHANGELOG(영문·한국어)의 Unreleased 절을 v2.8.1 절로 옮깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)