### PR TITLE
refactor(editor): card editors self-register and the wheel filter is gesture-scoped

### DIFF
--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -212,6 +212,7 @@ SOURCES += main.cpp\
 	widgets/cards/StageSelectionModel.cpp \
 	widgets/cards/DeviceSelectionModel.cpp \
 	widgets/cards/FilterCardEditorFactory.cpp \
+	widgets/cards/FilterCardEditorRegistry.cpp \
 	widgets/cards/IncludeCardEditor.cpp \
 	widgets/cards/PreampCardEditor.cpp \
 	widgets/cards/ReferenceCardView.cpp \
@@ -418,6 +419,7 @@ HEADERS  += \
 	widgets/cards/StageSelectionModel.h \
 	widgets/cards/DeviceSelectionModel.h \
 	widgets/cards/FilterCardEditorFactory.h \
+	widgets/cards/FilterCardEditorRegistry.h \
 	widgets/cards/IncludeCardEditor.h \
 	widgets/cards/PreampCardEditor.h \
 	widgets/cards/ReferenceCardView.h \

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -73,12 +73,12 @@ FilterTable::FilterTable(MainWindow* mainWindow, QWidget* parent)
 	// so adding a filter GUI no longer means editing this list. FilterTable owns
 	// the returned instances and deletes them in its destructor.
 	factories = FilterGUIFactoryRegistry::createFactories();
-
-	QApplication::instance()->installEventFilter(this);
 }
 
 FilterTable::~FilterTable()
 {
+	// Only installed while a wheel-scroll gesture is active (see wheelEvent);
+	// removing an uninstalled filter is a documented no-op.
 	if (QApplication::instance() != nullptr)
 		QApplication::instance()->removeEventFilter(this);
 
@@ -95,6 +95,13 @@ void FilterTable::initialize(QScrollArea* scrollArea, const QList<shared_ptr<Abs
 	this->scrollArea = scrollArea;
 	this->outputDevices = outputDevices;
 	this->inputDevices = inputDevices;
+
+	// The resize hook only cares about the scroll area itself, so filter that
+	// one object instead of every event in the application. The app-global
+	// filter that redirects wheel events away from child widgets is installed
+	// per scroll gesture in wheelEvent(). Every open tab used to keep an
+	// always-on application filter each. (audit #146 TD041)
+	scrollArea->installEventFilter(this);
 
 	for (IFilterGUIFactory* factory : factories)
 		factory->initialize(this);

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -177,7 +177,7 @@ private:
 	void insertLinesFromMimeData(const QMimeData* mimeData, int dropRow);
 
 	MainWindow* mainWindow;
-	QScrollArea* scrollArea;
+	QScrollArea* scrollArea = nullptr;
 	QGridLayout* gridLayout;
 	QLabel* insertArrow;
 	QPoint dragStartPos;
@@ -188,11 +188,14 @@ private:
 	Item* selectionStart = nullptr;
 	QList<IFilterGUIFactory*> factories;
 	bool scrollingNow = false;
+	// True while the app-global wheel-redirect filter is installed; see
+	// wheelEvent()/eventFilter(). (audit #146 TD041)
+	bool appWheelFilterInstalled = false;
 	QPointF scrollStartPoint;
 	QList<std::shared_ptr<AbstractAPOInfo>> outputDevices;
 	QList<std::shared_ptr<AbstractAPOInfo>> inputDevices;
 	std::shared_ptr<AbstractAPOInfo> selectedDevice;
-	int selectedChannelMask;
+	int selectedChannelMask = 0;
 	QString configPath;
 	int minimumHeightHint = 0;
 	int presetScrollX = -1;

--- a/Editor/FilterTableParts/FilterTable.Events.cpp
+++ b/Editor/FilterTableParts/FilterTable.Events.cpp
@@ -138,6 +138,15 @@ void FilterTable::keyPressEvent(QKeyEvent* event)
 
 void FilterTable::wheelEvent(QWheelEvent* event)
 {
+	// While the gesture lasts, wheel events over child widgets must reach the
+	// list instead of the widget under the cursor; only an application-wide
+	// filter sees events targeted at descendants. Installed here and removed
+	// when the gesture ends so idle tables filter nothing. (audit #146 TD041)
+	if (!appWheelFilterInstalled)
+	{
+		QApplication::instance()->installEventFilter(this);
+		appWheelFilterInstalled = true;
+	}
 	scrollingNow = true;
 	scrollStartPoint = event->globalPosition();
 
@@ -169,7 +178,14 @@ bool FilterTable::eventFilter(QObject* obj, QEvent* event)
 			QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
 
 			if ((mouseEvent->globalPos() - scrollStartPoint).manhattanLength() > GUIHelper::scale(30))
+			{
 				scrollingNow = false;
+				if (appWheelFilterInstalled)
+				{
+					QApplication::instance()->removeEventFilter(this);
+					appWheelFilterInstalled = false;
+				}
+			}
 		}
 	}
 

--- a/Editor/widgets/FilterCardModel.cpp
+++ b/Editor/widgets/FilterCardModel.cpp
@@ -71,6 +71,14 @@ QString firstCapture(const QRegularExpression& expression, const QString& text)
 // Reproduces the same labelling the legacy BiQuad GUI shows so the modern card
 // agrees with it for the LSC/HSC/LPQ/HPQ/PEQ/Modal variants that the previous
 // regex did not recognize.
+//
+// Deliberately NOT routed through BiQuadCommand::parse (audit #146 TD019,
+// skipped): the engine parser is intentionally lossy - missing tokens are
+// synthesized as defaults and variants are merged (see BiQuadCommand.h, audit
+// #109 F007) - while this badge must echo only what the author wrote, in the
+// author's own spelling. The structural pieces already come from shared
+// sources: the command vocabulary from FilterFactoryRegistry and the type
+// titles from BiQuadCommand's table (above).
 QString summarizeBiquad(const QString& parameters, const QString& code, const QString& state)
 {
 	QStringList parts;

--- a/Editor/widgets/cards/ChannelCardEditor.cpp
+++ b/Editor/widgets/cards/ChannelCardEditor.cpp
@@ -133,3 +133,9 @@ void ChannelCardEditor::commitSelection()
 	parameters = model.serialize();
 	emit updateModel();
 }
+
+#include "FilterCardEditorRegistry.h"
+
+REGISTER_FILTER_CARD_EDITOR(channel, [](FilterTable*, const QString&, const QString& parameters) -> IFilterGUI* {
+	return new ChannelCardEditor(parameters);
+})

--- a/Editor/widgets/cards/ConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/ConvolutionCardEditor.cpp
@@ -272,3 +272,14 @@ void ConvolutionCardEditor::updateFileInfo()
 	view->setState(state);
 	importButton->setVisible(offerImport);
 }
+
+#include "FilterCardEditorRegistry.h"
+#include "filters/ConvolutionCommand.h"
+
+REGISTER_FILTER_CARD_EDITOR(convolution, [](FilterTable* filterTable, const QString& command, const QString& parameters) -> IFilterGUI* {
+	// ConvolutionCommand owns the line grammar; the path it yields preserves
+	// the author's quotes/variables so store() round-trips the config text.
+	ConvolutionCommand cmd;
+	ConvolutionCommand::parse(command.trimmed().toStdWString(), parameters.toStdWString(), cmd);
+	return new ConvolutionCardEditor(filterTable, QString::fromStdWString(cmd.path));
+})

--- a/Editor/widgets/cards/DeviceCardEditor.cpp
+++ b/Editor/widgets/cards/DeviceCardEditor.cpp
@@ -168,3 +168,9 @@ void DeviceCardEditor::reloadChips()
 
 	updating = false;
 }
+
+#include "FilterCardEditorRegistry.h"
+
+REGISTER_FILTER_CARD_EDITOR(device, [](FilterTable* filterTable, const QString&, const QString& parameters) -> IFilterGUI* {
+	return new DeviceCardEditor(filterTable, parameters);
+})

--- a/Editor/widgets/cards/FilterCardEditorFactory.cpp
+++ b/Editor/widgets/cards/FilterCardEditorFactory.cpp
@@ -1,80 +1,19 @@
 #include "FilterCardEditorFactory.h"
 
 #include <QString>
-#include <unordered_map>
-#include <vector>
 
 #include "Editor/IFilterGUI.h"
-#include "ChannelCardEditor.h"
-#include "ConvolutionCardEditor.h"
-#include "MultiConvolutionCardEditor.h"
-#include "DeviceCardEditor.h"
-#include "IncludeCardEditor.h"
-#include "PreampCardEditor.h"
-#include "StageCardEditor.h"
-#include "VSTCardEditor.h"
-#include "filters/ConvolutionCommand.h"
-#include "filters/MultiConvolutionCommand.h"
-#include "filters/VSTPluginFilter.h"
-#include "filters/VSTPluginFilterFactory.h"
-#include "helpers/VSTPluginLibrary.h"
-#include "helpers/MemoryHelper.h"
+#include "FilterCardEditorRegistry.h"
 
 IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QString& command, const QString& parameters)
 {
+	// The roster lives in the card editors' own translation units via
+	// REGISTER_FILTER_CARD_EDITOR (see FilterCardEditorRegistry.h); this
+	// function is just the lookup, so adding a card no longer means editing
+	// an if-chain here. (audit #146 TD003)
 	const QString normalizedCommand = command.trimmed().toLower();
-	if (normalizedCommand == QStringLiteral("preamp"))
-		return new PreampCardEditor(PreampCardEditor::parseGain(parameters));
-	if (normalizedCommand == QStringLiteral("channel"))
-		return new ChannelCardEditor(parameters);
-	if (normalizedCommand == QStringLiteral("device"))
-		return new DeviceCardEditor(filterTable, parameters);
-	if (normalizedCommand == QStringLiteral("stage"))
-		return new StageCardEditor(parameters);
-	if (normalizedCommand == QStringLiteral("include"))
-		return new IncludeCardEditor(filterTable, parameters);
-	if (normalizedCommand == QStringLiteral("convolution"))
-	{
-		// ConvolutionCommand owns the line grammar; the path it yields preserves
-		// the author's quotes/variables so store() round-trips the config text.
-		ConvolutionCommand cmd;
-		ConvolutionCommand::parse(command.trimmed().toStdWString(), parameters.toStdWString(), cmd);
-		return new ConvolutionCardEditor(filterTable, QString::fromStdWString(cmd.path));
-	}
-	if (normalizedCommand == QStringLiteral("multiconvolution"))
-	{
-		// MultiConvolutionCommand owns the line grammar (mapping and simple
-		// forms); the card hosts the mapping in the skin's routing view.
-		MultiConvolutionCommand cmd;
-		MultiConvolutionCommand::parse(command.trimmed().toStdWString(), parameters.toStdWString(), cmd);
-		return new MultiConvolutionCardEditor(filterTable, cmd.mappings, QString::fromStdWString(cmd.path));
-	}
-	if (normalizedCommand == QStringLiteral("vstplugin"))
-	{
-		// Parse the line into the engine's VST filter (no plugin DLL is loaded
-		// for configPath == L""), then hand the opaque state to the card editor.
-		// The store()/parse round-trip is verified lossless (--selftest-vst).
-		VSTPluginFilterFactory factory;
-		std::wstring commandWStr = L"VSTPlugin";
-		std::wstring paramWStr = parameters.toStdWString();
-		std::vector<IFilter*> filters = factory.createFilter(L"", commandWStr, paramWStr);
-		VSTCardEditor* editor;
-		if (!filters.empty())
-		{
-			VSTPluginFilter* filter = static_cast<VSTPluginFilter*>(filters[0]);
-			editor = new VSTCardEditor(filter->getLibrary(), filter->getChunkData(), filter->getParamMap());
-		}
-		else
-		{
-			editor = new VSTCardEditor(VSTPluginLibrary::getInstance(L""), L"", std::unordered_map<std::wstring, float>());
-		}
-		for (IFilter* f : filters)
-		{
-			f->~IFilter();
-			MemoryHelper::free(f);
-		}
-		return editor;
-	}
-
-	return nullptr;
+	FilterCardEditorCreator creator = FilterCardEditorRegistry::find(normalizedCommand);
+	if (creator == nullptr)
+		return nullptr;
+	return creator(filterTable, command, parameters);
 }

--- a/Editor/widgets/cards/FilterCardEditorRegistry.cpp
+++ b/Editor/widgets/cards/FilterCardEditorRegistry.cpp
@@ -1,0 +1,44 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2015  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include <QHash>
+
+#include "FilterCardEditorRegistry.h"
+
+namespace
+{
+// Function-local static so registrations from other translation units'
+// static initializers never race a not-yet-constructed map.
+QHash<QString, FilterCardEditorCreator>& registry()
+{
+	static QHash<QString, FilterCardEditorCreator> map;
+	return map;
+}
+}
+
+bool FilterCardEditorRegistry::registerEditor(const QString& lowercaseCommand, FilterCardEditorCreator creator)
+{
+	registry().insert(lowercaseCommand, creator);
+	return true;
+}
+
+FilterCardEditorCreator FilterCardEditorRegistry::find(const QString& normalizedCommand)
+{
+	return registry().value(normalizedCommand, nullptr);
+}

--- a/Editor/widgets/cards/FilterCardEditorRegistry.h
+++ b/Editor/widgets/cards/FilterCardEditorRegistry.h
@@ -1,0 +1,53 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2015  Jonas Thedering
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <QString>
+
+class FilterTable;
+class IFilterGUI;
+
+using FilterCardEditorCreator = IFilterGUI* (*)(FilterTable* filterTable, const QString& command, const QString& parameters);
+
+// Self-registration for the modern card editors, mirroring the engine's
+// REGISTER_FILTER_FACTORY and the Editor's REGISTER_FILTER_GUI_FACTORY: each
+// card editor's .cpp is the single place it joins the roster, so adding a card
+// no longer means editing a hand-maintained if-chain in
+// FilterCardEditorFactory. Commands are keyed lowercase; unlike the two
+// factory registries there is no ordering, because card commands are exact
+// keyword matches. (audit #146 TD003)
+class FilterCardEditorRegistry
+{
+public:
+	static bool registerEditor(const QString& lowercaseCommand, FilterCardEditorCreator creator);
+
+	// The creator registered for the lowercased command keyword, or nullptr
+	// when no card editor covers it.
+	static FilterCardEditorCreator find(const QString& normalizedCommand);
+};
+
+// Registers a card editor for a (lowercase identifier) command keyword. The
+// editor's .cpp is compiled straight into the Editor executable, so its static
+// initializer always runs and no /WHOLEARCHIVE is needed.
+#define REGISTER_FILTER_CARD_EDITOR(keyword, ...) \
+	namespace \
+	{ \
+		const bool keyword##CardEditorRegistered = FilterCardEditorRegistry::registerEditor(QStringLiteral(#keyword), __VA_ARGS__); \
+	}

--- a/Editor/widgets/cards/IncludeCardEditor.cpp
+++ b/Editor/widgets/cards/IncludeCardEditor.cpp
@@ -252,3 +252,9 @@ void IncludeCardEditor::importToConfig()
 	updateFileInfo();
 	emit updateModel();
 }
+
+#include "FilterCardEditorRegistry.h"
+
+REGISTER_FILTER_CARD_EDITOR(include, [](FilterTable* filterTable, const QString&, const QString& parameters) -> IFilterGUI* {
+	return new IncludeCardEditor(filterTable, parameters);
+})

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
@@ -441,3 +441,13 @@ void MultiConvolutionCardEditor::updateFileInfo()
 	importButton->setVisible(offerImport);
 	rebuildRoutingView();
 }
+
+#include "FilterCardEditorRegistry.h"
+
+REGISTER_FILTER_CARD_EDITOR(multiconvolution, [](FilterTable* filterTable, const QString& command, const QString& parameters) -> IFilterGUI* {
+	// MultiConvolutionCommand owns the line grammar (mapping and simple
+	// forms); the card hosts the mapping in the skin's routing view.
+	MultiConvolutionCommand cmd;
+	MultiConvolutionCommand::parse(command.trimmed().toStdWString(), parameters.toStdWString(), cmd);
+	return new MultiConvolutionCardEditor(filterTable, cmd.mappings, QString::fromStdWString(cmd.path));
+})

--- a/Editor/widgets/cards/PreampCardEditor.cpp
+++ b/Editor/widgets/cards/PreampCardEditor.cpp
@@ -129,3 +129,9 @@ QString PreampCardEditor::gainText() const
 {
 	return QLocale::c().toString(currentGain, 'f', 1);
 }
+
+#include "FilterCardEditorRegistry.h"
+
+REGISTER_FILTER_CARD_EDITOR(preamp, [](FilterTable*, const QString&, const QString& parameters) -> IFilterGUI* {
+	return new PreampCardEditor(PreampCardEditor::parseGain(parameters));
+})

--- a/Editor/widgets/cards/StageCardEditor.cpp
+++ b/Editor/widgets/cards/StageCardEditor.cpp
@@ -112,3 +112,9 @@ void StageCardEditor::chipToggled()
 		model.setSelected(chip.token, chip.button->isChecked());
 	emit updateModel();
 }
+
+#include "FilterCardEditorRegistry.h"
+
+REGISTER_FILTER_CARD_EDITOR(stage, [](FilterTable*, const QString&, const QString& parameters) -> IFilterGUI* {
+	return new StageCardEditor(parameters);
+})

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -582,3 +582,38 @@ void VSTCardEditor::updatePermissionWarning()
 		warningTextEdit->setVisible(true);
 	}
 }
+
+#include <unordered_map>
+#include <vector>
+
+#include "FilterCardEditorRegistry.h"
+#include "filters/VSTPluginFilter.h"
+#include "filters/VSTPluginFilterFactory.h"
+#include "helpers/VSTPluginLibrary.h"
+#include "helpers/MemoryHelper.h"
+
+REGISTER_FILTER_CARD_EDITOR(vstplugin, [](FilterTable*, const QString&, const QString& parameters) -> IFilterGUI* {
+	// Parse the line into the engine's VST filter (no plugin DLL is loaded
+	// for configPath == L""), then hand the opaque state to the card editor.
+	// The store()/parse round-trip is verified lossless (--selftest-vst).
+	VSTPluginFilterFactory factory;
+	std::wstring commandWStr = L"VSTPlugin";
+	std::wstring paramWStr = parameters.toStdWString();
+	std::vector<IFilter*> filters = factory.createFilter(L"", commandWStr, paramWStr);
+	VSTCardEditor* editor;
+	if (!filters.empty())
+	{
+		VSTPluginFilter* filter = static_cast<VSTPluginFilter*>(filters[0]);
+		editor = new VSTCardEditor(filter->getLibrary(), filter->getChunkData(), filter->getParamMap());
+	}
+	else
+	{
+		editor = new VSTCardEditor(VSTPluginLibrary::getInstance(L""), L"", std::unordered_map<std::wstring, float>());
+	}
+	for (IFilter* f : filters)
+	{
+		f->~IFilter();
+		MemoryHelper::free(f);
+	}
+	return editor;
+})


### PR DESCRIPTION
감사 #146 보류분 중 에디터 3건(TD003, TD041, TD019 처분)입니다.

- **TD003:** 카드 에디터 8종이 자기 TU에서 REGISTER_FILTER_CARD_EDITOR로 등록하고, FilterCardEditorFactory::create는 조회만 합니다(기존 두 레지스트리 패턴의 미러).
- **TD041:** 탭마다 상시 걸려 있던 앱 전역 이벤트 필터를 제거했습니다. 스크롤 영역 Resize 훅은 해당 객체에 직접 걸고, 휠 리다이렉트 필터는 휠 제스처가 시작될 때 설치해 끝나면 제거합니다. 생성자 변경으로 드러난 잠복 uninitMemberVar 2건도 in-class 초기화로 함께 고쳤습니다.
- **TD019(스킵 처분):** 배지를 BiQuadCommand::parse 경유로 바꾸라는 권고는 감사 #109 F007에서 확인된 의도적 lossy 파서(누락 토큰 기본값 합성)와 충돌합니다. 배지는 작성자가 쓴 텍스트만 보여줘야 하므로 표시용 정규식을 유지하고, 근거 주석을 코드에 박아 다음 감사의 재지적을 막았습니다. 어휘·타입 제목은 이미 공유 소스를 씁니다.

검증은 Editor 빌드, EditorLogicTests 170 체크, studio 갤러리 122장 픽셀 동일(경로 문자열까지 맞추기 위해 같은 이름의 디렉터리로 렌더), cppcheck 2.21.0 깨끗입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)