### PR TITLE
refactor(skins): drop dead includes left over from the Skins.cpp split

### DIFF
--- a/Editor/skins/MatrixSkin.cpp
+++ b/Editor/skins/MatrixSkin.cpp
@@ -8,39 +8,20 @@
 
 #include "Skins.h"
 
-#include <QAction>
-#include <QComboBox>
-#include <QDial>
 #include <QEvent>
 #include <QFontMetrics>
-#include <QFontMetricsF>
-#include <QIcon>
 #include <QLabel>
-#include <QLayout>
 #include <QPainter>
 #include <QPainterPath>
-#include <QPixmap>
-#include <QStyle>
 #include <QToolBar>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
 
-#include "filters/BiQuad.h"
-
 #include "Editor/SkinManager.h"
-#include "Editor/helpers/GUIHelper.h"
-#include "Editor/skins/RackChrome.h"
 #include "Editor/skins/cards/MatrixReferenceCardView.h"
-#include "Editor/skins/pickers/StudioFilterPicker.h"
-#include "Editor/skins/pickers/MinimalFilterPicker.h"
-#include "Editor/skins/pickers/SoftFilterPicker.h"
-#include "Editor/skins/pickers/RackFilterPicker.h"
 #include "Editor/skins/pickers/MatrixFilterPicker.h"
 #include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
-#include "Editor/widgets/routing/StepListRoutingRenderer.h"
-#include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
-#include "Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h"
 #include "SkinPaint.h"
 #include "SkinSupport.h"
 

--- a/Editor/skins/MinimalSkin.cpp
+++ b/Editor/skins/MinimalSkin.cpp
@@ -8,40 +8,20 @@
 
 #include "Skins.h"
 
-#include <QAction>
-#include <QComboBox>
-#include <QDial>
-#include <QEvent>
 #include <QFontMetrics>
 #include <QFontMetricsF>
 #include <QHBoxLayout>
-#include <QIcon>
 #include <QLabel>
-#include <QLayout>
 #include <QPainter>
 #include <QPainterPath>
-#include <QPixmap>
-#include <QStyle>
 #include <QToolBar>
-#include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
 
-#include "filters/BiQuad.h"
-
 #include "Editor/SkinManager.h"
-#include "Editor/helpers/GUIHelper.h"
-#include "Editor/skins/RackChrome.h"
-#include "Editor/skins/pickers/StudioFilterPicker.h"
 #include "Editor/skins/pickers/MinimalFilterPicker.h"
-#include "Editor/skins/pickers/SoftFilterPicker.h"
-#include "Editor/skins/pickers/RackFilterPicker.h"
-#include "Editor/skins/pickers/MatrixFilterPicker.h"
 #include "Editor/skins/cards/MinimalReferenceCardView.h"
-#include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
 #include "Editor/widgets/routing/StepListRoutingRenderer.h"
-#include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
-#include "Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h"
 #include "SkinPaint.h"
 #include "SkinSupport.h"
 

--- a/Editor/skins/RackSkin.cpp
+++ b/Editor/skins/RackSkin.cpp
@@ -8,39 +8,17 @@
 
 #include "Skins.h"
 
-#include <QAction>
-#include <QComboBox>
-#include <QDial>
-#include <QEvent>
-#include <QFontMetrics>
 #include <QFontMetricsF>
-#include <QHBoxLayout>
-#include <QIcon>
 #include <QLabel>
-#include <QLayout>
 #include <QPainter>
 #include <QPainterPath>
-#include <QPixmap>
-#include <QStyle>
 #include <QToolBar>
-#include <QVBoxLayout>
 #include <QWidget>
-#include <QtMath>
-
-#include "filters/BiQuad.h"
 
 #include "Editor/SkinManager.h"
-#include "Editor/helpers/GUIHelper.h"
 #include "Editor/skins/RackChrome.h"
 #include "Editor/skins/cards/RackReferenceCardView.h"
-#include "Editor/skins/pickers/StudioFilterPicker.h"
-#include "Editor/skins/pickers/MinimalFilterPicker.h"
-#include "Editor/skins/pickers/SoftFilterPicker.h"
 #include "Editor/skins/pickers/RackFilterPicker.h"
-#include "Editor/skins/pickers/MatrixFilterPicker.h"
-#include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
-#include "Editor/widgets/routing/StepListRoutingRenderer.h"
-#include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
 #include "Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h"
 #include "SkinPaint.h"
 #include "SkinSupport.h"

--- a/Editor/skins/SoftSkin.cpp
+++ b/Editor/skins/SoftSkin.cpp
@@ -9,42 +9,25 @@
 #include "Skins.h"
 
 #include <QAction>
-#include <QComboBox>
-#include <QDial>
-#include <QEvent>
 #include <QFontMetrics>
 #include <QFontMetricsF>
-#include <QHBoxLayout>
 #include <QIcon>
 #include <QCoreApplication>
 #include <QLabel>
-#include <QLayout>
 #include <QLinearGradient>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
 #include <QRegularExpression>
-#include <QStyle>
 #include <QToolBar>
-#include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
 
-#include "filters/BiQuad.h"
-
 #include "Editor/SkinManager.h"
 #include "Editor/helpers/GUIHelper.h"
-#include "Editor/skins/RackChrome.h"
-#include "Editor/skins/pickers/StudioFilterPicker.h"
-#include "Editor/skins/pickers/MinimalFilterPicker.h"
 #include "Editor/skins/pickers/SoftFilterPicker.h"
-#include "Editor/skins/pickers/RackFilterPicker.h"
-#include "Editor/skins/pickers/MatrixFilterPicker.h"
 #include "Editor/skins/cards/SoftReferenceCardView.h"
-#include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
-#include "Editor/widgets/routing/StepListRoutingRenderer.h"
 #include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
-#include "Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h"
 #include "SkinPaint.h"
 #include "SkinSupport.h"
 

--- a/Editor/skins/StudioSkin.cpp
+++ b/Editor/skins/StudioSkin.cpp
@@ -11,19 +11,11 @@
 #include <QAction>
 #include <QComboBox>
 #include <QDial>
-#include <QEvent>
-#include <QFontMetrics>
 #include <QFontMetricsF>
-#include <QHBoxLayout>
-#include <QIcon>
 #include <QLabel>
-#include <QLayout>
 #include <QPainter>
 #include <QPainterPath>
-#include <QPixmap>
-#include <QStyle>
 #include <QToolBar>
-#include <QVBoxLayout>
 #include <QWidget>
 #include <QtMath>
 
@@ -32,18 +24,9 @@
 
 #include "Editor/SkinManager.h"
 #include "Editor/helpers/GUIHelper.h"
-#include "Editor/skins/RackChrome.h"
 #include "Editor/skins/cards/StudioReferenceCardView.h"
 #include "Editor/skins/pickers/StudioFilterPicker.h"
-#include "Editor/skins/pickers/MinimalFilterPicker.h"
-#include "Editor/skins/pickers/SoftFilterPicker.h"
-#include "Editor/skins/pickers/RackFilterPicker.h"
-#include "Editor/skins/pickers/MatrixFilterPicker.h"
-#include "Editor/widgets/routing/CrosspointMatrixRoutingRenderer.h"
-#include "Editor/widgets/routing/StepListRoutingRenderer.h"
-#include "Editor/widgets/routing/BlockChipRoutingRenderer.h"
 #include "Editor/widgets/routing/LightTraceRoutingRenderer.h"
-#include "Editor/widgets/routing/HardwarePatchbayRoutingRenderer.h"
 #include "SkinPaint.h"
 #include "SkinSupport.h"
 


### PR DESCRIPTION
## Summary

Follow-up to #185. When the five skins were split out of the monolithic Skins.cpp, every skin file kept the full include roster. Each skin .cpp still included the other four skins' pickers, routing renderers it never instantiates, `filters/BiQuad.h` (only Studio actually uses BiQuad for its band-colour law), and several unused Qt headers.

This removes 91 dead includes across the five skin files. Kept everywhere: `SkinPaint.h` (free functions such as `withAlpha`/`mixColor`/`skinArcPoint` — a plain class-name grep misses them), `SkinSupport.h` (declares the roster function each file defines), and `QtMath` where `qCeil`/`qFloor`/trig functions are used.

One candidate turned out to be live and stayed: `RackFilterPicker.h` in RackSkin.cpp (`RackFilterPickerView` — the class name carries a `View` suffix, which the first word-boundary scan missed and the build caught).

## Verification

- Editor builds clean (VS18 / Qt 6.10.1, avx2 config).
- Offscreen skin gallery: 880/880 shots byte-identical (SHA-256) to the pre-change baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)