### PR TITLE
refactor(editor): link the engine from the Editor's own sources only

### DIFF
--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -154,6 +154,9 @@ SOURCES += main.cpp\
 	../filters/IncludeFilterFactory.cpp \
 	../filters/ChannelFilter.cpp \
 	../filters/ConvolutionFilter.cpp \
+	../filters/ConvolutionFilePath.cpp \
+	../filters/MultiConvolutionCommand.cpp \
+	../ConfigurationFileReader.cpp \
 	../filters/IrCache.cpp \
 	../parser/ParserExtensions.cpp \
 	../parser/RegexFunctions.cpp \
@@ -175,6 +178,11 @@ SOURCES += main.cpp\
 	../filters/VSTPluginFilter.cpp \
 	../filters/VSTPluginFilterFactory.cpp \
 	../helpers/VSTPluginInstance.cpp \
+	../helpers/VSTPluginInstance.Editor.cpp \
+	../helpers/VSTPluginInstance.State.cpp \
+	../helpers/VSTPluginInstance.VST2.cpp \
+	../helpers/VSTPluginInstance.VST3.cpp \
+	../helpers/PerfProfile.cpp \
 	guis/LoudnessCorrectionFilterGUI.cpp \
 	guis/LoudnessCorrectionFilterGUIFactory.cpp \
 	../filters/loudnessCorrection/LoudnessCorrectionCommand.cpp \
@@ -559,30 +567,14 @@ build_pass:CONFIG(debug, debug|release) {
 include($$PWD/../common.pri)
 QMAKE_LIBDIR += $$LIBSNDFILE_LIB $$FFTW_LIB $$MUPARSERX_LIB $$VELOPACK_LIB
 
-# Include Common.lib
-LIBS += Common.lib
-contains(QT_ARCH, arm64) {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../ARM64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../ARM64/Release"
-	}
-} else:contains(QT_ARCH, x86_64) {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../x64/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../x64/Release"
-	}
-} else {
-	build_pass:CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR += "../x32/Debug"
-
-	} else {
-		QMAKE_LIBDIR += "../x32/Release"
-	}
-}
+# The Editor deliberately does NOT link Common.lib: every engine source it
+# needs is compiled directly (SOURCES above) under the Editor's own SIMD
+# flags, so the analysis panel's FilterEngine runs with the variant's /arch.
+# Linking the MSBuild lib on top used to silently decide symbol ownership by
+# link order and let a missing SOURCES entry be papered over by a copy built
+# with different flags. A missing engine file now fails the link loudly -
+# add it here AND to Common.vcxproj. (audit #146 TD013, maintainer decision
+# 2026-07-04)
 
 RESOURCES += \
 	Editor.qrc


### PR DESCRIPTION
감사 #146 TD013 처분(사용자 결정: 직접 소스 단일화)입니다.

- Editor.pro의 `LIBS += Common.lib`와 arch별 MSBuild 출력 디렉터리 링크를 제거했습니다. 이제 엔진 심볼의 출처는 Editor가 자기 SIMD 플래그로 직접 컴파일한 소스 하나뿐이고, 목록에서 빠진 파일은 링크 에러로 시끄럽게 드러납니다.
- 제거해 보니 lib가 조용히 메워 주던 소스가 8개 있었습니다(PerfProfile, ConvolutionFilePath, ConfigurationFileReader, MultiConvolutionCommand, VSTPluginInstance 부분 파일 4종). 전부 명시적 SOURCES 항목이 됐습니다. 이 8개는 그동안 MSBuild 쪽 플래그로 빌드된 사본이 Editor에 링크되고 있었다는 뜻이기도 합니다.
- 위성 앱(DeviceSelector/UpdateChecker)은 원래 Common.lib만 쓰는 단일 출처 구조라 그대로 둡니다.

검증은 빈 빌드 디렉터리에서의 클린 qmake+nmake 성공과 studio 갤러리 122장 픽셀 동일입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)