### PR TITLE
refactor(engine): report per-line load facts to an attachable trace sink

### DIFF
--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -300,6 +300,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="AbstractAPOInfo.h" />
+    <ClInclude Include="ConfigLoadTrace.h" />
     <ClInclude Include="ConfigurationFileReader.h" />
     <ClInclude Include="DeviceAPOInfo.h" />
     <ClInclude Include="FilterConfiguration.h" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -184,6 +184,7 @@
     </ClInclude>
     <ClInclude Include="VoicemeeterAPOInfo.h" />
     <ClInclude Include="AbstractAPOInfo.h" />
+    <ClInclude Include="ConfigLoadTrace.h" />
     <ClInclude Include="ConfigurationFileReader.h" />
     <ClInclude Include="DeviceAPOInfo.h" />
     <ClInclude Include="FilterConfiguration.h" />

--- a/ConfigLoadTrace.h
+++ b/ConfigLoadTrace.h
@@ -1,0 +1,73 @@
+/*
+    This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+    Per-line facts collected while FilterEngine loads a configuration, so a UI
+    (the Editor) can echo evaluation results next to the config rows: which If
+    branch ran, what an Eval computed, which lines a false branch swallowed.
+    Collection is off unless a sink is attached via
+    FilterEngine::setLoadTraceSink; the APO runtime never attaches one, so the
+    audio service pays nothing beyond a null check per reported event.
+*/
+
+#pragma once
+
+#include <string>
+
+struct ConfigLoadTraceEntry
+{
+	enum class Kind
+	{
+		// An If/ElseIf line. result says what happened to the condition;
+		// active mirrors result == Result::True.
+		Condition,
+		// An Else line: active says whether the else-branch body executes.
+		// result stays NotEvaluated (an Else has no expression).
+		ElseBranch,
+		// An Eval line: text carries the expression result, or the parser
+		// message when error is set.
+		Eval,
+		// A line with inline `expression` segments: text carries the fully
+		// substituted parameter string the downstream factories saw.
+		InlineValue,
+		// Any line a false branch swallowed before the other factories saw
+		// it. Comment lines are not reported (they never execute anyway).
+		SkippedLine,
+	};
+
+	// How a Condition line's expression fared. NotEvaluated marks an ElseIf
+	// whose chain was already satisfied (the engine short-circuits without
+	// evaluating) and the ElseIf/Else-without-If misuse cases.
+	enum class Result
+	{
+		True,
+		False,
+		NotEvaluated,
+		Error,
+	};
+
+	// Absolute path of the config file the line is in (as the engine opened
+	// it) and the 1-based line number within that file. Stamped by
+	// FilterEngine::traceLoadEvent; factories fill only the fields below.
+	std::wstring file;
+	int line = 0;
+
+	Kind kind = Kind::SkippedLine;
+	Result result = Result::NotEvaluated;
+	// Kind::Condition/ElseBranch: the branch body will execute.
+	bool active = false;
+	// Kind::Eval/InlineValue payload, or the parser error message.
+	std::wstring text;
+	bool error = false;
+};
+
+// Receives entries during FilterEngine::loadConfig. Calls arrive on whichever
+// thread loads the configuration. With a caller-supplied custom path the load
+// runs synchronously inside initialize()/loadConfig() and no registry
+// notification worker is started, so a plain single-threaded collector is
+// safe there (the Editor's analysis engine is exactly that case).
+class ConfigLoadTraceSink
+{
+public:
+	virtual ~ConfigLoadTraceSink() = default;
+	virtual void addEntry(const ConfigLoadTraceEntry& entry) = 0;
+};

--- a/Editor/AnalysisThread.cpp
+++ b/Editor/AnalysisThread.cpp
@@ -119,6 +119,11 @@ unsigned AnalysisThread::getProcessedFrames() const
 	return processedFrames;
 }
 
+const std::vector<ConfigLoadTraceEntry>& AnalysisThread::getLoadTrace() const
+{
+	return resultLoadTrace;
+}
+
 void AnalysisThread::run()
 {
 	while (true)
@@ -166,9 +171,25 @@ void AnalysisThread::run()
 
 		qint64 startTime = timer.nsecsElapsed();
 
+		// Collects the engine's per-line load facts (branch decisions, Eval
+		// values, skipped lines). With a custom config path initialize() loads
+		// synchronously and starts no notification worker, so a plain vector
+		// needs no locking here.
+		struct Collector : ConfigLoadTraceSink
+		{
+			std::vector<ConfigLoadTraceEntry> entries;
+			void addEntry(const ConfigLoadTraceEntry& entry) override
+			{
+				entries.push_back(entry);
+			}
+		};
+		Collector traceCollector;
+
 		FilterEngine engine;
+		engine.setLoadTraceSink(&traceCollector);
 		engine.setDeviceInfo(device->isInput(), true, device->getDeviceName(), device->getConnectionName(), device->getDeviceGuid(), device->getDeviceString());
 		engine.initialize(sampleRate, channelCount, channelCount, channelCount, channelMask, frameCount, configPath.toStdWString());
+		engine.setLoadTraceSink(nullptr);
 		double initializationTime = (timer.nsecsElapsed() - startTime) / 1e6;
 
 		if (frameCount != lastFrameCount || channelCount != lastChannelCount)
@@ -295,6 +316,7 @@ void AnalysisThread::run()
 		this->initializationTime = initializationTime;
 		this->processingTime = processingTime;
 		this->processedFrames = processedFrames;
+		this->resultLoadTrace = std::move(traceCollector.entries);
 		mutex.unlock();
 
 		qDebug("Analysis took %.1f ms", timer.nsecsElapsed() / 1e6);

--- a/Editor/AnalysisThread.h
+++ b/Editor/AnalysisThread.h
@@ -19,11 +19,14 @@
 
 #pragma once
 
+#include <vector>
+
 #include <QThread>
 #include <QMutex>
 #include <QWaitCondition>
 #include <fftw3.h>
 
+#include "ConfigLoadTrace.h"
 #include "DeviceAPOInfo.h"
 
 class AnalysisThread : public QThread
@@ -45,6 +48,11 @@ public:
 	double getInitializationTime() const;
 	double getProcessingTime() const;
 	unsigned getProcessedFrames() const;
+	// Per-line facts the engine reported while loading the analyzed config
+	// (branch decisions, Eval values, skipped lines; dynamic-commands
+	// campaign). Like the other getters, only valid between beginGetResult()
+	// and endGetResult().
+	const std::vector<ConfigLoadTraceEntry>& getLoadTrace() const;
 
 signals:
 	void analysisFinished();
@@ -73,6 +81,7 @@ private:
 	double initializationTime = 0.0;
 	double processingTime = 0.0;
 	int processedFrames = 0;
+	std::vector<ConfigLoadTraceEntry> resultLoadTrace;
 
 	// internal (not protected by mutex)
 	int lastFrameCount = -1;

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -29,6 +29,7 @@
 #include <QJsonObject>
 #include <QVector>
 
+#include "ConfigLoadTrace.h"
 #include "Editor/helpers/DisableWheelFilter.h"
 #include "Editor/widgets/FilterCardModel.h"
 #include "Editor/widgets/FilterListModel.h"
@@ -148,6 +149,14 @@ public:
 	void setRenderMode(RenderMode mode);
 	RenderMode getRenderMode() const;
 
+	// Facts from the analysis engine's most recent configuration load,
+	// filtered by the caller to this table's file (dynamic-commands campaign).
+	// Entry line numbers are 1-based; lookup is by 0-based row index. Facts
+	// go stale between a structural edit and the next analysis run - readers
+	// treat them as advisory, never as the document.
+	void setLoadTraceFacts(const QVector<ConfigLoadTraceEntry>& facts);
+	QList<ConfigLoadTraceEntry> loadTraceFactsForRow(int row) const;
+
 signals:
 	void linesChanged();
 
@@ -244,6 +253,9 @@ private:
 	int presetScrollX = -1;
 	int presetScrollY = -1;
 	RenderMode renderMode = ModernCards;
+	// Analysis load facts keyed by 0-based row index; a row can carry more
+	// than one entry (an Eval line with inline segments reports both).
+	QMultiHash<int, ConfigLoadTraceEntry> loadTraceFacts;
 };
 
 template<typename T> inline uint qHash(const QList<T>& list)

--- a/Editor/FilterTableParts/FilterTable.Events.cpp
+++ b/Editor/FilterTableParts/FilterTable.Events.cpp
@@ -293,6 +293,32 @@ void FilterTable::setConfigPath(const QString& value)
 	configPath = value;
 }
 
+void FilterTable::setLoadTraceFacts(const QVector<ConfigLoadTraceEntry>& facts)
+{
+	loadTraceFacts.clear();
+	for (const ConfigLoadTraceEntry& fact : facts)
+	{
+		if (fact.line > 0)
+			loadTraceFacts.insert(fact.line - 1, fact);
+	}
+
+	// The dynamic-command presentations read the facts at paint time; repaint
+	// the rows so lamps/readouts follow the analysis run that just finished.
+	if (gridLayout == nullptr)
+		return;
+	for (int row = 0; row < model.items().count(); row++)
+	{
+		QLayoutItem* cell = gridLayout->itemAtPosition(row, 0);
+		if (cell != nullptr && cell->widget() != nullptr)
+			cell->widget()->update();
+	}
+}
+
+QList<ConfigLoadTraceEntry> FilterTable::loadTraceFactsForRow(int row) const
+{
+	return loadTraceFacts.values(row);
+}
+
 FilterTable::Item* FilterTable::getFocusedItem() const
 {
 	return model.focused();

--- a/Editor/MainWindowParts/MainWindow.Analysis.cpp
+++ b/Editor/MainWindowParts/MainWindow.Analysis.cpp
@@ -8,6 +8,7 @@
 #include <QStringBuilder>
 #include <QStyle>
 #include <QScrollArea>
+#include <QDir>
 #include <QFileInfo>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -89,6 +90,30 @@ void MainWindow::updateAnalysisPanel()
 	analysisPlotScene->setFreqData(analysisThread->getFreqData(), analysisThread->getFreqDataLength(), sampleRate);
 	if (eqGraphView != nullptr)
 		eqGraphView->setNodes(analysisPlotScene->getNodes(), static_cast<unsigned>(sampleRate), ui->analysisChannelComboBox->currentText());
+
+	// Hand the engine's per-line load facts (dynamic-commands campaign) to
+	// every open tab whose file took part in this load. A tab whose file was
+	// not part of the analyzed chain receives an empty set, which clears any
+	// stale facts from a previous device/config selection.
+	{
+		const std::vector<ConfigLoadTraceEntry>& trace = analysisThread->getLoadTrace();
+		for (int i = 0; i < ui->tabWidget->count(); i++)
+		{
+			QScrollArea* scrollArea = qobject_cast<QScrollArea*>(ui->tabWidget->widget(i));
+			FilterTable* filterTable = scrollArea != nullptr ? qobject_cast<FilterTable*>(scrollArea->widget()) : nullptr;
+			if (filterTable == nullptr || filterTable->getConfigPath().isEmpty())
+				continue;
+			const QString tabPath = QDir::toNativeSeparators(filterTable->getConfigPath());
+			QVector<ConfigLoadTraceEntry> tabFacts;
+			for (const ConfigLoadTraceEntry& entry : trace)
+			{
+				const QString entryPath = QDir::toNativeSeparators(QString::fromStdWString(entry.file));
+				if (entryPath.compare(tabPath, Qt::CaseInsensitive) == 0)
+					tabFacts.append(entry);
+			}
+			filterTable->setLoadTraceFacts(tabFacts);
+		}
+	}
 
 	auto setSeverity = [](QLabel* label, const char* severity)
 	{

--- a/FilterEngine.h
+++ b/FilterEngine.h
@@ -40,6 +40,9 @@ namespace mup {
 class ParserX;
 }
 
+struct ConfigLoadTraceEntry;
+class ConfigLoadTraceSink;
+
 #pragma AVRT_VTABLES_BEGIN
 class FilterEngine
 {
@@ -76,6 +79,14 @@ public:
 	// sampleRate / 100 formula. (audit #146 TD033)
 	unsigned getTransitionLength() const {return transitionLength;}
 	mup::ParserX* getParser() {return parser.get();}
+	// Attach before initialize()/loadConfig(); entries describe every load
+	// that runs while attached. The engine does not own the sink; pass nullptr
+	// to detach. The Editor's analysis engine is the only expected consumer -
+	// the APO runtime never attaches one.
+	void setLoadTraceSink(ConfigLoadTraceSink* sink) {traceSink = sink;}
+	// Factories report an evaluation fact for the line currently being
+	// parsed; the engine stamps the file/line position. No-op without a sink.
+	void traceLoadEvent(ConfigLoadTraceEntry entry);
 	// Returns true if the active configuration (or any transition target) carries
 	// state across blocks or has a tail. Used by the APO to skip processing on
 	// silent input when safe. Conservative: returns true while a config swap is
@@ -122,6 +133,12 @@ private:
 	unsigned maxFrameCount = 0;
 
 	// only used during loading
+	ConfigLoadTraceSink* traceSink = nullptr;
+	// Position of the line loadConfigFile is currently feeding to the
+	// factories; saved/restored across Include recursion like the channel
+	// names. Only meaningful while a sink is attached.
+	std::wstring traceFile;
+	int traceLine = 0;
 	std::vector<std::unique_ptr<FilterInfo>> filterInfos;
 	std::vector<std::wstring> currentChannelNames;
 	std::vector<std::wstring> lastChannelNames;

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -25,6 +25,7 @@
 #define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #include <sndfile.h>
 
+#include "ConfigLoadTrace.h"
 #include "FilterEngine.h"
 #include "helpers/LogHelper.h"
 #include "Tests/TestHarness.h"
@@ -465,6 +466,78 @@ void testProcessWithoutConfigurationDoesNotCrash(test::Harness& harness)
 		"process() without a configuration wrote output despite zero channel counts");
 }
 
+// Dynamic-commands campaign: the engine reports per-line facts while loading
+// (branch decisions, Eval values, swallowed lines) through an attached
+// ConfigLoadTraceSink so the Editor can echo them next to the config rows.
+// This pins the whole grammar over one representative config: an Eval, a
+// taken If with a nested false If inside, a short-circuited ElseIf, a dead
+// Else, inline `expression` substitution, and file/line stamping.
+void testConfigLoadTrace(test::Harness& harness)
+{
+	const std::wstring configPath = writeConfig(harness, L"trace.txt",
+		"Eval: x = 2 + 3\n"          // line 1: Eval -> "5"
+		"If: x == 5\n"               // line 2: Condition true
+		"Preamp: -3 dB\n"            // line 3: executes, no entry
+		"If: x > 100\n"              // line 4: Condition false
+		"Delay: 1 ms\n"              // line 5: SkippedLine
+		"EndIf:\n"                   // line 6: closes nested scope, no entry
+		"ElseIf: x == 4\n"           // line 7: chain satisfied -> NotEvaluated
+		"Preamp: -1 dB\n"            // line 8: SkippedLine
+		"Else:\n"                    // line 9: ElseBranch, inactive
+		"Preamp: -2 dB\n"            // line 10: SkippedLine
+		"EndIf:\n"                   // line 11: closes outer scope, no entry
+		"Preamp: `x - 10` dB\n");    // line 12: InlineValue "-5 dB"
+
+	struct Collector : ConfigLoadTraceSink
+	{
+		std::vector<ConfigLoadTraceEntry> entries;
+		void addEntry(const ConfigLoadTraceEntry& entry) override
+		{
+			entries.push_back(entry);
+		}
+	};
+	Collector collector;
+
+	FilterEngine engine;
+	engine.setLoadTraceSink(&collector);
+	initializeEngine(engine, 48000, 2, 512, configPath);
+
+	const std::vector<ConfigLoadTraceEntry>& entries = collector.entries;
+	harness.requireEqual((int)entries.size(), 9, "load trace entry count");
+
+	auto expectEntry = [&](int index, int line, ConfigLoadTraceEntry::Kind kind,
+		ConfigLoadTraceEntry::Result result, bool active, const std::string& what) {
+		const ConfigLoadTraceEntry& entry = entries[(size_t)index];
+		harness.expectEqual(entry.line, line, what + ": line");
+		harness.expect(entry.kind == kind, what + ": kind");
+		harness.expect(entry.result == result, what + ": result");
+		harness.expectEqual(entry.active, active, what + ": active");
+		harness.expect(entry.file == configPath, what + ": file stamp");
+	};
+
+	expectEntry(0, 1, ConfigLoadTraceEntry::Kind::Eval, ConfigLoadTraceEntry::Result::NotEvaluated, false, "Eval");
+	harness.expect(collector.entries[0].text == L"5", "Eval reports the computed value");
+	harness.expectFalse(collector.entries[0].error, "Eval reports no error");
+	expectEntry(1, 2, ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::True, true, "outer If");
+	expectEntry(2, 4, ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::False, false, "nested If");
+	expectEntry(3, 5, ConfigLoadTraceEntry::Kind::SkippedLine, ConfigLoadTraceEntry::Result::NotEvaluated, false, "swallowed Delay");
+	expectEntry(4, 7, ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::NotEvaluated, false, "short-circuited ElseIf");
+	expectEntry(5, 8, ConfigLoadTraceEntry::Kind::SkippedLine, ConfigLoadTraceEntry::Result::NotEvaluated, false, "swallowed Preamp");
+	expectEntry(6, 9, ConfigLoadTraceEntry::Kind::ElseBranch, ConfigLoadTraceEntry::Result::NotEvaluated, false, "dead Else");
+	expectEntry(7, 10, ConfigLoadTraceEntry::Kind::SkippedLine, ConfigLoadTraceEntry::Result::NotEvaluated, false, "swallowed Preamp inside the dead Else");
+	expectEntry(8, 12, ConfigLoadTraceEntry::Kind::InlineValue, ConfigLoadTraceEntry::Result::NotEvaluated, false, "inline value");
+	// The engine trims only the command key, not the parameter text, so the
+	// substituted string keeps the space after the colon - the entry reports
+	// exactly what the downstream factories saw.
+	harness.expect(collector.entries[8].text == L" -5 dB", "inline substitution reports the resolved parameters");
+
+	// A second load without a sink must not crash and must add nothing.
+	engine.setLoadTraceSink(nullptr);
+	engine.loadConfig(configPath);
+	harness.expectEqual((int)collector.entries.size(), (int)entries.size(),
+		"detached sink receives nothing on a reload");
+}
+
 } // namespace
 
 int main()
@@ -479,6 +552,7 @@ int main()
 	testMultiConvolutionIgnoresChannelSelection(harness);
 	testConfigSwapCrossfades(harness);
 	testRealBrirCrossfeed(harness);
+	testConfigLoadTrace(harness);
 
 	removeTestDirectory();
 	harness.report();

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -34,6 +34,7 @@
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
 #include "helpers/ChannelHelper.h"
+#include "ConfigLoadTrace.h"
 #include "ConfigurationFileReader.h"
 #include "FilterEngine.h"
 // The individual filter factories self-register via REGISTER_FILTER_FACTORY, and
@@ -122,6 +123,13 @@ void FilterEngine::loadConfigFile(const wstring& path)
 		return;
 
 	vector<wstring> savedChannelNames = currentChannelNames;
+	// Load-trace position: like the channel names, the position is saved and
+	// restored across the Include recursion so entries reported after a nested
+	// file returns are stamped with the outer file again.
+	wstring savedTraceFile = move(traceFile);
+	int savedTraceLine = traceLine;
+	traceFile = path;
+	traceLine = 0;
 
 	for (auto it = factories.cbegin(); it != factories.cend(); it++)
 	{
@@ -135,6 +143,7 @@ void FilterEngine::loadConfigFile(const wstring& path)
 	{
 		string encodedLine;
 		getline(inputStream, encodedLine);
+		traceLine++;
 		if (encodedLine.size() > 0 && encodedLine[encodedLine.size() - 1] == '\r')
 			encodedLine.resize(encodedLine.size() - 1);
 
@@ -222,6 +231,17 @@ void FilterEngine::loadConfigFile(const wstring& path)
 
 	// restore channels selected in outer configuration file
 	currentChannelNames = savedChannelNames;
+	traceFile = move(savedTraceFile);
+	traceLine = savedTraceLine;
+}
+
+void FilterEngine::traceLoadEvent(ConfigLoadTraceEntry entry)
+{
+	if (traceSink == nullptr)
+		return;
+	entry.file = traceFile;
+	entry.line = traceLine;
+	traceSink->addEntry(entry);
 }
 
 void FilterEngine::watchRegistryKey(const std::wstring& key)

--- a/filters/ExpressionFilterFactory.cpp
+++ b/filters/ExpressionFilterFactory.cpp
@@ -24,6 +24,7 @@
 #include "helpers/StringHelper.h"
 #include "parser/ParserExtensions.h"
 #include "parser/RegistryFunctions.h"
+#include "ConfigLoadTrace.h"
 #include "FilterEngine.h"
 #include "filters/FilterFactoryRegistry.h"
 #include "ExpressionCommand.h"
@@ -38,6 +39,7 @@ using namespace mup;
 void ExpressionFilterFactory::initialize(FilterEngine* engine)
 {
 	parser = engine->getParser();
+	this->engine = engine;
 	parser->DefineConst(L"inputChannelCount", mup::int_type(engine->getInputChannelCount()));
 	parser->DefineConst(L"outputChannelCount", mup::int_type(engine->getOutputChannelCount()));
 	parser->DefineConst(L"sampleRate", mup::float_type(engine->getSampleRate()));
@@ -58,6 +60,8 @@ vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath
 	// Lex through the shared codec, then evaluate the expression segments in
 	// place so the other factories see the substituted parameter text.
 	wstring output;
+	bool hadInlineExpression = false;
+	bool inlineError = false;
 	for (const InlineExpression::Segment& segment : InlineExpression::split(parameters))
 	{
 		if (!segment.isExpression)
@@ -66,6 +70,7 @@ vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath
 			continue;
 		}
 
+		hadInlineExpression = true;
 		try
 		{
 			parser->SetExpr(segment.text);
@@ -81,14 +86,28 @@ vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath
 		catch (const ParserError& e)
 		{
 			LogF(L"Error while evaluating inline expression %s: %s", segment.text.c_str(), e.GetMsg().c_str());
+			inlineError = true;
 		}
 	}
 
 	parameters = output;
 
+	if (hadInlineExpression)
+	{
+		// Load-trace (dynamic-commands campaign): the Editor shows what a
+		// line's `expression` segments resolved to on this load.
+		ConfigLoadTraceEntry entry;
+		entry.kind = ConfigLoadTraceEntry::Kind::InlineValue;
+		entry.text = output;
+		entry.error = inlineError;
+		engine->traceLoadEvent(std::move(entry));
+	}
+
 	EvalCommand evalCmd;
 	if (EvalCommand::parse(command, parameters, evalCmd))
 	{
+		ConfigLoadTraceEntry entry;
+		entry.kind = ConfigLoadTraceEntry::Kind::Eval;
 		try
 		{
 			parser->SetExpr(evalCmd.expression);
@@ -99,11 +118,15 @@ vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath
 			else
 				resultString = result.ToString().c_str();
 			TraceF(L"Expression %s evaluated to %s", evalCmd.expression.c_str(), resultString.c_str());
+			entry.text = resultString;
 		}
 		catch (const ParserError& e)
 		{
 			LogF(L"Error while evaluating expression %s: %s", evalCmd.expression.c_str(), e.GetMsg().c_str());
+			entry.text = e.GetMsg();
+			entry.error = true;
 		}
+		engine->traceLoadEvent(std::move(entry));
 
 		// command has been handled
 		command = L"";

--- a/filters/ExpressionFilterFactory.h
+++ b/filters/ExpressionFilterFactory.h
@@ -33,4 +33,5 @@ public:
 
 private:
 	mup::ParserX* parser = nullptr;
+	FilterEngine* engine = nullptr;
 };

--- a/filters/IfFilterFactory.cpp
+++ b/filters/IfFilterFactory.cpp
@@ -22,6 +22,7 @@
 #include "helpers/StringHelper.h"
 #include "parser/RegexFunctions.h"
 #include "parser/RegistryFunctions.h"
+#include "ConfigLoadTrace.h"
 #include "FilterEngine.h"
 #include "filters/FilterFactoryRegistry.h"
 #include "IfCommand.h"
@@ -36,6 +37,7 @@ using namespace mup;
 void IfFilterFactory::initialize(FilterEngine* engine)
 {
 	parser = engine->getParser();
+	this->engine = engine;
 }
 
 vector<IFilter*> IfFilterFactory::startOfConfiguration()
@@ -68,6 +70,20 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 	bool isIfFamily = IfCommand::parse(command, parameters, cmd);
 	const wstring& expression = cmd.expression;
 
+	// Load-trace reporting (dynamic-commands campaign): the Editor echoes
+	// branch decisions next to the config rows. Every reported line sets
+	// traced so the generic skipped-line report below does not double-count
+	// the line that made the branch false.
+	bool traced = false;
+	auto traceBranch = [&](ConfigLoadTraceEntry::Kind kind, ConfigLoadTraceEntry::Result result, bool active) {
+		ConfigLoadTraceEntry entry;
+		entry.kind = kind;
+		entry.result = result;
+		entry.active = active;
+		engine->traceLoadEvent(entry);
+		traced = true;
+	};
+
 	if (isIfFamily && cmd.kind == IfCommand::Kind::If)
 	{
 		if (falseCount == 0)
@@ -81,6 +97,8 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 					TraceF(L"If(%s) evaluated to %s", expression.c_str(), result.ToString().c_str());
 				else
 					TraceF(L"If(%s) evaluated to %s (%s)", expression.c_str(), result.ToString().c_str(), isTrue ? L"true" : L"false");
+				traceBranch(ConfigLoadTraceEntry::Kind::Condition,
+					isTrue ? ConfigLoadTraceEntry::Result::True : ConfigLoadTraceEntry::Result::False, isTrue);
 
 				if (isTrue)
 				{
@@ -95,6 +113,7 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 			catch (const ParserError& e)
 			{
 				LogF(L"Error while evaluating If(%s): %s", expression.c_str(), e.GetMsg().c_str());
+				traceBranch(ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::Error, false);
 				falseCount++;
 			}
 		}
@@ -110,9 +129,13 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 			if (trueCount == 0)
 			{
 				LogF(L"ElseIf without If!");
+				traceBranch(ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 			}
 			else
 			{
+				// The previous branch is active; the chain is satisfied and
+				// this condition is never looked at.
+				traceBranch(ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 				falseCount++;
 				trueCount--;
 			}
@@ -128,6 +151,8 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 					TraceF(L"ElseIf(%s) evaluated to %s", expression.c_str(), result.ToString().c_str());
 				else
 					TraceF(L"ElseIf(%s) evaluated to %s (%s)", expression.c_str(), result.ToString().c_str(), isTrue ? L"true" : L"false");
+				traceBranch(ConfigLoadTraceEntry::Kind::Condition,
+					isTrue ? ConfigLoadTraceEntry::Result::True : ConfigLoadTraceEntry::Result::False, isTrue);
 
 				if (isTrue)
 				{
@@ -139,7 +164,14 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 			catch (const ParserError& e)
 			{
 				LogF(L"Error while evaluating ElseIf(%s): %s", expression.c_str(), e.GetMsg().c_str());
+				traceBranch(ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::Error, false);
 			}
+		}
+		else if (falseCount == 1)
+		{
+			// falseCount == 1 without executeElse: an earlier branch of this
+			// chain already ran, so the condition is short-circuited.
+			traceBranch(ConfigLoadTraceEntry::Kind::Condition, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 		}
 	}
 	else if (isIfFamily && cmd.kind == IfCommand::Kind::Else)
@@ -149,18 +181,25 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 			if (trueCount == 0)
 			{
 				LogF(L"Else without If!");
+				traceBranch(ConfigLoadTraceEntry::Kind::ElseBranch, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 			}
 			else
 			{
+				traceBranch(ConfigLoadTraceEntry::Kind::ElseBranch, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 				falseCount++;
 				trueCount--;
 			}
 		}
 		else if (falseCount == 1 && executeElse)
 		{
+			traceBranch(ConfigLoadTraceEntry::Kind::ElseBranch, ConfigLoadTraceEntry::Result::NotEvaluated, true);
 			falseCount--;
 			trueCount++;
 			executeElse = false;
+		}
+		else if (falseCount == 1)
+		{
+			traceBranch(ConfigLoadTraceEntry::Kind::ElseBranch, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 		}
 	}
 	else if (isIfFamily && cmd.kind == IfCommand::Kind::EndIf)
@@ -182,8 +221,15 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 	}
 
 	if (falseCount > 0)
+	{
+		// A line inside a false branch. Report it as skipped unless this very
+		// line already carries a branch entry, and never report comments
+		// (they would not have executed anyway).
+		if (!traced && !command.empty() && command[0] != L'#')
+			traceBranch(ConfigLoadTraceEntry::Kind::SkippedLine, ConfigLoadTraceEntry::Result::NotEvaluated, false);
 		// skip line for further factories
 		command = L"";
+	}
 
 	return vector<IFilter*>();
 }

--- a/filters/IfFilterFactory.h
+++ b/filters/IfFilterFactory.h
@@ -36,6 +36,7 @@ public:
 
 private:
 	mup::ParserX* parser = nullptr;
+	FilterEngine* engine = nullptr;
 
 	unsigned trueCount = 0;
 	unsigned falseCount = 0;


### PR DESCRIPTION
## What

Groundwork for the dynamic-commands presentations (campaign issue trail: #178, #179). The card UIs need to know which `If` branch ran, what an `Eval` computed, and which lines a false branch swallowed. The engine now reports those facts while loading a configuration, through a `ConfigLoadTraceSink` that only the Editor attaches — the APO runtime never sets one, so its load path gains a null check per reported event and nothing else.

- **`ConfigLoadTrace.h`** — entry struct (kind: Condition / ElseBranch / Eval / InlineValue / SkippedLine; condition result True/False/NotEvaluated/Error; active flag; value text; file/line stamp) and the sink interface.
- **`FilterEngine`** — tracks the file/line position while parsing (saved/restored across `Include` recursion, mirroring the channel-name save) and stamps it onto every entry in `traceLoadEvent`.
- **`IfFilterFactory`** — reports each evaluated If/ElseIf condition, short-circuited ElseIf chains and dead Else branches as NotEvaluated, and every line a false branch swallows (comments excluded). The line that made a branch false is not double-reported as skipped.
- **`ExpressionFilterFactory`** — reports Eval results (or the parser error message) and the substituted parameter text of lines with inline `` `expression` `` segments, exactly as the downstream factories saw it (leading whitespace preserved — pinned by test).
- **Editor plumbing** — `AnalysisThread` collects the trace of the analyzed config (no locking needed: a custom-path load is synchronous inside `initialize()` and starts no notification worker), `MainWindow::updateAnalysisPanel` routes each open tab the entries of its own file (case-insensitive native-path match), and `FilterTable` stores them keyed by 0-based row (`setLoadTraceFacts`/`loadTraceFactsForRow`) for the per-skin presentations to consume.

## Verification

- `EngineOrchestrationTests` — new `testConfigLoadTrace` pins the whole grammar over one config: Eval value, taken If, nested false If, swallowed lines, short-circuited ElseIf, dead Else, inline substitution text, file/line stamps, and that a detached sink receives nothing on reload. 543 checks pass.
- Editor (qmake/nmake) builds clean with the new plumbing.
- No user-visible change: rendering is untouched until the skin presentations land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)