### PR TITLE
ci: share one provisioning module between CI and setup-build.ps1

### DIFF
--- a/.github/scripts/New-BuildMatrix.ps1
+++ b/.github/scripts/New-BuildMatrix.ps1
@@ -34,12 +34,14 @@ foreach ($variant in $manifest.Variants) {
   # Keys mirror what build.yml's hand-written matrix.include block used to define.
   # windows-2025-vs2026 ships VS 2026 (v145); windows-11-arm still ships VS 2022
   # (v143) — the build step picks the platform toolset from matrix.platform.
+  # The per-variant asset zip names are NOT expanded into the matrix: the
+  # download step resolves them from the manifest by platform+simd via
+  # .github/scripts/Provisioning.psm1 (Get-DependencyDownloadSpec).
   $entry = [ordered]@{
     name            = $variant.Name
     os              = if ($isArm) { 'windows-11-arm' } else { 'windows-2025-vs2026' }
     platform        = $variant.Platform
     simd_variant    = $variant.Simd
-    muparserx_asset = $variant.Muparserx
     msvcdevplatform = if ($isArm) { 'arm64' } else { 'x64' }
     uses_vcpkg      = [bool]$variant.UsesVcpkg
     can_execute     = [bool]$variant.RunnerCanExecute
@@ -53,12 +55,6 @@ foreach ($variant in $manifest.Variants) {
   }
   if ($variant.QtArchFlag) {
     $entry.qt_arch_flag = $variant.QtArchFlag
-  }
-  if ($variant.Fftw) {
-    $entry.fftw_asset = $variant.Fftw
-  }
-  if ($variant.Sndfile) {
-    $entry.libsndfile_asset = $variant.Sndfile
   }
 
   $include += [pscustomobject]$entry

--- a/.github/scripts/Provisioning.psm1
+++ b/.github/scripts/Provisioning.psm1
@@ -1,0 +1,385 @@
+<#
+.SYNOPSIS
+    Shared build-dependency provisioning for CI and local setup: pinned
+    release-asset download + SHA-256 verification, the vcpkg-based FFTW /
+    libsndfile / muparserx rebuild for the sse2/avx variants, and the
+    aqt-based Qt install.
+
+.DESCRIPTION
+    .github/workflows/build.yml and setup-build.ps1 used to each carry their
+    own copy of these three provisioning steps, and the copies drifted (audit
+    finding TD015). This module is the single implementation; both consumers
+    import it with a relative path:
+
+      Import-Module .\.github\scripts\Provisioning.psm1 -Force
+
+    Exported functions:
+      Get-SimdVariantEntry        variant lookup in the simd-variants.psd1 manifest
+      Get-DependencyDownloadSpec  manifest -> download list (URLs + SHA-256 pins)
+      Invoke-DependencyDownload   download / cache-reuse, verify, extract loop
+      Build-VcpkgDependencies     vcpkg FFTW+libsndfile build & muparserx rebuild
+      Install-QtSdk               aqt-based Qt install, returns the Qt root
+
+    All pinned names, tags, and hashes come from .github/simd-variants.psd1
+    (Import-PowerShellDataFile at the call site); this module never hardcodes
+    an asset name or hash.
+#>
+
+# Module functions do not inherit the caller's preference variables, so set
+# fail-fast behaviour here to match the inline `$ErrorActionPreference = "Stop"`
+# both consumers used before the extraction.
+$ErrorActionPreference = 'Stop'
+
+function Get-SimdVariantEntry {
+    <#
+    .SYNOPSIS
+        Returns the manifest Variants entry for a Platform/Simd pair, or throws.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [hashtable]$Manifest,
+        [Parameter(Mandatory)] [ValidateSet('x64', 'ARM64')] [string]$Platform,
+        [Parameter(Mandatory)] [string]$Simd
+    )
+
+    $entry = $Manifest.Variants |
+        Where-Object { $_.Platform -eq $Platform -and $_.Simd -eq $Simd } |
+        Select-Object -First 1
+    if (-not $entry) {
+        throw "No asset mapping for Platform=$Platform, Variant=$Simd"
+    }
+    return $entry
+}
+
+function Get-DependencyDownloadSpec {
+    <#
+    .SYNOPSIS
+        Expands the manifest into the list of prebuilt binary downloads for one
+        variant: muparserx and velopack_libc always, plus FFTW and libsndfile
+        for the variants that do not build them from vcpkg.
+
+    .DESCRIPTION
+        Each returned hashtable carries Repo, Asset, Url, Sha256, and
+        Destination (under $DepsRoot). URLs always use releases/download/<Tag>
+        (never releases/latest) and every entry carries the SHA-256 recorded in
+        simd-variants.psd1, so a new upload to the personal dependency forks
+        cannot change what gets linked without a reviewed manifest diff.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [hashtable]$Manifest,
+        [Parameter(Mandatory)] [string]$DepsRoot,
+        [Parameter(Mandatory)] [ValidateSet('x64', 'ARM64')] [string]$Platform,
+        [Parameter(Mandatory)] [string]$Simd
+    )
+
+    $variant = Get-SimdVariantEntry -Manifest $Manifest -Platform $Platform -Simd $Simd
+    $pins = $Manifest.DependencyReleases
+
+    # Resolves one DependencyReleases-pinned asset to a download entry.
+    function Resolve-PinnedDownload {
+        param([string]$Repo, [string]$Asset, [string]$DestinationLeaf)
+
+        $pin = $pins[$Repo]
+        if (-not $pin) {
+            throw "No pinned tag or explicit URL for $Repo in simd-variants.psd1"
+        }
+        $sha256 = $pin.Sha256[$Asset]
+        if (-not $sha256) {
+            throw "No pinned SHA-256 for $Asset in simd-variants.psd1"
+        }
+        return @{
+            Repo        = $Repo
+            Asset       = $Asset
+            Url         = "https://github.com/$Repo/releases/download/$($pin.Tag)/$Asset"
+            Sha256      = $sha256
+            Destination = Join-Path $DepsRoot $DestinationLeaf
+        }
+    }
+
+    $velopackVersion = $Manifest.Shared.VelopackLibcVersion
+    $downloads = @(
+        (Resolve-PinnedDownload -Repo 'TheFireKahuna/muparserx' -Asset $variant.Muparserx -DestinationLeaf 'muparserx'),
+        @{
+            # Velopack C/C++ runtime (Velopack.h + import libs + DLLs for every
+            # platform). Always fetched regardless of SIMD variant; the Editor
+            # links it for auto-update. Not covered by DependencyReleases (the
+            # URL is release-tag based already), so its SHA-256 pin rides on
+            # Shared.VelopackLibcVersion / Shared.VelopackLibcSha256.
+            Repo        = 'velopack/velopack'
+            Asset       = "velopack_libc_$velopackVersion.zip"
+            Url         = "https://github.com/velopack/velopack/releases/download/$velopackVersion/velopack_libc_$velopackVersion.zip"
+            Sha256      = $Manifest.Shared.VelopackLibcSha256
+            Destination = Join-Path $DepsRoot 'velopack_libc'
+        }
+    )
+
+    if (-not $variant.UsesVcpkg) {
+        $downloads += (Resolve-PinnedDownload -Repo 'TheFireKahuna/amd-fftw' -Asset $variant.Fftw -DestinationLeaf 'fftw')
+        $downloads += (Resolve-PinnedDownload -Repo 'TheFireKahuna/libsndfile' -Asset $variant.Sndfile -DestinationLeaf 'libsndfile')
+    }
+
+    return $downloads
+}
+
+function Invoke-DependencyFetch {
+    # Internal: single network fetch, kept separate so tests can mock the
+    # network away. Same curl invocation both consumers used inline.
+    param(
+        [Parameter(Mandatory)] [string]$Url,
+        [Parameter(Mandatory)] [string]$OutFile
+    )
+
+    curl.exe --fail --location --retry 5 --retry-delay 5 --output $OutFile $Url
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to download $Url"
+    }
+}
+
+function Invoke-DependencyDownload {
+    <#
+    .SYNOPSIS
+        Downloads (or reuses cached) release asset zips, verifies their SHA-256
+        against the pinned value, and extracts them to their destinations.
+
+    .DESCRIPTION
+        Entries come from Get-DependencyDownloadSpec. A download whose SHA-256
+        does not match the pin is refused. With -ReuseCachedDownloads (local
+        setup-build.ps1 use) an already-present zip in $DownloadRoot is not
+        re-downloaded, and a mismatching zip is deleted so the next run
+        redownloads it; without the switch (CI use, fresh runner) every asset
+        is downloaded and a mismatch fails hard without touching the file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [hashtable[]]$Downloads,
+        [Parameter(Mandatory)] [string]$DownloadRoot,
+        [switch]$ReuseCachedDownloads
+    )
+
+    New-Item -ItemType Directory -Force -Path $DownloadRoot | Out-Null
+
+    foreach ($download in $Downloads) {
+        $zipPath = Join-Path $DownloadRoot $download.Asset
+
+        if ($ReuseCachedDownloads -and (Test-Path $zipPath)) {
+            Write-Host "  [cached] $($download.Asset)"
+        }
+        else {
+            Write-Host "Downloading $($download.Repo) release asset $($download.Asset)"
+            Invoke-DependencyFetch -Url $download.Url -OutFile $zipPath
+        }
+
+        if ($download.Sha256) {
+            $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash
+            if ($actual -ne $download.Sha256) {
+                if ($ReuseCachedDownloads) {
+                    Remove-Item $zipPath -Force
+                    throw "SHA-256 mismatch for $($download.Asset): expected $($download.Sha256), got $actual (stale cache removed; rerun to redownload)"
+                }
+                throw "SHA-256 mismatch for $($download.Asset): expected $($download.Sha256), got $actual"
+            }
+            Write-Host "Verified SHA-256 for $($download.Asset)"
+        }
+
+        New-Item -ItemType Directory -Force -Path $download.Destination | Out-Null
+        Expand-Archive -Path $zipPath -DestinationPath $download.Destination -Force
+        Write-Host "Extracted $($download.Asset) -> $($download.Destination)"
+    }
+}
+
+function Copy-RequiredFile {
+    # Internal: copies the first file under $SourceRoot matching any of
+    # $Patterns (after $Filter) to $Destination, or throws. Used by the vcpkg
+    # dependency build to pick the right FFTW/libsndfile artifacts.
+    param(
+        [string]$SourceRoot,
+        [string[]]$Patterns,
+        [scriptblock]$Filter,
+        [string]$Destination
+    )
+
+    foreach ($pattern in $Patterns) {
+        $found = @(Get-ChildItem -Path $SourceRoot -Recurse -Filter $pattern -File -ErrorAction SilentlyContinue | Where-Object $Filter)
+        if ($found.Count -gt 0) {
+            New-Item -ItemType Directory -Force -Path (Split-Path $Destination -Parent) | Out-Null
+            Copy-Item -Path $found[0].FullName -Destination $Destination -Force
+            Write-Host "Copied $($found[0].FullName) -> $Destination"
+            return
+        }
+    }
+
+    throw "Could not find required file under $SourceRoot matching $($Patterns -join ', ')"
+}
+
+function Build-VcpkgDependencies {
+    <#
+    .SYNOPSIS
+        Builds FFTW and libsndfile from vcpkg and rebuilds muparserx from
+        source with the variant's /arch flag, for the x64 sse2/avx variants
+        that have no prebuilt binary assets.
+
+    .DESCRIPTION
+        Requires an imported MSVC environment (cl.exe / lib.exe on PATH):
+        dot-source Import-VsDevEnvironment.ps1 and call
+        Import-VsDevEnvironment "x64" before calling this. Prefers a
+        preinstalled vcpkg ($env:VCPKG_INSTALLATION_ROOT, as on GitHub
+        runners); otherwise clones vcpkg into $VcpkgFallbackRoot pinned to
+        $VcpkgCommit. Output lands in the same deps/ layout the download path
+        produces (fftw/include, fftw/Release, libsndfile/include,
+        libsndfile/build/Release, muparserx/build/Release).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$DepsRoot,
+        [Parameter(Mandatory)] [string]$VcpkgFallbackRoot,
+        [Parameter(Mandatory)] [ValidateSet('sse2', 'avx')] [string]$SimdVariant,
+        [Parameter(Mandatory)] [string]$VcpkgCommit
+    )
+
+    if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+        throw "cl.exe is not on PATH; import the MSVC environment first (Import-VsDevEnvironment)"
+    }
+
+    $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+    if (-not $vcpkgRoot -or -not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
+        $vcpkgRoot = $VcpkgFallbackRoot
+        if (-not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
+            # Pin vcpkg to the manifest commit: cloning a moving HEAD would let
+            # the portfiles (and thus the FFTW/libsndfile binaries built here)
+            # change without a reviewed diff in simd-variants.psd1. --depth 1
+            # keeps the clone small; the pinned commit is fetched by SHA and
+            # checked out.
+            git clone --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
+            if ($LASTEXITCODE -ne 0) { throw "Failed to clone vcpkg" }
+            git -C $vcpkgRoot fetch --depth 1 origin $VcpkgCommit
+            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch pinned vcpkg commit $VcpkgCommit" }
+            git -C $vcpkgRoot checkout --detach $VcpkgCommit
+            if ($LASTEXITCODE -ne 0) { throw "Failed to check out pinned vcpkg commit $VcpkgCommit" }
+            & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
+            if ($LASTEXITCODE -ne 0) { throw "vcpkg bootstrap failed" }
+        }
+    }
+
+    $vcpkgExe = Join-Path $vcpkgRoot "vcpkg.exe"
+    $fftwFeature = if ($SimdVariant -eq "avx") { "fftw3[avx,threads]:x64-windows" } else { "fftw3[sse2,threads]:x64-windows" }
+    & $vcpkgExe install $fftwFeature "libsndfile:x64-windows" --clean-after-build
+    if ($LASTEXITCODE -ne 0) {
+        throw "vcpkg dependency install failed"
+    }
+
+    $installedRoot = Join-Path $vcpkgRoot "installed\x64-windows"
+    $fftwInclude = Join-Path $DepsRoot "fftw\include"
+    $fftwRelease = Join-Path $DepsRoot "fftw\Release"
+    $sndInclude = Join-Path $DepsRoot "libsndfile\include"
+    $sndRelease = Join-Path $DepsRoot "libsndfile\build\Release"
+
+    New-Item -ItemType Directory -Force -Path $fftwInclude, $fftwRelease, $sndInclude, $sndRelease | Out-Null
+    Copy-Item -Path (Join-Path $installedRoot "include\fftw3.h") -Destination $fftwInclude -Force
+    Copy-Item -Path (Join-Path $installedRoot "include\sndfile*.h*") -Destination $sndInclude -Force
+
+    # The project links the double-precision FFTW only; filter out the float /
+    # long-double / threading variants vcpkg may also produce.
+    $doubleFftwFilter = { $_.Name -notmatch "fftw3f|fftw3l|threads|omp" }
+    Copy-RequiredFile (Join-Path $installedRoot "lib") @("libfftw3.lib", "fftw3.lib", "libfftw3-3.lib") $doubleFftwFilter (Join-Path $fftwRelease "libfftw3.lib")
+    Copy-RequiredFile (Join-Path $installedRoot "lib") @("sndfile.lib") { $true } (Join-Path $sndRelease "sndfile.lib")
+
+    Get-ChildItem -Path (Join-Path $installedRoot "bin") -Filter "*.dll" -File | Copy-Item -Destination $sndRelease -Force
+    $fftwDlls = @(Get-ChildItem -Path (Join-Path $installedRoot "bin") -Filter "*fftw3*.dll" -File | Where-Object $doubleFftwFilter)
+    if ($fftwDlls.Count -eq 0) {
+        throw "Could not find FFTW runtime DLLs in vcpkg output"
+    }
+    $fftwDlls | Copy-Item -Destination $fftwRelease -Force
+    if (-not (Test-Path (Join-Path $fftwRelease "libfftw3.dll"))) {
+        Copy-Item -Path $fftwDlls[0].FullName -Destination (Join-Path $fftwRelease "libfftw3.dll") -Force
+    }
+
+    # Rebuild muparserx from the downloaded source carrier with this variant's
+    # /arch flag (the prebuilt avx2 zip only supplies parser/*.cpp here), so no
+    # AVX2 code is linked into the sse2/avx builds.
+    $parserDir = Join-Path $DepsRoot "muparserx\parser"
+    $muparserBuildDir = Join-Path $DepsRoot "muparserx\build\Release"
+    $muparserObjDir = Join-Path $DepsRoot "muparserx\build\obj-$SimdVariant"
+    New-Item -ItemType Directory -Force -Path $muparserBuildDir, $muparserObjDir | Out-Null
+
+    $archArg = if ($SimdVariant -eq "avx") { "/arch:AVX" } else { "" }
+    $objects = @()
+    $sources = Get-ChildItem -Path $parserDir -Filter "*.cpp" -File | Where-Object { $_.Name -ne "mpTest.cpp" }
+    foreach ($source in $sources) {
+        $objectPath = Join-Path $muparserObjDir ($source.BaseName + ".obj")
+        $clArgs = @("/nologo", "/c", "/EHsc", "/std:c++17", "/O2", "/MD", "/DNDEBUG", "/DMUP_USE_WIDE_STRING", "/I$parserDir", "/Fo$objectPath")
+        if ($archArg) {
+            $clArgs += $archArg
+        }
+        $clArgs += $source.FullName
+        & cl.exe @clArgs
+        if ($LASTEXITCODE -ne 0) {
+            throw "muParserX compile failed for $($source.Name)"
+        }
+        $objects += $objectPath
+    }
+
+    $muparserLib = Join-Path $muparserBuildDir "muparserx.lib"
+    & lib.exe /nologo "/OUT:$muparserLib" $objects
+    if ($LASTEXITCODE -ne 0) {
+        throw "muParserX library creation failed"
+    }
+}
+
+function Install-QtSdk {
+    <#
+    .SYNOPSIS
+        Installs Qt via aqtinstall for the given platform and returns the Qt
+        root directory (the folder containing bin\qmake.exe).
+
+    .DESCRIPTION
+        Requires python on PATH. Writes aqt-settings.ini under $WorkspaceRoot
+        with concurrency 1 (parallel extraction raced intermittently on CI)
+        and installs the qtbase/qttools/qtsvg/qttranslations archives only.
+        Native tool output is routed to the host so the returned value is just
+        the Qt root path.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$WorkspaceRoot,
+        [Parameter(Mandatory)] [ValidateSet('x64', 'ARM64')] [string]$Platform,
+        [string]$QtVersion = '6.10.1'
+    )
+
+    $configPath = Join-Path $WorkspaceRoot "aqt-settings.ini"
+    Set-Content -Path $configPath -Encoding ASCII -Value @(
+        "[aqt]",
+        "concurrency: 1"
+    )
+
+    python -m pip install --upgrade "setuptools>=70.1.0" "py7zr==1.0.*" "aqtinstall==3.2.*" | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to install aqtinstall"
+    }
+
+    $qtHost = if ($Platform -eq "ARM64") { "windows_arm64" } else { "windows" }
+    $qtArch = if ($Platform -eq "ARM64") { "win64_msvc2022_arm64" } else { "win64_msvc2022_64" }
+    $qtArchDir = if ($Platform -eq "ARM64") { "msvc2022_arm64" } else { "msvc2022_64" }
+    $qtOutput = Join-Path $WorkspaceRoot "Qt"
+
+    python -m aqt -c $configPath install-qt $qtHost desktop $QtVersion $qtArch `
+        --autodesktop `
+        --outputdir $qtOutput `
+        --archives qtbase qttools qtsvg qttranslations `
+        --external 7z | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Qt installation failed"
+    }
+
+    $qtRoot = Join-Path $qtOutput (Join-Path $QtVersion $qtArchDir)
+    if (-not (Test-Path (Join-Path $qtRoot "bin\qmake.exe"))) {
+        throw "qmake.exe not found under $qtRoot"
+    }
+    if (-not (Test-Path (Join-Path $qtRoot "include\QtCore\QCoreApplication"))) {
+        throw "QtCore headers not found under $qtRoot"
+    }
+
+    return $qtRoot
+}
+
+Export-ModuleMember -Function Get-SimdVariantEntry, Get-DependencyDownloadSpec, Invoke-DependencyDownload, Build-VcpkgDependencies, Install-QtSdk

--- a/.github/scripts/Tests/Provisioning.Tests.ps1
+++ b/.github/scripts/Tests/Provisioning.Tests.ps1
@@ -1,0 +1,375 @@
+# Pester 5 tests for .github/scripts/Provisioning.psm1
+#
+# Provisioning.psm1 is the single implementation of the dependency
+# download+verify loop, the vcpkg dependency build, and the aqt Qt install
+# that .github/workflows/build.yml and setup-build.ps1 used to duplicate
+# (audit finding TD015). The download+verify loop is the supply-chain gate:
+# a wrong URL fetches the wrong artifact, and a verification bug lets an
+# unreviewed upload into shipped binaries. These tests lock down URL
+# construction, pin resolution, and the hash-verification failure paths.
+#
+# No test touches the network: the module's only fetch primitive
+# (Invoke-DependencyFetch) is mocked in module scope, and the extraction
+# tests run against real zips created on the fly with Compress-Archive.
+# Fixture manifests are written as actual .psd1 files and loaded with
+# Import-PowerShellDataFile, the same restricted-language path production
+# uses for .github/simd-variants.psd1.
+
+BeforeAll {
+    $script:ModulePath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Provisioning.psm1')).Path
+    Import-Module $script:ModulePath -Force
+
+    $script:RepoManifestPath = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' 'simd-variants.psd1')).Path
+    $script:RepoManifest = Import-PowerShellDataFile -Path $script:RepoManifestPath
+
+    $script:TempDirs = [System.Collections.Generic.List[string]]::new()
+
+    function New-TempDir {
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ("provtest-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $dir | Out-Null
+        $script:TempDirs.Add($dir)
+        return $dir
+    }
+
+    # Creates a small real zip (Expand-Archive needs a valid archive) and
+    # returns its path plus lowercase SHA-256, ready to pin in a fixture.
+    function New-FixtureZip {
+        param(
+            [Parameter(Mandatory)] [string]$Directory,
+            [Parameter(Mandatory)] [string]$Name,
+            [string]$InnerFileName = 'payload.txt',
+            [string]$Content = 'fixture payload'
+        )
+        $staging = New-TempDir
+        Set-Content -Path (Join-Path $staging $InnerFileName) -Value $Content -Encoding ASCII
+        $zipPath = Join-Path $Directory $Name
+        Compress-Archive -Path (Join-Path $staging '*') -DestinationPath $zipPath -Force
+        $sha = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        return [pscustomobject]@{ Path = $zipPath; Sha256 = $sha; InnerFileName = $InnerFileName }
+    }
+
+    # Writes a minimal manifest fixture with the same shape as
+    # .github/simd-variants.psd1 and loads it via Import-PowerShellDataFile.
+    # Two variants: 'testy' (prebuilt assets) and 'vc' (UsesVcpkg).
+    function New-FixtureManifest {
+        param(
+            [string]$MuparserxSha = 'aa11',
+            [string]$FftwSha = 'bb22',
+            [string]$SndfileSha = 'cc33',
+            [string]$VelopackSha = 'dd44',
+            [switch]$OmitFftwPin,
+            [switch]$OmitMuparserxHash
+        )
+
+        $muparserxHashLine = if ($OmitMuparserxHash) { "'unrelated.zip' = 'ee55'" } else { "'mup.zip' = '$MuparserxSha'" }
+        $fftwPinBlock = if ($OmitFftwPin) { '' } else {
+@"
+        'TheFireKahuna/amd-fftw' = @{
+            Tag    = '5.9'
+            Sha256 = @{ 'fftw.zip' = '$FftwSha' }
+        }
+"@
+        }
+
+        $text = @"
+@{
+    Variants = @(
+        @{
+            Name      = 'windows-x64-testy'
+            Platform  = 'x64'
+            Simd      = 'testy'
+            Muparserx = 'mup.zip'
+            Fftw      = 'fftw.zip'
+            Sndfile   = 'snd.zip'
+            UsesVcpkg = `$false
+        }
+        @{
+            Name      = 'windows-x64-vc'
+            Platform  = 'x64'
+            Simd      = 'vc'
+            Muparserx = 'mup.zip'
+            Fftw      = `$null
+            Sndfile   = `$null
+            UsesVcpkg = `$true
+        }
+    )
+    Shared = @{
+        VelopackLibcVersion = '9.9.9'
+        VelopackLibcSha256  = '$VelopackSha'
+    }
+    DependencyReleases = @{
+        'TheFireKahuna/muparserx' = @{
+            Tag    = '4.0.99'
+            Sha256 = @{ $muparserxHashLine }
+        }
+$fftwPinBlock
+        'TheFireKahuna/libsndfile' = @{
+            Tag    = '1.9.9'
+            Sha256 = @{ 'snd.zip' = '$SndfileSha' }
+        }
+    }
+}
+"@
+        $path = Join-Path (New-TempDir) 'fixture-variants.psd1'
+        Set-Content -Path $path -Value $text -Encoding ASCII
+        return Import-PowerShellDataFile -Path $path
+    }
+}
+
+AfterAll {
+    foreach ($dir in $script:TempDirs) {
+        Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Variable -Name ProvisioningTestGoodZip -Scope Global -ErrorAction SilentlyContinue
+}
+
+Describe "Provisioning.psm1" {
+    Context "exported surface" {
+        It "exports exactly the shared provisioning functions" {
+            $exported = (Get-Command -Module Provisioning).Name | Sort-Object
+            $exported | Should -Be @(
+                'Build-VcpkgDependencies',
+                'Get-DependencyDownloadSpec',
+                'Get-SimdVariantEntry',
+                'Install-QtSdk',
+                'Invoke-DependencyDownload'
+            )
+        }
+    }
+
+    Context "Get-SimdVariantEntry" {
+        It "finds a variant by platform and simd in the repo manifest" {
+            $entry = Get-SimdVariantEntry -Manifest $script:RepoManifest -Platform 'x64' -Simd 'avx2'
+            $entry.Name | Should -Be 'windows-x64-avx2'
+        }
+
+        It "throws the historical message for an unknown variant" {
+            { Get-SimdVariantEntry -Manifest $script:RepoManifest -Platform 'x64' -Simd 'mmx' } |
+                Should -Throw "No asset mapping for Platform=x64, Variant=mmx"
+        }
+    }
+
+    Context "Get-DependencyDownloadSpec against the repo manifest" {
+        BeforeAll {
+            $script:DepsRoot = Join-Path (New-TempDir) 'deps'
+        }
+
+        It "builds the four avx2 downloads with pinned releases/download URLs" {
+            $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'x64' -Simd 'avx2'
+            $downloads.Count | Should -Be 4
+
+            $mupTag = $script:RepoManifest.DependencyReleases['TheFireKahuna/muparserx'].Tag
+            $fftwTag = $script:RepoManifest.DependencyReleases['TheFireKahuna/amd-fftw'].Tag
+            $sndTag = $script:RepoManifest.DependencyReleases['TheFireKahuna/libsndfile'].Tag
+            $veloVer = $script:RepoManifest.Shared.VelopackLibcVersion
+
+            $byRepo = @{}
+            foreach ($d in $downloads) { $byRepo[$d.Repo] = $d }
+
+            $byRepo['TheFireKahuna/muparserx'].Url |
+                Should -Be "https://github.com/TheFireKahuna/muparserx/releases/download/$mupTag/muparserx-msvc-release-x64-avx2.zip"
+            $byRepo['TheFireKahuna/amd-fftw'].Url |
+                Should -Be "https://github.com/TheFireKahuna/amd-fftw/releases/download/$fftwTag/fftw-windows-release-x64-avx2.zip"
+            $byRepo['TheFireKahuna/libsndfile'].Url |
+                Should -Be "https://github.com/TheFireKahuna/libsndfile/releases/download/$sndTag/libsndfile-x64-avx2.zip"
+            $byRepo['velopack/velopack'].Url |
+                Should -Be "https://github.com/velopack/velopack/releases/download/$veloVer/velopack_libc_$veloVer.zip"
+        }
+
+        It "targets the deps/ layout both consumers share" {
+            $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'x64' -Simd 'avx2'
+            $byRepo = @{}
+            foreach ($d in $downloads) { $byRepo[$d.Repo] = $d }
+
+            $byRepo['TheFireKahuna/muparserx'].Destination | Should -Be (Join-Path $script:DepsRoot 'muparserx')
+            $byRepo['velopack/velopack'].Destination | Should -Be (Join-Path $script:DepsRoot 'velopack_libc')
+            $byRepo['TheFireKahuna/amd-fftw'].Destination | Should -Be (Join-Path $script:DepsRoot 'fftw')
+            $byRepo['TheFireKahuna/libsndfile'].Destination | Should -Be (Join-Path $script:DepsRoot 'libsndfile')
+        }
+
+        It "resolves the pinned SHA-256 for every avx2 asset" {
+            $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'x64' -Simd 'avx2'
+            foreach ($d in $downloads) {
+                $d.Sha256 | Should -Match '^[0-9a-fA-F]{64}$' -Because "$($d.Asset) must carry a pinned hash"
+            }
+            ($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/amd-fftw' }).Sha256 |
+                Should -Be $script:RepoManifest.DependencyReleases['TheFireKahuna/amd-fftw'].Sha256['fftw-windows-release-x64-avx2.zip']
+        }
+
+        It "leaves FFTW and libsndfile to vcpkg for the sse2 variant" {
+            $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'x64' -Simd 'sse2'
+            @($downloads).Count | Should -Be 2
+            @($downloads | ForEach-Object { $_.Repo }) | Sort-Object |
+                Should -Be @('TheFireKahuna/muparserx', 'velopack/velopack')
+        }
+
+        It "selects the ARM64 assets for the neon variant" {
+            $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'ARM64' -Simd 'neon'
+            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/amd-fftw' }).Asset | Should -Be 'fftw-windows-release-arm64.zip'
+            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/muparserx' }).Asset | Should -Be 'muparserx-msvc-release-ARM64.zip'
+            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/libsndfile' }).Asset | Should -Be 'libsndfile-arm64.zip'
+        }
+
+        It "resolves every variant in the repo manifest without error (drift guard)" {
+            foreach ($variant in $script:RepoManifest.Variants) {
+                $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform $variant.Platform -Simd $variant.Simd
+                foreach ($d in $downloads) {
+                    $d.Url | Should -Match '^https://github\.com/.+/releases/download/.+' -Because "$($variant.Name) / $($d.Asset) must download from a pinned tag, never releases/latest"
+                    $d.Sha256 | Should -Not -BeNullOrEmpty -Because "$($variant.Name) / $($d.Asset) must be hash-pinned"
+                }
+            }
+        }
+    }
+
+    Context "pin resolution from a fixture psd1" {
+        BeforeAll {
+            $script:FixtureDepsRoot = Join-Path (New-TempDir) 'deps'
+        }
+
+        It "builds URLs from the fixture's pinned tags" {
+            $manifest = New-FixtureManifest
+            $downloads = Get-DependencyDownloadSpec -Manifest $manifest -DepsRoot $script:FixtureDepsRoot -Platform 'x64' -Simd 'testy'
+            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/muparserx' }).Url |
+                Should -Be 'https://github.com/TheFireKahuna/muparserx/releases/download/4.0.99/mup.zip'
+            @($downloads | Where-Object { $_.Repo -eq 'velopack/velopack' }).Url |
+                Should -Be 'https://github.com/velopack/velopack/releases/download/9.9.9/velopack_libc_9.9.9.zip'
+        }
+
+        It "throws when a referenced repo has no DependencyReleases pin" {
+            $manifest = New-FixtureManifest -OmitFftwPin
+            { Get-DependencyDownloadSpec -Manifest $manifest -DepsRoot $script:FixtureDepsRoot -Platform 'x64' -Simd 'testy' } |
+                Should -Throw "No pinned tag or explicit URL for TheFireKahuna/amd-fftw in simd-variants.psd1"
+        }
+
+        It "throws when the asset has no pinned SHA-256" {
+            $manifest = New-FixtureManifest -OmitMuparserxHash
+            { Get-DependencyDownloadSpec -Manifest $manifest -DepsRoot $script:FixtureDepsRoot -Platform 'x64' -Simd 'testy' } |
+                Should -Throw "No pinned SHA-256 for mup.zip in simd-variants.psd1"
+        }
+    }
+
+    Context "Invoke-DependencyDownload verify / cache-reuse logic" {
+        BeforeEach {
+            $script:DownloadRoot = Join-Path (New-TempDir) '_downloads'
+            New-Item -ItemType Directory -Force -Path $script:DownloadRoot | Out-Null
+            $script:Destination = Join-Path (New-TempDir) 'dest'
+            $script:GoodZip = New-FixtureZip -Directory (New-TempDir) -Name 'dep.zip'
+            # Mock bodies with -ModuleName run in the module's session state,
+            # where the test file's $script: variables are invisible; hand the
+            # fixture path over via a global instead.
+            $global:ProvisioningTestGoodZip = $script:GoodZip.Path
+        }
+
+        It "reuses a cached zip without touching the network and still verifies + extracts it" {
+            Mock -ModuleName Provisioning Invoke-DependencyFetch { throw "network must not be touched" }
+            Copy-Item $script:GoodZip.Path (Join-Path $script:DownloadRoot 'dep.zip')
+
+            $entry = @{
+                Repo        = 'example/repo'
+                Asset       = 'dep.zip'
+                Url         = 'https://example.invalid/dep.zip'
+                Sha256      = $script:GoodZip.Sha256
+                Destination = $script:Destination
+            }
+            $output = Invoke-DependencyDownload -Downloads @($entry) -DownloadRoot $script:DownloadRoot -ReuseCachedDownloads 6>&1 | Out-String
+
+            Should -Invoke Invoke-DependencyFetch -ModuleName Provisioning -Exactly -Times 0
+            $output | Should -Match '\[cached\] dep\.zip'
+            $output | Should -Match 'Verified SHA-256 for dep\.zip'
+            Test-Path (Join-Path $script:Destination $script:GoodZip.InnerFileName) | Should -BeTrue
+        }
+
+        It "downloads when the zip is absent, then verifies and extracts" {
+            Mock -ModuleName Provisioning Invoke-DependencyFetch {
+                Copy-Item $global:ProvisioningTestGoodZip $OutFile
+            }
+
+            $entry = @{
+                Repo        = 'example/repo'
+                Asset       = 'dep.zip'
+                Url         = 'https://example.invalid/dep.zip'
+                Sha256      = $script:GoodZip.Sha256
+                Destination = $script:Destination
+            }
+            Invoke-DependencyDownload -Downloads @($entry) -DownloadRoot $script:DownloadRoot -ReuseCachedDownloads 6>$null
+
+            Should -Invoke Invoke-DependencyFetch -ModuleName Provisioning -Exactly -Times 1
+            Test-Path (Join-Path $script:Destination $script:GoodZip.InnerFileName) | Should -BeTrue
+        }
+
+        It "removes a mismatching cached zip and points at the rerun (setup-build behavior)" {
+            Mock -ModuleName Provisioning Invoke-DependencyFetch { throw "network must not be touched" }
+            Copy-Item $script:GoodZip.Path (Join-Path $script:DownloadRoot 'dep.zip')
+
+            $entry = @{
+                Repo        = 'example/repo'
+                Asset       = 'dep.zip'
+                Url         = 'https://example.invalid/dep.zip'
+                Sha256      = ('f' * 64)
+                Destination = $script:Destination
+            }
+            { Invoke-DependencyDownload -Downloads @($entry) -DownloadRoot $script:DownloadRoot -ReuseCachedDownloads 6>$null } |
+                Should -Throw "SHA-256 mismatch for dep.zip: expected *stale cache removed; rerun to redownload*"
+            Test-Path (Join-Path $script:DownloadRoot 'dep.zip') | Should -BeFalse -Because "a poisoned cache entry must not survive for the next run"
+            Test-Path $script:Destination | Should -BeFalse -Because "nothing may be extracted from an unverified zip"
+        }
+
+        It "fails a mismatching fresh download without the cache wording (CI behavior)" {
+            Mock -ModuleName Provisioning Invoke-DependencyFetch {
+                Copy-Item $global:ProvisioningTestGoodZip $OutFile
+            }
+
+            $entry = @{
+                Repo        = 'example/repo'
+                Asset       = 'dep.zip'
+                Url         = 'https://example.invalid/dep.zip'
+                Sha256      = ('f' * 64)
+                Destination = $script:Destination
+            }
+            $failure = $null
+            try {
+                Invoke-DependencyDownload -Downloads @($entry) -DownloadRoot $script:DownloadRoot 6>$null
+            } catch {
+                $failure = $_
+            }
+            $failure | Should -Not -BeNullOrEmpty
+            $failure.Exception.Message | Should -Match '^SHA-256 mismatch for dep\.zip: expected f{64}, got [0-9A-Fa-f]{64}$'
+            Test-Path $script:Destination | Should -BeFalse -Because "nothing may be extracted from an unverified zip"
+        }
+
+        It "provisions a whole fixture-manifest variant from a pre-seeded cache without network (dry run)" {
+            Mock -ModuleName Provisioning Invoke-DependencyFetch { throw "network must not be touched" }
+
+            $zips = @{}
+            foreach ($name in @('mup.zip', 'fftw.zip', 'snd.zip', 'velopack_libc_9.9.9.zip')) {
+                $zips[$name] = New-FixtureZip -Directory $script:DownloadRoot -Name $name -InnerFileName "$name.txt"
+            }
+            $manifest = New-FixtureManifest -MuparserxSha $zips['mup.zip'].Sha256 `
+                -FftwSha $zips['fftw.zip'].Sha256 `
+                -SndfileSha $zips['snd.zip'].Sha256 `
+                -VelopackSha $zips['velopack_libc_9.9.9.zip'].Sha256
+            $depsRoot = Join-Path (New-TempDir) 'deps'
+
+            $downloads = Get-DependencyDownloadSpec -Manifest $manifest -DepsRoot $depsRoot -Platform 'x64' -Simd 'testy'
+            Invoke-DependencyDownload -Downloads $downloads -DownloadRoot $script:DownloadRoot -ReuseCachedDownloads 6>$null
+
+            Should -Invoke Invoke-DependencyFetch -ModuleName Provisioning -Exactly -Times 0
+            Test-Path (Join-Path $depsRoot 'muparserx\mup.zip.txt') | Should -BeTrue
+            Test-Path (Join-Path $depsRoot 'fftw\fftw.zip.txt') | Should -BeTrue
+            Test-Path (Join-Path $depsRoot 'libsndfile\snd.zip.txt') | Should -BeTrue
+            Test-Path (Join-Path $depsRoot 'velopack_libc\velopack_libc_9.9.9.zip.txt') | Should -BeTrue
+        }
+    }
+
+    Context "thin wrappers (parameter contracts only; no vcpkg/Qt runs here)" {
+        It "Build-VcpkgDependencies only accepts the vcpkg-built variants sse2 and avx" {
+            { Build-VcpkgDependencies -DepsRoot 'x' -VcpkgFallbackRoot 'y' -SimdVariant 'avx2' -VcpkgCommit 'z' } |
+                Should -Throw -ErrorId 'ParameterArgumentValidationError,Build-VcpkgDependencies'
+        }
+
+        It "Install-QtSdk only accepts the platforms the manifest builds" {
+            { Install-QtSdk -WorkspaceRoot 'x' -Platform 'x86' } |
+                Should -Throw -ErrorId 'ParameterArgumentValidationError,Install-QtSdk'
+        }
+    }
+}

--- a/.github/simd-variants.psd1
+++ b/.github/simd-variants.psd1
@@ -11,9 +11,14 @@
 #   loader, so it is safe to import in CI).
 #
 # CONSUMERS
-#   - setup-build.ps1                       (dependency download + pinned tags/hashes)
+#   - .github/scripts/Provisioning.psm1     (shared download+verify / vcpkg /
+#                                            Qt provisioning; expands Variants +
+#                                            DependencyReleases into download specs)
+#   - setup-build.ps1                       (dependency download + pinned tags/hashes,
+#                                            via Provisioning.psm1)
 #   - .github/workflows/build.yml           ("Resolve pinned dependency tags" step +
-#                                            dependency download verification)
+#                                            dependency download verification,
+#                                            via Provisioning.psm1)
 #   - .github/scripts/New-BuildMatrix.ps1   (expands Variants into the build.yml
 #                                            job matrix — the matrix is no longer
 #                                            hand-written in YAML)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,95 +186,35 @@ jobs:
       run: |
         $ErrorActionPreference = "Stop"
         $manifest = Import-PowerShellDataFile -Path "${{ github.workspace }}\.github\simd-variants.psd1"
-        "VELOPACK_LIBC_VERSION=$($manifest.Shared.VelopackLibcVersion)" >> $env:GITHUB_ENV
         "VST3_TAG=$($manifest.Shared.Vst3Tag)" >> $env:GITHUB_ENV
         "HIGHWAY_TAG=$($manifest.Shared.HighwayTag)" >> $env:GITHUB_ENV
         "TCLAP_TAG=$($manifest.Shared.TclapTag)" >> $env:GITHUB_ENV
-        Write-Host "velopack_libc version: $($manifest.Shared.VelopackLibcVersion)"
         Write-Host "VST3 tag: $($manifest.Shared.Vst3Tag)"
         Write-Host "Highway tag: $($manifest.Shared.HighwayTag)"
         Write-Host "TCLAP tag: $($manifest.Shared.TclapTag)"
 
+    # Supply-chain pins: the prebuilt binary dependencies (and velopack_libc)
+    # are downloaded from a pinned release tag and verified against the SHA-256
+    # recorded in .github/simd-variants.psd1, so a new upload to those personal
+    # forks cannot change what CI links without a reviewed manifest diff. The
+    # download+verify loop lives in .github/scripts/Provisioning.psm1, shared
+    # with setup-build.ps1 (TD015).
     - name: Download dependency release assets
       shell: pwsh
       run: |
         $ErrorActionPreference = "Stop"
+        Import-Module "${{ github.workspace }}\.github\scripts\Provisioning.psm1" -Force
 
-        $downloadRoot = "${{ github.workspace }}\deps\_downloads"
-        New-Item -ItemType Directory -Force -Path $downloadRoot | Out-Null
-
-        # Supply-chain pins: the three prebuilt binary dependencies are downloaded
-        # from a pinned release tag and verified against the SHA-256 recorded in
-        # .github/simd-variants.psd1, so a new upload to those personal forks
-        # cannot change what CI links without a reviewed manifest diff.
         $manifest = Import-PowerShellDataFile -Path "${{ github.workspace }}\.github\simd-variants.psd1"
-        $pins = $manifest.DependencyReleases
+        $downloads = Get-DependencyDownloadSpec -Manifest $manifest `
+          -DepsRoot "${{ github.workspace }}\deps" `
+          -Platform "${{ matrix.platform }}" `
+          -Simd "${{ matrix.simd_variant }}"
+        Invoke-DependencyDownload -Downloads $downloads `
+          -DownloadRoot "${{ github.workspace }}\deps\_downloads"
 
-        $downloads = @(
-          @{
-            Repo = "TheFireKahuna/muparserx"
-            Asset = "${{ matrix.muparserx_asset }}"
-            Destination = "${{ github.workspace }}\deps\muparserx"
-          },
-          @{
-            # Velopack C/C++ runtime (Velopack.h + import libs + DLLs). Always fetched;
-            # the Editor links it for auto-update. Version comes from
-            # .github/simd-variants.psd1 (Shared.VelopackLibcVersion), shared with setup-build.ps1.
-            Repo = "velopack/velopack"
-            Asset = "velopack_libc_${{ env.VELOPACK_LIBC_VERSION }}.zip"
-            Url = "https://github.com/velopack/velopack/releases/download/${{ env.VELOPACK_LIBC_VERSION }}/velopack_libc_${{ env.VELOPACK_LIBC_VERSION }}.zip"
-            Destination = "${{ github.workspace }}\deps\velopack_libc"
-          }
-        )
-
-        if ("${{ matrix.uses_vcpkg }}" -ne "true") {
-          $downloads += @(
-            @{
-              Repo = "TheFireKahuna/amd-fftw"
-              Asset = "${{ matrix.fftw_asset }}"
-              Destination = "${{ github.workspace }}\deps\fftw"
-            },
-            @{
-              Repo = "TheFireKahuna/libsndfile"
-              Asset = "${{ matrix.libsndfile_asset }}"
-              Destination = "${{ github.workspace }}\deps\libsndfile"
-            }
-          )
-        }
-
-        foreach ($download in $downloads) {
-          $pin = $pins[$download.Repo]
-          $url = if ($download.Url) {
-            $download.Url
-          } elseif ($pin) {
-            "https://github.com/$($download.Repo)/releases/download/$($pin.Tag)/$($download.Asset)"
-          } else {
-            throw "No pinned tag or explicit URL for $($download.Repo) in simd-variants.psd1"
-          }
-          $zipPath = Join-Path $downloadRoot $download.Asset
-
-          Write-Host "Downloading $($download.Repo) release asset $($download.Asset)"
-          curl.exe --fail --location --retry 5 --retry-delay 5 --output $zipPath $url
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to download $url"
-          }
-
-          if ($pin) {
-            $expected = $pin.Sha256[$download.Asset]
-            if (-not $expected) {
-              throw "No pinned SHA-256 for $($download.Asset) in simd-variants.psd1"
-            }
-            $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash
-            if ($actual -ne $expected) {
-              throw "SHA-256 mismatch for $($download.Asset): expected $expected, got $actual"
-            }
-            Write-Host "Verified SHA-256 for $($download.Asset)"
-          }
-
-          New-Item -ItemType Directory -Force -Path $download.Destination | Out-Null
-          Expand-Archive -Path $zipPath -DestinationPath $download.Destination -Force
-        }
-
+    # The vcpkg FFTW/libsndfile build and the muparserx /arch rebuild live in
+    # .github/scripts/Provisioning.psm1, shared with setup-build.ps1 (TD015).
     - name: Build lower-SIMD dependency binaries
       if: ${{ matrix.uses_vcpkg == true }}
       shell: pwsh
@@ -284,95 +224,15 @@ jobs:
         # Canonical vswhere/VsDevCmd import, shared with the Qt build step below
         # and setup-build.ps1.
         . .\.github\scripts\Import-VsDevEnvironment.ps1
-
-        function Copy-RequiredFile {
-          param(
-            [string]$SourceRoot,
-            [string[]]$Patterns,
-            [scriptblock]$Filter,
-            [string]$Destination
-          )
-
-          foreach ($pattern in $Patterns) {
-            $matches = @(Get-ChildItem -Path $SourceRoot -Recurse -Filter $pattern -File -ErrorAction SilentlyContinue | Where-Object $Filter)
-            if ($matches.Count -gt 0) {
-              New-Item -ItemType Directory -Force -Path (Split-Path $Destination -Parent) | Out-Null
-              Copy-Item -Path $matches[0].FullName -Destination $Destination -Force
-              Write-Host "Copied $($matches[0].FullName) -> $Destination"
-              return
-            }
-          }
-
-          throw "Could not find required file under $SourceRoot matching $($Patterns -join ', ')"
-        }
+        Import-Module "${{ github.workspace }}\.github\scripts\Provisioning.psm1" -Force
 
         Import-VsDevEnvironment "${{ matrix.msvcdevplatform }}"
 
-        $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
-        if (-not $vcpkgRoot -or -not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
-          $vcpkgRoot = "${{ github.workspace }}\vcpkg"
-          git clone --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
-          & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
-        }
-
-        $vcpkgExe = Join-Path $vcpkgRoot "vcpkg.exe"
-        $fftwFeature = if ("${{ matrix.simd_variant }}" -eq "avx") { "fftw3[avx,threads]:x64-windows" } else { "fftw3[sse2,threads]:x64-windows" }
-        & $vcpkgExe install $fftwFeature "libsndfile:x64-windows" --clean-after-build
-        if ($LASTEXITCODE -ne 0) {
-          throw "vcpkg dependency install failed"
-        }
-
-        $installedRoot = Join-Path $vcpkgRoot "installed\x64-windows"
-        $fftwInclude = "${{ github.workspace }}\deps\fftw\include"
-        $fftwRelease = "${{ github.workspace }}\deps\fftw\Release"
-        $sndInclude = "${{ github.workspace }}\deps\libsndfile\include"
-        $sndRelease = "${{ github.workspace }}\deps\libsndfile\build\Release"
-
-        New-Item -ItemType Directory -Force -Path $fftwInclude, $fftwRelease, $sndInclude, $sndRelease | Out-Null
-        Copy-Item -Path (Join-Path $installedRoot "include\fftw3.h") -Destination $fftwInclude -Force
-        Copy-Item -Path (Join-Path $installedRoot "include\sndfile*.h*") -Destination $sndInclude -Force
-
-        $doubleFftwFilter = { $_.Name -notmatch "fftw3f|fftw3l|threads|omp" }
-        Copy-RequiredFile (Join-Path $installedRoot "lib") @("libfftw3.lib", "fftw3.lib", "libfftw3-3.lib") $doubleFftwFilter (Join-Path $fftwRelease "libfftw3.lib")
-        Copy-RequiredFile (Join-Path $installedRoot "lib") @("sndfile.lib") { $true } (Join-Path $sndRelease "sndfile.lib")
-
-        Get-ChildItem -Path (Join-Path $installedRoot "bin") -Filter "*.dll" -File | Copy-Item -Destination $sndRelease -Force
-        $fftwDlls = @(Get-ChildItem -Path (Join-Path $installedRoot "bin") -Filter "*fftw3*.dll" -File | Where-Object $doubleFftwFilter)
-        if ($fftwDlls.Count -eq 0) {
-          throw "Could not find FFTW runtime DLLs in vcpkg output"
-        }
-        $fftwDlls | Copy-Item -Destination $fftwRelease -Force
-        if (-not (Test-Path (Join-Path $fftwRelease "libfftw3.dll"))) {
-          Copy-Item -Path $fftwDlls[0].FullName -Destination (Join-Path $fftwRelease "libfftw3.dll") -Force
-        }
-
-        $parserDir = "${{ github.workspace }}\deps\muparserx\parser"
-        $muparserBuildDir = "${{ github.workspace }}\deps\muparserx\build\Release"
-        $muparserObjDir = "${{ github.workspace }}\deps\muparserx\build\obj-${{ matrix.simd_variant }}"
-        New-Item -ItemType Directory -Force -Path $muparserBuildDir, $muparserObjDir | Out-Null
-
-        $archArg = if ("${{ matrix.simd_variant }}" -eq "avx") { "/arch:AVX" } else { "" }
-        $objects = @()
-        $sources = Get-ChildItem -Path $parserDir -Filter "*.cpp" -File | Where-Object { $_.Name -ne "mpTest.cpp" }
-        foreach ($source in $sources) {
-          $objectPath = Join-Path $muparserObjDir ($source.BaseName + ".obj")
-          $args = @("/nologo", "/c", "/EHsc", "/std:c++17", "/O2", "/MD", "/DNDEBUG", "/DMUP_USE_WIDE_STRING", "/I$parserDir", "/Fo$objectPath")
-          if ($archArg) {
-            $args += $archArg
-          }
-          $args += $source.FullName
-          & cl.exe @args
-          if ($LASTEXITCODE -ne 0) {
-            throw "muParserX compile failed for $($source.Name)"
-          }
-          $objects += $objectPath
-        }
-
-        $muparserLib = Join-Path $muparserBuildDir "muparserx.lib"
-        & lib.exe /nologo "/OUT:$muparserLib" $objects
-        if ($LASTEXITCODE -ne 0) {
-          throw "muParserX library creation failed"
-        }
+        $manifest = Import-PowerShellDataFile -Path "${{ github.workspace }}\.github\simd-variants.psd1"
+        Build-VcpkgDependencies -DepsRoot "${{ github.workspace }}\deps" `
+          -VcpkgFallbackRoot "${{ github.workspace }}\vcpkg" `
+          -SimdVariant "${{ matrix.simd_variant }}" `
+          -VcpkgCommit $manifest.Shared.VcpkgCommit
 
     # Clone tclap repository (header-only library). Pinned like the other source
     # dependencies; the tag comes from .github/simd-variants.psd1 (Shared.TclapTag).
@@ -512,41 +372,16 @@ jobs:
       with:
         python-version: '3.12'
 
-    # Install Qt for Editor, DeviceSelector, and UpdateChecker.
-    # Keep aqt concurrency at 1 to avoid intermittent archive extraction races.
+    # Install Qt for Editor, DeviceSelector, and UpdateChecker. The aqt install
+    # (concurrency 1: parallel extraction raced intermittently) lives in
+    # .github/scripts/Provisioning.psm1, shared with setup-build.ps1 (TD015).
     - name: Install Qt
       shell: pwsh
       run: |
         $ErrorActionPreference = "Stop"
+        Import-Module "${{ github.workspace }}\.github\scripts\Provisioning.psm1" -Force
 
-        $configPath = "${{ github.workspace }}\aqt-settings.ini"
-        Set-Content -Path $configPath -Encoding ASCII -Value @(
-          "[aqt]",
-          "concurrency: 1"
-        )
-
-        python -m pip install --upgrade "setuptools>=70.1.0" "py7zr==1.0.*" "aqtinstall==3.2.*"
-
-        $qtHost = if ("${{ matrix.platform }}" -eq "ARM64") { "windows_arm64" } else { "windows" }
-        $qtArch = if ("${{ matrix.platform }}" -eq "ARM64") { "win64_msvc2022_arm64" } else { "win64_msvc2022_64" }
-        $qtArchDir = if ("${{ matrix.platform }}" -eq "ARM64") { "msvc2022_arm64" } else { "msvc2022_64" }
-        $qtOutput = "${{ github.workspace }}\Qt"
-
-        python -m aqt -c $configPath install-qt $qtHost desktop 6.10.1 $qtArch `
-          --autodesktop `
-          --outputdir $qtOutput `
-          --archives qtbase qttools qtsvg qttranslations `
-          --external 7z
-
-        $qtRoot = Join-Path $qtOutput "6.10.1\$qtArchDir"
-        if (-not (Test-Path (Join-Path $qtRoot "bin\qmake.exe"))) {
-          Write-Error "qmake.exe not found under $qtRoot"
-          exit 1
-        }
-        if (-not (Test-Path (Join-Path $qtRoot "include\QtCore\QCoreApplication"))) {
-          Write-Error "QtCore headers not found under $qtRoot"
-          exit 1
-        }
+        $qtRoot = Install-QtSdk -WorkspaceRoot "${{ github.workspace }}" -Platform "${{ matrix.platform }}"
 
         echo "QT_ROOT=$qtRoot" >> $env:GITHUB_ENV
         echo "Qt6_DIR=$qtRoot" >> $env:GITHUB_ENV

--- a/setup-build.ps1
+++ b/setup-build.ps1
@@ -43,14 +43,10 @@ $workspace = $PSScriptRoot
 $manifestPath = Join-Path $workspace ".github\simd-variants.psd1"
 $simdManifest = Import-PowerShellDataFile -Path $manifestPath
 
-# velopack_libc ships as a single cross-platform zip attached to the velopack/velopack
-# release. The version is pinned in the manifest so the asset name and download URL
-# stay in sync with CI.
-$velopackLibcVersion = $simdManifest.Shared.VelopackLibcVersion
-
-# Supply-chain pins for the prebuilt binary dependencies: release tag plus SHA-256
-# per asset, shared with build.yml. Downloads are refused on hash mismatch.
-$dependencyPins = $simdManifest.DependencyReleases
+# Shared provisioning implementation (download+verify, vcpkg build, Qt install),
+# consumed by both this script and .github/workflows/build.yml so the two can
+# no longer drift (audit finding TD015).
+Import-Module (Join-Path $workspace ".github\scripts\Provisioning.psm1") -Force
 
 Write-Host "=== EqualizerAPO-XT Build Setup ===" -ForegroundColor Cyan
 Write-Host "Workspace: $workspace"
@@ -60,103 +56,21 @@ Write-Host ""
 
 # --- Dependency asset mapping (driven by .github/simd-variants.psd1) ---
 $variant = if ($Platform -eq "ARM64") { "neon" } else { $SimdVariant }
-$variantEntry = $simdManifest.Variants | Where-Object { $_.Platform -eq $Platform -and $_.Simd -eq $variant } | Select-Object -First 1
-if (-not $variantEntry) {
-    throw "No asset mapping for Platform=$Platform, Variant=$variant"
-}
-
-# Reshape the manifest entry into the { muparserx; fftw; sndfile } hashtable the
-# download loop below expects. Variants built from vcpkg leave fftw/sndfile $null,
-# which keeps them out of $downloads exactly as before.
-$assets = @{ muparserx = $variantEntry.Muparserx }
-if ($variantEntry.Fftw)    { $assets.fftw = $variantEntry.Fftw }
-if ($variantEntry.Sndfile) { $assets.sndfile = $variantEntry.Sndfile }
-
-$usesVcpkg = $Platform -eq "x64" -and ($SimdVariant -eq "sse2" -or $SimdVariant -eq "avx")
+$variantEntry = Get-SimdVariantEntry -Manifest $simdManifest -Platform $Platform -Simd $variant
+$usesVcpkg = [bool]$variantEntry.UsesVcpkg
 
 # --- 1. Download binary dependencies ---
 Write-Host "`n=== Step 1: Download Dependencies ===" -ForegroundColor Yellow
 
 $depsDir = Join-Path $workspace "deps"
 $downloadDir = Join-Path $depsDir "_downloads"
-New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
 
-$downloads = @(
-    @{
-        Repo        = "TheFireKahuna/muparserx"
-        Asset       = $assets.muparserx
-        Destination = Join-Path $depsDir "muparserx"
-    },
-    @{
-        # Velopack C/C++ runtime (Velopack.h + import libs + DLLs for every platform).
-        # Always fetched regardless of SIMD variant; the Editor links it for auto-update.
-        # Not covered by DependencyReleases (the URL is release-tag based already), so
-        # its SHA-256 pin rides on the download entry itself.
-        Repo        = "velopack/velopack"
-        Asset       = "velopack_libc_$velopackLibcVersion.zip"
-        Url         = "https://github.com/velopack/velopack/releases/download/$velopackLibcVersion/velopack_libc_$velopackLibcVersion.zip"
-        Sha256      = $simdManifest.Shared.VelopackLibcSha256
-        Destination = Join-Path $depsDir "velopack_libc"
-    }
-)
-
-if (-not $usesVcpkg) {
-    if ($assets.fftw) {
-        $downloads += @{
-            Repo        = "TheFireKahuna/amd-fftw"
-            Asset       = $assets.fftw
-            Destination = Join-Path $depsDir "fftw"
-        }
-    }
-    if ($assets.sndfile) {
-        $downloads += @{
-            Repo        = "TheFireKahuna/libsndfile"
-            Asset       = $assets.sndfile
-            Destination = Join-Path $depsDir "libsndfile"
-        }
-    }
-}
-
-foreach ($dl in $downloads) {
-    $pin = $dependencyPins[$dl.Repo]
-    $url = if ($dl.Url) {
-        $dl.Url
-    } elseif ($pin) {
-        "https://github.com/$($dl.Repo)/releases/download/$($pin.Tag)/$($dl.Asset)"
-    } else {
-        throw "No pinned tag or explicit URL for $($dl.Repo) in simd-variants.psd1"
-    }
-    $zipPath = Join-Path $downloadDir $dl.Asset
-
-    if (Test-Path $zipPath) {
-        Write-Host "  [cached] $($dl.Asset)"
-    } else {
-        Write-Host "  Downloading $($dl.Asset) from $($dl.Repo)..."
-        curl.exe --fail --location --retry 5 --retry-delay 5 --output $zipPath $url
-        if ($LASTEXITCODE -ne 0) {
-            throw "Failed to download $url"
-        }
-    }
-
-    if ($pin -or $dl.Sha256) {
-        # DependencyReleases pins are per-asset; velopack_libc carries its pin on
-        # the download entry (Shared.VelopackLibcSha256 in simd-variants.psd1).
-        $expected = if ($dl.Sha256) { $dl.Sha256 } else { $pin.Sha256[$dl.Asset] }
-        if (-not $expected) {
-            throw "No pinned SHA-256 for $($dl.Asset) in simd-variants.psd1"
-        }
-        $actual = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash
-        if ($actual -ne $expected) {
-            Remove-Item $zipPath -Force
-            throw "SHA-256 mismatch for $($dl.Asset): expected $expected, got $actual (stale cache removed; rerun to redownload)"
-        }
-        Write-Host "  Verified SHA-256 for $($dl.Asset)"
-    }
-
-    New-Item -ItemType Directory -Force -Path $dl.Destination | Out-Null
-    Expand-Archive -Path $zipPath -DestinationPath $dl.Destination -Force
-    Write-Host "  -> $($dl.Destination)"
-}
+# muparserx and velopack_libc always; FFTW and libsndfile only for the variants
+# that do not build them from vcpkg. URLs and SHA-256 pins come from the
+# manifest; a cached zip in deps\_downloads is reused, and a mismatching one is
+# deleted so the next run redownloads it.
+$downloads = Get-DependencyDownloadSpec -Manifest $simdManifest -DepsRoot $depsDir -Platform $Platform -Simd $variant
+Invoke-DependencyDownload -Downloads $downloads -DownloadRoot $downloadDir -ReuseCachedDownloads
 
 # For SSE2/AVX variants, build FFTW and libsndfile from vcpkg
 if ($usesVcpkg) {
@@ -166,78 +80,10 @@ if ($usesVcpkg) {
     . (Join-Path $workspace ".github\scripts\Import-VsDevEnvironment.ps1")
     Import-VsDevEnvironment "x64"
 
-    $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
-    if (-not $vcpkgRoot -or -not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
-        $vcpkgRoot = Join-Path $workspace "vcpkg"
-        if (-not (Test-Path (Join-Path $vcpkgRoot "vcpkg.exe"))) {
-            # Pin vcpkg to the manifest commit: cloning a moving HEAD would let the
-            # portfiles (and thus the FFTW/libsndfile binaries built here) change
-            # without a reviewed diff in simd-variants.psd1. --depth 1 keeps the
-            # clone small; the pinned commit is fetched by SHA and checked out.
-            $vcpkgCommit = $simdManifest.Shared.VcpkgCommit
-            git clone --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
-            if ($LASTEXITCODE -ne 0) { throw "Failed to clone vcpkg" }
-            git -C $vcpkgRoot fetch --depth 1 origin $vcpkgCommit
-            if ($LASTEXITCODE -ne 0) { throw "Failed to fetch pinned vcpkg commit $vcpkgCommit" }
-            git -C $vcpkgRoot checkout --detach $vcpkgCommit
-            if ($LASTEXITCODE -ne 0) { throw "Failed to check out pinned vcpkg commit $vcpkgCommit" }
-            & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
-        }
-    }
-
-    $vcpkgExe = Join-Path $vcpkgRoot "vcpkg.exe"
-    $fftwFeature = if ($SimdVariant -eq "avx") { "fftw3[avx,threads]:x64-windows" } else { "fftw3[sse2,threads]:x64-windows" }
-    & $vcpkgExe install $fftwFeature "libsndfile:x64-windows" --clean-after-build
-    if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed" }
-
-    $installedRoot = Join-Path $vcpkgRoot "installed\x64-windows"
-
-    # Copy FFTW
-    $fftwInclude = Join-Path $depsDir "fftw\include"
-    $fftwRelease = Join-Path $depsDir "fftw\Release"
-    New-Item -ItemType Directory -Force -Path $fftwInclude, $fftwRelease | Out-Null
-    Copy-Item (Join-Path $installedRoot "include\fftw3.h") $fftwInclude -Force
-
-    $doubleFftwFilter = { $_.Name -notmatch "fftw3f|fftw3l|threads|omp" }
-    $fftwLibFiles = @(Get-ChildItem (Join-Path $installedRoot "lib") -Recurse -Filter "*fftw3*" -File | Where-Object $doubleFftwFilter | Where-Object { $_.Extension -eq ".lib" })
-    if ($fftwLibFiles.Count -gt 0) {
-        Copy-Item $fftwLibFiles[0].FullName (Join-Path $fftwRelease "libfftw3.lib") -Force
-    }
-    $fftwDlls = @(Get-ChildItem (Join-Path $installedRoot "bin") -Filter "*fftw3*.dll" -File | Where-Object $doubleFftwFilter)
-    $fftwDlls | Copy-Item -Destination $fftwRelease -Force
-    if (-not (Test-Path (Join-Path $fftwRelease "libfftw3.dll")) -and $fftwDlls.Count -gt 0) {
-        Copy-Item $fftwDlls[0].FullName (Join-Path $fftwRelease "libfftw3.dll") -Force
-    }
-
-    # Copy libsndfile
-    $sndInclude = Join-Path $depsDir "libsndfile\include"
-    $sndRelease = Join-Path $depsDir "libsndfile\build\Release"
-    New-Item -ItemType Directory -Force -Path $sndInclude, $sndRelease | Out-Null
-    Copy-Item (Join-Path $installedRoot "include\sndfile*.h*") $sndInclude -Force
-    $sndLibs = Get-ChildItem (Join-Path $installedRoot "lib") -Filter "sndfile.lib" -File
-    if ($sndLibs) { Copy-Item $sndLibs[0].FullName (Join-Path $sndRelease "sndfile.lib") -Force }
-    Get-ChildItem (Join-Path $installedRoot "bin") -Filter "*.dll" -File | Copy-Item -Destination $sndRelease -Force
-
-    # Rebuild muparserx with correct arch flags
-    $parserDir = Join-Path $depsDir "muparserx\parser"
-    $muparserBuildDir = Join-Path $depsDir "muparserx\build\Release"
-    $muparserObjDir = Join-Path $depsDir "muparserx\build\obj-$SimdVariant"
-    New-Item -ItemType Directory -Force -Path $muparserBuildDir, $muparserObjDir | Out-Null
-
-    $archArg = if ($SimdVariant -eq "avx") { "/arch:AVX" } else { "" }
-    $objects = @()
-    $sources = Get-ChildItem $parserDir -Filter "*.cpp" -File | Where-Object { $_.Name -ne "mpTest.cpp" }
-    foreach ($source in $sources) {
-        $objectPath = Join-Path $muparserObjDir ($source.BaseName + ".obj")
-        $clArgs = @("/nologo", "/c", "/EHsc", "/std:c++17", "/O2", "/MD", "/DNDEBUG", "/DMUP_USE_WIDE_STRING", "/I$parserDir", "/Fo$objectPath")
-        if ($archArg) { $clArgs += $archArg }
-        $clArgs += $source.FullName
-        & cl.exe @clArgs
-        if ($LASTEXITCODE -ne 0) { throw "muParserX compile failed for $($source.Name)" }
-        $objects += $objectPath
-    }
-    & lib.exe /nologo "/OUT:$(Join-Path $muparserBuildDir 'muparserx.lib')" $objects
-    if ($LASTEXITCODE -ne 0) { throw "muParserX lib creation failed" }
+    Build-VcpkgDependencies -DepsRoot $depsDir `
+        -VcpkgFallbackRoot (Join-Path $workspace "vcpkg") `
+        -SimdVariant $SimdVariant `
+        -VcpkgCommit $simdManifest.Shared.VcpkgCommit
 }
 
 Write-Host "  Dependencies downloaded." -ForegroundColor Green
@@ -299,35 +145,15 @@ if (Test-Path (Join-Path $highwayDir "hwy\highway.h")) {
 }
 
 # --- 3. Install Qt ---
+# $qtArchDir is also needed by the verification section below when Qt was
+# installed on an earlier run and this one passes -SkipQt.
+$qtArchDir = if ($Platform -eq "ARM64") { "msvc2022_arm64" } else { "msvc2022_64" }
 if ($SkipQt) {
     Write-Host "`n=== Step 3: Qt Installation (SKIPPED) ===" -ForegroundColor Yellow
 } else {
     Write-Host "`n=== Step 3: Install Qt $QtVersion ===" -ForegroundColor Yellow
 
-    python -m pip install --upgrade "setuptools>=70.1.0" "py7zr==1.0.*" "aqtinstall==3.2.*" --quiet
-    if ($LASTEXITCODE -ne 0) { throw "Failed to install aqtinstall" }
-
-    $qtHost = if ($Platform -eq "ARM64") { "windows_arm64" } else { "windows" }
-    $qtArch = if ($Platform -eq "ARM64") { "win64_msvc2022_arm64" } else { "win64_msvc2022_64" }
-    $qtArchDir = if ($Platform -eq "ARM64") { "msvc2022_arm64" } else { "msvc2022_64" }
-    $qtOutput = Join-Path $workspace "Qt"
-
-    # Write aqt config to limit concurrency
-    $aqtConfig = Join-Path $workspace "aqt-settings.ini"
-    Set-Content -Path $aqtConfig -Encoding ASCII -Value @("[aqt]", "concurrency: 1")
-
-    python -m aqt -c $aqtConfig install-qt $qtHost desktop $QtVersion $qtArch `
-        --autodesktop `
-        --outputdir $qtOutput `
-        --archives qtbase qttools qtsvg qttranslations `
-        --external 7z
-
-    if ($LASTEXITCODE -ne 0) { throw "Qt installation failed" }
-
-    $qtRoot = Join-Path $qtOutput "$QtVersion\$qtArchDir"
-    if (-not (Test-Path (Join-Path $qtRoot "bin\qmake.exe"))) {
-        throw "qmake.exe not found after Qt installation"
-    }
+    $qtRoot = Install-QtSdk -WorkspaceRoot $workspace -Platform $Platform -QtVersion $QtVersion
 
     Write-Host "  Qt installed at: $qtRoot" -ForegroundColor Green
 }


### PR DESCRIPTION
감사 #146 보류분 TD015입니다. 의존성 다운로드+SHA 검증 루프, vcpkg/muparserx 재빌드, aqt Qt 설치가 build.yml과 setup-build.ps1에 이중 구현돼 이미 한 번 표류했던 것을 .github/scripts/Provisioning.psm1 하나로 합쳤습니다(-395줄/+57줄). Pester 19케이스가 URL 구성·핀 해석 실패·캐시 재사용(모의 fetch로 네트워크 0회 증명)·오염 캐시 축출·미검증 zip 미해제 불변식을 덮습니다.

성공 경로는 문자 단위 동일(드라이런으로 4개 자산 URL·해시 일치 확인)하고, 의도된 강화가 셋 있습니다. CI도 velopack_libc zip을 SHA 검증하고, CI의 vcpkg 폴백 클론이 manifest 커밋으로 고정되며, setup-build의 조용한 복사 실패가 명시적 throw로 바뀝니다.

vcpkg/Qt 래퍼의 실전 실행은 PR CI(avx2)에 없으므로, 머지 후 workflow_dispatch 전체 매트릭스 1회로 sse2/avx 레그까지 검증한 뒤 다음 릴리스를 진행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)