### PR TITLE
docs(changelog): file the Unreleased entries under v2.9.2 and v2.10.0

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.10.0 (2026-07-04)
 
 - Editor의 필터 목록이 실행 취소와 다시 실행을 지원합니다(Edit 메뉴,
   Ctrl+Z / Ctrl+Y). 행 추가·삭제·붙여넣기·드래그 이동, 노브 드래그, 텍스트
@@ -15,6 +15,9 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
   묶여 되돌려지고, 입력란에 포커스가 있을 때는 입력란 자체의 실행 취소가
   우선합니다.
   ([#166](https://github.com/115dkk/EqualizerAPO-XT/pull/166))
+
+## v2.9.2 (2026-07-04)
+
 - Legacy rows 모드를 진짜 유산 편집기로 복원했습니다. 그동안 옛 행들이 현대
   스킨 크롬 안에 끼워져 렌더됐는데, 이제 네이티브 Windows 스타일, 기본 제목
   표시줄, 시스템 글꼴, 클래식 노브, 원래의 Copy 노드 그래프로 시작하고 이

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.10.0 — 2026-07-04
 
 - The Editor's filter list supports undo and redo (Edit menu, Ctrl+Z /
   Ctrl+Y). Every edit counts: adding, deleting, pasting and dragging rows,
@@ -20,6 +20,9 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
   Legacy rows modes. A knob drag or a typing run undoes as one step, and
   text fields keep their own in-field undo while focused.
   ([#166](https://github.com/115dkk/EqualizerAPO-XT/pull/166))
+
+## v2.9.2 — 2026-07-04
+
 - Restored the Legacy rows mode to the true heritage editor. It used to render
   the old rows inside the modern skinned chrome; it now starts with the native
   Windows style, standard title bar, system fonts, classic knobs and the


### PR DESCRIPTION
Moves the two shipped Unreleased entries to their release sections: the heritage Legacy rows restoration (#165) under v2.9.2 and the filter-list undo/redo (#166) under v2.10.0, in both the English and Korean changelogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)