### PR TITLE
fix(vst2): give each plugin instance its own time-info struct

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -12,7 +12,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
   플러그인들이 시간 정보 구조체 하나를 공유해, 한 플러그인이 시간을 묻는
   동안 다른 스트림이 그 값을 덮어쓸 수 있었습니다. 이제 플러그인
   인스턴스마다 자기 것을 갖습니다.
-  ([#162](https://github.com/115dkk/EqualizerAPO-XT/pull/162))
+  ([#163](https://github.com/115dkk/EqualizerAPO-XT/pull/163))
 
 ## v2.9.0 (2026-07-04)
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,14 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- VST2 호스트의 데이터 경쟁을 고쳤습니다. 서로 다른 오디오 스트림에서 도는
+  플러그인들이 시간 정보 구조체 하나를 공유해, 한 플러그인이 시간을 묻는
+  동안 다른 스트림이 그 값을 덮어쓸 수 있었습니다. 이제 플러그인
+  인스턴스마다 자기 것을 갖습니다.
+  ([#162](https://github.com/115dkk/EqualizerAPO-XT/pull/162))
+
 ## v2.9.0 (2026-07-04)
 
 - Device Selector와 Update Checker가 한국어를 지원합니다(Qt 자체 대화 상자

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
   streams shared one global time-info structure, so a plugin asking for the
   current time could read a value another stream was writing. Each plugin
   instance now has its own.
-  ([#162](https://github.com/115dkk/EqualizerAPO-XT/pull/162))
+  ([#163](https://github.com/115dkk/EqualizerAPO-XT/pull/163))
 
 ## v2.9.0 — 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- Fixed a data race in the VST2 host: plugins running in different audio
+  streams shared one global time-info structure, so a plugin asking for the
+  current time could read a value another stream was writing. Each plugin
+  instance now has its own.
+  ([#162](https://github.com/115dkk/EqualizerAPO-XT/pull/162))
+
 ## v2.9.0 — 2026-07-04
 
 - Device Selector and Update Checker now speak Korean (complete catalogs,

--- a/helpers/VSTPluginInstance.VST2.cpp
+++ b/helpers/VSTPluginInstance.VST2.cpp
@@ -27,7 +27,11 @@ using namespace std;
 
 #define equalizerApoVSTID VST_FOURCC('E', 'A', 'P', 'O');
 
-vst_time_info vstTime{ 0,0,0,0,0,0,0,0,0,0,{0}, 0xFFFF };
+vst_time_info* VSTPluginInstance::hostTimeInfo()
+{
+	vstTime.sampleRate = getSampleRate();
+	return &vstTime;
+}
 
 static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t index, int64_t value, const char* ptr, float opt)
 {
@@ -67,10 +71,8 @@ static intptr_t callback(struct vst_effect_t* effect, int32_t opcode, int32_t in
 		return effect != NULL ? effect->control(effect, VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, NULL, 0.0f) : 0;
 
 	case VST_HOST_OPCODE_GET_TIME:
-		if (instance != NULL) {
-			vstTime.sampleRate = instance->getSampleRate();
-			return (intptr_t)&vstTime;
-		}
+		if (instance != NULL)
+			return (intptr_t)instance->hostTimeInfo();
 		return 0;
 
 	case VST_HOST_OPCODE_GET_SAMPLE_RATE:

--- a/helpers/VSTPluginInstance.h
+++ b/helpers/VSTPluginInstance.h
@@ -77,6 +77,11 @@ public:
 
 	void setSizeWindowFunc(std::function<void(int, int)> func);
 	void onSizeWindow(int w, int h);
+	// Backing store for VST_HOST_OPCODE_GET_TIME, refreshed and returned per
+	// call. Per instance: plugins in different audio streams process
+	// concurrently, and a shared global here let them race on one struct.
+	// (audit #146 TD029)
+	vst_time_info* hostTimeInfo();
 
 private:
 	class VST3HostContext;
@@ -114,4 +119,5 @@ private:
 	int usedChannelCount = -1;
 	int processLevel = 0;
 	int language = 1;
+	vst_time_info vstTime{ 0,0,0,0,0,0,0,0,0,0,{0}, 0xFFFF };
 };


### PR DESCRIPTION
감사 #146 TD029 처분(사용자 결정: 다중 동시 인스턴스 지원, 멤버화)입니다.

- VST_HOST_OPCODE_GET_TIME이 파일 전역 vst_time_info 하나를 돌려주던 것을 인스턴스 멤버로 옮겼습니다. 콜백은 이미 effect->host_internal로 인스턴스를 역참조하고 있어 hostTimeInfo() 접근자 하나로 정리됩니다. 서로 다른 스트림의 플러그인들이 동시에 시간을 물어도 더는 한 구조체를 놓고 경쟁하지 않습니다.

검증은 4개 스위트 전체 통과(VstHostTests 21 체크 포함), cppcheck 깨끗입니다. fix라 머지 시 v2.9.1 릴리스가 나가므로 TD013 PR을 먼저 머지한 뒤 마지막에 머지합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)