### PR TITLE
ci: serve the pinned dependencies from 115dkk-owned mirrors

### DIFF
--- a/.github/scripts/Provisioning.psm1
+++ b/.github/scripts/Provisioning.psm1
@@ -99,7 +99,7 @@ function Get-DependencyDownloadSpec {
 
     $velopackVersion = $Manifest.Shared.VelopackLibcVersion
     $downloads = @(
-        (Resolve-PinnedDownload -Repo 'TheFireKahuna/muparserx' -Asset $variant.Muparserx -DestinationLeaf 'muparserx'),
+        (Resolve-PinnedDownload -Repo '115dkk/muparserx' -Asset $variant.Muparserx -DestinationLeaf 'muparserx'),
         @{
             # Velopack C/C++ runtime (Velopack.h + import libs + DLLs for every
             # platform). Always fetched regardless of SIMD variant; the Editor
@@ -115,8 +115,8 @@ function Get-DependencyDownloadSpec {
     )
 
     if (-not $variant.UsesVcpkg) {
-        $downloads += (Resolve-PinnedDownload -Repo 'TheFireKahuna/amd-fftw' -Asset $variant.Fftw -DestinationLeaf 'fftw')
-        $downloads += (Resolve-PinnedDownload -Repo 'TheFireKahuna/libsndfile' -Asset $variant.Sndfile -DestinationLeaf 'libsndfile')
+        $downloads += (Resolve-PinnedDownload -Repo '115dkk/amd-fftw' -Asset $variant.Fftw -DestinationLeaf 'fftw')
+        $downloads += (Resolve-PinnedDownload -Repo '115dkk/libsndfile' -Asset $variant.Sndfile -DestinationLeaf 'libsndfile')
     }
 
     return $downloads

--- a/.github/scripts/Tests/Provisioning.Tests.ps1
+++ b/.github/scripts/Tests/Provisioning.Tests.ps1
@@ -64,7 +64,7 @@ BeforeAll {
         $muparserxHashLine = if ($OmitMuparserxHash) { "'unrelated.zip' = 'ee55'" } else { "'mup.zip' = '$MuparserxSha'" }
         $fftwPinBlock = if ($OmitFftwPin) { '' } else {
 @"
-        'TheFireKahuna/amd-fftw' = @{
+        '115dkk/amd-fftw' = @{
             Tag    = '5.9'
             Sha256 = @{ 'fftw.zip' = '$FftwSha' }
         }
@@ -98,12 +98,12 @@ BeforeAll {
         VelopackLibcSha256  = '$VelopackSha'
     }
     DependencyReleases = @{
-        'TheFireKahuna/muparserx' = @{
+        '115dkk/muparserx' = @{
             Tag    = '4.0.99'
             Sha256 = @{ $muparserxHashLine }
         }
 $fftwPinBlock
-        'TheFireKahuna/libsndfile' = @{
+        '115dkk/libsndfile' = @{
             Tag    = '1.9.9'
             Sha256 = @{ 'snd.zip' = '$SndfileSha' }
         }
@@ -158,20 +158,20 @@ Describe "Provisioning.psm1" {
             $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'x64' -Simd 'avx2'
             $downloads.Count | Should -Be 4
 
-            $mupTag = $script:RepoManifest.DependencyReleases['TheFireKahuna/muparserx'].Tag
-            $fftwTag = $script:RepoManifest.DependencyReleases['TheFireKahuna/amd-fftw'].Tag
-            $sndTag = $script:RepoManifest.DependencyReleases['TheFireKahuna/libsndfile'].Tag
+            $mupTag = $script:RepoManifest.DependencyReleases['115dkk/muparserx'].Tag
+            $fftwTag = $script:RepoManifest.DependencyReleases['115dkk/amd-fftw'].Tag
+            $sndTag = $script:RepoManifest.DependencyReleases['115dkk/libsndfile'].Tag
             $veloVer = $script:RepoManifest.Shared.VelopackLibcVersion
 
             $byRepo = @{}
             foreach ($d in $downloads) { $byRepo[$d.Repo] = $d }
 
-            $byRepo['TheFireKahuna/muparserx'].Url |
-                Should -Be "https://github.com/TheFireKahuna/muparserx/releases/download/$mupTag/muparserx-msvc-release-x64-avx2.zip"
-            $byRepo['TheFireKahuna/amd-fftw'].Url |
-                Should -Be "https://github.com/TheFireKahuna/amd-fftw/releases/download/$fftwTag/fftw-windows-release-x64-avx2.zip"
-            $byRepo['TheFireKahuna/libsndfile'].Url |
-                Should -Be "https://github.com/TheFireKahuna/libsndfile/releases/download/$sndTag/libsndfile-x64-avx2.zip"
+            $byRepo['115dkk/muparserx'].Url |
+                Should -Be "https://github.com/115dkk/muparserx/releases/download/$mupTag/muparserx-msvc-release-x64-avx2.zip"
+            $byRepo['115dkk/amd-fftw'].Url |
+                Should -Be "https://github.com/115dkk/amd-fftw/releases/download/$fftwTag/fftw-windows-release-x64-avx2.zip"
+            $byRepo['115dkk/libsndfile'].Url |
+                Should -Be "https://github.com/115dkk/libsndfile/releases/download/$sndTag/libsndfile-x64-avx2.zip"
             $byRepo['velopack/velopack'].Url |
                 Should -Be "https://github.com/velopack/velopack/releases/download/$veloVer/velopack_libc_$veloVer.zip"
         }
@@ -181,10 +181,10 @@ Describe "Provisioning.psm1" {
             $byRepo = @{}
             foreach ($d in $downloads) { $byRepo[$d.Repo] = $d }
 
-            $byRepo['TheFireKahuna/muparserx'].Destination | Should -Be (Join-Path $script:DepsRoot 'muparserx')
+            $byRepo['115dkk/muparserx'].Destination | Should -Be (Join-Path $script:DepsRoot 'muparserx')
             $byRepo['velopack/velopack'].Destination | Should -Be (Join-Path $script:DepsRoot 'velopack_libc')
-            $byRepo['TheFireKahuna/amd-fftw'].Destination | Should -Be (Join-Path $script:DepsRoot 'fftw')
-            $byRepo['TheFireKahuna/libsndfile'].Destination | Should -Be (Join-Path $script:DepsRoot 'libsndfile')
+            $byRepo['115dkk/amd-fftw'].Destination | Should -Be (Join-Path $script:DepsRoot 'fftw')
+            $byRepo['115dkk/libsndfile'].Destination | Should -Be (Join-Path $script:DepsRoot 'libsndfile')
         }
 
         It "resolves the pinned SHA-256 for every avx2 asset" {
@@ -192,22 +192,22 @@ Describe "Provisioning.psm1" {
             foreach ($d in $downloads) {
                 $d.Sha256 | Should -Match '^[0-9a-fA-F]{64}$' -Because "$($d.Asset) must carry a pinned hash"
             }
-            ($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/amd-fftw' }).Sha256 |
-                Should -Be $script:RepoManifest.DependencyReleases['TheFireKahuna/amd-fftw'].Sha256['fftw-windows-release-x64-avx2.zip']
+            ($downloads | Where-Object { $_.Repo -eq '115dkk/amd-fftw' }).Sha256 |
+                Should -Be $script:RepoManifest.DependencyReleases['115dkk/amd-fftw'].Sha256['fftw-windows-release-x64-avx2.zip']
         }
 
         It "leaves FFTW and libsndfile to vcpkg for the sse2 variant" {
             $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'x64' -Simd 'sse2'
             @($downloads).Count | Should -Be 2
             @($downloads | ForEach-Object { $_.Repo }) | Sort-Object |
-                Should -Be @('TheFireKahuna/muparserx', 'velopack/velopack')
+                Should -Be @('115dkk/muparserx', 'velopack/velopack')
         }
 
         It "selects the ARM64 assets for the neon variant" {
             $downloads = Get-DependencyDownloadSpec -Manifest $script:RepoManifest -DepsRoot $script:DepsRoot -Platform 'ARM64' -Simd 'neon'
-            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/amd-fftw' }).Asset | Should -Be 'fftw-windows-release-arm64.zip'
-            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/muparserx' }).Asset | Should -Be 'muparserx-msvc-release-ARM64.zip'
-            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/libsndfile' }).Asset | Should -Be 'libsndfile-arm64.zip'
+            @($downloads | Where-Object { $_.Repo -eq '115dkk/amd-fftw' }).Asset | Should -Be 'fftw-windows-release-arm64.zip'
+            @($downloads | Where-Object { $_.Repo -eq '115dkk/muparserx' }).Asset | Should -Be 'muparserx-msvc-release-ARM64.zip'
+            @($downloads | Where-Object { $_.Repo -eq '115dkk/libsndfile' }).Asset | Should -Be 'libsndfile-arm64.zip'
         }
 
         It "resolves every variant in the repo manifest without error (drift guard)" {
@@ -229,8 +229,8 @@ Describe "Provisioning.psm1" {
         It "builds URLs from the fixture's pinned tags" {
             $manifest = New-FixtureManifest
             $downloads = Get-DependencyDownloadSpec -Manifest $manifest -DepsRoot $script:FixtureDepsRoot -Platform 'x64' -Simd 'testy'
-            @($downloads | Where-Object { $_.Repo -eq 'TheFireKahuna/muparserx' }).Url |
-                Should -Be 'https://github.com/TheFireKahuna/muparserx/releases/download/4.0.99/mup.zip'
+            @($downloads | Where-Object { $_.Repo -eq '115dkk/muparserx' }).Url |
+                Should -Be 'https://github.com/115dkk/muparserx/releases/download/4.0.99/mup.zip'
             @($downloads | Where-Object { $_.Repo -eq 'velopack/velopack' }).Url |
                 Should -Be 'https://github.com/velopack/velopack/releases/download/9.9.9/velopack_libc_9.9.9.zip'
         }
@@ -238,7 +238,7 @@ Describe "Provisioning.psm1" {
         It "throws when a referenced repo has no DependencyReleases pin" {
             $manifest = New-FixtureManifest -OmitFftwPin
             { Get-DependencyDownloadSpec -Manifest $manifest -DepsRoot $script:FixtureDepsRoot -Platform 'x64' -Simd 'testy' } |
-                Should -Throw "No pinned tag or explicit URL for TheFireKahuna/amd-fftw in simd-variants.psd1"
+                Should -Throw "No pinned tag or explicit URL for 115dkk/amd-fftw in simd-variants.psd1"
         }
 
         It "throws when the asset has no pinned SHA-256" {

--- a/.github/simd-variants.psd1
+++ b/.github/simd-variants.psd1
@@ -63,7 +63,7 @@
 #     VelopackLibcSha256   SHA-256 of that zip; bumped together with the version.
 #     Vst3Tag              steinbergmedia/vst3_pluginterfaces git tag/ref.
 #     HighwayTag           google/highway git tag/ref.
-#     TclapTag             TheFireKahuna/tclap git tag/ref.
+#     TclapTag             115dkk/tclap git tag/ref.
 #     VcpkgCommit          microsoft/vcpkg commit for the sse2/avx vcpkg builds.
 #
 #   DependencyReleases = supply-chain pins for the prebuilt binary dependencies.
@@ -174,7 +174,7 @@
         Vst3Tag             = 'v3.8.0_build_66'
         # google/highway — header-only portable SIMD.
         HighwayTag          = '1.4.0'
-        # TheFireKahuna/tclap — header-only CLI parser (tag 1.2.5 = fork HEAD).
+        # 115dkk/tclap — header-only CLI parser (tag 1.2.5 = fork HEAD).
         TclapTag            = '1.2.5'
         # microsoft/vcpkg — commit the sse2/avx dependency builds (FFTW,
         # libsndfile) check out. Pinned so a moving vcpkg HEAD cannot silently
@@ -182,8 +182,12 @@
         VcpkgCommit         = 'd87340acc46bdeda386037b38aca30136e667e47'
     }
 
+    # The prebuilt binaries are served from 115dkk-owned forks (audit #146
+    # TD036): the originals lived on a third-party account, so availability
+    # depended on it. The forks carry byte-identical assets (hashes below are
+    # unchanged) mirrored from TheFireKahuna releases of the same tags.
     DependencyReleases = @{
-        'TheFireKahuna/amd-fftw' = @{
+        '115dkk/amd-fftw' = @{
             Tag    = '5.1'
             Sha256 = @{
                 'fftw-windows-release-x64-avx2.zip'   = '5b2a56aededb8503b064e4e70dfdf9cf5c23f7b5220eaa47abfd6d3362344d0e'
@@ -192,7 +196,7 @@
                 'fftw-windows-release-arm64.zip'      = '26ef7e10fe47426e601f45e9767f468f407d85c4f4011985185f7d8926464529'
             }
         }
-        'TheFireKahuna/muparserx' = @{
+        '115dkk/muparserx' = @{
             Tag    = '4.0.13'
             Sha256 = @{
                 'muparserx-msvc-release-x64-avx2.zip'   = '5639167ce626c85a28f5c71f5f716533097d09895d388717177be9191d1f4b0e'
@@ -201,7 +205,7 @@
                 'muparserx-msvc-release-ARM64.zip'      = 'e4e3391e557a4bd61686efed886f49c469c9e274a3a1a3ba2cbeaf58b51d0c42'
             }
         }
-        'TheFireKahuna/libsndfile' = @{
+        '115dkk/libsndfile' = @{
             Tag    = '1.2.2'
             Sha256 = @{
                 'libsndfile-x64-avx2.zip'   = '7613683be2e9a826c36d9aa5ec5afdad1907b6e80e877e36501e6610fefa7df0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
     - name: Download TCLAP
       uses: actions/checkout@v6
       with:
-        repository: TheFireKahuna/tclap
+        repository: 115dkk/tclap
         ref: ${{ env.TCLAP_TAG }}
         token: ${{ secrets.GITHUB_TOKEN }}
         path: deps/tclap

--- a/docs/LocalDependencySetup.md
+++ b/docs/LocalDependencySetup.md
@@ -33,7 +33,7 @@ GitHub Actions artifact를 직접 받는 방법은 CI 설정과 방향이 맞습
 - AOCL-FFTW 5.1: `fftw-windows-release-x64-avx2.zip`
 - muparserx 4.0.13: `muparserx-msvc-release-x64-avx2.zip`
 - libsndfile 1.2.2: `libsndfile-x64-avx2.zip`
-- TCLAP 1.2.5: `TheFireKahuna/tclap` tag `1.2.5`
+- TCLAP 1.2.5: `115dkk/tclap` tag `1.2.5`
 - Qt 6.10.1 `win64_msvc2022_64`: `qtbase`, `qttools`, `qtsvg`, `qttranslations`
 - 7-Zip `7zr.exe`: Qt 7z 패키지 압축 해제용
 - Visual Studio Build Tools 2026 ATL: `Microsoft.VisualStudio.Component.VC.14.51.ATL`

--- a/setup-build.ps1
+++ b/setup-build.ps1
@@ -107,7 +107,7 @@ if ($tclapCachedTag -eq $tclapTag -and $tclapCachedTag) {
         Write-Host "  Cached TCLAP is not at $tclapTag; re-cloning..."
         Remove-Item $tclapDir -Recurse -Force
     }
-    git clone --depth 1 --branch $tclapTag https://github.com/TheFireKahuna/tclap $tclapDir
+    git clone --depth 1 --branch $tclapTag https://github.com/115dkk/tclap $tclapDir
     if ($LASTEXITCODE -ne 0) { throw "Failed to clone TCLAP" }
     Write-Host "  -> $tclapDir"
 }


### PR DESCRIPTION
감사 #146 TD036 처분(사용자 결정: 미러 전환)입니다.

- TheFireKahuna 계정의 amd-fftw, muparserx, libsndfile, tclap을 115dkk로 포크하고, 바이너리 릴리스 자산 12개를 manifest의 SHA-256로 검증한 뒤 같은 태그의 미러 릴리스로 올렸습니다. 업로드 후 미러에서 재다운로드해 왕복 해시 검증까지 마쳤습니다(바이트 동일, 핀 해시 무변경).
- simd-variants.psd1 키, Provisioning.psm1, Pester 픽스처, build.yml의 tclap checkout, setup-build.ps1의 tclap 클론, LocalDependencySetup.md가 전부 미러를 가리킵니다. CHANGELOG/README의 역사 서술은 그대로 둡니다.

로컬 검증은 psd1 Import, Test-VariantSync, Pester 37/37, YAML 파싱입니다. PR CI의 avx2 레그가 미러에서 실제로 내려받아 살아 있는 검증을 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)