### PR TITLE
chore(setup): only pass aqt --external 7z when 7z is on PATH

### DIFF
--- a/.github/scripts/Provisioning.psm1
+++ b/.github/scripts/Provisioning.psm1
@@ -362,11 +362,19 @@ function Install-QtSdk {
     $qtArchDir = if ($Platform -eq "ARM64") { "msvc2022_arm64" } else { "msvc2022_64" }
     $qtOutput = Join-Path $WorkspaceRoot "Qt"
 
-    python -m aqt -c $configPath install-qt $qtHost desktop $QtVersion $qtArch `
-        --autodesktop `
-        --outputdir $qtOutput `
-        --archives qtbase qttools qtsvg qttranslations `
-        --external 7z | Out-Host
+    # CI runners ship 7z.exe and extraction is faster with it, but local dev
+    # machines often lack it; aqt's bundled py7zr handles extraction fine, so
+    # only request the external tool when it is actually on PATH.
+    $aqtArgs = @(
+        '-c', $configPath, 'install-qt', $qtHost, 'desktop', $QtVersion, $qtArch,
+        '--autodesktop',
+        '--outputdir', $qtOutput,
+        '--archives', 'qtbase', 'qttools', 'qtsvg', 'qttranslations'
+    )
+    if (Get-Command 7z -ErrorAction SilentlyContinue) {
+        $aqtArgs += @('--external', '7z')
+    }
+    python -m aqt @aqtArgs | Out-Host
     if ($LASTEXITCODE -ne 0) {
         throw "Qt installation failed"
     }


### PR DESCRIPTION
## Summary
- setup-build.ps1's Qt step (Provisioning.psm1 `Install-QtSdk`) always passed `--external 7z` to aqt, which aborts immediately on machines without 7z.exe on PATH — locally it died with a bare "Qt installation failed".
- The external extractor is now requested only when `7z` actually resolves; otherwise aqt falls back to its bundled py7zr, which extracts the same archives correctly (verified by a full local Qt 6.10.1 reinstall).
- CI behavior is unchanged: hosted runners ship 7z.exe, so the flag is still passed there.

## Test plan
- [x] Local `Invoke-Pester .github/scripts/Tests` — 37/37 passed
- [x] Local Qt 6.10.1 install via py7zr path + `setup-build.ps1 -SkipQt` verification all \[OK]
- [x] Common.vcxproj Release x64 builds against the restored deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)