### PR TITLE
docs(changelog): file the Unreleased entry under v2.10.1

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -6,7 +6,7 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 버전은 CI가 커밋 메시지의 Conventional Commits 타입을 읽어 자동으로 올리므로, 일부 번호는 건너뛰었습니다(1.7, 1.9, 1.12.1, 1.14, 1.16, 1.23, 1.25는 릴리스된 적이 없습니다). v1.10.1까지는 태그에 `-main.<run>` 접미사가 붙었고, v1.11.0부터는 깨끗한 `vX.Y.Z` 이름을 씁니다. 각 버전의 설치 파일은 [Releases 페이지](https://github.com/115dkk/EqualizerAPO-XT/releases)에 있습니다.
 
-## Unreleased
+## v2.10.1 (2026-07-04)
 
 - Edit 메뉴의 undo/redo 한국어 이름을 실행 취소/다시 실행에서 수정
   취소/다시 수정으로 바꿨습니다. 기존 Windows 표준 표현은 프로그램을

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ types, so some version numbers were skipped (1.7, 1.9, 1.12.1, 1.14, 1.16,
 tags are clean `vX.Y.Z` names. Installers for every version are on the
 [Releases page](https://github.com/115dkk/EqualizerAPO-XT/releases).
 
-## Unreleased
+## v2.10.1 — 2026-07-04
 
 - Renamed the Korean Edit-menu labels for undo/redo from 실행 취소/다시 실행
   to 수정 취소/다시 수정: the stock Windows wording can read as if it were


### PR DESCRIPTION
Moves the Korean undo/redo label rename (#168) from Unreleased to its v2.10.1 section in both changelogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)