### PR TITLE
feat(editor): keep cards alive on inline-expression lines

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,12 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 파라미터에 백틱 인라인 식이 든 줄도 이제 카드를 유지합니다. Preamp와
+  Delay 카드는 동적 모드로 열려 노브가 꺼지고 값 자리에 식 원문이
+  표시되며(계산된 값은 분석 판독에 나타남), 그 외 편집기는 원문을 잘못
+  읽는 대신 raw 본문으로 물러납니다. 이런 Preamp 줄이 0.0 dB로 표시되고
+  노브를 한 번만 돌려도 식이 소리 없이 지워지던 위험도 함께 고쳤습니다.
+  ([#184](https://github.com/115dkk/EqualizerAPO-XT/pull/184))
 - 프로그래밍 계열 설정 명령(`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`)이 이름
   없는 맨텍스트 행 대신 정식 카드가 됐습니다. 줄마다 분기 종류를 말하는
   배지(IF/ELIF/ELSE/ENDIF/EVAL)가 붙고 조건식이나 수식이 카드 요약으로

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Lines whose parameters hold an inline `` `expression` `` keep their card
+  now. The Preamp and Delay cards open in a dynamic mode - the knob powers
+  down and the value position shows the expression as written, with the
+  computed value appearing in the analysis readouts - and every other editor
+  stands down to the raw body instead of misreading the text. This also
+  fixes a hazard where such a Preamp line displayed 0.0 dB and a single
+  knob turn silently erased the expression.
+  ([#184](https://github.com/115dkk/EqualizerAPO-XT/pull/184))
 - The programmatic config commands (`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`)
   are cards now instead of anonymous raw-text rows: each line carries a badge
   for its branch kind (IF/ELIF/ELSE/ENDIF/EVAL) with the condition or

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -110,7 +110,13 @@ QList<GalleryRow> galleryRows()
 		// the IIR card states the order and both coefficient rows (a 2nd-order
 		// Butterworth low-pass at fs/4, a0 = 1). Appended last so the row
 		// numbers of every earlier scene stay stable against the shot baseline.
-		{ QStringLiteral("iir"), QStringLiteral("Filter: ON IIR Order 2 Coefficients 0.2929 0.5858 0.2929 1.0 -0.0 0.1716") }
+		{ QStringLiteral("iir"), QStringLiteral("Filter: ON IIR Order 2 Coefficients 0.2929 0.5858 0.2929 1.0 -0.0 0.1716") },
+		// A dynamic line (inline `expression` gain): the Preamp card opens in
+		// dynamic mode - powered-down knob, the expression as a token in the
+		// value position - instead of parsing the text as 0.0 and destroying
+		// the expression on the first knob turn. Appended last (the iir
+		// lesson: mid-list insertion renumbers every following scene).
+		{ QStringLiteral("dynpreamp"), QStringLiteral("Preamp: `bass + 3` dB") }
 	};
 }
 

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -66,6 +66,11 @@ struct CommandRowInfo
 	// (empty when unknown); valueError marks a parser failure.
 	QString evalText;
 	bool valueError = false;
+	// True when the line's parameters carry inline `expression` segments, so
+	// its numbers are decided at load time. Rows without a dynamic-capable
+	// editor host the shared raw body; skins extend their raw-body styling
+	// to these rows through this flag.
+	bool dynamicLine = false;
 };
 
 // Interactive state for the list-level add/insert chrome: the trailing

--- a/Editor/skins/MatrixSkin.cpp
+++ b/Editor/skins/MatrixSkin.cpp
@@ -609,7 +609,7 @@ public:
 		// designation cell (the "#" marker cell's construction) and the raw
 		// line a sunken mono line cell - 1px rules, radius 0, verbatim text.
 		if ((info.type == QStringLiteral("text") || info.type == QStringLiteral("if")
-			|| info.type == QStringLiteral("eval")) && body != nullptr)
+			|| info.type == QStringLiteral("eval") || info.dynamicLine) && body != nullptr)
 		{
 			const SkinTokens& tokens = SkinManager::instance()->tokens();
 			if (QLabel* glyph = body->findChild<QLabel*>(QStringLiteral("FilterCardRawGlyph")))

--- a/Editor/skins/MinimalSkin.cpp
+++ b/Editor/skins/MinimalSkin.cpp
@@ -656,7 +656,7 @@ public:
 		// the raw-mode tag. Rows are rebuilt on skin/theme switches, so
 		// construction-time token values stay current.
 		if ((info.type == QStringLiteral("text") || info.type == QStringLiteral("if")
-			|| info.type == QStringLiteral("eval")) && body != nullptr)
+			|| info.type == QStringLiteral("eval") || info.dynamicLine) && body != nullptr)
 		{
 			const SkinTokens& tk = SkinManager::instance()->tokens();
 			if (QLabel* rawText = body->findChild<QLabel*>(QStringLiteral("FilterCardRawText")))

--- a/Editor/skins/RackSkin.cpp
+++ b/Editor/skins/RackSkin.cpp
@@ -535,7 +535,7 @@ public:
 		// here, and a powered-down unit dims its segments at the same time
 		// (rows are rebuilt whenever the line's state changes).
 		if ((info.type == QStringLiteral("text") || info.type == QStringLiteral("if")
-			|| info.type == QStringLiteral("eval")) && body != nullptr)
+			|| info.type == QStringLiteral("eval") || info.dynamicLine) && body != nullptr)
 		{
 			if (QLabel* raw = body->findChild<QLabel*>(QStringLiteral("FilterCardRawText")))
 			{

--- a/Editor/skins/SoftSkin.cpp
+++ b/Editor/skins/SoftSkin.cpp
@@ -908,7 +908,8 @@ public:
 	{
 		Q_UNUSED(card);
 		const bool rawBodyRow = info.type == QStringLiteral("text")
-			|| info.type == QStringLiteral("if") || info.type == QStringLiteral("eval");
+			|| info.type == QStringLiteral("if") || info.type == QStringLiteral("eval")
+			|| info.dynamicLine;
 		if (info.legacyRow || !rawBodyRow)
 			return;
 
@@ -921,7 +922,7 @@ public:
 		// row has settled (the gallery's processEvents() delivers it too).
 		// Known limit: a later rebuildSummary() (raw edit, row reshuffle)
 		// restores the as-written text until the row is rebuilt.
-		if (header != nullptr && info.type != QStringLiteral("text"))
+		if (header != nullptr && info.type != QStringLiteral("text") && !info.dynamicLine)
 		{
 			if (QLabel* summary = header->findChild<QLabel*>(QStringLiteral("FilterCardSummary")))
 			{

--- a/Editor/skins/StudioSkin.cpp
+++ b/Editor/skins/StudioSkin.cpp
@@ -1481,10 +1481,11 @@ public:
 			return;
 
 		if (info.type == QStringLiteral("text") || info.type == QStringLiteral("if")
-			|| info.type == QStringLiteral("eval"))
+			|| info.type == QStringLiteral("eval") || info.dynamicLine)
 		{
-			// Raw text (bare note lines) and the If/Eval logic rows, whose
-			// bodies still host the shared raw editor, are data behind glass.
+			// Raw text (bare note lines), the If/Eval logic rows and dynamic
+			// lines without a dynamic-capable editor, whose bodies host the
+			// shared raw editor, are data behind glass.
 			// FilterCardRow lays a shared inline style on the preview label
 			// (inline outranks any sheet rule), and that default speaks a
 			// half-radius 4px - illegal under the one-8px-round law - so

--- a/Editor/widgets/FilterCardModel.cpp
+++ b/Editor/widgets/FilterCardModel.cpp
@@ -4,6 +4,7 @@
 #include <QRegularExpression>
 #include <QSet>
 
+#include "filters/ExpressionCommand.h"
 #include "filters/FilterFactoryRegistry.h"
 #include "filters/BiQuadCommand.h"
 
@@ -139,6 +140,19 @@ bool FilterCardModel::isPureCommentLine(const QString& line)
 {
 	QString trimmed = line.trimmed();
 	return trimmed.startsWith('#') && !isDisabledCommandLine(line);
+}
+
+bool FilterCardModel::hasInlineExpressions(const QString& parameters)
+{
+	// Cheap pre-check before the lexer: a line without a backtick can have
+	// no expression segment.
+	if (!parameters.contains(QLatin1Char('`')))
+		return false;
+	const std::vector<InlineExpression::Segment> segments = InlineExpression::split(parameters.toStdWString());
+	for (const InlineExpression::Segment& segment : segments)
+		if (segment.isExpression)
+			return true;
+	return false;
 }
 
 QString FilterCardModel::commandForLine(const QString& line, QString* parameters)

--- a/Editor/widgets/FilterCardModel.h
+++ b/Editor/widgets/FilterCardModel.h
@@ -68,6 +68,13 @@ public:
 	// A line that is a note, not a disabled command; such a line has no
 	// "command: parameters" shape, so FilterTable routes it to the comment card.
 	static bool isPureCommentLine(const QString& line);
+	// True when the parameter text carries inline `expression` segments (the
+	// shared InlineExpression lexer decides, so "\`" escapes and empty
+	// segments follow the engine exactly). Such a line's numbers are decided
+	// at load time; editors that would parse and re-serialize them must stand
+	// down or open in dynamic mode, or a knob turn silently destroys the
+	// expression.
+	static bool hasInlineExpressions(const QString& parameters);
 
 private:
 	static QStringList parseChannelList(const QString& text);

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -149,7 +149,15 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	connect(lineEdit, SIGNAL(editingFinished()), this, SLOT(lineEditingFinished()));
 	bodyStack->addWidget(lineEdit);
 
-	IRoutingRenderer* routingRenderer = (descriptor.type == QStringLiteral("copy"))
+	// A Copy line with inline `expression` factors must not open the routing
+	// view: its parser would read the unresolved text as garbage and the
+	// first edit would serialize the expression away. Such lines keep the
+	// raw body (dynamic-value contract), like every other dynamic line
+	// without a dynamic-capable editor.
+	QString routingParameters;
+	FilterCardModel::commandForLine(item->text, &routingParameters);
+	IRoutingRenderer* routingRenderer = (descriptor.type == QStringLiteral("copy")
+		&& !FilterCardModel::hasInlineExpressions(routingParameters))
 		? SkinManager::instance()->routingRenderer() : nullptr;
 
 	if (routingRenderer != nullptr)
@@ -314,6 +322,11 @@ CommandRowInfo FilterCardRow::currentRowInfo() const
 	info.focused = table != nullptr && table->getFocusedItem() == item;
 	info.depth = descriptor.depth;
 	info.logicDepth = descriptor.logicDepth;
+	{
+		QString parameters;
+		FilterCardModel::commandForLine(item->text, &parameters);
+		info.dynamicLine = FilterCardModel::hasInlineExpressions(parameters);
+	}
 
 	// Fold in the analysis engine's load facts for this line (dynamic
 	// commands): branch truth for the If family, computed values for

--- a/Editor/widgets/cards/DelayCardEditor.cpp
+++ b/Editor/widgets/cards/DelayCardEditor.cpp
@@ -4,9 +4,11 @@
 
 #include <QComboBox>
 #include <QHBoxLayout>
+#include <QLabel>
 #include <QLocale>
 #include <QVBoxLayout>
 
+#include "Editor/SkinManager.h"
 #include "Editor/widgets/AudioKnob.h"
 #include "Editor/widgets/EditableValue.h"
 #include "filters/DelayCommand.h"
@@ -39,6 +41,36 @@ double knobValueToDelay(int value)
 
 DelayCardEditor::DelayCardEditor(double delay, bool isMs, QWidget* parent)
 	: IFilterGUI(parent), msMode(isMs)
+{
+	editableValue = new EditableValue(this);
+	editableValue->setObjectName(QStringLiteral("DelayCardValue"));
+	editableValue->setUnit(msMode ? QStringLiteral("ms") : tr("samples"));
+	editableValue->setDecimals(msMode ? 2 : 0);
+	connect(editableValue, SIGNAL(valueChanged(double)), this, SLOT(valueChanged(double)));
+	buildLayout(editableValue);
+
+	setDelay(delay, false);
+}
+
+DelayCardEditor::DelayCardEditor(const QString& dynamicParameters, QWidget* parent)
+	: IFilterGUI(parent), dynamicParameters(dynamicParameters.trimmed())
+{
+	QLabel* token = new QLabel(this->dynamicParameters, this);
+	token->setObjectName(QStringLiteral("DynamicValueToken"));
+	token->setTextInteractionFlags(Qt::TextSelectableByMouse);
+	QFont mono(token->font());
+	mono.setFamily(SkinManager::instance()->tokens().monoFontFamily);
+	token->setFont(mono);
+	token->setToolTip(tr("Computed when the configuration loads; edit the raw line to change the expression."));
+	buildLayout(token);
+
+	knob->setEnabled(false);
+	// The unit lives inside the as-written text; a live selector would
+	// promise a mode change the card cannot serialize.
+	unitCombo->setVisible(false);
+}
+
+void DelayCardEditor::buildLayout(QWidget* valueWidget)
 {
 	setObjectName(QStringLiteral("DelayCardEditor"));
 	setAttribute(Qt::WA_StyledBackground, true);
@@ -73,28 +105,29 @@ DelayCardEditor::DelayCardEditor(double delay, bool isMs, QWidget* parent)
 	connect(unitCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(unitChanged(int)));
 	valueLayout->addWidget(unitCombo);
 
-	editableValue = new EditableValue(valueBlock);
-	editableValue->setObjectName(QStringLiteral("DelayCardValue"));
-	editableValue->setUnit(msMode ? QStringLiteral("ms") : tr("samples"));
-	editableValue->setDecimals(msMode ? 2 : 0);
-	connect(editableValue, SIGNAL(valueChanged(double)), this, SLOT(valueChanged(double)));
-	valueLayout->addWidget(editableValue);
+	valueWidget->setParent(valueBlock);
+	valueLayout->addWidget(valueWidget);
 
 	layout->addWidget(valueBlock, 0, Qt::AlignVCenter);
 	layout->addStretch(1);
-
-	setDelay(delay, false);
 }
 
 void DelayCardEditor::store(QString& command, QString& parameters)
 {
+	command = QStringLiteral("Delay");
+	// Dynamic mode reproduces the expression verbatim; nothing emits
+	// updateModel there, so this is belt and braces.
+	if (!dynamicParameters.isEmpty())
+	{
+		parameters = dynamicParameters;
+		return;
+	}
+
 	// Serialize through the shared DelayCommand codec so the engine parser and
 	// both Editor GUIs agree on one "<delay> ms|samples" format.
 	DelayCommand cmd;
 	cmd.delay = currentDelay;
 	cmd.isMs = msMode;
-
-	command = QStringLiteral("Delay");
 	parameters = QString::fromStdWString(cmd.serialize());
 }
 
@@ -154,7 +187,15 @@ QString DelayCardEditor::delayText() const
 
 #include "FilterCardEditorRegistry.h"
 
+#include "Editor/widgets/FilterCardModel.h"
+
 REGISTER_FILTER_CARD_EDITOR(delay, [](FilterTable*, const QString& command, const QString& parameters) -> IFilterGUI* {
+	// An inline `expression` delay opens the dynamic card (token instead of
+	// a number, knob powered down) - the engine parser below would reject the
+	// unresolved text and drop the row to the raw body otherwise.
+	if (FilterCardModel::hasInlineExpressions(parameters))
+		return new DelayCardEditor(parameters);
+
 	// Parse through the engine's shared routine; a line it rejects falls back
 	// to the legacy factory chain, exactly like the legacy GUI factory.
 	DelayCommand cmd;

--- a/Editor/widgets/cards/DelayCardEditor.h
+++ b/Editor/widgets/cards/DelayCardEditor.h
@@ -18,6 +18,11 @@ class DelayCardEditor : public IFilterGUI
 
 public:
 	explicit DelayCardEditor(double delay, bool isMs, QWidget* parent = nullptr);
+	// Dynamic mode for a line whose delay is an inline `expression`: the
+	// knob powers down, the unit selector hides (the unit lives inside the
+	// as-written text), the value position shows the expression token, and
+	// store() reproduces the parameters verbatim.
+	explicit DelayCardEditor(const QString& dynamicParameters, QWidget* parent = nullptr);
 
 	void store(QString& command, QString& parameters) override;
 
@@ -27,6 +32,7 @@ private slots:
 	void unitChanged(int index);
 
 private:
+	void buildLayout(QWidget* valueWidget);
 	void setDelay(double value, bool notify);
 	QString delayText() const;
 
@@ -36,4 +42,6 @@ private:
 	double currentDelay = 0.0;
 	bool msMode = true;
 	bool updating = false;
+	// Non-empty in dynamic mode: the as-written parameter text to reproduce.
+	QString dynamicParameters;
 };

--- a/Editor/widgets/cards/FilterCardEditorFactory.cpp
+++ b/Editor/widgets/cards/FilterCardEditorFactory.cpp
@@ -1,8 +1,10 @@
 #include "FilterCardEditorFactory.h"
 
+#include <QSet>
 #include <QString>
 
 #include "Editor/IFilterGUI.h"
+#include "Editor/widgets/FilterCardModel.h"
 #include "FilterCardEditorRegistry.h"
 
 IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QString& command, const QString& parameters)
@@ -12,6 +14,23 @@ IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QStr
 	// function is just the lookup, so adding a card no longer means editing
 	// an if-chain here. (audit #146 TD003)
 	const QString normalizedCommand = command.trimmed().toLower();
+
+	// A line with inline `expression` parameters has its numbers decided at
+	// load time. An editor that parses and re-serializes would read garbage
+	// and a single interaction would rewrite the line without the
+	// expression, so only editors with a dynamic mode may open; everything
+	// else stands down and the line falls to the legacy chain, where the
+	// Expression GUI factory blanks it into the raw body - the pre-card
+	// safety net the card-first lookup used to bypass.
+	if (FilterCardModel::hasInlineExpressions(parameters))
+	{
+		static const QSet<QString> dynamicCapable = {
+			QStringLiteral("preamp"), QStringLiteral("delay")
+		};
+		if (!dynamicCapable.contains(normalizedCommand))
+			return nullptr;
+	}
+
 	FilterCardEditorCreator creator = FilterCardEditorRegistry::find(normalizedCommand);
 	if (creator == nullptr)
 		return nullptr;

--- a/Editor/widgets/cards/PreampCardEditor.cpp
+++ b/Editor/widgets/cards/PreampCardEditor.cpp
@@ -7,6 +7,7 @@
 #include <QLocale>
 #include <QRegularExpression>
 
+#include "Editor/SkinManager.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "Editor/widgets/AudioKnob.h"
 #include "Editor/widgets/EditableValue.h"
@@ -33,6 +34,35 @@ double knobValueToGain(int value)
 
 PreampCardEditor::PreampCardEditor(double dbGain, QWidget* parent)
 	: IFilterGUI(parent)
+{
+	editableValue = new EditableValue(this);
+	editableValue->setObjectName(QStringLiteral("PreampCardValue"));
+	editableValue->setUnit(QStringLiteral("dB"));
+	connect(editableValue, SIGNAL(valueChanged(double)), this, SLOT(valueChanged(double)));
+	buildLayout(editableValue);
+
+	setGain(dbGain, false);
+}
+
+PreampCardEditor::PreampCardEditor(const QString& dynamicParameters, QWidget* parent)
+	: IFilterGUI(parent), dynamicParameters(dynamicParameters.trimmed())
+{
+	// The value position carries the expression as written; the knob stays as
+	// hardware but is powered down (there is no number to point at until the
+	// engine loads the configuration).
+	QLabel* token = new QLabel(this->dynamicParameters, this);
+	token->setObjectName(QStringLiteral("DynamicValueToken"));
+	token->setTextInteractionFlags(Qt::TextSelectableByMouse);
+	QFont mono(token->font());
+	mono.setFamily(SkinManager::instance()->tokens().monoFontFamily);
+	token->setFont(mono);
+	token->setToolTip(tr("Computed when the configuration loads; edit the raw line to change the expression."));
+	buildLayout(token);
+
+	knob->setEnabled(false);
+}
+
+void PreampCardEditor::buildLayout(QWidget* valueWidget)
 {
 	setObjectName(QStringLiteral("PreampCardEditor"));
 	setAttribute(Qt::WA_StyledBackground, true);
@@ -63,21 +93,24 @@ PreampCardEditor::PreampCardEditor(double dbGain, QWidget* parent)
 	caption->setObjectName(QStringLiteral("PreampCardCaption"));
 	valueLayout->addWidget(caption);
 
-	editableValue = new EditableValue(valueBlock);
-	editableValue->setObjectName(QStringLiteral("PreampCardValue"));
-	editableValue->setUnit(QStringLiteral("dB"));
-	connect(editableValue, SIGNAL(valueChanged(double)), this, SLOT(valueChanged(double)));
-	valueLayout->addWidget(editableValue);
+	valueWidget->setParent(valueBlock);
+	valueLayout->addWidget(valueWidget);
 
 	layout->addWidget(valueBlock, 0, Qt::AlignVCenter);
 	layout->addStretch(1);
-
-	setGain(dbGain, false);
 }
 
 void PreampCardEditor::store(QString& command, QString& parameters)
 {
 	command = QStringLiteral("Preamp");
+	// Dynamic mode reproduces the expression verbatim - the card never
+	// writes a computed number over it. (Nothing emits updateModel in that
+	// mode, so this is belt and braces.)
+	if (!dynamicParameters.isEmpty())
+	{
+		parameters = dynamicParameters;
+		return;
+	}
 	parameters = QStringLiteral("%0 dB").arg(QLocale::c().toString(currentGain, 'f', 1));
 }
 
@@ -132,6 +165,13 @@ QString PreampCardEditor::gainText() const
 
 #include "FilterCardEditorRegistry.h"
 
+#include "Editor/widgets/FilterCardModel.h"
+
 REGISTER_FILTER_CARD_EDITOR(preamp, [](FilterTable*, const QString&, const QString& parameters) -> IFilterGUI* {
+	// An inline `expression` gain opens the dynamic card (token instead of a
+	// number, knob powered down) so no interaction can overwrite the
+	// expression with a parsed 0.0.
+	if (FilterCardModel::hasInlineExpressions(parameters))
+		return new PreampCardEditor(parameters);
 	return new PreampCardEditor(PreampCardEditor::parseGain(parameters));
 })

--- a/Editor/widgets/cards/PreampCardEditor.h
+++ b/Editor/widgets/cards/PreampCardEditor.h
@@ -11,6 +11,12 @@ class PreampCardEditor : public IFilterGUI
 
 public:
 	explicit PreampCardEditor(double dbGain, QWidget* parent = nullptr);
+	// Dynamic mode for a line whose gain is an inline `expression`: the knob
+	// is powered down, the value position shows the expression as written (a
+	// token, not a number), nothing ever re-serializes the line, and store()
+	// reproduces the parameters verbatim. The raw editor stays the way to
+	// change the expression; the analysis readouts show the computed value.
+	explicit PreampCardEditor(const QString& dynamicParameters, QWidget* parent = nullptr);
 
 	void store(QString& command, QString& parameters) override;
 
@@ -21,6 +27,7 @@ private slots:
 	void valueChanged(double value);
 
 private:
+	void buildLayout(QWidget* valueWidget);
 	void setGain(double value, bool notify);
 	QString gainText() const;
 
@@ -28,4 +35,6 @@ private:
 	EditableValue* editableValue = nullptr;
 	double currentGain = 0.0;
 	bool updating = false;
+	// Non-empty in dynamic mode: the as-written parameter text to reproduce.
+	QString dynamicParameters;
 };

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,7 +17,7 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 1. 변형별 릴리스 채널을 단일 바이너리 런타임 SIMD dispatch로 대체합니다([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
 2. 격주 자동 코드 감사가 찾아낸 문제를 처리합니다.
 3. 커뮤니티 피드백 라운드를 반영해 Editor 스킨을 다듬습니다(1차: Soft 파스텔 재작업, 다크 모드 상태 대비, 분석 패널 한칸 배치. 3차: 그래픽 EQ 모던 카드, 카드 추가·삽입 계약, Device Selector 스킨 동기화, [#172](https://github.com/115dkk/EqualizerAPO-XT/pull/172)).
-4. 프로그래밍 계열 설정 명령(`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`) 전용 에디터를 만듭니다. 다섯 스킨이 분석 판정으로 블록을 각자의 계기로 표현하고, 픽커가 이 명령들을 삽입하며, 계수 직접 입력 IIR 줄도 전용 카드를 받았습니다([#178](https://github.com/115dkk/EqualizerAPO-XT/pull/178), [#182](https://github.com/115dkk/EqualizerAPO-XT/pull/182), [#183](https://github.com/115dkk/EqualizerAPO-XT/pull/183)). 남은 조각은 백틱 인라인 식이 든 줄에서 카드를 유지하는 것입니다.
+4. 프로그래밍 계열 설정 명령(`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`) 전용 에디터 — 완료. 다섯 스킨이 분석 판정으로 블록을 각자의 계기로 표현하고, 픽커가 이 명령들을 삽입하며, 계수 직접 입력 IIR 줄과 백틱 인라인 식이 든 줄도 각자의 카드를 유지합니다([#178](https://github.com/115dkk/EqualizerAPO-XT/pull/178), [#182](https://github.com/115dkk/EqualizerAPO-XT/pull/182), [#183](https://github.com/115dkk/EqualizerAPO-XT/pull/183), [#184](https://github.com/115dkk/EqualizerAPO-XT/pull/184)).
 
 ## 주요 기능
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Current work areas:
 1. Runtime SIMD dispatch in a single binary, replacing the per-variant release channels ([docs/RuntimeDispatchEpic.md](docs/RuntimeDispatchEpic.md)).
 2. Acting on findings from the biweekly automated code audit.
 3. Refining the Editor skins from community feedback rounds (round 1: the Soft pastel rework, dark-mode state contrast, and the compact analysis panel; round 3: the modern GraphicEQ card, the insertion contract and the skinned Device Selector, [#172](https://github.com/115dkk/EqualizerAPO-XT/pull/172)).
-4. A dedicated editor for the programmatic config commands (`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`). Each skin presents blocks with its own instrument driven by the analysis run, the picker inserts the vocabulary, and custom-coefficient IIR lines have their own card ([#178](https://github.com/115dkk/EqualizerAPO-XT/pull/178), [#182](https://github.com/115dkk/EqualizerAPO-XT/pull/182), [#183](https://github.com/115dkk/EqualizerAPO-XT/pull/183)); the remaining piece is keeping cards alive on lines with inline `` `expression` `` parameters.
+4. Editors for the programmatic config commands (`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`) — complete. Each skin presents blocks with its own instrument driven by the analysis run, the picker inserts the vocabulary, custom-coefficient IIR lines have their own card, and lines with inline `` `expression` `` parameters keep their card in a dynamic mode ([#178](https://github.com/115dkk/EqualizerAPO-XT/pull/178), [#182](https://github.com/115dkk/EqualizerAPO-XT/pull/182), [#183](https://github.com/115dkk/EqualizerAPO-XT/pull/183), [#184](https://github.com/115dkk/EqualizerAPO-XT/pull/184)).
 
 ## Features
 

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -585,6 +585,20 @@ void testFilterCardDescriptors()
 	FilterCardDescriptor bareText = FilterCardModel::describeLine("plain note line without a command");
 	expectEqual(bareText.title, "Text", "bare text line title");
 	expectEqual(bareText.summary, "plain note line without a command", "bare text line keeps its content as summary");
+
+	// Dynamic-value contract: hasInlineExpressions must follow the engine's
+	// InlineExpression lexer exactly, because it decides which lines may not
+	// open a parsing editor (a knob turn would serialize the expression
+	// away). Escaped backticks are literal, an empty `` still counts as an
+	// expression (the engine reports its evaluation error), and the content
+	// of an unterminated trailing expression is dropped like the engine
+	// drops it.
+	expectTrue(FilterCardModel::hasInlineExpressions("`bass + 3` dB"), "backtick expression detected");
+	expectTrue(FilterCardModel::hasInlineExpressions("prefix `x` suffix"), "embedded expression detected");
+	expectFalse(FilterCardModel::hasInlineExpressions("-3 dB"), "plain number is not dynamic");
+	expectFalse(FilterCardModel::hasInlineExpressions("\\` literal backtick"), "escaped backtick is literal");
+	expectTrue(FilterCardModel::hasInlineExpressions("``"), "empty expression still counts");
+	expectFalse(FilterCardModel::hasInlineExpressions("`unterminated"), "unterminated trailing expression is dropped");
 }
 
 void testFilterCardDepths()

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="..\..\filters\StageCommand.cpp" />
     <ClCompile Include="..\..\filters\BiQuadCommand.cpp" />
     <ClCompile Include="..\..\filters\DeviceCommand.cpp" />
+    <ClCompile Include="..\..\filters\ExpressionCommand.cpp" />
     <ClCompile Include="..\..\helpers\StringHelper.cpp" />
     <ClCompile Include="..\..\filters\ChannelCommand.cpp" />
     <ClCompile Include="..\..\filters\FilterFactoryRegistry.cpp" />


### PR DESCRIPTION
## What

The dynamic-commands campaign''s last piece (#178, #180, #182, #183) — and a live-hazard fix. The card-first editor lookup (audit #146 TD004) bypassed the legacy chain''s backtick suppression, so a `Preamp: ``vol`` dB` line opened the numeric Preamp card reading **0.0 dB**, and a single knob turn silently rewrote the line without the expression.

- **`FilterCardModel::hasInlineExpressions`** — delegates to the engine''s `InlineExpression` lexer, so `\``-escapes, empty ` `` ` segments and unterminated trailing expressions behave exactly like the engine (pinned by new tests).
- **Registry guard** — parsing editors stand down on dynamic lines and the row falls to the legacy chain''s raw body (the pre-card safety net), except editors with a dynamic mode.
- **Dynamic mode (Preamp, Delay)** — the card stays: knob powered down, the value position carries the expression as written (selectable mono token + explanatory tooltip; Delay hides its unit selector since the unit lives inside the text). Nothing emits `updateModel`; `store()` reproduces the parameters verbatim. The analysis readouts added in #182 show the computed value next to the token after a run.
- **Copy guard** — expression factors no longer open the routing view (its serializer would destroy them); those lines keep the raw body.
- **`CommandRowInfo.dynamicLine`** — all five skins extend their raw-body styling to dynamic lines without a dynamic-capable editor.
- **Gallery** — new `dynpreamp` row (appended last) renders the token card per skin.

## Verification

- EditorLogicTests **321 checks pass** (lexer-contract cases added; `ExpressionCommand.cpp` joins the test build).
- Full gallery renders **880 shots**; byte-compare against the regenerated 850-shot baseline: **zero changed, exactly the 30 new dynpreamp shots.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)