### PR TITLE
docs(changelog): file the Unreleased entries under v2.9.0

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.9.0 (2026-07-04)
 
 - Device Selector와 Update Checker가 한국어를 지원합니다(Qt 자체 대화 상자
   포함 완역). 두 프로그램 모두 Windows 표시 언어 대신 Editor에서 고른

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.9.0 — 2026-07-04
 
 - Device Selector and Update Checker now speak Korean (complete catalogs,
   including Qt's own dialogs) and follow the language you picked in the


### PR DESCRIPTION
v2.9.0 릴리스가 만들어졌으므로 CHANGELOG(영문·한국어)의 Unreleased 절을 v2.9.0 절로 옮깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)