### PR TITLE
refactor(editor): widget-free FilterListModel, incremental rows, fail-collect harness

### DIFF
--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -229,6 +229,7 @@ SOURCES += main.cpp\
 	widgets/EqGraphView.cpp \
 	widgets/FilterCardModel.cpp \
 	widgets/FilterCardRow.cpp \
+	widgets/FilterListModel.cpp \
 	widgets/FilterPickerView.cpp \
 	widgets/ValueScrubBox.cpp \
 	widgets/TitleBar.cpp \
@@ -436,6 +437,7 @@ HEADERS  += \
 	widgets/EqGraphView.h \
 	widgets/FilterCardModel.h \
 	widgets/FilterCardRow.h \
+	widgets/FilterListModel.h \
 	widgets/FilterPickerView.h \
 	widgets/ValueScrubBox.h \
 	widgets/TitleBar.h \

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -82,8 +82,8 @@ FilterTable::~FilterTable()
 	if (QApplication::instance() != nullptr)
 		QApplication::instance()->removeEventFilter(this);
 
-	qDeleteAll(items);
-	items.clear();
+	// The items themselves are owned and deleted by the FilterListModel member.
+	// (audit #146 TD032)
 
 	for (IFilterGUIFactory* factory : factories)
 		delete factory;
@@ -112,7 +112,7 @@ void FilterTable::updateDeviceAndChannelMask(shared_ptr<AbstractAPOInfo> selecte
 	this->selectedDevice = selectedDevice;
 	this->selectedChannelMask = channelMask;
 
-	if (!items.empty())
+	if (!model.items().isEmpty())
 		updateGuis();
 }
 
@@ -121,7 +121,7 @@ void FilterTable::clearRows()
 	// Persist each row's GUI preferences before its widget (and the GUI it owns)
 	// is destroyed, then null the pointer so a following updateGuis() does not
 	// read a dangling gui in its own preference-save pass.
-	for (Item* item : items)
+	for (Item* item : model.items())
 	{
 		if (item->gui != nullptr)
 		{
@@ -169,7 +169,7 @@ void FilterTable::updateGuis()
 
 	QVector<int> rowDepths = FilterCardModel::calculateDepths(getLines());
 	int row = 0;
-	for (Item* item : items)
+	for (Item* item : model.items())
 	{
 		IFilterGUI* gui = createRowGui(item->text);
 
@@ -295,7 +295,7 @@ IFilterGUI* FilterTable::createRowGui(const QString& line)
 
 void FilterTable::updateSingleRowGui(Item* item)
 {
-	int rowIndex = items.indexOf(item);
+	int rowIndex = model.items().indexOf(item);
 	if (rowIndex < 0 || gridLayout == nullptr)
 		return;
 
@@ -346,5 +346,178 @@ void FilterTable::updateSingleRowGui(Item* item)
 
 	propagateChannels();
 	disableWheelForWidgets();
+	update();
+}
+
+namespace
+{
+// Moves the layout cell at (fromRow, 0) to (toRow, 0), preserving the cell's
+// alignment. QGridLayout has no native row insertion, so the incremental
+// paths re-address the reused cells one by one; the widgets themselves are
+// not recreated, which is what makes those paths cheap. Returns false when
+// the source cell is unexpectedly empty. (audit #146 TD040)
+bool moveGridCell(QGridLayout* gridLayout, int fromRow, int toRow)
+{
+	QLayoutItem* cell = gridLayout->itemAtPosition(fromRow, 0);
+	if (cell == nullptr)
+		return false;
+
+	if (QWidget* widget = cell->widget())
+	{
+		const Qt::Alignment alignment = cell->alignment();
+		// removeWidget deletes the old QWidgetItem, so read the alignment first.
+		gridLayout->removeWidget(widget);
+		gridLayout->addWidget(widget, toRow, 0, alignment);
+	}
+	else
+	{
+		// The stretch spacer is a plain QLayoutItem; removeItem leaves it alive.
+		gridLayout->removeItem(cell);
+		gridLayout->addItem(cell, toRow, 0);
+	}
+	return true;
+}
+}
+
+bool FilterTable::renumberRowsBelow(int firstRow, const QVector<int>& rowDepths)
+{
+	for (int i = firstRow; i < model.items().count(); i++)
+	{
+		QLayoutItem* cell = gridLayout->itemAtPosition(i, 0);
+		FilterCardRow* cardRow = cell != nullptr ? qobject_cast<FilterCardRow*>(cell->widget()) : nullptr;
+		if (cardRow == nullptr)
+			return false;
+		cardRow->updateRowPosition(i + 1, i < rowDepths.size() ? rowDepths[i] : 0);
+	}
+	return true;
+}
+
+void FilterTable::insertRowAt(int index)
+{
+	// (audit #146 TD040) Card-path incremental insert. The model already
+	// contains the new item at index; create only that row widget and shift
+	// the rows/toolbar/spacer below one grid row down. Any inconsistency falls
+	// back to the full rebuild, which is always correct.
+	const int itemCount = int(model.items().count());
+	if (renderMode != ModernCards || gridLayout == nullptr || index < 0 || index >= itemCount)
+	{
+		updateGuis();
+		return;
+	}
+
+	QElapsedTimer timer;
+	timer.start();
+
+	// Before the splice the grid still holds the OLD layout: itemCount - 1 row
+	// widgets at rows 0..itemCount-2, the toolbar at itemCount-1 and the
+	// stretch spacer at itemCount. Shift bottom-up so no two cells collide.
+	const int oldSpacerRow = itemCount;
+	for (int gridRow = oldSpacerRow; gridRow >= index; gridRow--)
+	{
+		if (!moveGridCell(gridLayout, gridRow, gridRow + 1))
+		{
+			updateGuis();
+			return;
+		}
+	}
+	gridLayout->setRowStretch(oldSpacerRow, 0);
+	gridLayout->setRowStretch(oldSpacerRow + 1, 1);
+
+	// Build the new row through the same selection policy as updateGuis(). The
+	// factory startOfFile/endOfFile bracket is skipped like updateSingleRowGui:
+	// the stateful factories (Convolution/GraphicEQ/MultiConvolution) only
+	// cache the config path there, which an edit inside the loaded file does
+	// not change.
+	Item* item = model.items().at(index);
+	IFilterGUI* gui = createRowGui(item->text);
+
+	QVector<int> rowDepths = FilterCardModel::calculateDepths(getLines());
+	int depth = index < rowDepths.size() ? rowDepths[index] : 0;
+	QWidget* rowWidget = new FilterCardRow(this, index + 1, item, gui, depth);
+	gridLayout->addWidget(rowWidget, index, 0);
+
+	item->gui = gui;
+	if (gui != nullptr)
+	{
+		gui->loadPreferences(item->prefs);
+		// Card mode never connects updateModel here, matching updateGuis().
+		connect(gui, SIGNAL(updateChannels()), this, SLOT(updateChannels()));
+	}
+
+	// Rows below the insertion point keep their widgets, but their 1-based
+	// number and possibly their include/channel scope depth changed.
+	if (!renumberRowsBelow(index + 1, rowDepths))
+	{
+		updateGuis();
+		return;
+	}
+
+	propagateChannels();
+	disableWheelForWidgets();
+	// The insertion replaced the selection and the row widgets read selection
+	// state on paint; repaint them all like a full rebuild would have.
+	updateRowWidgets();
+
+	qDebug("Incremental insert took %d ms", int(timer.elapsed()));
+	update();
+}
+
+void FilterTable::removeRowAt(int index)
+{
+	// (audit #146 TD040) Card-path incremental remove. The model no longer
+	// contains the item; delete only its row widget and shift the cells below
+	// one grid row up. Any inconsistency falls back to the full rebuild.
+	const int itemCount = int(model.items().count());
+	if (renderMode != ModernCards || gridLayout == nullptr || index < 0 || index > itemCount)
+	{
+		updateGuis();
+		return;
+	}
+
+	QElapsedTimer timer;
+	timer.start();
+
+	QLayoutItem* cell = gridLayout->itemAtPosition(index, 0);
+	QWidget* oldRow = cell != nullptr ? cell->widget() : nullptr;
+	if (oldRow == nullptr)
+	{
+		updateGuis();
+		return;
+	}
+	gridLayout->removeWidget(oldRow);
+	// Delete synchronously (the clearRows() precedent), not via deleteLater():
+	// the model already freed the Item this row points at, and a deferred
+	// deletion would leave a window where a queued GUI signal (e.g. a VST
+	// editor timer emitting updateModel) dereferences the dangling item.
+	// deleteSelectedLines is only reached from FilterTable's own key handler
+	// and the MainWindow edit actions, never from inside the row widget, so
+	// the widget is not on the current event dispatch path.
+	delete oldRow;
+
+	// Old grid layout: row widgets at 0..itemCount (one more than the model
+	// now has), the toolbar at itemCount+1 and the spacer at itemCount+2.
+	const int oldSpacerRow = itemCount + 2;
+	for (int gridRow = index + 1; gridRow <= oldSpacerRow; gridRow++)
+	{
+		if (!moveGridCell(gridLayout, gridRow, gridRow - 1))
+		{
+			updateGuis();
+			return;
+		}
+	}
+	gridLayout->setRowStretch(oldSpacerRow, 0);
+	gridLayout->setRowStretch(oldSpacerRow - 1, 1);
+
+	QVector<int> rowDepths = FilterCardModel::calculateDepths(getLines());
+	if (!renumberRowsBelow(index, rowDepths))
+	{
+		updateGuis();
+		return;
+	}
+
+	propagateChannels();
+	updateRowWidgets();
+
+	qDebug("Incremental remove took %d ms", int(timer.elapsed()));
 	update();
 }

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -27,8 +27,10 @@
 #include <QScrollArea>
 #include <QMenu>
 #include <QJsonObject>
+#include <QVector>
 
 #include "Editor/helpers/DisableWheelFilter.h"
+#include "Editor/widgets/FilterListModel.h"
 #include "Editor/widgets/FilterPickerView.h"
 #include "DeviceAPOInfo.h"
 #include "FilterTemplate.h"
@@ -63,21 +65,12 @@ public:
 		LegacyRows
 	};
 
-	struct Item
-	{
-		Item()
-		{
-		}
-
-		Item(const QString& text)
-		{
-			this->text = text;
-		}
-
-		QString text;
-		QVariantMap prefs;
-		IFilterGUI* gui = nullptr;
-	};
+	// The document/selection state was extracted into the widget-free
+	// FilterListModel (Editor/widgets/FilterListModel.h) so it is unit-testable
+	// in EditorLogicTests. Item stays as an alias so the FilterTable::Item
+	// spelling used by FilterCardRow, FilterTableRow and the metatype below
+	// keeps compiling unchanged. (audit #146 TD032)
+	using Item = FilterListItem;
 
 	explicit FilterTable(MainWindow* mainWindow, QWidget* parent = 0);
 	~FilterTable();
@@ -173,8 +166,20 @@ private:
 	// policy edits happen once. (audit #146 TD005)
 	IFilterGUI* createRowGui(const QString& line);
 	// Inserts the mime data's lines at dropRow and makes them the selection.
-	// Shared by paste() and dropEvent(). (audit #146 TD006)
-	void insertLinesFromMimeData(const QMimeData* mimeData, int dropRow);
+	// Shared by paste() and dropEvent(). Returns the number of inserted lines
+	// so the callers can take the incremental single-row path. (audit #146 TD006)
+	int insertLinesFromMimeData(const QMimeData* mimeData, int dropRow);
+	// Incremental structural updates for the card path only: splice one row
+	// widget into/out of the grid and re-address the rows below, instead of
+	// tearing down and rebuilding every row widget. Both fall back to
+	// updateGuis() on any inconsistency, and LegacyRows always takes the full
+	// rebuild (frozen fallback, docs/FilterListUiPolicy.md). (audit #146 TD040)
+	void insertRowAt(int index);
+	void removeRowAt(int index);
+	// Refreshes number/depth of the card rows at document index >= firstRow in
+	// place after an incremental splice. Returns false when a row widget is
+	// not a FilterCardRow (caller falls back to updateGuis). (audit #146 TD040)
+	bool renumberRowsBelow(int firstRow, const QVector<int>& rowDepths);
 
 	MainWindow* mainWindow;
 	QScrollArea* scrollArea = nullptr;
@@ -182,10 +187,9 @@ private:
 	QLabel* insertArrow;
 	QPoint dragStartPos;
 	bool internalDrag = false;
-	QList<Item*> items;
-	QSet<Item*> selected;
-	Item* focused = nullptr;
-	Item* selectionStart = nullptr;
+	// Owns the config lines and the selection state; see FilterListModel for
+	// the item ownership rules. (audit #146 TD032)
+	FilterListModel model;
 	QList<IFilterGUIFactory*> factories;
 	bool scrollingNow = false;
 	// True while the app-global wheel-redirect filter is installed; see

--- a/Editor/FilterTableParts/FilterTable.Clipboard.cpp
+++ b/Editor/FilterTableParts/FilterTable.Clipboard.cpp
@@ -57,30 +57,18 @@ void FilterTable::cut()
 
 void FilterTable::copy()
 {
-	QString text;
-	QList<QVariantMap> prefsList;
-	bool first = true;
-	for (Item* item : items)
-	{
-		if (selected.contains(item))
-		{
-			if (first)
-				first = false;
-			else
-				text += "\n";
-			text += item->text;
-			prefsList.append(item->prefs);
-		}
-	}
+	// The payload (selected lines in document order + aligned prefs) is pure
+	// model state; only the clipboard hand-off stays here. (audit #146 TD032)
+	if (model.selected().isEmpty())
+		return;
 
-	if (selected.size() > 0)
-	{
-		FilterTableMimeData* mimeData = new FilterTableMimeData;
-		mimeData->setText(text);
-		mimeData->setPrefsList(prefsList);
-		QClipboard* clipboard = QApplication::clipboard();
-		clipboard->setMimeData(mimeData);
-	}
+	FilterListModel::CopyPayload payload = model.copyPayload();
+
+	FilterTableMimeData* mimeData = new FilterTableMimeData;
+	mimeData->setText(payload.text);
+	mimeData->setPrefsList(payload.prefsList);
+	QClipboard* clipboard = QApplication::clipboard();
+	clipboard->setMimeData(mimeData);
 }
 
 void FilterTable::paste()
@@ -89,25 +77,26 @@ void FilterTable::paste()
 	const QMimeData* mimeData = clipboard->mimeData();
 	if (mimeData->hasText())
 	{
-		int dropRow = items.size();
-		for (int i = 0; i < items.size(); i++)
-		{
-			if (selected.contains(items[i]))
-			{
-				dropRow = i;
-				break;
-			}
-		}
+		int dropRow = model.firstSelectedIndex();
+		if (dropRow == -1)
+			dropRow = model.items().size();
 
-		insertLinesFromMimeData(mimeData, dropRow);
+		int insertedCount = insertLinesFromMimeData(mimeData, dropRow);
 
 		emit linesChanged();
-		updateGuis();
+		// A single pasted line is the common case: splice just that row into
+		// the card grid instead of rebuilding every row. (audit #146 TD040)
+		if (insertedCount == 1 && renderMode == ModernCards)
+			insertRowAt(dropRow);
+		else
+			updateGuis();
 	}
 }
 
-void FilterTable::insertLinesFromMimeData(const QMimeData* mimeData, int dropRow)
+int FilterTable::insertLinesFromMimeData(const QMimeData* mimeData, int dropRow)
 {
+	// The QMimeData unpacking stays here; the insertion and the selection
+	// replacement are model state. (audit #146 TD032)
 	QString text = mimeData->text();
 	QStringList textLines = text.split("\n");
 	QList<QVariantMap> prefsList;
@@ -115,54 +104,29 @@ void FilterTable::insertLinesFromMimeData(const QMimeData* mimeData, int dropRow
 	if (filterTableMimeData != nullptr)
 		prefsList = filterTableMimeData->getPrefsList();
 
-	selected.clear();
-	focused = nullptr;
-	selectionStart = nullptr;
-	for (int i = 0; i < textLines.size(); i++)
-	{
-		QString line = textLines[i];
-		Item* item = new Item(line);
-		if (i < prefsList.size())
-			item->prefs = prefsList[i];
-		selected.insert(item);
-		items.insert(dropRow++, item);
-		if (focused == nullptr)
-		{
-			focused = item;
-			selectionStart = item;
-		}
-	}
+	return int(model.insertLines(textLines, prefsList, dropRow).count());
 }
 
 void FilterTable::deleteSelectedLines()
 {
-	QList<Item*> newItems;
-	for (Item* item : items)
-	{
-		if (selected.contains(item))
-		{
-			if (item == focused)
-				focused = nullptr;
-			if (item == selectionStart)
-				selectionStart = nullptr;
-			delete item;
-		}
-		else
-		{
-			newItems.append(item);
-		}
-	}
-	selected.clear();
-	items = newItems;
+	// A single-row deletion keeps every other row widget alive and splices
+	// just one out of the grid. Multi-row deletions (and the frozen legacy
+	// path) keep the full rebuild. (audit #146 TD040)
+	int removedIndex = -1;
+	if (renderMode == ModernCards && model.selected().size() == 1)
+		removedIndex = int(model.items().indexOf(*model.selected().cbegin()));
+
+	model.deleteSelected();
 	emit linesChanged();
-	updateGuis();
+	if (removedIndex >= 0)
+		removeRowAt(removedIndex);
+	else
+		updateGuis();
 }
 
 void FilterTable::selectAll()
 {
-	selected.clear();
-	for (Item* item : items)
-		selected.insert(item);
+	model.selectAll();
 	updateRowWidgets();
 }
 
@@ -178,7 +142,12 @@ void FilterTable::addActionTriggered()
 	if (chooseFilterTemplate(&filterTemplate, p))
 	{
 		addLine(filterTemplate.getLine());
-		updateGuis();
+		// The toolbar add appends exactly one line; splice just that row into
+		// the card grid. (audit #146 TD040)
+		if (renderMode == ModernCards)
+			insertRowAt(int(model.items().count()) - 1);
+		else
+			updateGuis();
 	}
 }
 
@@ -193,9 +162,9 @@ void FilterTable::savePreferences()
 	{
 		QStringList prefLines;
 
-		for (int i = 0; i < items.size(); i++)
+		for (int i = 0; i < model.items().size(); i++)
 		{
-			Item* item = items[i];
+			Item* item = model.items()[i];
 
 			if (item->gui != nullptr)
 			{

--- a/Editor/FilterTableParts/FilterTable.DragDrop.cpp
+++ b/Editor/FilterTableParts/FilterTable.DragDrop.cpp
@@ -110,15 +110,21 @@ void FilterTable::dropEvent(QDropEvent* event)
 
 		int dropRow = rowForPos(event->pos(), true);
 		if (dropRow == -1)
-			dropRow = items.size();
+			dropRow = model.items().size();
 
-		insertLinesFromMimeData(mimeData, dropRow);
+		int insertedCount = insertLinesFromMimeData(mimeData, dropRow);
 		event->accept();
 
 		if (!internalDrag)
 		{
 			emit linesChanged();
-			updateGuis();
+			// A single dropped line splices into the card grid; internal drags
+			// keep the full rebuild in mouseMoveEvent after the originals are
+			// removed. (audit #146 TD040)
+			if (insertedCount == 1 && renderMode == ModernCards)
+				insertRowAt(dropRow);
+			else
+				updateGuis();
 		}
 	}
 

--- a/Editor/FilterTableParts/FilterTable.Events.cpp
+++ b/Editor/FilterTableParts/FilterTable.Events.cpp
@@ -54,40 +54,32 @@ void FilterTable::keyPressEvent(QKeyEvent* event)
 {
 	if (event->key() == Qt::Key_Down || event->key() == Qt::Key_Up)
 	{
-		if (focused != nullptr)
+		if (model.focused() != nullptr)
 		{
-			int row = items.indexOf(focused);
+			int row = model.items().indexOf(model.focused());
 			if (row != -1)
 			{
 				int newRow = row;
-				if (event->key() == Qt::Key_Down && row + 1 < items.size())
+				if (event->key() == Qt::Key_Down && row + 1 < model.items().size())
 					newRow = row + 1;
 				else if (event->key() == Qt::Key_Up && row - 1 >= 0)
 					newRow = row - 1;
 
 				if (newRow != row)
 				{
-					focused = items[newRow];
+					Item* newFocused = model.items()[newRow];
+					model.setFocused(newFocused);
 					if (event->modifiers() & Qt::ControlModifier)
 					{
 					}
 					else if (event->modifiers() & Qt::ShiftModifier)
 					{
-						int startRow = items.indexOf(selectionStart);
-						if (startRow != -1)
-						{
-							selected.clear();
-							for (int i = min(startRow, newRow); i <= max(startRow, newRow); i++)
-							{
-								selected.insert(items[i]);
-							}
-						}
+						model.selectRangeFromAnchor(newFocused);
 					}
 					else
 					{
-						selected.clear();
-						selected.insert(focused);
-						selectionStart = focused;
+						model.selectOnly(newFocused);
+						model.setSelectionStart(newFocused);
 					}
 
 					ensureRowVisible(newRow);
@@ -99,19 +91,20 @@ void FilterTable::keyPressEvent(QKeyEvent* event)
 
 	if (event->key() == Qt::Key_Space)
 	{
-		if (focused != nullptr)
+		if (model.focused() != nullptr)
 		{
-			if (!(event->modifiers() & Qt::ControlModifier) || !selected.remove(focused))
-				selected.insert(focused);
+			// Plain Space selects; Ctrl+Space toggles.
+			if (!(event->modifiers() & Qt::ControlModifier) || !model.deselect(model.focused()))
+				model.select(model.focused());
 			updateRowWidgets();
 		}
 	}
 
 	if (event->key() == Qt::Key_F2)
 	{
-		if (focused != nullptr)
+		if (model.focused() != nullptr)
 		{
-			int rowIndex = items.indexOf(focused);
+			int rowIndex = model.items().indexOf(model.focused());
 			if (rowIndex != -1)
 			{
 				QLayoutItem* layoutItem = gridLayout->itemAtPosition(rowIndex, 0);
@@ -281,7 +274,7 @@ void FilterTable::disableWheelForWidgets()
 
 void FilterTable::updateRowWidgets()
 {
-	for (int i = 0; i < items.size(); i++)
+	for (int i = 0; i < model.items().size(); i++)
 	{
 		QLayoutItem* layoutItem = gridLayout->itemAtPosition(i, 0);
 		if (layoutItem != nullptr && layoutItem->widget() != nullptr)
@@ -302,12 +295,12 @@ void FilterTable::setConfigPath(const QString& value)
 
 FilterTable::Item* FilterTable::getFocusedItem() const
 {
-	return focused;
+	return model.focused();
 }
 
 const QSet<FilterTable::Item*>& FilterTable::getSelectedItems() const
 {
-	return selected;
+	return model.selected();
 }
 
 const QList<shared_ptr<AbstractAPOInfo>>& FilterTable::getOutputDevices() const

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -76,7 +76,7 @@ void FilterTable::propagateChannels()
 {
 	vector<wstring> channelNames = getChannelNames();
 
-	for (Item* item : items)
+	for (Item* item : model.items())
 	{
 		if (item->gui != nullptr)
 			item->gui->configureChannels(channelNames);
@@ -85,24 +85,17 @@ void FilterTable::propagateChannels()
 
 QList<QString> FilterTable::getLines()
 {
-	QList<QString> result;
-	for (Item* item : items)
-		result.append(item->text);
-
-	return result;
+	return model.lines();
 }
 
 void FilterTable::setLines(const QString& configPath, const QList<QString>& lines)
 {
 	this->configPath = configPath;
 
-	qDeleteAll(items);
-	items.clear();
-
-	for (QString line : lines)
-	{
-		items.append(new Item(line));
-	}
+	// The document reset (including moving focus/anchor to the first line)
+	// lives in the model; the per-file GUI preference restore below stays
+	// here because it reads the registry. (audit #146 TD032)
+	model.setLines(lines);
 
 	QSettings settings(QString::fromWCharArray(EDITOR_PER_FILE_REGPATH), QSettings::NativeFormat);
 	settings.beginGroup(QString(configPath).replace('\\', '|'));
@@ -126,9 +119,9 @@ void FilterTable::setLines(const QString& configPath, const QList<QString>& line
 				QString prefCommand = prefLine.mid(index + 1, index2 - index - 1);
 				QString prefString = prefLine.mid(index2 + 1);
 
-				if (lineNumber <= items.size())
+				if (lineNumber <= model.items().size())
 				{
-					Item* item = items[lineNumber - 1];
+					Item* item = model.items()[lineNumber - 1];
 
 					QString command;
 					int index = item->text.indexOf(':');
@@ -144,33 +137,12 @@ void FilterTable::setLines(const QString& configPath, const QList<QString>& line
 	setScrollOffsets(settings.value("scrollX", 0).toInt(), settings.value("scrollY", 0).toInt());
 	settings.endGroup();
 
-	if (!items.isEmpty())
-	{
-		focused = items[0];
-		selectionStart = items[0];
-	}
-	else
-	{
-		focused = nullptr;
-		selectionStart = nullptr;
-	}
-
 	updateGuis();
 }
 
 FilterTable::Item* FilterTable::addLine(const QString& line, FilterTable::Item* before)
 {
-	Item* newItem = new Item(line);
-
-	if (before != nullptr)
-	{
-		int index = items.indexOf(before);
-		items.insert(index, newItem);
-	}
-	else
-	{
-		items.append(newItem);
-	}
+	Item* newItem = model.addLine(line, before);
 
 	emit linesChanged();
 
@@ -179,23 +151,11 @@ FilterTable::Item* FilterTable::addLine(const QString& line, FilterTable::Item* 
 
 void FilterTable::removeItem(FilterTable::Item* item)
 {
-	int index = items.indexOf(item);
-	if (index == -1)
+	// The removal and the selection/focus repair live in the model; the signal
+	// stays a widget concern. (audit #146 TD032)
+	if (!model.removeItem(item))
 		return;
 
-	items.removeAt(index);
-	Item* replacement = nullptr;
-	if (!items.isEmpty())
-		replacement = items[qMin(index, items.size() - 1)];
-
-	if (selected.remove(item) > 0 && replacement != nullptr)
-		selected.insert(replacement);
-	if (focused == item)
-		focused = replacement;
-	if (selectionStart == item)
-		selectionStart = replacement;
-
-	delete item;
 	emit linesChanged();
 }
 
@@ -371,7 +331,7 @@ void FilterTable::updateSizeHints()
 	// crash on a plain restyle). Nothing to size while the rows are being rebuilt.
 	if (gridLayout == nullptr)
 		return;
-	for (int i = 0; i < items.size(); i++)
+	for (int i = 0; i < model.items().size(); i++)
 	{
 		QLayoutItem* layoutItem = gridLayout->itemAtPosition(i, 0);
 		if (layoutItem == nullptr)

--- a/Editor/FilterTableParts/FilterTable.Mouse.cpp
+++ b/Editor/FilterTableParts/FilterTable.Mouse.cpp
@@ -54,39 +54,32 @@ void FilterTable::mousePressEvent(QMouseEvent* event)
 {
 	if (event->buttons() & Qt::LeftButton)
 	{
+		// Pixel-to-row hit testing stays here; the selection state math lives
+		// in FilterListModel. (audit #146 TD032)
 		int row = rowForPos(event->pos(), false);
 		if (row != -1)
 		{
-			Item* item = items[row];
+			Item* item = model.items()[row];
 
 			if (event->modifiers() & Qt::ControlModifier)
 			{
-				if (!selected.remove(item))
-					selected.insert(item);
-				selectionStart = item;
+				if (!model.deselect(item))
+					model.select(item);
+				model.setSelectionStart(item);
 			}
 			else if (event->modifiers() & Qt::ShiftModifier)
 			{
-				int startRow = items.indexOf(selectionStart);
-				if (startRow != -1)
-				{
-					selected.clear();
-					for (int i = min(startRow, row); i <= max(startRow, row); i++)
-					{
-						selected.insert(items[i]);
-					}
-				}
+				model.selectRangeFromAnchor(item);
 			}
 			else
 			{
-				if (!selected.contains(item))
-				{
-					selected.clear();
-					selected.insert(item);
-				}
-				selectionStart = item;
+				// Clicking an already-selected row keeps the multi-selection
+				// intact so it can be dragged as a group.
+				if (!model.isSelected(item))
+					model.selectOnly(item);
+				model.setSelectionStart(item);
 			}
-			focused = item;
+			model.setFocused(item);
 			ensureRowVisible(row);
 			updateRowWidgets();
 
@@ -94,9 +87,9 @@ void FilterTable::mousePressEvent(QMouseEvent* event)
 		}
 		else
 		{
-			selected.clear();
-			focused = nullptr;
-			selectionStart = nullptr;
+			model.clearSelection();
+			model.setFocused(nullptr);
+			model.setSelectionStart(nullptr);
 			updateRowWidgets();
 		}
 	}
@@ -109,15 +102,14 @@ void FilterTable::mouseReleaseEvent(QMouseEvent* event)
 		int row = rowForPos(event->pos(), false);
 		if (row != -1)
 		{
-			Item* item = items[row];
+			Item* item = model.items()[row];
 
 			if (!(event->modifiers() & Qt::ControlModifier) && !(event->modifiers() & Qt::ShiftModifier))
 			{
-				if (selected.contains(item) && selectionStart == item)
-				{
-					selected.clear();
-					selected.insert(item);
-				}
+				// A plain click that did not turn into a drag collapses the
+				// multi-selection down to the clicked row.
+				if (model.isSelected(item) && model.selectionStart() == item)
+					model.selectOnly(item);
 			}
 			ensureRowVisible(row);
 			updateRowWidgets();
@@ -131,23 +123,18 @@ void FilterTable::mouseMoveEvent(QMouseEvent* event)
 	{
 		if ((event->pos() - dragStartPos).manhattanLength() >= QApplication::startDragDistance())
 		{
-			QString text;
-			QList<QVariantMap> prefsList;
-			bool first = true;
+			// Widget-side pass: persist each selected row's GUI preferences
+			// (the drag payload must carry the latest edits) and hit-test the
+			// drag start against the row headers. The payload itself is the
+			// model's copy payload. (audit #146 TD032)
 			int i = 0;
 			bool dragPosInside = false;
-			for (Item* item : items)
+			for (Item* item : model.items())
 			{
-				if (selected.contains(item))
+				if (model.selected().contains(item))
 				{
-					if (first)
-						first = false;
-					else
-						text += "\n";
-					text += item->text;
 					if (item->gui != nullptr)
 						item->gui->storePreferences(item->prefs);
-					prefsList.append(item->prefs);
 
 					if (!dragPosInside)
 					{
@@ -176,30 +163,24 @@ void FilterTable::mouseMoveEvent(QMouseEvent* event)
 				i++;
 			}
 
-			if (selected.size() > 0 && dragPosInside)
+			if (!model.selected().isEmpty() && dragPosInside)
 			{
+				FilterListModel::CopyPayload payload = model.copyPayload();
 				FilterTableMimeData* mimeData = new FilterTableMimeData;
-				mimeData->setText(text);
-				mimeData->setPrefsList(prefsList);
+				mimeData->setText(payload.text);
+				mimeData->setPrefsList(payload.prefsList);
 
 				QDrag* drag = new QDrag(this);
 				drag->setMimeData(mimeData);
-				QSet<Item*> selectedBefore = selected;
+				QSet<Item*> selectedBefore = model.selected();
 				internalDrag = true;
 				Qt::DropAction action = drag->exec(Qt::MoveAction | Qt::CopyAction);
 				internalDrag = false;
 				if (action == Qt::MoveAction)
 				{
-					for (Item* item : selectedBefore)
-					{
-						items.removeOne(item);
-						if (focused == item)
-							focused = nullptr;
-						if (selectionStart == item)
-							selectionStart = nullptr;
-						selected.remove(item);
-						delete item;
-					}
+					// An internal move already re-selected the dropped copies
+					// (insertLinesFromMimeData); remove the originals.
+					model.removeItems(selectedBefore);
 				}
 
 				if (action != Qt::IgnoreAction)

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -305,6 +305,42 @@ void FilterCardRow::editText()
 		editButton->setChecked(true);
 }
 
+void FilterCardRow::updateRowPosition(int rowNumber, int depth)
+{
+	// (audit #146 TD040) The constructor puts the number into numberLabel and
+	// the depth into the outer layout's left margin, the descriptor (scope
+	// rail painting) and the skin styling hooks. Refresh those in place.
+	if (numberLabel != nullptr)
+	{
+		// A skin's prepareCommandRow may have rewritten the plain number into
+		// its own coordinate grammar at construction (MatrixSkin: "3" -> "B3",
+		// bus letter + line). The prefix only depends on the command type,
+		// which does not change for a shifted row, so keep any non-digit
+		// prefix and replace just the trailing line number - the same text a
+		// full rebuild would produce.
+		const QString text = numberLabel->text();
+		int digitStart = int(text.size());
+		while (digitStart > 0 && text.at(digitStart - 1).isDigit())
+			digitStart--;
+		numberLabel->setText(text.left(digitStart) + QString::number(rowNumber));
+	}
+
+	if (descriptor.depth != depth)
+	{
+		descriptor.depth = depth;
+		if (layout() != nullptr)
+			layout()->setContentsMargins(8 + depth * SkinManager::instance()->tokens().channelGroupIndent, 4, 8, 4);
+		// Re-derives the descriptor at the new depth and refreshes the badge,
+		// the scopeDepth style property and the frame/header stylesheets
+		// (refreshStateProperties), then repaints.
+		rebuildSummary();
+	}
+	else
+	{
+		update();
+	}
+}
+
 QSize FilterCardRow::sizeHint() const
 {
 	// Blank lines collapse to a thin spacer; no header, no body, just a few

--- a/Editor/widgets/FilterCardRow.h
+++ b/Editor/widgets/FilterCardRow.h
@@ -24,6 +24,11 @@ public:
 
 	QRect getHeaderRect() const;
 	void editText();
+	// In-place refresh of the 1-based row number and the include/channel scope
+	// depth after an incremental row insert/remove above this row, so shifted
+	// rows do not need to be rebuilt. Updates exactly what the constructor
+	// derived from its number/depth arguments. (audit #146 TD040)
+	void updateRowPosition(int rowNumber, int depth);
 	QSize sizeHint() const override;
 	QSize minimumSizeHint() const override;
 

--- a/Editor/widgets/FilterListModel.cpp
+++ b/Editor/widgets/FilterListModel.cpp
@@ -1,0 +1,202 @@
+#include <QtAlgorithms>
+
+#include "FilterListModel.h"
+
+// The mutation/selection semantics below are moved verbatim from FilterTable
+// (FilterTable.Clipboard.cpp / FilterTable.Model.cpp / FilterTable.Mouse.cpp)
+// so they can be unit-tested; behavioral notes cite the original call sites.
+// (audit #146 TD032)
+
+FilterListModel::~FilterListModel()
+{
+	qDeleteAll(itemList);
+}
+
+QList<QString> FilterListModel::lines() const
+{
+	QList<QString> result;
+	for (FilterListItem* item : itemList)
+		result.append(item->text);
+
+	return result;
+}
+
+void FilterListModel::setLines(const QList<QString>& lines)
+{
+	qDeleteAll(itemList);
+	itemList.clear();
+	// FilterTable::setLines never cleared the selection set, leaving it full
+	// of pointers into the deleted document; clear it so a reused address in
+	// the new document can never appear pre-selected.
+	selectedSet.clear();
+
+	for (const QString& line : lines)
+		itemList.append(new FilterListItem(line));
+
+	if (!itemList.isEmpty())
+	{
+		focusedItem = itemList[0];
+		selectionStartItem = itemList[0];
+	}
+	else
+	{
+		focusedItem = nullptr;
+		selectionStartItem = nullptr;
+	}
+}
+
+FilterListItem* FilterListModel::addLine(const QString& line, const FilterListItem* before)
+{
+	FilterListItem* newItem = new FilterListItem(line);
+
+	if (before != nullptr)
+	{
+		int index = itemList.indexOf(before);
+		itemList.insert(index, newItem);
+	}
+	else
+	{
+		itemList.append(newItem);
+	}
+
+	return newItem;
+}
+
+bool FilterListModel::removeItem(FilterListItem* item)
+{
+	int index = itemList.indexOf(item);
+	if (index == -1)
+		return false;
+
+	itemList.removeAt(index);
+	FilterListItem* replacement = nullptr;
+	if (!itemList.isEmpty())
+		replacement = itemList[qMin(index, int(itemList.size()) - 1)];
+
+	if (selectedSet.remove(item) && replacement != nullptr)
+		selectedSet.insert(replacement);
+	if (focusedItem == item)
+		focusedItem = replacement;
+	if (selectionStartItem == item)
+		selectionStartItem = replacement;
+
+	delete item;
+	return true;
+}
+
+void FilterListModel::removeItems(const QSet<FilterListItem*>& itemsToRemove)
+{
+	for (FilterListItem* item : itemsToRemove)
+	{
+		itemList.removeOne(item);
+		if (focusedItem == item)
+			focusedItem = nullptr;
+		if (selectionStartItem == item)
+			selectionStartItem = nullptr;
+		selectedSet.remove(item);
+		delete item;
+	}
+}
+
+QList<FilterListItem*> FilterListModel::insertLines(const QStringList& lines, const QList<QVariantMap>& prefsList, int dropRow)
+{
+	QList<FilterListItem*> inserted;
+
+	selectedSet.clear();
+	focusedItem = nullptr;
+	selectionStartItem = nullptr;
+	for (int i = 0; i < lines.size(); i++)
+	{
+		FilterListItem* item = new FilterListItem(lines[i]);
+		if (i < prefsList.size())
+			item->prefs = prefsList[i];
+		selectedSet.insert(item);
+		itemList.insert(dropRow++, item);
+		if (focusedItem == nullptr)
+		{
+			focusedItem = item;
+			selectionStartItem = item;
+		}
+		inserted.append(item);
+	}
+
+	return inserted;
+}
+
+void FilterListModel::deleteSelected()
+{
+	QList<FilterListItem*> newItems;
+	for (FilterListItem* item : itemList)
+	{
+		if (selectedSet.contains(item))
+		{
+			if (item == focusedItem)
+				focusedItem = nullptr;
+			if (item == selectionStartItem)
+				selectionStartItem = nullptr;
+			delete item;
+		}
+		else
+		{
+			newItems.append(item);
+		}
+	}
+	selectedSet.clear();
+	itemList = newItems;
+}
+
+void FilterListModel::selectOnly(FilterListItem* item)
+{
+	selectedSet.clear();
+	selectedSet.insert(item);
+}
+
+void FilterListModel::selectAll()
+{
+	selectedSet.clear();
+	for (FilterListItem* item : itemList)
+		selectedSet.insert(item);
+}
+
+void FilterListModel::selectRangeFromAnchor(const FilterListItem* target)
+{
+	int startRow = itemList.indexOf(selectionStartItem);
+	int targetRow = itemList.indexOf(target);
+	if (startRow == -1 || targetRow == -1)
+		return;
+
+	selectedSet.clear();
+	for (int i = qMin(startRow, targetRow); i <= qMax(startRow, targetRow); i++)
+		selectedSet.insert(itemList[i]);
+}
+
+int FilterListModel::firstSelectedIndex() const
+{
+	for (int i = 0; i < itemList.size(); i++)
+	{
+		if (selectedSet.contains(itemList[i]))
+			return i;
+	}
+
+	return -1;
+}
+
+FilterListModel::CopyPayload FilterListModel::copyPayload() const
+{
+	CopyPayload payload;
+	bool first = true;
+	for (FilterListItem* item : itemList)
+	{
+		if (!selectedSet.contains(item))
+			continue;
+
+		if (first)
+			first = false;
+		else
+			payload.text += '\n';
+		payload.text += item->text;
+		payload.prefsList.append(item->prefs);
+	}
+
+	return payload;
+}

--- a/Editor/widgets/FilterListModel.h
+++ b/Editor/widgets/FilterListModel.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <QList>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+#include <QVariant>
+
+class IFilterGUI;
+
+// One line of the loaded config file. The gui pointer is stored opaquely for
+// the widget layer (FilterTable/FilterCardRow own and dereference it); the
+// model never touches it, so this header stays QtCore-only and links into
+// EditorLogicTests. (audit #146 TD032)
+struct FilterListItem
+{
+	FilterListItem()
+	{
+	}
+
+	FilterListItem(const QString& text)
+	{
+		this->text = text;
+	}
+
+	QString text;
+	QVariantMap prefs;
+	IFilterGUI* gui = nullptr;
+};
+
+// The widget-free document/selection model behind FilterTable, extracted so
+// the mutation and selection logic is unit-testable without a QWidget.
+// (audit #146 TD032)
+//
+// Ownership: the model owns every FilterListItem it hands out. Items are
+// deleted when they are removed (removeItem/removeItems/deleteSelected),
+// replaced (setLines) or when the model is destroyed - exactly the lifetime
+// FilterTable managed inline before the extraction. Callers must not delete
+// items themselves and must drop raw pointers after any removing mutation.
+class FilterListModel
+{
+public:
+	FilterListModel() = default;
+	~FilterListModel();
+
+	FilterListModel(const FilterListModel&) = delete;
+	FilterListModel& operator=(const FilterListModel&) = delete;
+
+	// --- document ---
+
+	const QList<FilterListItem*>& items() const
+	{
+		return itemList;
+	}
+
+	// The document text, one entry per item.
+	QList<QString> lines() const;
+
+	// Replaces the whole document. Focus and the selection anchor move to the
+	// first line (or null when empty) and the selection set is cleared.
+	// (FilterTable historically left the selection set holding pointers into
+	// the deleted document; clearing it here removes that dangling state.)
+	void setLines(const QList<QString>& lines);
+
+	// Inserts a new line before the given item, or appends when before is
+	// null. Returns the created item. Selection state is not changed.
+	FilterListItem* addLine(const QString& line, const FilterListItem* before = nullptr);
+
+	// Removes and deletes one item. Selection, focus and the anchor move to
+	// the neighbouring item (the one now at the removed index, or the last).
+	// Returns false when the item is not part of the document.
+	bool removeItem(FilterListItem* item);
+
+	// Removes and deletes the given items without picking a replacement
+	// selection (the internal drag-move semantics: the drop already selected
+	// the inserted copies).
+	void removeItems(const QSet<FilterListItem*>& itemsToRemove);
+
+	// Inserts the lines at dropRow (0..items().size()) with prefs aligned by
+	// index (missing entries stay empty). The inserted items replace the
+	// selection; focus and the anchor land on the first inserted line.
+	// Returns the inserted items in document order.
+	QList<FilterListItem*> insertLines(const QStringList& lines, const QList<QVariantMap>& prefsList, int dropRow);
+
+	// Removes and deletes exactly the selected items, clears the selection and
+	// drops focus/anchor if they pointed at a deleted item.
+	void deleteSelected();
+
+	// --- selection ---
+
+	const QSet<FilterListItem*>& selected() const
+	{
+		return selectedSet;
+	}
+
+	FilterListItem* focused() const
+	{
+		return focusedItem;
+	}
+
+	FilterListItem* selectionStart() const
+	{
+		return selectionStartItem;
+	}
+
+	void setFocused(FilterListItem* item)
+	{
+		focusedItem = item;
+	}
+
+	void setSelectionStart(FilterListItem* item)
+	{
+		selectionStartItem = item;
+	}
+
+	bool isSelected(FilterListItem* item) const
+	{
+		return selectedSet.contains(item);
+	}
+
+	void select(FilterListItem* item)
+	{
+		selectedSet.insert(item);
+	}
+
+	// Returns whether the item had been selected (the Ctrl-click toggle needs
+	// the old state).
+	bool deselect(FilterListItem* item)
+	{
+		return selectedSet.remove(item);
+	}
+
+	// Makes the item the only selected one.
+	void selectOnly(FilterListItem* item);
+
+	void clearSelection()
+	{
+		selectedSet.clear();
+	}
+
+	void selectAll();
+
+	// Shift-click/Shift-arrow range selection: replaces the selection with the
+	// contiguous run between the current anchor (selectionStart) and target.
+	// Leaves the selection untouched when the anchor or target is not part of
+	// the document, matching the widget's historical behavior.
+	void selectRangeFromAnchor(const FilterListItem* target);
+
+	// Document index of the topmost selected item, or -1 when nothing is
+	// selected (paste uses it as the insertion row).
+	int firstSelectedIndex() const;
+
+	// --- clipboard payload ---
+
+	// The selected items in document order: their text joined with '\n' and
+	// one prefs map per line. Feeds cut/copy and the drag mime data.
+	struct CopyPayload
+	{
+		QString text;
+		QList<QVariantMap> prefsList;
+	};
+
+	CopyPayload copyPayload() const;
+
+private:
+	QList<FilterListItem*> itemList;
+	QSet<FilterListItem*> selectedSet;
+	FilterListItem* focusedItem = nullptr;
+	FilterListItem* selectionStartItem = nullptr;
+};

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -20,6 +20,7 @@
 #include "Editor/import/ImportExecutor.h"
 #include "Editor/import/ImportManifest.h"
 #include "Editor/widgets/FilterCardModel.h"
+#include "Editor/widgets/FilterListModel.h"
 #include "Editor/widgets/cards/ChannelSelectionModel.h"
 #include "Editor/widgets/cards/DeviceSelectionModel.h"
 #include "Editor/widgets/cards/StageSelectionModel.h"
@@ -35,7 +36,10 @@ namespace
 // Generic assertion primitives are shared with the other suites via the
 // header-only harness. The QString helpers below convert at the boundary so
 // EditorLogicTests can keep its Qt-specific checks (expectPath) alongside.
-test::Harness harness("EditorLogicTests");
+// The suite runs under FailurePolicy::Collect so one broken feature block no
+// longer hides the findings of every block after it (audit #146 TD035); the
+// require* wrappers keep the gating checks aborting like before.
+test::Harness harness("EditorLogicTests", test::FailurePolicy::Collect);
 
 std::string toStd(const QString& s)
 {
@@ -82,12 +86,130 @@ void expectEqual(int actual, int expected, const QString& message)
 		actual == expected,
 		toStd(QString("%1: expected %2, got %3").arg(message).arg(expected).arg(actual)));
 }
+
+// require counterparts of the wrappers above: same message format, but they
+// abort on failure regardless of the Collect policy. Use them for checks
+// whose failure would make the following lines unsafe (size checks before
+// indexing, fixture-creation checks).
+void requireTrue(bool value, const QString& message)
+{
+	harness.require(value, toStd(message));
 }
 
-int main(int argc, char** argv)
+// FilterListModel: the widget-free document/selection model extracted from
+// FilterTable so its mutation and selection logic is testable without a
+// QWidget. (audit #146 TD032)
+static void testFilterListModel()
 {
-	QCoreApplication app(argc, argv);
+	FilterListModel model;
 
+	// setLines resets the document, focuses/anchors the first line and starts
+	// with an empty selection.
+	model.setLines(QList<QString>() << "Preamp: -6 dB" << "Include: a.txt" << "Delay: 10 ms");
+	expectEqual((int)model.items().size(), 3, "setLines creates one item per line");
+	expectEqual(model.lines().join('\n'), "Preamp: -6 dB\nInclude: a.txt\nDelay: 10 ms", "lines() round-trips setLines");
+	expectTrue(model.focused() == model.items()[0], "setLines focuses the first line");
+	expectTrue(model.selectionStart() == model.items()[0], "setLines anchors the selection on the first line");
+	expectTrue(model.selected().isEmpty(), "setLines starts with an empty selection");
+
+	// addLine inserts before an anchor item, or appends without one.
+	FilterListItem* added = model.addLine("Filter: ON PK Fc 1000 Hz Gain -3 dB Q 0.71", model.items()[1]);
+	expectEqual((int)model.items().indexOf(added), 1, "addLine inserts before the anchor");
+	FilterListItem* appended = model.addLine("GraphicEQ: 20 -1; 1000 2");
+	expectEqual((int)model.items().indexOf(appended), (int)model.items().size() - 1, "addLine without anchor appends");
+
+	// Range selection math (the Shift-click/Shift-arrow logic): anchor..target
+	// in either direction; a missing anchor leaves the selection untouched.
+	model.setSelectionStart(model.items()[1]);
+	model.selectRangeFromAnchor(model.items()[3]);
+	expectEqual((int)model.selected().size(), 3, "range selection spans anchor..target");
+	expectTrue(model.selected().contains(model.items()[1]) && model.selected().contains(model.items()[2])
+		&& model.selected().contains(model.items()[3]),
+		"range selection selects exactly the rows between anchor and target");
+	model.selectRangeFromAnchor(model.items()[0]);
+	expectEqual((int)model.selected().size(), 2, "a reversed range selects target..anchor");
+	expectTrue(model.selected().contains(model.items()[0]) && model.selected().contains(model.items()[1]),
+		"the reversed range selects rows 0..1");
+	model.setSelectionStart(nullptr);
+	model.selectRangeFromAnchor(model.items()[2]);
+	expectEqual((int)model.selected().size(), 2, "a missing anchor leaves the selection unchanged");
+
+	// Copy payload: selected lines in document order joined with \n, one prefs
+	// map per line, regardless of the selection's insertion order.
+	model.items()[0]->prefs.insert("expanded", true);
+	model.items()[1]->prefs.insert("expanded", false);
+	model.clearSelection();
+	model.select(model.items()[1]);
+	model.select(model.items()[0]);
+	FilterListModel::CopyPayload payload = model.copyPayload();
+	expectEqual(payload.text, model.items()[0]->text + '\n' + model.items()[1]->text,
+		"copy payload joins selected lines in document order");
+	expectEqual((int)payload.prefsList.size(), 2, "copy payload carries one prefs map per line");
+	expectTrue(payload.prefsList[0].value("expanded").toBool() && !payload.prefsList[1].value("expanded").toBool(),
+		"copy payload prefs align with their lines");
+	expectEqual(model.firstSelectedIndex(), 0, "firstSelectedIndex finds the topmost selected row");
+
+	// insertLines at a position replaces the selection with the inserted items
+	// and focuses/anchors the first inserted line (the paste semantics).
+	QList<FilterListItem*> inserted = model.insertLines(
+		QStringList() << "Channel: L R" << "Preamp: -2 dB",
+		QList<QVariantMap>() << QVariantMap({ { "expanded", true } }), 2);
+	expectEqual((int)inserted.size(), 2, "insertLines returns the inserted items");
+	expectEqual((int)model.items().indexOf(inserted[0]), 2, "insertLines inserts at the drop row");
+	expectEqual((int)model.items().indexOf(inserted[1]), 3, "insertLines keeps the pasted order");
+	expectEqual((int)model.selected().size(), 2, "insertLines replaces the selection with the inserted lines");
+	expectTrue(model.selected().contains(inserted[0]) && model.selected().contains(inserted[1]),
+		"insertLines selects exactly the inserted lines");
+	expectTrue(model.focused() == inserted[0], "insertLines focuses the first inserted line");
+	expectTrue(model.selectionStart() == inserted[0], "insertLines anchors on the first inserted line");
+	expectTrue(inserted[0]->prefs.value("expanded").toBool() && inserted[1]->prefs.isEmpty(),
+		"insertLines aligns prefs by index and leaves extra lines without prefs");
+
+	// deleteSelected removes exactly the selection, clears it and drops the
+	// focus/anchor when they pointed at deleted rows.
+	const int countBefore = (int)model.items().size();
+	QList<QString> expectedRemaining;
+	for (FilterListItem* item : model.items())
+	{
+		if (!model.selected().contains(item))
+			expectedRemaining.append(item->text);
+	}
+	model.deleteSelected();
+	expectEqual((int)model.items().size(), countBefore - 2, "deleteSelected removes exactly the selected rows");
+	expectEqual(model.lines().join('\n'), expectedRemaining.join('\n'), "deleteSelected keeps the other rows in order");
+	expectTrue(model.selected().isEmpty(), "deleteSelected clears the selection");
+	expectTrue(model.focused() == nullptr && model.selectionStart() == nullptr,
+		"deleteSelected drops focus/anchor pointing at deleted rows");
+
+	// selectAll selects every row.
+	model.selectAll();
+	expectEqual((int)model.selected().size(), (int)model.items().size(), "selectAll selects every row");
+
+	// removeItem moves the selection, focus and anchor onto the neighbouring
+	// row (the item now at the removed index).
+	model.clearSelection();
+	FilterListItem* victim = model.items()[1];
+	model.select(victim);
+	model.setFocused(victim);
+	model.setSelectionStart(victim);
+	expectTrue(model.removeItem(victim), "removeItem removes a known item");
+	FilterListItem* replacement = model.items()[1];
+	expectTrue(model.selected().contains(replacement), "removeItem re-selects the neighbouring row");
+	expectTrue(model.focused() == replacement && model.selectionStart() == replacement,
+		"removeItem moves focus and anchor to the neighbouring row");
+	expectFalse(model.removeItem(nullptr), "removeItem rejects items outside the document");
+}
+
+
+void requireEqual(int actual, int expected, const QString& message)
+{
+	harness.require(
+		actual == expected,
+		toStd(QString("%1: expected %2, got %3").arg(message).arg(expected).arg(actual)));
+}
+
+void testConvolutionPathHelper()
+{
 	const QString configPath = "C:/EqualizerAPO/config/config.txt";
 
 	expectPath(
@@ -116,7 +238,10 @@ int main(int argc, char** argv)
 	expectFalse(
 		ConvolutionPathHelper::relativePathLooksContainedLexically("C:/Impulse/room.wav"),
 		"absolute path was accepted as relative");
+}
 
+void testUpdateInfoFormatter()
+{
 	QJsonObject release;
 	release["download-url"] = "https://example.invalid";
 	QJsonArray versions;
@@ -135,7 +260,10 @@ int main(int argc, char** argv)
 		fail("release notes were not HTML-escaped");
 	if (!html.contains("&lt;script&gt;alert(1)&lt;/script&gt;") || !html.contains("Fix &amp; verify"))
 		fail("escaped release notes are missing");
+}
 
+void testVelopackUpdateInfo()
+{
 	expectEqual(
 		VelopackUpdateInfo::githubLatestReleaseUrl("https://github.com/115dkk/EqualizerAPO-XT/"),
 		"https://api.github.com/repos/115dkk/EqualizerAPO-XT/releases/latest",
@@ -161,7 +289,13 @@ int main(int argc, char** argv)
 	expectFalse(
 		VelopackUpdateInfo::isNewerVersion("1.4.0", "1.4.3"),
 		"older package version was considered newer");
+}
 
+// Builds the GitHub release fixture shared by testVelopackGitHubRelease() and
+// testVelopackFeeds(): the feed conversion takes the release document as its
+// fallback source, so both blocks work on the identical document.
+QJsonDocument makeGitHubReleaseDoc()
+{
 	QJsonObject githubRelease;
 	githubRelease["tag_name"] = "v1.4.4-main.77";
 	githubRelease["name"] = "EqualizerAPO-XT 1.4.4-main.77";
@@ -182,7 +316,12 @@ int main(int argc, char** argv)
 		{ "browser_download_url", "https://example.invalid/setup.exe" },
 	}));
 	githubRelease["assets"] = releaseAssets;
-	QJsonDocument githubReleaseDoc(githubRelease);
+	return QJsonDocument(githubRelease);
+}
+
+void testVelopackGitHubRelease()
+{
+	QJsonDocument githubReleaseDoc = makeGitHubReleaseDoc();
 
 	expectTrue(
 		VelopackUpdateInfo::isGitHubRelease(githubReleaseDoc),
@@ -195,6 +334,11 @@ int main(int argc, char** argv)
 		VelopackUpdateInfo::fromGitHubRelease(githubReleaseDoc, "x64-avx2", "1.4.3").object().value("download-url").toString(),
 		"https://example.invalid/setup.exe",
 		"GitHub release fallback setup URL");
+}
+
+void testVelopackFeeds()
+{
+	QJsonDocument githubReleaseDoc = makeGitHubReleaseDoc();
 
 	QJsonArray feedAssets;
 	feedAssets.append(QJsonObject({
@@ -230,7 +374,10 @@ int main(int argc, char** argv)
 	expectTrue(
 		VelopackUpdateInfo::fromVelopackFeed(feedDoc, githubReleaseDoc, "x64-avx2", "1.4.4-main.77").isEmpty(),
 		"same Velopack version produced an update");
+}
 
+void testFilterCardDescriptors()
+{
 	FilterCardDescriptor preamp = FilterCardModel::describeLine("Preamp: -6 dB");
 	expectEqual(preamp.badge, "PRE", "preamp card badge");
 	expectEqual(preamp.title, "Preamp", "preamp card title");
@@ -295,7 +442,10 @@ int main(int argc, char** argv)
 	FilterCardDescriptor multiConvBare = FilterCardModel::describeLine("MultiConvolution:");
 	expectEqual(multiConvBare.badge, "MCONV", "bare multiconvolution keeps its badge");
 	expectEqual(multiConvBare.type, "convolution", "bare multiconvolution keeps convolution styling");
+}
 
+void testFilterCardDepths()
+{
 	QVector<int> depths = FilterCardModel::calculateDepths(QList<QString>({
 		"Channel: L R",
 		"Preamp: -6 dB",
@@ -306,7 +456,7 @@ int main(int argc, char** argv)
 		"Channel: ALL",
 		"Filter: ON PK Fc 1000 Hz Gain -3 dB Q 0.71"
 	}));
-	expectEqual(depths.size(), 8, "channel depth count");
+	requireEqual(depths.size(), 8, "channel depth count");
 	expectEqual(depths[0], 0, "channel command depth");
 	expectEqual(depths[1], 1, "scoped preamp depth");
 	expectEqual(depths[2], 1, "include depth");
@@ -315,429 +465,460 @@ int main(int argc, char** argv)
 	expectEqual(depths[5], 1, "post-comment channel depth");
 	expectEqual(depths[6], 0, "channel all depth");
 	expectEqual(depths[7], 0, "post channel-all depth");
+}
 
-	{
-		QTemporaryDir tempDir;
-		expectTrue(tempDir.isValid(), "QTemporaryDir must be valid");
+void testConfigImport()
+{
+	QTemporaryDir tempDir;
+	requireTrue(tempDir.isValid(), "QTemporaryDir must be valid");
 
-		QString surroundDir = tempDir.path() + "/Surround";
-		expectTrue(QDir().mkpath(surroundDir), "failed to create Surround dir");
+	QString surroundDir = tempDir.path() + "/Surround";
+	expectTrue(QDir().mkpath(surroundDir), "failed to create Surround dir");
 
-		auto writeText = [](const QString& path, const QString& body) {
-			QFile f(path);
-			expectTrue(f.open(QIODevice::WriteOnly | QIODevice::Text), QString("could not open %1 for write").arg(path));
-			QTextStream ts(&f);
-			ts << body;
-		};
-		auto writeBlob = [](const QString& path, int bytes) {
-			QFile f(path);
-			expectTrue(f.open(QIODevice::WriteOnly), QString("could not open %1 for write").arg(path));
-			f.write(QByteArray(bytes, '\0'));
-		};
+	auto writeText = [](const QString& path, const QString& body) {
+		QFile f(path);
+		expectTrue(f.open(QIODevice::WriteOnly | QIODevice::Text), QString("could not open %1 for write").arg(path));
+		QTextStream ts(&f);
+		ts << body;
+	};
+	auto writeBlob = [](const QString& path, int bytes) {
+		QFile f(path);
+		expectTrue(f.open(QIODevice::WriteOnly), QString("could not open %1 for write").arg(path));
+		f.write(QByteArray(bytes, '\0'));
+	};
 
-		writeText(surroundDir + "/main.txt",
-			"# main\n"
-			"Preamp: -3 dB\n"
-			"Include: child.txt\n"
-			"Convolution: ir.wav\n");
-		writeText(surroundDir + "/child.txt",
-			"Convolution: nested.wav\n");
-		writeBlob(surroundDir + "/ir.wav", 128);
-		writeBlob(surroundDir + "/nested.wav", 64);
+	writeText(surroundDir + "/main.txt",
+		"# main\n"
+		"Preamp: -3 dB\n"
+		"Include: child.txt\n"
+		"Convolution: ir.wav\n");
+	writeText(surroundDir + "/child.txt",
+		"Convolution: nested.wav\n");
+	writeBlob(surroundDir + "/ir.wav", 128);
+	writeBlob(surroundDir + "/nested.wav", 64);
 
-		EqAPO::Import::ImportManifest manifest = EqAPO::Import::ConfigDependencyScanner::scan(
-			surroundDir + "/main.txt", tempDir.path() + "/configdir");
+	EqAPO::Import::ImportManifest manifest = EqAPO::Import::ConfigDependencyScanner::scan(
+		surroundDir + "/main.txt", tempDir.path() + "/configdir");
 
-		expectFalse(manifest.hasErrors, "scan should not flag any errors for this tree");
-		expectEqual(int(manifest.items.size()), 4, "expected root + child + ir + nested");
+	expectFalse(manifest.hasErrors, "scan should not flag any errors for this tree");
+	requireEqual(int(manifest.items.size()), 4, "expected root + child + ir + nested");
 
-		expectEqual(manifest.items[0].kind, "Root", "first item must be the root config");
-		expectEqual(manifest.items[0].destRelative, "Surround/main.txt", "root dest path");
-		expectTrue(manifest.totalBytes > 0, "totalBytes should be positive");
+	expectEqual(manifest.items[0].kind, "Root", "first item must be the root config");
+	expectEqual(manifest.items[0].destRelative, "Surround/main.txt", "root dest path");
+	expectTrue(manifest.totalBytes > 0, "totalBytes should be positive");
 
-		QStringList destRels;
-		for (const auto& item : manifest.items)
-			destRels.append(item.destRelative);
-		expectTrue(destRels.contains("Surround/main.txt"), "root present in items");
-		expectTrue(destRels.contains("Surround/child.txt"), "include child present");
-		expectTrue(destRels.contains("Surround/ir.wav"), "ir wav present");
-		expectTrue(destRels.contains("Surround/nested.wav"), "nested wav present");
+	QStringList destRels;
+	for (const auto& item : manifest.items)
+		destRels.append(item.destRelative);
+	expectTrue(destRels.contains("Surround/main.txt"), "root present in items");
+	expectTrue(destRels.contains("Surround/child.txt"), "include child present");
+	expectTrue(destRels.contains("Surround/ir.wav"), "ir wav present");
+	expectTrue(destRels.contains("Surround/nested.wav"), "nested wav present");
 
-		// Missing reference should surface as a non-fatal warning + hasErrors.
-		writeText(surroundDir + "/broken.txt", "Convolution: does_not_exist.wav\n");
-		auto broken = EqAPO::Import::ConfigDependencyScanner::scan(surroundDir + "/broken.txt", tempDir.path() + "/configdir");
-		expectTrue(broken.hasErrors, "missing dependency must flag hasErrors");
-		expectTrue(!broken.warnings.isEmpty(), "missing dependency must produce a warning");
+	// Missing reference should surface as a non-fatal warning + hasErrors.
+	writeText(surroundDir + "/broken.txt", "Convolution: does_not_exist.wav\n");
+	auto broken = EqAPO::Import::ConfigDependencyScanner::scan(surroundDir + "/broken.txt", tempDir.path() + "/configdir");
+	expectTrue(broken.hasErrors, "missing dependency must flag hasErrors");
+	expectTrue(!broken.warnings.isEmpty(), "missing dependency must produce a warning");
 
-		QString configDest = tempDir.path() + "/configdir";
-		EqAPO::Import::ExecutionResult exec = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
-		expectTrue(exec.success, "executor should succeed on clean manifest");
-		expectEqual(exec.filesCopied, 4, "executor must copy four files");
+	QString configDest = tempDir.path() + "/configdir";
+	EqAPO::Import::ExecutionResult exec = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
+	expectTrue(exec.success, "executor should succeed on clean manifest");
+	expectEqual(exec.filesCopied, 4, "executor must copy four files");
 
-		expectTrue(QFile::exists(configDest + "/Surround/main.txt"), "main.txt missing after import");
-		expectTrue(QFile::exists(configDest + "/Surround/child.txt"), "child.txt missing after import");
-		expectTrue(QFile::exists(configDest + "/Surround/ir.wav"), "ir.wav missing after import");
-		expectTrue(QFile::exists(configDest + "/Surround/nested.wav"), "nested.wav missing after import");
+	expectTrue(QFile::exists(configDest + "/Surround/main.txt"), "main.txt missing after import");
+	expectTrue(QFile::exists(configDest + "/Surround/child.txt"), "child.txt missing after import");
+	expectTrue(QFile::exists(configDest + "/Surround/ir.wav"), "ir.wav missing after import");
+	expectTrue(QFile::exists(configDest + "/Surround/nested.wav"), "nested.wav missing after import");
 
-		// Re-executing should be idempotent (overwrites are allowed).
-		EqAPO::Import::ExecutionResult exec2 = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
-		expectTrue(exec2.success, "second execute should also succeed");
-		expectEqual(exec2.filesCopied, 4, "second execute should still report four copies");
+	// Re-executing should be idempotent (overwrites are allowed).
+	EqAPO::Import::ExecutionResult exec2 = EqAPO::Import::ImportExecutor::execute(manifest, configDest);
+	expectTrue(exec2.success, "second execute should also succeed");
+	expectEqual(exec2.filesCopied, 4, "second execute should still report four copies");
 
-		// A bare impulse-response file - the path the ConvolutionCardEditor
-		// import button takes - scans to a single-item manifest rooted at the
-		// file itself (no .txt recursion), keeping the source folder name as a
-		// subdirectory so the copy lands at config/<folder>/<file>.
-		QString convConfigDest = tempDir.path() + "/conv-configdir";
-		EqAPO::Import::ImportManifest single = EqAPO::Import::ConfigDependencyScanner::scan(
-			surroundDir + "/ir.wav", convConfigDest);
-		expectFalse(single.hasErrors, "single wav scan should not flag errors");
-		expectEqual(int(single.items.size()), 1, "single wav scan yields exactly one item");
-		expectEqual(single.items[0].kind, "Root", "single wav item is the root");
-		expectEqual(single.items[0].destRelative, "Surround/ir.wav", "single wav keeps its source folder");
-		expectEqual(single.rootDest, "Surround/ir.wav", "single wav rootDest mirrors the item");
+	// A bare impulse-response file - the path the ConvolutionCardEditor
+	// import button takes - scans to a single-item manifest rooted at the
+	// file itself (no .txt recursion), keeping the source folder name as a
+	// subdirectory so the copy lands at config/<folder>/<file>.
+	QString convConfigDest = tempDir.path() + "/conv-configdir";
+	EqAPO::Import::ImportManifest single = EqAPO::Import::ConfigDependencyScanner::scan(
+		surroundDir + "/ir.wav", convConfigDest);
+	expectFalse(single.hasErrors, "single wav scan should not flag errors");
+	requireEqual(int(single.items.size()), 1, "single wav scan yields exactly one item");
+	expectEqual(single.items[0].kind, "Root", "single wav item is the root");
+	expectEqual(single.items[0].destRelative, "Surround/ir.wav", "single wav keeps its source folder");
+	expectEqual(single.rootDest, "Surround/ir.wav", "single wav rootDest mirrors the item");
 
-		EqAPO::Import::ExecutionResult singleExec = EqAPO::Import::ImportExecutor::execute(single, convConfigDest);
-		expectTrue(singleExec.success, "single wav import should succeed");
-		expectEqual(singleExec.filesCopied, 1, "single wav import copies exactly one file");
-		expectTrue(QFile::exists(convConfigDest + "/Surround/ir.wav"), "ir.wav missing after single-file import");
-	}
+	EqAPO::Import::ExecutionResult singleExec = EqAPO::Import::ImportExecutor::execute(single, convConfigDest);
+	expectTrue(singleExec.success, "single wav import should succeed");
+	expectEqual(singleExec.filesCopied, 1, "single wav import copies exactly one file");
+	expectTrue(QFile::exists(convConfigDest + "/Surround/ir.wav"), "ir.wav missing after single-file import");
+}
 
-	{
-		// ChannelSelectionModel serialization identity: for equivalent
-		// selections the in-place chip editor must write the same bytes the
-		// legacy multi-select dialog produced (standard positions in the
-		// dialog's checkbox order, then non-standard device channels, then
-		// custom names).
-		const std::vector<std::wstring> stereo = { L"L", L"R" };
-		const std::vector<std::wstring> surround51 = { L"L", L"R", L"C", L"LFE", L"RL", L"RR" };
-		const std::vector<std::wstring> surround71 = { L"L", L"R", L"C", L"LFE", L"RL", L"RR", L"SL", L"SR" };
+void testChannelSelectionModel()
+{
+	// ChannelSelectionModel serialization identity: for equivalent
+	// selections the in-place chip editor must write the same bytes the
+	// legacy multi-select dialog produced (standard positions in the
+	// dialog's checkbox order, then non-standard device channels, then
+	// custom names).
+	const std::vector<std::wstring> stereo = { L"L", L"R" };
+	const std::vector<std::wstring> surround51 = { L"L", L"R", L"C", L"LFE", L"RL", L"RR" };
+	const std::vector<std::wstring> surround71 = { L"L", L"R", L"C", L"LFE", L"RL", L"RR", L"SL", L"SR" };
 
-		ChannelSelectionModel model;
-		model.load("L R C", surround51);
-		expectEqual(model.serialize(), "C L R", "5.1 selection must serialize in dialog order");
+	ChannelSelectionModel model;
+	model.load("L R C", surround51);
+	expectEqual(model.serialize(), "C L R", "5.1 selection must serialize in dialog order");
 
-		model.load("R L", stereo);
-		expectEqual(model.serialize(), "L R", "written order canonicalizes like the dialog");
+	model.load("R L", stereo);
+	expectEqual(model.serialize(), "L R", "written order canonicalizes like the dialog");
 
-		// Position numbers resolve against the device order (engine
-		// semantics, ChannelHelper::getChannelIndex), and are written back
-		// as names like the dialog did.
-		model.load("2", stereo);
-		expectEqual(model.serialize(), "R", "numeric selector resolves in device order");
+	// Position numbers resolve against the device order (engine
+	// semantics, ChannelHelper::getChannelIndex), and are written back
+	// as names like the dialog did.
+	model.load("2", stereo);
+	expectEqual(model.serialize(), "R", "numeric selector resolves in device order");
 
-		// Historical aliases follow the engine: SUB -> LFE, SL <-> RL.
-		model.load("SUB", surround51);
-		expectEqual(model.serialize(), "LFE", "SUB alias selects the LFE chip");
-		model.load("SL", surround51);
-		expectEqual(model.serialize(), "RL", "SL on a back-channel device selects RL");
+	// Historical aliases follow the engine: SUB -> LFE, SL <-> RL.
+	model.load("SUB", surround51);
+	expectEqual(model.serialize(), "LFE", "SUB alias selects the LFE chip");
+	model.load("SL", surround51);
+	expectEqual(model.serialize(), "RL", "SL on a back-channel device selects RL");
 
-		model.load("SR SL LFE", surround71);
-		expectEqual(model.serialize(), "SL SR LFE", "7.1 selection serializes in dialog order");
+	model.load("SR SL LFE", surround71);
+	expectEqual(model.serialize(), "SL SR LFE", "7.1 selection serializes in dialog order");
 
-		// ALL wins over individual selections, exactly like the dialog.
-		model.load("ALL L", surround51);
-		expectTrue(model.allSelected(), "ALL token sets the all-channels state");
-		expectEqual(model.serialize(), "ALL", "ALL serializes alone");
+	// ALL wins over individual selections, exactly like the dialog.
+	model.load("ALL L", surround51);
+	expectTrue(model.allSelected(), "ALL token sets the all-channels state");
+	expectEqual(model.serialize(), "ALL", "ALL serializes alone");
 
-		// Custom/virtual channels keep their written order after the device
-		// chips, matching the dialog's list section.
-		model.load("VSL L VSR", stereo);
-		expectEqual(model.serialize(), "L VSL VSR", "custom names follow device channels");
-		model.toggle("R");
-		expectEqual(model.serialize(), "L R VSL VSR", "toggling keeps canonical order");
-		model.toggle("L");
-		expectEqual(model.serialize(), "R VSL VSR", "deselecting removes the token");
+	// Custom/virtual channels keep their written order after the device
+	// chips, matching the dialog's list section.
+	model.load("VSL L VSR", stereo);
+	expectEqual(model.serialize(), "L VSL VSR", "custom names follow device channels");
+	model.toggle("R");
+	expectEqual(model.serialize(), "L R VSL VSR", "toggling keeps canonical order");
+	model.toggle("L");
+	expectEqual(model.serialize(), "R VSL VSR", "deselecting removes the token");
 
-		expectFalse(model.addCustom("  "), "blank custom name is rejected");
-		expectFalse(model.addCustom("A B"), "multi-token custom name is rejected");
-		expectTrue(model.addCustom(" vrr "), "custom name is trimmed and accepted");
-		expectEqual(model.serialize(), "R VSL VSR VRR", "added custom name serializes upper-cased");
+	expectFalse(model.addCustom("  "), "blank custom name is rejected");
+	expectFalse(model.addCustom("A B"), "multi-token custom name is rejected");
+	expectTrue(model.addCustom(" vrr "), "custom name is trimmed and accepted");
+	expectEqual(model.serialize(), "R VSL VSR VRR", "added custom name serializes upper-cased");
 
-		// addCustom resolves aliases against the device set too: SUB selects
-		// the LFE chip instead of duplicating it as a custom name.
-		model.load("", surround51);
-		expectTrue(model.addCustom("sub"), "SUB through addCustom is accepted");
-		expectEqual(model.serialize(), "LFE", "SUB resolves to the device's LFE chip");
-	}
+	// addCustom resolves aliases against the device set too: SUB selects
+	// the LFE chip instead of duplicating it as a custom name.
+	model.load("", surround51);
+	expectTrue(model.addCustom("sub"), "SUB through addCustom is accepted");
+	expectEqual(model.serialize(), "LFE", "SUB resolves to the device's LFE chip");
+}
 
-	{
-		// DeviceSelectionModel serialization identity: for equivalent device
-		// selections the in-place chip editor must write the same bytes the
-		// legacy change-button dialog produced - "all", or each selected
-		// device's device string joined with "; " in list order (output
-		// devices first, then input). Matching runs through the shared
-		// DeviceCommand codec, the same one the engine uses, so a chip is
-		// pre-selected exactly when the engine would match that device.
-		auto dev = [](const QString& deviceString, const QString& name, bool installed, bool isInput) {
-			DeviceEntry e;
-			e.deviceString = deviceString;
-			e.name = name;
-			e.installed = installed;
-			e.isInput = isInput;
-			return e;
-		};
-		const QString devSpeakers = "Speakers Realtek HD Audio {0.0.0.00000000}.{aaaaaaaa-1111-2222-3333-444444444444}";
-		const QString devHeadphones = "Headphones Realtek HD Audio {0.0.0.00000000}.{bbbbbbbb-1111-2222-3333-444444444444}";
-		const QString devDigital = "Digital Output Realtek HD Audio {0.0.0.00000000}.{cccccccc-1111-2222-3333-444444444444}";
-		const QString devMic = "Microphone Realtek HD Audio {0.0.1.00000000}.{dddddddd-1111-2222-3333-444444444444}";
-		const QList<DeviceEntry> devices = {
-			dev(devSpeakers, "Speakers", true, false),
-			dev(devHeadphones, "Headphones", true, false),
-			dev(devDigital, "Digital Output", false, false),
-			dev(devMic, "Microphone", true, true),
-		};
+void testDeviceSelectionModel()
+{
+	// DeviceSelectionModel serialization identity: for equivalent device
+	// selections the in-place chip editor must write the same bytes the
+	// legacy change-button dialog produced - "all", or each selected
+	// device's device string joined with "; " in list order (output
+	// devices first, then input). Matching runs through the shared
+	// DeviceCommand codec, the same one the engine uses, so a chip is
+	// pre-selected exactly when the engine would match that device.
+	auto dev = [](const QString& deviceString, const QString& name, bool installed, bool isInput) {
+		DeviceEntry e;
+		e.deviceString = deviceString;
+		e.name = name;
+		e.installed = installed;
+		e.isInput = isInput;
+		return e;
+	};
+	const QString devSpeakers = "Speakers Realtek HD Audio {0.0.0.00000000}.{aaaaaaaa-1111-2222-3333-444444444444}";
+	const QString devHeadphones = "Headphones Realtek HD Audio {0.0.0.00000000}.{bbbbbbbb-1111-2222-3333-444444444444}";
+	const QString devDigital = "Digital Output Realtek HD Audio {0.0.0.00000000}.{cccccccc-1111-2222-3333-444444444444}";
+	const QString devMic = "Microphone Realtek HD Audio {0.0.1.00000000}.{dddddddd-1111-2222-3333-444444444444}";
+	const QList<DeviceEntry> devices = {
+		dev(devSpeakers, "Speakers", true, false),
+		dev(devHeadphones, "Headphones", true, false),
+		dev(devDigital, "Digital Output", false, false),
+		dev(devMic, "Microphone", true, true),
+	};
 
-		DeviceSelectionModel model;
+	DeviceSelectionModel model;
 
-		// The literal lowercase "all" line is the all-devices state, like the
-		// dialog's "All devices" choice: it round-trips to "all" and marks no
-		// individual chip selected.
-		model.load("all", devices);
-		expectTrue(model.allSelected(), "literal 'all' sets the all-devices state");
-		expectEqual(model.serialize(), "all", "all-devices serializes back as 'all'");
+	// The literal lowercase "all" line is the all-devices state, like the
+	// dialog's "All devices" choice: it round-trips to "all" and marks no
+	// individual chip selected.
+	model.load("all", devices);
+	expectTrue(model.allSelected(), "literal 'all' sets the all-devices state");
+	expectEqual(model.serialize(), "all", "all-devices serializes back as 'all'");
 
-		// An empty parameter is not the all state and selects nothing.
-		model.load("", devices);
-		expectFalse(model.allSelected(), "empty parameter is not the all state");
-		expectEqual(model.serialize(), "", "no selection serializes empty");
+	// An empty parameter is not the all state and selects nothing.
+	model.load("", devices);
+	expectFalse(model.allSelected(), "empty parameter is not the all state");
+	expectEqual(model.serialize(), "", "no selection serializes empty");
 
-		// A full device-string pattern pre-selects exactly that endpoint and
-		// round-trips byte-for-byte, GUID included.
-		model.load(devSpeakers, devices);
-		expectFalse(model.allSelected(), "a specific device is not the all state");
-		expectEqual(model.serialize(), devSpeakers, "single device round-trips verbatim");
+	// A full device-string pattern pre-selects exactly that endpoint and
+	// round-trips byte-for-byte, GUID included.
+	model.load(devSpeakers, devices);
+	expectFalse(model.allSelected(), "a specific device is not the all state");
+	expectEqual(model.serialize(), devSpeakers, "single device round-trips verbatim");
 
-		// A bare word matches as a case-insensitive substring (DeviceCommand
-		// semantics) and is rewritten to the matched device's full string.
-		model.load("headphones", devices);
-		expectEqual(model.serialize(), devHeadphones, "word pattern selects and canonicalizes to the device string");
+	// A bare word matches as a case-insensitive substring (DeviceCommand
+	// semantics) and is rewritten to the matched device's full string.
+	model.load("headphones", devices);
+	expectEqual(model.serialize(), devHeadphones, "word pattern selects and canonicalizes to the device string");
 
-		// Multiple patterns, written input-first, serialize in list order
-		// (output devices first, then input) joined with "; ".
-		model.load(devMic + "; " + devSpeakers, devices);
-		expectEqual(model.serialize(), devSpeakers + "; " + devMic, "multiple devices serialize in list order");
+	// Multiple patterns, written input-first, serialize in list order
+	// (output devices first, then input) joined with "; ".
+	model.load(devMic + "; " + devSpeakers, devices);
+	expectEqual(model.serialize(), devSpeakers + "; " + devMic, "multiple devices serialize in list order");
 
-		// toggle() flips one chip and keeps canonical list order.
-		model.load(devSpeakers, devices);
-		model.toggle(devHeadphones);
-		expectEqual(model.serialize(), devSpeakers + "; " + devHeadphones, "toggling on adds a chip in list order");
-		model.toggle(devSpeakers);
-		expectEqual(model.serialize(), devHeadphones, "toggling off removes the token");
+	// toggle() flips one chip and keeps canonical list order.
+	model.load(devSpeakers, devices);
+	model.toggle(devHeadphones);
+	expectEqual(model.serialize(), devSpeakers + "; " + devHeadphones, "toggling on adds a chip in list order");
+	model.toggle(devSpeakers);
+	expectEqual(model.serialize(), devHeadphones, "toggling off removes the token");
 
-		// "All devices" wins over individual selections, like the dialog.
-		model.load(devSpeakers, devices);
-		model.setAllSelected(true);
-		expectEqual(model.serialize(), "all", "All overrides individual selections");
-	}
+	// "All devices" wins over individual selections, like the dialog.
+	model.load(devSpeakers, devices);
+	model.setAllSelected(true);
+	expectEqual(model.serialize(), "all", "All overrides individual selections");
+}
 
-	{
-		// MultiConvolutionRoutingAdapter: mappings <-> the routing views'
-		// Assignment type must round-trip, because the card serializes the
-		// edited view back into the config line. IR channels ride as decimal
-		// summand channels at unity factor.
-		using Mapping = MultiConvolutionCommand::Mapping;
+void testMultiConvolutionRoutingAdapter()
+{
+	// MultiConvolutionRoutingAdapter: mappings <-> the routing views'
+	// Assignment type must round-trip, because the card serializes the
+	// edited view back into the config line. IR channels ride as decimal
+	// summand channels at unity factor.
+	using Mapping = MultiConvolutionCommand::Mapping;
 
-		const std::vector<Mapping> brir = {{L"L", {0, 1}}, {L"R", {2, 3}}};
-		std::vector<Assignment> assignments = MultiConvolutionRoutingAdapter::toAssignments(brir, 4);
-		expectEqual((int)assignments.size(), 2, "two mappings become two assignments");
-		expectTrue(assignments.size() == 2
-			&& assignments[0].targetChannel == L"L" && assignments[0].sourceSum.size() == 2
-			&& assignments[0].sourceSum[0].channel == L"0" && assignments[0].sourceSum[1].channel == L"1"
-			&& assignments[0].sourceSum[0].factor == 1.0 && !assignments[0].sourceSum[0].isDecibel,
-			"IR channels become decimal summands at unity factor");
+	const std::vector<Mapping> brir = {{L"L", {0, 1}}, {L"R", {2, 3}}};
+	std::vector<Assignment> assignments = MultiConvolutionRoutingAdapter::toAssignments(brir, 4);
+	requireEqual((int)assignments.size(), 2, "two mappings become two assignments");
+	expectTrue(assignments.size() == 2
+		&& assignments[0].targetChannel == L"L" && assignments[0].sourceSum.size() == 2
+		&& assignments[0].sourceSum[0].channel == L"0" && assignments[0].sourceSum[1].channel == L"1"
+		&& assignments[0].sourceSum[0].factor == 1.0 && !assignments[0].sourceSum[0].isDecibel,
+		"IR channels become decimal summands at unity factor");
 
-		std::vector<Mapping> roundTrip = MultiConvolutionRoutingAdapter::toMappings(assignments);
-		expectTrue(roundTrip.size() == 2
-			&& roundTrip[0].targetChannel == L"L" && roundTrip[0].irChannels == std::vector<unsigned>({0, 1})
-			&& roundTrip[1].targetChannel == L"R" && roundTrip[1].irChannels == std::vector<unsigned>({2, 3}),
-			"assignments convert back to the same mappings");
+	std::vector<Mapping> roundTrip = MultiConvolutionRoutingAdapter::toMappings(assignments);
+	expectTrue(roundTrip.size() == 2
+		&& roundTrip[0].targetChannel == L"L" && roundTrip[0].irChannels == std::vector<unsigned>({0, 1})
+		&& roundTrip[1].targetChannel == L"R" && roundTrip[1].irChannels == std::vector<unsigned>({2, 3}),
+		"assignments convert back to the same mappings");
 
-		// The simple form expands to every file channel for display, and to
-		// nothing when the channel count is unknown (callers must not offer
-		// editing then).
-		std::vector<Assignment> expanded = MultiConvolutionRoutingAdapter::toAssignments({{L"Wet", {}}}, 3);
-		expectTrue(expanded.size() == 1 && expanded[0].sourceSum.size() == 3
-			&& expanded[0].sourceSum[2].channel == L"2",
-			"the simple form expands to every file channel");
-		std::vector<Assignment> unknown = MultiConvolutionRoutingAdapter::toAssignments({{L"Wet", {}}}, 0);
-		expectTrue(unknown.size() == 1 && unknown[0].sourceSum.empty(),
-			"an unknown channel count expands to nothing");
+	// The simple form expands to every file channel for display, and to
+	// nothing when the channel count is unknown (callers must not offer
+	// editing then).
+	std::vector<Assignment> expanded = MultiConvolutionRoutingAdapter::toAssignments({{L"Wet", {}}}, 3);
+	expectTrue(expanded.size() == 1 && expanded[0].sourceSum.size() == 3
+		&& expanded[0].sourceSum[2].channel == L"2",
+		"the simple form expands to every file channel");
+	std::vector<Assignment> unknown = MultiConvolutionRoutingAdapter::toAssignments({{L"Wet", {}}}, 0);
+	expectTrue(unknown.size() == 1 && unknown[0].sourceSum.empty(),
+		"an unknown channel count expands to nothing");
 
-		// Seeded placeholder rows (empty sums) and non-numeric summands are
-		// dropped on the way back, like Copy's serializer skips empty rows.
-		std::vector<Assignment> edited = assignments;
-		Assignment seeded;
-		seeded.targetChannel = L"C";
-		edited.push_back(seeded);
-		Assignment::Summand bogus;
-		bogus.factor = 1.0;
-		bogus.channel = L"VSL";
-		edited[0].sourceSum.push_back(bogus);
-		std::vector<Mapping> cleaned = MultiConvolutionRoutingAdapter::toMappings(edited);
-		expectTrue(cleaned.size() == 2 && cleaned[0].irChannels == std::vector<unsigned>({0, 1}),
-			"placeholder rows and non-numeric summands are dropped");
+	// Seeded placeholder rows (empty sums) and non-numeric summands are
+	// dropped on the way back, like Copy's serializer skips empty rows.
+	std::vector<Assignment> edited = assignments;
+	Assignment seeded;
+	seeded.targetChannel = L"C";
+	edited.push_back(seeded);
+	Assignment::Summand bogus;
+	bogus.factor = 1.0;
+	bogus.channel = L"VSL";
+	edited[0].sourceSum.push_back(bogus);
+	std::vector<Mapping> cleaned = MultiConvolutionRoutingAdapter::toMappings(edited);
+	expectTrue(cleaned.size() == 2 && cleaned[0].irChannels == std::vector<unsigned>({0, 1}),
+		"placeholder rows and non-numeric summands are dropped");
 
-		// Source ports: "0".."N-1" from the file, then any referenced index
-		// beyond the file so stale connections stay visible and removable.
-		QStringList ports = MultiConvolutionRoutingAdapter::sourcePorts(2, {{L"L", {0, 7}}});
-		expectEqual(ports.join(','), QString("0,1,7"), "ports are the file channels plus stale references");
-		QStringList portsNoFile = MultiConvolutionRoutingAdapter::sourcePorts(0, {{L"L", {2, 1}}});
-		expectEqual(portsNoFile.join(','), QString("1,2"), "without a file only referenced indices appear, sorted");
-	}
+	// Source ports: "0".."N-1" from the file, then any referenced index
+	// beyond the file so stale connections stay visible and removable.
+	QStringList ports = MultiConvolutionRoutingAdapter::sourcePorts(2, {{L"L", {0, 7}}});
+	expectEqual(ports.join(','), QString("0,1,7"), "ports are the file channels plus stale references");
+	QStringList portsNoFile = MultiConvolutionRoutingAdapter::sourcePorts(0, {{L"L", {2, 1}}});
+	expectEqual(portsNoFile.join(','), QString("1,2"), "without a file only referenced indices appear, sorted");
+}
 
-	{
-		// StageSelectionModel serialization identity: known stages come back in
-		// the legacy checkbox GUI's canonical order (pre-mix, post-mix,
-		// capture), case-insensitively parsed through the shared StageCommand
-		// codec; unlike the legacy GUI, tokens outside the vocabulary survive
-		// an edit in their written order.
-		StageSelectionModel model;
+void testStageSelectionModel()
+{
+	// StageSelectionModel serialization identity: known stages come back in
+	// the legacy checkbox GUI's canonical order (pre-mix, post-mix,
+	// capture), case-insensitively parsed through the shared StageCommand
+	// codec; unlike the legacy GUI, tokens outside the vocabulary survive
+	// an edit in their written order.
+	StageSelectionModel model;
 
-		model.load("post-mix pre-mix");
-		expectTrue(model.isSelected("pre-mix") && model.isSelected("post-mix"), "both written stages are selected");
-		expectFalse(model.isSelected("capture"), "capture stays unselected");
-		expectEqual(model.serialize(), "pre-mix post-mix", "known stages serialize in canonical order");
+	model.load("post-mix pre-mix");
+	expectTrue(model.isSelected("pre-mix") && model.isSelected("post-mix"), "both written stages are selected");
+	expectFalse(model.isSelected("capture"), "capture stays unselected");
+	expectEqual(model.serialize(), "pre-mix post-mix", "known stages serialize in canonical order");
 
-		model.load("Pre-Mix CAPTURE");
-		expectEqual(model.serialize(), "pre-mix capture", "selectors are case-insensitive and lower-cased");
+	model.load("Pre-Mix CAPTURE");
+	expectEqual(model.serialize(), "pre-mix capture", "selectors are case-insensitive and lower-cased");
 
-		model.load("pre-mix render foo");
-		expectEqual(model.unknownTokens().join(' '), "render foo", "unknown tokens are reported");
-		expectEqual(model.serialize(), "pre-mix render foo", "unknown tokens survive after the known stages");
-		model.setSelected("pre-mix", false);
-		model.setSelected("capture", true);
-		expectEqual(model.serialize(), "capture render foo", "toggles keep the unknown tokens");
+	model.load("pre-mix render foo");
+	expectEqual(model.unknownTokens().join(' '), "render foo", "unknown tokens are reported");
+	expectEqual(model.serialize(), "pre-mix render foo", "unknown tokens survive after the known stages");
+	model.setSelected("pre-mix", false);
+	model.setSelected("capture", true);
+	expectEqual(model.serialize(), "capture render foo", "toggles keep the unknown tokens");
 
-		model.load("");
-		expectEqual(model.serialize(), "", "an empty selection serializes empty (matches no stage)");
-		model.setSelected("capture", true);
-		expectEqual(model.serialize(), "capture", "a single selection writes just its token");
-	}
+	model.load("");
+	expectEqual(model.serialize(), "", "an empty selection serializes empty (matches no stage)");
+	model.setSelected("capture", true);
+	expectEqual(model.serialize(), "capture", "a single selection writes just its token");
+}
 
-	{
-		// StudioRoutingModel: the Light Trace view's working model must seed
-		// and resolve exactly like the legacy CopyFilterGUIScene (channel rows,
-		// LFE/SUB alias, 1-based numeric positions, the constant input port)
-		// while preserving load order, so an edit-free round trip emits the
-		// assignments in the order they were written.
-		auto formatted = [](const std::vector<Assignment>& list) {
-			QString out;
-			for (const Assignment& a : list)
+void testStudioRoutingModel()
+{
+	// StudioRoutingModel: the Light Trace view's working model must seed
+	// and resolve exactly like the legacy CopyFilterGUIScene (channel rows,
+	// LFE/SUB alias, 1-based numeric positions, the constant input port)
+	// while preserving load order, so an edit-free round trip emits the
+	// assignments in the order they were written.
+	auto formatted = [](const std::vector<Assignment>& list) {
+		QString out;
+		for (const Assignment& a : list)
+		{
+			if (!out.isEmpty())
+				out += ' ';
+			out += QString::fromStdWString(a.targetChannel) + '=';
+			bool first = true;
+			for (const Assignment::Summand& s : a.sourceSum)
 			{
-				if (!out.isEmpty())
-					out += ' ';
-				out += QString::fromStdWString(a.targetChannel) + '=';
-				bool first = true;
-				for (const Assignment::Summand& s : a.sourceSum)
-				{
-					if (!first)
-						out += '+';
-					first = false;
-					out += QString::number(s.factor) + (s.isDecibel ? "db" : "") + '*'
-						+ (s.channel.empty() ? QStringLiteral("<const>") : QString::fromStdWString(s.channel));
-				}
+				if (!first)
+					out += '+';
+				first = false;
+				out += QString::number(s.factor) + (s.isDecibel ? "db" : "") + '*'
+					+ (s.channel.empty() ? QStringLiteral("<const>") : QString::fromStdWString(s.channel));
 			}
-			return out;
-		};
-		auto summand = [](double factor, const wchar_t* channel, bool isDecibel = false) {
-			Assignment::Summand s;
-			s.factor = factor;
-			s.isDecibel = isDecibel;
-			s.channel = channel;
-			return s;
-		};
+		}
+		return out;
+	};
+	auto summand = [](double factor, const wchar_t* channel, bool isDecibel = false) {
+		Assignment::Summand s;
+		s.factor = factor;
+		s.isDecibel = isDecibel;
+		s.channel = channel;
+		return s;
+	};
 
-		const std::vector<std::wstring> surround = { L"L", L"R", L"C", L"LFE" };
-		StudioRoutingModel::PortConfig copyMode;
+	const std::vector<std::wstring> surround = { L"L", L"R", L"C", L"LFE" };
+	StudioRoutingModel::PortConfig copyMode;
 
-		// Written order survives, SUB canonicalizes to the LFE chip, the
-		// unknown target VC becomes a new output chip.
-		std::vector<Assignment> loaded(2);
-		loaded[0].targetChannel = L"VC";
-		loaded[0].sourceSum = { summand(0.5, L"L"), summand(0.5, L"R") };
-		loaded[1].targetChannel = L"C";
-		loaded[1].sourceSum = { summand(1.0, L"SUB") };
+	// Written order survives, SUB canonicalizes to the LFE chip, the
+	// unknown target VC becomes a new output chip.
+	std::vector<Assignment> loaded(2);
+	loaded[0].targetChannel = L"VC";
+	loaded[0].sourceSum = { summand(0.5, L"L"), summand(0.5, L"R") };
+	loaded[1].targetChannel = L"C";
+	loaded[1].sourceSum = { summand(1.0, L"SUB") };
 
-		StudioRoutingModel model;
-		model.load(loaded, surround, copyMode);
-		expectEqual(model.inputPorts().join(','), "L,R,C,LFE,", "inputs are the channels plus the constant port");
-		expectTrue(model.constInput(model.inputPorts().size() - 1), "the last input is the constant port");
-		expectEqual(model.outputPorts().join(','), "L,R,C,LFE,VC", "the unknown target joins the output row");
-		expectEqual(formatted(model.assignments()), "VC=0.5*L+0.5*R C=1*LFE",
-			"round trip keeps written order and canonicalizes SUB to LFE");
+	StudioRoutingModel model;
+	model.load(loaded, surround, copyMode);
+	expectEqual(model.inputPorts().join(','), "L,R,C,LFE,", "inputs are the channels plus the constant port");
+	expectTrue(model.constInput(model.inputPorts().size() - 1), "the last input is the constant port");
+	expectEqual(model.outputPorts().join(','), "L,R,C,LFE,VC", "the unknown target joins the output row");
+	expectEqual(formatted(model.assignments()), "VC=0.5*L+0.5*R C=1*LFE",
+		"round trip keeps written order and canonicalizes SUB to LFE");
 
-		// 1-based numeric positions resolve like the engine.
-		std::vector<Assignment> numeric(1);
-		numeric[0].targetChannel = L"3";
-		numeric[0].sourceSum = { summand(1.0, L"1") };
-		model.load(numeric, { L"L", L"R", L"C" }, copyMode);
-		expectEqual(formatted(model.assignments()), "C=1*L", "numeric positions canonicalize to channel names");
+	// 1-based numeric positions resolve like the engine.
+	std::vector<Assignment> numeric(1);
+	numeric[0].targetChannel = L"3";
+	numeric[0].sourceSum = { summand(1.0, L"1") };
+	model.load(numeric, { L"L", L"R", L"C" }, copyMode);
+	expectEqual(formatted(model.assignments()), "C=1*L", "numeric positions canonicalize to channel names");
 
-		// Edit operations: virtual output, unity trace, factor grammar
-		// (',' reads as '.', "db" suffix any case, empty removes).
-		model.load({}, { L"L", L"R" }, copyMode);
-		expectEqual(formatted(model.assignments()), "", "seeded chips without traces emit nothing");
-		const int vx = model.addOutput("VX");
-		expectTrue(vx >= 0 && model.outputPorts().last() == "VX", "a new output chip is appended");
-		expectEqual(model.addOutput("L"), 0, "an existing name reuses its chip");
-		model.addTrace(0, vx);
-		expectEqual(formatted(model.assignments()), "VX=1*L", "a drag connects at unity gain");
-		model.setFactorText(0, "0,5");
-		expectEqual(formatted(model.assignments()), "VX=0.5*L", "a comma factor reads as a decimal point");
-		model.setFactorText(0, "-6 dB");
-		expectEqual(formatted(model.assignments()), "VX=-6db*L", "a db suffix sets decibel mode");
-		model.setFactorText(0, "garbage");
-		expectEqual(formatted(model.assignments()), "VX=-6db*L", "unparsable text leaves the trace unchanged");
-		model.setFactorText(0, "");
-		expectEqual(formatted(model.assignments()), "", "an empty commit removes the trace");
+	// Edit operations: virtual output, unity trace, factor grammar
+	// (',' reads as '.', "db" suffix any case, empty removes).
+	model.load({}, { L"L", L"R" }, copyMode);
+	expectEqual(formatted(model.assignments()), "", "seeded chips without traces emit nothing");
+	const int vx = model.addOutput("VX");
+	expectTrue(vx >= 0 && model.outputPorts().last() == "VX", "a new output chip is appended");
+	expectEqual(model.addOutput("L"), 0, "an existing name reuses its chip");
+	model.addTrace(0, vx);
+	expectEqual(formatted(model.assignments()), "VX=1*L", "a drag connects at unity gain");
+	model.setFactorText(0, "0,5");
+	expectEqual(formatted(model.assignments()), "VX=0.5*L", "a comma factor reads as a decimal point");
+	model.setFactorText(0, "-6 dB");
+	expectEqual(formatted(model.assignments()), "VX=-6db*L", "a db suffix sets decibel mode");
+	model.setFactorText(0, "garbage");
+	expectEqual(formatted(model.assignments()), "VX=-6db*L", "unparsable text leaves the trace unchanged");
+	model.setFactorText(0, "");
+	expectEqual(formatted(model.assignments()), "", "an empty commit removes the trace");
 
-		// The constant port connects at factor 0.0 with no channel.
-		model.load({}, { L"L", L"R" }, copyMode);
-		model.addTrace(2, 0);
-		expectEqual(formatted(model.assignments()), "L=0*<const>", "the constant port writes a value summand");
+	// The constant port connects at factor 0.0 with no channel.
+	model.load({}, { L"L", L"R" }, copyMode);
+	model.addTrace(2, 0);
+	expectEqual(formatted(model.assignments()), "L=0*<const>", "the constant port writes a value summand");
 
-		// Fixed-source mode (MultiConvolution): the top row is exactly the
-		// given port list, no constant port, factors locked to unity.
-		StudioRoutingModel::PortConfig fixedMode;
-		fixedMode.fixedSources = QStringList() << "0" << "1" << "2" << "3";
-		fixedMode.allowFactors = false;
-		std::vector<Assignment> mapped(1);
-		mapped[0].targetChannel = L"L";
-		mapped[0].sourceSum = { summand(1.0, L"0"), summand(1.0, L"1") };
-		model.load(mapped, { L"L", L"R" }, fixedMode);
-		expectEqual(model.inputPorts().join(','), "0,1,2,3", "fixed sources are the whole top row");
-		expectFalse(model.constInput(model.inputPorts().size() - 1), "no constant port in fixed mode");
-		model.setFactorText(0, "0.5");
-		model.addTrace(2, 1);
-		expectEqual(formatted(model.assignments()), "L=1*0+1*1 R=1*2", "fixed mode keeps every factor at unity");
-	}
+	// Fixed-source mode (MultiConvolution): the top row is exactly the
+	// given port list, no constant port, factors locked to unity.
+	StudioRoutingModel::PortConfig fixedMode;
+	fixedMode.fixedSources = QStringList() << "0" << "1" << "2" << "3";
+	fixedMode.allowFactors = false;
+	std::vector<Assignment> mapped(1);
+	mapped[0].targetChannel = L"L";
+	mapped[0].sourceSum = { summand(1.0, L"0"), summand(1.0, L"1") };
+	model.load(mapped, { L"L", L"R" }, fixedMode);
+	expectEqual(model.inputPorts().join(','), "0,1,2,3", "fixed sources are the whole top row");
+	expectFalse(model.constInput(model.inputPorts().size() - 1), "no constant port in fixed mode");
+	model.setFactorText(0, "0.5");
+	model.addTrace(2, 1);
+	expectEqual(formatted(model.assignments()), "L=1*0+1*1 R=1*2", "fixed mode keeps every factor at unity");
+}
 
-	{
-		// ConfigFileCodec::decodeLines/encodeLines were extracted expressly as
-		// an independently testable seam but had no tests. (audit #146 TD031)
-		QList<QString> mixed = ConfigFileCodec::decodeLines(std::string("Preamp: -6 dB\r\nInclude: a.txt\nlast"));
-		expectEqual((int)mixed.size(), 3, "decodeLines splits CRLF and LF terminated lines");
-		expectEqual(mixed[0], "Preamp: -6 dB", "decodeLines strips the trailing CR");
-		expectEqual(mixed[2], "last", "decodeLines keeps the final unterminated line");
+void testConfigFileCodec()
+{
+	// ConfigFileCodec::decodeLines/encodeLines were extracted expressly as
+	// an independently testable seam but had no tests. (audit #146 TD031)
+	QList<QString> mixed = ConfigFileCodec::decodeLines(std::string("Preamp: -6 dB\r\nInclude: a.txt\nlast"));
+	requireEqual((int)mixed.size(), 3, "decodeLines splits CRLF and LF terminated lines");
+	expectEqual(mixed[0], "Preamp: -6 dB", "decodeLines strips the trailing CR");
+	expectEqual(mixed[2], "last", "decodeLines keeps the final unterminated line");
 
-		QList<QString> unicode = ConfigFileCodec::decodeLines(std::string("# caf\xC3\xA9"));
-		expectEqual(unicode[0], QString::fromUtf8("# caf\xC3\xA9"), "decodeLines decodes valid UTF-8");
+	QList<QString> unicode = ConfigFileCodec::decodeLines(std::string("# caf\xC3\xA9"));
+	expectEqual(unicode[0], QString::fromUtf8("# caf\xC3\xA9"), "decodeLines decodes valid UTF-8");
 
-		// 0xE9 alone is invalid UTF-8, so the system-ANSI fallback must engage.
-		// The decoded glyph depends on the machine's CP_ACP (e.g. CP1252 vs
-		// CP949), so only the line structure is asserted, not the character.
-		QList<QString> fallback = ConfigFileCodec::decodeLines(std::string("caf\xE9\r\nnext"));
-		expectEqual((int)fallback.size(), 2, "ANSI fallback still yields one entry per line");
-		expectEqual(fallback[1], "next", "ANSI fallback preserves the following line");
+	// 0xE9 alone is invalid UTF-8, so the system-ANSI fallback must engage.
+	// The decoded glyph depends on the machine's CP_ACP (e.g. CP1252 vs
+	// CP949), so only the line structure is asserted, not the character.
+	QList<QString> fallback = ConfigFileCodec::decodeLines(std::string("caf\xE9\r\nnext"));
+	requireEqual((int)fallback.size(), 2, "ANSI fallback still yields one entry per line");
+	expectEqual(fallback[1], "next", "ANSI fallback preserves the following line");
 
-		QByteArray encoded = ConfigFileCodec::encodeLines(QList<QString>() << "a" << QString::fromUtf8("caf\xC3\xA9"));
-		expectEqual(QString::fromUtf8(encoded), QString::fromUtf8("a\r\ncaf\xC3\xA9"), "encodeLines joins with CRLF, UTF-8, no trailing newline");
+	QByteArray encoded = ConfigFileCodec::encodeLines(QList<QString>() << "a" << QString::fromUtf8("caf\xC3\xA9"));
+	expectEqual(QString::fromUtf8(encoded), QString::fromUtf8("a\r\ncaf\xC3\xA9"), "encodeLines joins with CRLF, UTF-8, no trailing newline");
 
-		QList<QString> roundTrip = ConfigFileCodec::decodeLines(std::string(encoded.constData(), (size_t)encoded.size()));
-		expectEqual((int)roundTrip.size(), 2, "encodeLines output decodes back to the same line count");
-		expectEqual(roundTrip[1], QString::fromUtf8("caf\xC3\xA9"), "decode(encode(lines)) round-trips non-ASCII text");
-	}
+	QList<QString> roundTrip = ConfigFileCodec::decodeLines(std::string(encoded.constData(), (size_t)encoded.size()));
+	requireEqual((int)roundTrip.size(), 2, "encodeLines output decodes back to the same line count");
+	expectEqual(roundTrip[1], QString::fromUtf8("caf\xC3\xA9"), "decode(encode(lines)) round-trips non-ASCII text");
+}
+}
+
+int main(int argc, char** argv)
+{
+	QCoreApplication app(argc, argv);
+
+	testConvolutionPathHelper();
+	testUpdateInfoFormatter();
+	testVelopackUpdateInfo();
+	testVelopackGitHubRelease();
+	testVelopackFeeds();
+	testFilterCardDescriptors();
+	testFilterCardDepths();
+	testConfigImport();
+	testChannelSelectionModel();
+	testDeviceSelectionModel();
+	testMultiConvolutionRoutingAdapter();
+	testStageSelectionModel();
+	testStudioRoutingModel();
+	testConfigFileCodec();
+	testFilterListModel();
+
+	testFilterListModel();
 
 	harness.report();
 	return 0;

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp" />
     <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
+    <ClCompile Include="..\..\Editor\widgets\FilterListModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\cards\ChannelSelectionModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\cards\DeviceSelectionModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\cards\StageSelectionModel.cpp" />
@@ -141,6 +142,7 @@
     <ClInclude Include="..\..\Editor\import\ImportExecutor.h" />
     <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
+    <ClInclude Include="..\..\Editor\widgets\FilterListModel.h" />
     <ClInclude Include="..\..\Editor\widgets\cards\ChannelSelectionModel.h" />
     <ClInclude Include="..\..\Editor\widgets\cards\DeviceSelectionModel.h" />
     <ClInclude Include="..\..\filters\BiQuad.h" />

--- a/Tests/TestHarness.h
+++ b/Tests/TestHarness.h
@@ -2,18 +2,33 @@
 	This file is part of EqualizerAPO-XT.
 
 	Tiny, header-only, framework-free assertion harness shared by the test
-	suites (HybridConvTests, AudioRegressionTests, EditorLogicTests). It keeps
-	the common assertion primitives in one place so the suites no longer each
-	carry their own copy of fail()/expect()/expectEqual().
+	suites (HybridConvTests, AudioRegressionTests, EditorLogicTests,
+	EngineOrchestrationTests). It keeps the common assertion primitives in one
+	place so the suites no longer each carry their own copy of
+	fail()/expect()/expectEqual().
 
 	The harness deliberately avoids Qt and any heavy dependency so it can be
 	included from a plain console test as well as from the Qt-linked
 	EditorLogicTests. Messages are std::string; callers that work in another
 	string type convert at the boundary.
 
-	Semantics match the original hand-rolled helpers: a failed assertion prints
-	to stderr and exits the process with code 1, so the existing pass/fail
-	outcome of every suite is preserved.
+	Two failure policies exist; each suite picks one in the constructor.
+
+	- Abort (the default): a failed assertion prints to stderr and exits the
+	  process with code 1, matching the behaviour of the original hand-rolled
+	  helpers. All suites behave this way unless they opt out.
+	- Collect (opt-in): a failed expect*() prints the same stderr line,
+	  increments the failure counter and lets the suite continue; report()
+	  then prints a failure summary to stderr and exits with code 1. Collect
+	  exists because a failure at the top of a suite used to hide every
+	  finding below it, costing one CI round-trip per finding.
+	  (audit #146 TD035)
+
+	The require*() family always aborts on failure regardless of the policy.
+	It is for gating checks whose failure would make the following code unsafe
+	under Collect: size checks before indexing, null checks before
+	dereferencing, parse-success checks before field access. fail() likewise
+	always aborts.
 */
 
 #pragma once
@@ -26,18 +41,28 @@
 namespace test
 {
 
-// Counts assertions that passed within a single suite and labels failure
-// output with the suite name. One instance is created in each suite's main().
+// How a failed expect*() is handled; see the file comment. require*() and
+// fail() abort under either policy.
+enum class FailurePolicy
+{
+	Abort,
+	Collect
+};
+
+// Counts assertions that passed (and, under Collect, failed) within a single
+// suite and labels failure output with the suite name. One instance is
+// created in each suite's main().
 class Harness
 {
 public:
-	explicit Harness(std::string suiteName)
-		: name_(std::move(suiteName)), passed_(0)
+	explicit Harness(std::string suiteName, FailurePolicy policy = FailurePolicy::Abort)
+		: name_(std::move(suiteName)), policy_(policy), passed_(0), failed_(0)
 	{
 	}
 
 	// Prints the failure to stderr and terminates with exit code 1, matching
-	// the behaviour of the per-suite fail() helpers it replaces.
+	// the behaviour of the per-suite fail() helpers it replaces. Aborts under
+	// either policy.
 	[[noreturn]] void fail(const std::string& message) const
 	{
 		std::fprintf(stderr, "%s failed: %s\n", name_.c_str(), message.c_str());
@@ -49,7 +74,10 @@ public:
 	void expect(bool condition, const std::string& message)
 	{
 		if (!condition)
-			fail(message);
+		{
+			recordFailure(message);
+			return;
+		}
 		++passed_;
 	}
 
@@ -72,6 +100,32 @@ public:
 		{
 			std::ostringstream oss;
 			oss << message << ": expected '" << expected << "', got '" << actual << "'";
+			recordFailure(oss.str());
+			return;
+		}
+		++passed_;
+	}
+
+	// Gating assertion: aborts on failure regardless of the policy. Use it
+	// when the failure would make the following code unsafe (a size check
+	// before indexing, a null check before dereferencing). On success it
+	// counts as a passed check like the expect family.
+	void require(bool condition, const std::string& message)
+	{
+		if (!condition)
+			fail(message);
+		++passed_;
+	}
+
+	// Gating counterpart of expectEqual: same diagnostic format, but aborts
+	// on failure regardless of the policy.
+	template<typename A, typename B>
+	void requireEqual(const A& actual, const B& expected, const std::string& message)
+	{
+		if (!(actual == expected))
+		{
+			std::ostringstream oss;
+			oss << message << ": expected '" << expected << "', got '" << actual << "'";
 			fail(oss.str());
 		}
 		++passed_;
@@ -84,15 +138,35 @@ public:
 
 	// Emits a single "<suite> passed (<n> checks)" line on stdout. Suites that
 	// already print their own success banner can call this instead, or keep
-	// their banner and read passed() if they prefer.
+	// their banner and read passed() if they prefer. If Collect mode recorded
+	// any failures, prints a failure summary to stderr instead and exits with
+	// code 1 so the suite still fails the build.
 	void report() const
 	{
+		if (failed_ > 0)
+		{
+			std::fprintf(stderr, "%s FAILED (%u of %u checks failed)\n", name_.c_str(), failed_, passed_ + failed_);
+			std::exit(1);
+		}
 		std::printf("%s passed (%u checks)\n", name_.c_str(), passed_);
 	}
 
 private:
+	// Routes an expect*() failure according to the policy: Abort exits via
+	// fail(), Collect prints the identical stderr line and lets the suite
+	// continue so later findings still surface.
+	void recordFailure(const std::string& message)
+	{
+		if (policy_ == FailurePolicy::Abort)
+			fail(message);
+		std::fprintf(stderr, "%s failed: %s\n", name_.c_str(), message.c_str());
+		++failed_;
+	}
+
 	std::string name_;
+	FailurePolicy policy_;
 	unsigned passed_;
+	unsigned failed_;
 };
 
 } // namespace test


### PR DESCRIPTION
감사 #146 보류분의 마지막 코드 묶음(TD032, TD040, TD035)입니다.

- **TD032:** 문서/선택 상태(items·selected·focused·anchor)를 QWidget 밖의 QtCore 전용 FilterListModel로 추출했습니다. 변이·선택 논리(삽입, 삭제, 범위 선택 수학, 복사 페이로드)가 모델로 들어가 EditorLogicTests에서 전부 검증됩니다(+66 체크). 추출 과정에서 잠복 결함 하나가 드러났습니다. setLines가 선택 집합을 비우지 않아 삭제된 문서를 가리키는 포인터가 남던 것을 고쳤습니다.
- **TD040:** 한 줄짜리 구조 편집(필터 추가, 한 줄 붙여넣기/드롭, 한 행 삭제)은 전체 재구축 대신 해당 행 위젯 하나만 그리드에 끼우거나 빼고 아래 행들의 번호/들여쓰기를 제자리에서 갱신합니다. 카드 모드 한정이고(LegacyRows는 동결 정책대로 전체 재구축 유지), 레이아웃 불일치가 감지되면 언제나 updateGuis()로 폴백합니다. Matrix 스킨이 행 번호를 버스 문자로 재작성하는 것까지 보존하는 updateRowPosition() 훅을 FilterCardRow에 추가했습니다.
- **TD035:** 공용 테스트 하네스에 opt-in Collect 실패 정책(첫 실패가 아래 발견을 가리지 않음)과 항상 중단하는 require 계열을 추가했습니다. EditorLogicTests만 opt-in하고 740줄 main()을 14개 함수로 분할했으며, 인덱싱 전 크기 확인 등 8건을 require로 전환해 Collect 모드의 OOB 위험을 막았습니다.

검증은 4개 스위트 전체 통과, studio 갤러리 122장 픽셀 동일, matrix 갤러리 자기 검사 green, cppcheck 깨끗입니다. 증분 삽입/삭제 경로는 정적 렌더로는 안 밟히는 상호작용 경로라 폴백을 겹겹이 두었고, Matrix 스킨에서 중간 행 삽입/삭제의 수동 확인을 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)