### PR TITLE
fix(editor): restore the Legacy rows mode to the heritage editor

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,6 +6,15 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
+## Unreleased
+
+- Legacy rows 모드를 진짜 유산 편집기로 복원했습니다. 그동안 옛 행들이 현대
+  스킨 크롬 안에 끼워져 렌더됐는데, 이제 네이티브 Windows 스타일, 기본 제목
+  표시줄, 시스템 글꼴, 클래식 노브, 원래의 Copy 노드 그래프로 시작하고 이
+  모드에서는 스킨 선택이 비활성화됩니다. Modern cards와 Legacy rows 전환은
+  이제 전체 모습을 적용하기 위해 편집기를 재시작합니다.
+  ([#165](https://github.com/115dkk/EqualizerAPO-XT/pull/165))
+
 ## v2.9.1 (2026-07-04)
 
 - VST2 호스트의 데이터 경쟁을 고쳤습니다. 서로 다른 오디오 스트림에서 도는

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
+## Unreleased
+
+- Restored the Legacy rows mode to the true heritage editor. It used to render
+  the old rows inside the modern skinned chrome; it now starts with the native
+  Windows style, standard title bar, system fonts, classic knobs and the
+  original Copy node graph, with skins disabled while active. Switching between
+  Modern cards and Legacy rows now restarts the editor to apply the whole
+  presentation.
+  ([#165](https://github.com/115dkk/EqualizerAPO-XT/pull/165))
+
 ## v2.9.1 — 2026-07-04
 
 - Fixed a data race in the VST2 host: plugins running in different audio

--- a/Editor/FilterTableParts/FilterTable.Clipboard.cpp
+++ b/Editor/FilterTableParts/FilterTable.Clipboard.cpp
@@ -138,6 +138,21 @@ void FilterTable::addActionTriggered()
 	QRect rect = toolBar->actionGeometry(addAction);
 	QPoint p = toolBar->mapToGlobal(QPoint(rect.x(), rect.y() + rect.height()));
 	addAction->setChecked(false);
+	if (renderMode == LegacyRows)
+	{
+		// Heritage add flow: the classic cascading QMenu, the same one the
+		// legacy rows' own + button uses (FilterTableRow::on_actionAdd_triggered).
+		QMenu* menu = createAddPopupMenu();
+		QAction* chosen = menu->exec(p);
+		if (chosen != nullptr)
+		{
+			FilterTemplate t = chosen->data().value<FilterTemplate>();
+			addLine(t.getLine());
+			updateGuis();
+		}
+		menu->deleteLater();
+		return;
+	}
 	FilterTemplate filterTemplate;
 	if (chooseFilterTemplate(&filterTemplate, p))
 	{

--- a/Editor/MainWindowParts/MainWindow.Frame.cpp
+++ b/Editor/MainWindowParts/MainWindow.Frame.cpp
@@ -28,7 +28,10 @@
 void MainWindow::setupWindowChrome()
 {
 	QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
-	useCustomFrame = !settings.value("interface/nativeTitleBar", false).toBool();
+	// Heritage (legacy rows) keeps the stock Windows caption: the custom
+	// title strip is part of the modern presentation.
+	useCustomFrame = !settings.value("interface/nativeTitleBar", false).toBool()
+		&& !settings.value(QStringLiteral("interface/legacyRows"), false).toBool();
 	if (!useCustomFrame)
 		return;
 

--- a/Editor/MainWindowParts/MainWindow.Preferences.cpp
+++ b/Editor/MainWindowParts/MainWindow.Preferences.cpp
@@ -261,6 +261,14 @@ void MainWindow::setupRedesignActions()
 	darkThemeAction->setShortcut(QKeySequence(QStringLiteral("Ctrl+Alt+D")));
 	connect(darkThemeAction, SIGNAL(toggled(bool)), this, SLOT(darkThemeToggled(bool)));
 
+	if (SkinManager::instance()->isHeritage())
+	{
+		// Heritage is unskinned by definition; the choices come back with the
+		// modern presentation.
+		skinActionGroup->setEnabled(false);
+		darkThemeAction->setEnabled(false);
+	}
+
 	interfaceMenu->addSeparator();
 
 	// The gain knobs (Preamp card, biquad gain dial) span a configurable ±range;

--- a/Editor/MainWindowParts/MainWindow.ViewActions.cpp
+++ b/Editor/MainWindowParts/MainWindow.ViewActions.cpp
@@ -67,7 +67,28 @@ void MainWindow::interfaceModeSelected(QAction* action)
 	if (action == nullptr)
 		return;
 
-	setCurrentRenderMode(static_cast<FilterTable::RenderMode>(action->data().toInt()));
+	FilterTable::RenderMode mode = static_cast<FilterTable::RenderMode>(action->data().toInt());
+	if (mode == currentRenderMode)
+		return;
+
+	// The two modes are whole presentations, not just row widgets: heritage
+	// (legacy rows) runs unskinned on the native style, frame, font engine and
+	// system fonts. None of that can swap cleanly inside a live process, and a
+	// partial swap is exactly the modern-chrome-around-legacy-rows mixture this
+	// mode used to show. Restart into the chosen presentation instead.
+	if (QMessageBox::question(this, tr("Restart required"), tr("Configuration Editor will be restarted to apply the changed settings. Proceed?")) == QMessageBox::Yes)
+	{
+		// savePreferences() persists interface/legacyRows from this member on
+		// close, so setting it is what makes the restart come back changed.
+		currentRenderMode = mode;
+		restart = true;
+		close();
+	}
+	else
+	{
+		for (QAction* other : interfaceModeActionGroup->actions())
+			other->setChecked(static_cast<FilterTable::RenderMode>(other->data().toInt()) == currentRenderMode);
+	}
 }
 
 void MainWindow::skinSelected(QAction* action)

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -413,10 +413,19 @@ QList<FilterCardRow*> buildRows(QScrollArea& scrollArea, const QString& configPa
 	// every row collapses to a few pixels.
 	scrollArea.setWidgetResizable(true);
 	FilterTable* table = new FilterTable(nullptr);
+	if (qEnvironmentVariableIsSet("EAPO_GALLERY_LEGACY"))
+		table->setRenderMode(FilterTable::LegacyRows);
 	scrollArea.setWidget(table);
-	table->updateDeviceAndChannelMask(nullptr, 0);
 	QList<std::shared_ptr<AbstractAPOInfo>> outputDevices, inputDevices;
 	galleryDevices(outputDevices, inputDevices);
+	// The card path renders deviceless on purpose (its editors derive their
+	// ports from the command text). The heritage dump selects a synthetic
+	// device instead: the legacy CopyFilterGUI scene only populates through
+	// configureChannels(), which is empty without one.
+	if (qEnvironmentVariableIsSet("EAPO_GALLERY_LEGACY") && !outputDevices.isEmpty())
+		table->updateDeviceAndChannelMask(outputDevices.first(), 0);
+	else
+		table->updateDeviceAndChannelMask(nullptr, 0);
 	table->initialize(&scrollArea, outputDevices, inputDevices);
 	// The config path anchors relative reference resolution to the synthetic
 	// target files (buildReferenceFiles) and namespaces per-file row prefs in
@@ -585,6 +594,39 @@ int renderSkin(const QDir& outDir, const QString& skinId, const QString& configP
 
 namespace SkinGallery
 {
+// Heritage (legacy rows) verification: the mode is a single unskinned
+// presentation, so instead of the per-skin per-row matrix it renders two
+// whole-table dumps (active and commented rows) for eyeball regression checks.
+// Triggered by EAPO_GALLERY_LEGACY=1, used by the local runner scripts.
+int renderHeritage(const QDir& outDir, const QString& configPath)
+{
+	SkinManager::instance()->applyHeritage();
+
+	int failures = 0;
+	for (int commented = 0; commented <= 1; commented++)
+	{
+		QList<QString> lines;
+		for (const GalleryRow& row : galleryRows())
+			lines.append(commented ? QStringLiteral("# ") + row.line : row.line);
+
+		QScrollArea scrollArea;
+		scrollArea.resize(960, 720);
+		buildRows(scrollArea, configPath, lines);
+		scrollArea.show();
+		QCoreApplication::processEvents();
+
+		QPixmap dump = scrollArea.widget()->grab();
+		const QString fileName = outDir.filePath(QStringLiteral("heritage_%1.png")
+				.arg(commented ? QStringLiteral("disabled") : QStringLiteral("normal")));
+		if (dump.isNull() || !dump.save(fileName))
+		{
+			qWarning("SkinGallery: could not write %s", qPrintable(fileName));
+			failures++;
+		}
+	}
+	return failures;
+}
+
 int run(const QStringList& arguments)
 {
 	const int flagIndex = arguments.indexOf(QStringLiteral("--skin-gallery"));
@@ -625,6 +667,15 @@ int run(const QStringList& arguments)
 	}
 
 	int failures = 0;
+	if (qEnvironmentVariableIsSet("EAPO_GALLERY_LEGACY"))
+	{
+		// Heritage mode is skin-independent; render its two dumps and exit
+		// through the same no-teardown path below.
+		failures += renderHeritage(outDir, configPath);
+		const int status = failures == 0 ? 0 : 1;
+		std::fflush(nullptr);
+		std::_Exit(status);
+	}
 	for (const QString& skinId : skinIds)
 	{
 		failures += renderSkin(outDir, skinId.trimmed(), configPath, true);

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -40,6 +40,55 @@ bool SkinManager::isDark() const
 	return darkMode;
 }
 
+bool SkinManager::isHeritage() const
+{
+	return heritageMode;
+}
+
+void SkinManager::applyHeritage()
+{
+	CrashHandler::setBreadcrumb(L"applyHeritage (legacy rows)");
+	LogFStatic(L"Applying heritage presentation (legacy rows)");
+
+	heritageMode = true;
+	// Token donor and the base-class knob painter; nothing of the skin's own
+	// look survives below.
+	activeSkin = Skins::byId(QStringLiteral("studio"));
+	skinId = QStringLiteral("heritage");
+	darkMode = false;
+
+	// Classic light values for the custom painters that consume tokens. The
+	// widget chrome itself comes from the native style, untouched by QSS.
+	SkinTokens tokens = activeSkin->tokens(false);
+	tokens.background = QStringLiteral("#f0f0f0");
+	tokens.surface = QStringLiteral("#ffffff");
+	tokens.surfaceRaised = QStringLiteral("#f5f5f5");
+	tokens.surfaceSunken = QStringLiteral("#e8e8e8");
+	tokens.card = QStringLiteral("#ffffff");
+	tokens.cardHover = QStringLiteral("#f0f6fc");
+	tokens.text = QStringLiteral("#000000");
+	tokens.mutedText = QStringLiteral("#606060");
+	tokens.border = QStringLiteral("#adadad");
+	tokens.graph = QStringLiteral("#ffffff");
+	tokens.graphGridMajor = QStringLiteral("#c8c8c8");
+	tokens.graphGridMinor = QStringLiteral("#e4e4e4");
+	tokens.accent = QStringLiteral("#0078d7");
+	tokens.accent2 = QStringLiteral("#2b88d8");
+	tokens.focusRing = QStringLiteral("#0078d7");
+	tokens.fontFamily = QStringLiteral("Segoe UI");
+	tokens.monoFontFamily = QStringLiteral("Consolas");
+	currentTokens = tokens;
+
+	qApp->setStyleSheet(QString());
+	qApp->setPalette(qApp->style()->standardPalette());
+
+	emit skinChanged(currentTokens);
+	for (QWidget* widget : qApp->allWidgets())
+		widget->update();
+
+	LogFStatic(L"Heritage presentation applied");
+}
+
 namespace
 {
 QString substituteTokens(QString qss, const SkinTokens& tokens)
@@ -80,6 +129,7 @@ QString substituteTokens(QString qss, const SkinTokens& tokens)
 
 void SkinManager::applySkin(const QString& newSkinId, bool dark)
 {
+	heritageMode = false;
 	// Breadcrumb + unconditional log line: a skin-switch crash reported from
 	// the field (only two of five skins survived on a PC-bang machine, not
 	// reproducible on the dev machine) must identify the dying skin in the
@@ -137,11 +187,21 @@ void SkinManager::applySkin(const QString& newSkinId, bool dark)
 
 IRoutingRenderer* SkinManager::routingRenderer() const
 {
+	if (heritageMode)
+		return nullptr;
 	return activeSkin != nullptr ? activeSkin->routingRenderer() : nullptr;
 }
 
 void SkinManager::paintKnob(QPainter& painter, const QRect& rect, const KnobState& state) const
 {
+	if (heritageMode)
+	{
+		// The ISkin base implementation is the pre-skin AudioKnob painter,
+		// moved verbatim when the skins were introduced - exactly the
+		// heritage knob.
+		activeSkin->ISkin::paintKnob(painter, rect, state, currentTokens);
+		return;
+	}
 	if (activeSkin != nullptr)
 		activeSkin->paintKnob(painter, rect, state, currentTokens);
 }
@@ -195,6 +255,8 @@ void SkinManager::paintTitleBarChrome(QPainter& painter, const QRect& rect) cons
 
 void SkinManager::styleMainToolbar(QToolBar* toolBar) const
 {
+	if (heritageMode)
+		return; // native toolbar: the .ui's classic icons stay in place
 	if (toolBar == nullptr || activeSkin == nullptr)
 		return;
 	// Reset the shared mutable toolbar state before delegating so one skin's

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -28,10 +28,20 @@ public:
 	bool isDark() const;
 	void applySkin(const QString& skinId, bool dark);
 
+	// The heritage presentation behind the LegacyRows mode: no stylesheet, the
+	// platform's standard palette, and classic light token values for the few
+	// custom painters (analysis graph, knobs). The legacy rows are meant to be
+	// the unmodernized original editor, not skinned widgets inside modern
+	// chrome. (maintainer decision 2026-07-05)
+	void applyHeritage();
+	bool isHeritage() const;
+
 	// The Copy routing renderer for the active skin. Each skin draws channel
 	// routing in a completely different way (crosspoint matrix, step list, node
 	// graph, ...). Returns nullptr when the skin has no dedicated renderer yet,
 	// in which case the caller falls back to the legacy CopyFilterGUI.
+	// Always nullptr in heritage mode so Copy falls back to the classic
+	// CopyFilterGUI graphics scene.
 	IRoutingRenderer* routingRenderer() const;
 
 	// Paint a knob through the active skin (ISkin::paintKnob) with the current
@@ -70,4 +80,5 @@ private:
 	SkinTokens currentTokens;
 	QString skinId = QStringLiteral("studio");
 	bool darkMode = true;
+	bool heritageMode = false;
 };

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -364,19 +364,6 @@ int main(int argc, char* argv[])
 	// DeviceSelector and UpdateChecker. (audit #146 TD011)
 	QtAppBootstrap::addExecutableRelativePluginPath();
 
-	// Font rendering: force Qt's FreeType font engine on Windows instead of the
-	// default DirectWrite/GDI ClearType subpixel rasteriser. The bundled
-	// Pretendard ships as CFF/OTF, which ClearType renders with subpixel colour
-	// fringing that reads as blur on low-PPI monitors. High-DPI panels pack
-	// enough pixels to hide it (the UI looks crisp at 4K/150%) but a 1080p
-	// screen shows it plainly. FreeType uses grayscale antialiasing plus its own
-	// CFF hinting, which stays consistent across monitors regardless of DPI.
-	// Only set it when no platform is chosen externally, so the offscreen
-	// gallery / CI (QT_QPA_PLATFORM=offscreen) still win and a user can opt back
-	// into the default ClearType engine with QT_QPA_PLATFORM=windows.
-	if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
-		qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
-
 	// High-DPI: let Qt scale the whole UI by the monitor's device pixel ratio.
 	// The editor used to disable Qt scaling (QT_ENABLE_HIGHDPI_SCALING=0) and
 	// only hand-scale a few widget sizes through GUIHelper::scale, so on a 4K /
@@ -392,48 +379,86 @@ int main(int argc, char* argv[])
 	bool restart;
 	do
 	{
+		// LegacyRows is a whole presentation, not just a row widget: the
+		// heritage editor runs with the platform's native widget style, the
+		// stock ClearType font engine, and system fonts, exactly like the
+		// pre-skin editor. The skinned mode keeps the redesign stack below.
+		// Read the mode before QApplication so the font-engine choice follows
+		// an in-process restart. (maintainer decision 2026-07-05)
+		bool legacyRowsMode;
+		{
+			QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+			legacyRowsMode = settings.value(QStringLiteral("interface/legacyRows"), false).toBool();
+		}
+
+		// Font rendering (skinned mode): force Qt's FreeType font engine on
+		// Windows instead of the default DirectWrite/GDI ClearType subpixel
+		// rasteriser. The bundled Pretendard ships as CFF/OTF, which ClearType
+		// renders with subpixel colour fringing that reads as blur on low-PPI
+		// monitors. FreeType uses grayscale antialiasing plus its own CFF
+		// hinting, which stays consistent across monitors regardless of DPI.
+		// Only set it when no platform is chosen externally (offscreen gallery
+		// / CI must win) or when we set it ourselves on a previous loop pass.
+		static bool platformEnvSetByUs = false;
+		if (!legacyRowsMode && (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM") || platformEnvSetByUs))
+		{
+			qputenv("QT_QPA_PLATFORM", "windows:fontengine=freetype");
+			platformEnvSetByUs = true;
+		}
+		else if (legacyRowsMode && platformEnvSetByUs)
+		{
+			// Restarted from the skinned mode: hand the platform back to the
+			// stock ClearType engine for the heritage look.
+			qputenv("QT_QPA_PLATFORM", "windows");
+		}
+
 		QApplication application(argc, argv);
-		application.setStyle(new CustomStyle(QStyleFactory::create(QStringLiteral("Fusion"))));
+		// Heritage keeps the native widget style and the system UI fonts,
+		// like the pre-skin editor; the redesign stack below is skinned-only.
+		if (!legacyRowsMode)
+		{
+			application.setStyle(new CustomStyle(QStyleFactory::create(QStringLiteral("Fusion"))));
 
-		// Bundle the redesign's typefaces so the skins render identically
-		// regardless of what is installed: DM Sans / DM Mono carry the Latin
-		// look, Pretendard carries Korean. Static weight instances are used on
-		// purpose — Qt does not reliably select a weight off a variable font's
-		// wght axis, so a variable DM Sans / Pretendard rendered every QSS
-		// font-weight (600/700) at the thin default. Registering Regular/Medium/
-		// SemiBold/Bold per family lets font-weight resolve to a real face.
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-Regular.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-Medium.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-SemiBold.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-Bold.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMMono-Regular.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMMono-Medium.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-Regular.otf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-Medium.otf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-SemiBold.otf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-Bold.otf"));
-		// Sarasa Mono K: a true fixed-width CJK face, subset to Hangul + ASCII.
-		// It is the monospace Korean fallback so Korean in mono contexts keeps the
-		// grid instead of dropping to the proportional Pretendard. Regular + Bold
-		// cover the mono font-weights the skins use.
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/SarasaMonoK-Regular.ttf"));
-		QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/SarasaMonoK-Bold.ttf"));
+			// Bundle the redesign's typefaces so the skins render identically
+			// regardless of what is installed: DM Sans / DM Mono carry the Latin
+			// look, Pretendard carries Korean. Static weight instances are used on
+			// purpose — Qt does not reliably select a weight off a variable font's
+			// wght axis, so a variable DM Sans / Pretendard rendered every QSS
+			// font-weight (600/700) at the thin default. Registering Regular/Medium/
+			// SemiBold/Bold per family lets font-weight resolve to a real face.
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-Regular.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-Medium.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-SemiBold.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMSans-Bold.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMMono-Regular.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/DMMono-Medium.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-Regular.otf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-Medium.otf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-SemiBold.otf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/Pretendard-Bold.otf"));
+			// Sarasa Mono K: a true fixed-width CJK face, subset to Hangul + ASCII.
+			// It is the monospace Korean fallback so Korean in mono contexts keeps the
+			// grid instead of dropping to the proportional Pretendard. Regular + Bold
+			// cover the mono font-weights the skins use.
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/SarasaMonoK-Regular.ttf"));
+			QFontDatabase::addApplicationFont(QStringLiteral(":/fonts/SarasaMonoK-Bold.ttf"));
 
-		// Fallback chain for painted (non-QSS) text where Qt resolves a single
-		// QFont family. DM Sans/DM Mono lack Korean glyphs, so route CJK through
-		// Pretendard -> Noto Sans -> Malgun Gothic (Korean) / Microsoft YaHei
-		// (Chinese).
-		const QStringList cjkChain = {
-			QStringLiteral("Pretendard"),
-			QStringLiteral("Noto Sans KR"), QStringLiteral("Noto Sans"),
-			QStringLiteral("Malgun Gothic"), QStringLiteral("Microsoft YaHei")
-		};
-		QFont::insertSubstitutions(QStringLiteral("DM Sans"), cjkChain);
-		// Mono text puts Sarasa Mono K ahead of the proportional CJK chain so
-		// monospace Korean stays fixed-width; Consolas stays first for any Latin
-		// the embedded DM Mono might lack.
-		QFont::insertSubstitutions(QStringLiteral("DM Mono"),
-			QStringList{ QStringLiteral("Consolas"), QStringLiteral("Sarasa Mono K") } + cjkChain);
+			// Fallback chain for painted (non-QSS) text where Qt resolves a single
+			// QFont family. DM Sans/DM Mono lack Korean glyphs, so route CJK through
+			// Pretendard -> Noto Sans -> Malgun Gothic (Korean) / Microsoft YaHei
+			// (Chinese).
+			const QStringList cjkChain = {
+				QStringLiteral("Pretendard"),
+				QStringLiteral("Noto Sans KR"), QStringLiteral("Noto Sans"),
+				QStringLiteral("Malgun Gothic"), QStringLiteral("Microsoft YaHei")
+			};
+			QFont::insertSubstitutions(QStringLiteral("DM Sans"), cjkChain);
+			// Mono text puts Sarasa Mono K ahead of the proportional CJK chain so
+			// monospace Korean stays fixed-width; Consolas stays first for any Latin
+			// the embedded DM Mono might lack.
+			QFont::insertSubstitutions(QStringLiteral("DM Mono"),
+				QStringList{ QStringLiteral("Consolas"), QStringLiteral("Sarasa Mono K") } + cjkChain);
+		}
 
 		if (application.arguments().contains(QStringLiteral("--selftest-vst")))
 			return runVstRoundTripSelfTest();
@@ -456,6 +481,11 @@ int main(int argc, char* argv[])
 		}
 
 		QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+		if (legacyRowsMode)
+		{
+			SkinManager::instance()->applyHeritage();
+		}
+		else
 		{
 			QString skinId = settings.value(QStringLiteral("interface/skin"), QStringLiteral("studio")).toString();
 			bool dark = settings.value(QStringLiteral("interface/dark"), GUIHelper::isDarkMode()).toBool();

--- a/docs/FilterListUiPolicy.md
+++ b/docs/FilterListUiPolicy.md
@@ -30,11 +30,25 @@ where the current behavior lives and where the maintained code is.
 
 ## Why legacy is frozen rather than deleted
 
-`LegacyRows` (`FilterTableRow`) is the original Qt-table-style row UI. It is kept
-as a reversible fallback: if a regression turns up in the card UI, switching the
-render mode back to `LegacyRows` restores a known-good list view without a
-revert. Deleting it now would remove that safety net for no immediate benefit.
-The cost of keeping it is small as long as it stays frozen.
+`LegacyRows` (`FilterTableRow`) is the original Qt-table-style row UI, kept
+permanently by maintainer decision (2026-07-05): it is the heritage editor,
+preserved as the unmodernized original design, not a deprecation candidate.
+
+## The heritage presentation
+
+Legacy rows are a whole presentation, not just a different row widget. When
+`interface/legacyRows` is set the Editor starts with the platform's native
+widget style (no Fusion/CustomStyle), no skin stylesheet or palette
+(`SkinManager::applyHeritage`), the stock ClearType font engine and system
+fonts (no bundled DM Sans/Pretendard), the native Windows caption (no custom
+TitleBar), the classic cascading add menu, and the classic `CopyFilterGUI`
+node scene (no skin routing renderer). Skin and dark-theme menu items are
+disabled while it is active. Switching between the modes restarts the Editor:
+none of those pieces can swap cleanly in a live process, and a partial swap is
+exactly the modern-chrome-around-legacy-rows mixture this mode must not show.
+
+The offscreen gallery renders the heritage presentation with
+`EAPO_GALLERY_LEGACY=1` (two whole-table dumps) for eyeball regression checks.
 
 ## The rule for contributors
 


### PR DESCRIPTION
사용자 결정(2026-07-05: 레거시 로우 영구 보존, 단 현대화되지 않은 원형 그대로) 반영입니다.

- 지금까지 Legacy rows는 옛 행 위젯이 현대 스킨 크롬(스킨 파워 버튼, 스킨 노브, 다크 QSS, 커스텀 타이틀바) 안에 끼워진 혼종이었고 Copy 본문은 비어 있었습니다. 이제 `interface/legacyRows`는 하나의 유산 프레젠테이션 전체를 선택합니다. 네이티브 위젯 스타일, 스킨 없음(클래식 라이트 토큰 + 스킨 도입 전 원형 노브 페인터), 기본 ClearType 엔진과 시스템 글꼴, 네이티브 창 제목 표시줄, 클래식 계단식 추가 메뉴, 클래식 Copy 노드 씬입니다.
- 유산 모드에서는 스킨/다크 테마 메뉴가 비활성화되고, 모드 전환은 기존 재시작 루프로 편집기를 재시작합니다(라이브 반쪽 전환이 바로 이번에 고친 혼종이었습니다).
- 갤러리에 EAPO_GALLERY_LEGACY 유산 덤프를 추가해(합성 장치 선택 포함 — 레거시 Copy 씬은 장치 채널로만 채워짐) 회귀를 눈으로 잡을 수 있게 했고, FilterListUiPolicy.md에 영구 보존 결정과 프레젠테이션 규칙을 기록했습니다.

검증은 유산 덤프 실측(클래식 노브·빨간 오류 텍스트·계수 간선이 있는 Copy 노드 그래프), 스킨 카드 경로 무영향(studio 갤러리 122장 픽셀 동일), EditorLogicTests 236 체크, cppcheck 깨끗입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)