### PR TITLE
ci(audio-live-repro): runner-selectable live harness + 24H2 uninstall-regression gate

### DIFF
--- a/.github/scripts/Diagnose-LiveEndpoint.ps1
+++ b/.github/scripts/Diagnose-LiveEndpoint.ps1
@@ -105,8 +105,11 @@ param(
     #               INACTIVE after the AudioSrv-only uninstall AND an
     #               AudioEndpointBuilder restart brought it back).
     # expect-fixed : verify a FIXED release (exit 0 = endpoint STAYED ACTIVE
-    #               through the real uninstall, so the shipped fix works; exit 2
-    #               = it went inactive, i.e. the fix is absent or ineffective).
+    #               through the real uninstall AND no EQ CLSID was left dangling
+    #               in FxProperties; exit 2 = the endpoint went inactive OR the
+    #               registry stayed dirty - on OS build 26100+ the dirty case is
+    #               the NOKEY-branch deleteKey failing on the OS-created
+    #               FxProperties subkeys, issue #189).
     [Parameter(Mandatory = $false)]
     [ValidateSet('reproduce', 'expect-fixed')]
     [string]$Mode = 'reproduce'
@@ -204,9 +207,14 @@ $afterVeloState = Get-EndpointActivity $afterVelo
 $afterAebState  = Get-EndpointActivity $afterAeb
 
 # The registry being CLEAN after uninstall is what makes the live disappearance
-# the AudioEndpointBuilder/stale-graph bug rather than a registry-delete bug. We
-# report it but do not gate on it (a not-clean registry is a different finding,
-# covered by Diagnose-AudioUninstall.ps1 / Diagnose-DanglingOnFailure.ps1).
+# the AudioEndpointBuilder/stale-graph bug rather than a registry-delete bug.
+# In reproduce mode it is reported but not gated on (a not-clean registry is a
+# different finding). In expect-fixed mode it IS part of the pass criteria:
+# on OS build 26100+ (Windows 11 24H2 codebase / Server 2025) the OS creates
+# subkeys under FxProperties, DeviceAPOInfo::uninstall's NOKEY-branch deleteKey
+# fails on them, and the uninstall then leaves the removed EQ CLSIDs dangling
+# in FxProperties (issue #189). A release only counts as fixed when the
+# endpoint survives AND no EQ GUID is left behind.
 $registryClean = [bool]$afterVelo.registryClean
 
 # Whether the EQ APO was actually live before the uninstall. If it was never
@@ -248,12 +256,20 @@ elseif ($afterVeloState -eq 'Unknown') {
 }
 elseif ($Mode -eq 'expect-fixed') {
     # Validating a FIXED release: the endpoint must STAY ACTIVE through the real
-    # uninstall (the shipped ApoRegistration::uninstall restarts AudioEndpointBuilder).
+    # uninstall (the shipped ApoRegistration::uninstall restarts AudioEndpointBuilder)
+    # AND the registry must be clean afterwards (no EQ CLSID left dangling -
+    # the 26100+ FxProperties-subkey regression, issue #189).
     if ($afterVeloState -eq 'Active') {
         $verdicts.Add('(fixed) PASS: the endpoint STAYED ACTIVE through the real uninstall - with audio in use and no reboot. The shipped build restarts AudioEndpointBuilder during uninstall, so removing the APO no longer drops the device.')
     }
     else {
         $verdicts.Add("(fixed) FAIL: the endpoint went INACTIVE/missing after the real uninstall (after-state=$afterVeloState). The AudioEndpointBuilder restart did not take effect during uninstall - the fix is absent or ineffective in this build.")
+    }
+    if ($registryClean) {
+        $verdicts.Add('(fixed) Registry is CLEAN after uninstall: no EQ APO GUID left in FxProperties.')
+    }
+    else {
+        $verdicts.Add('(fixed) FAIL: the uninstall left an EQ APO GUID dangling in FxProperties. On OS build 26100+ this is the NOKEY-branch deleteKey failing on the OS-created FxProperties subkeys (issue #189); the per-device restore never completed.')
     }
 }
 elseif ($reproduced) {
@@ -304,11 +320,16 @@ if ($inconclusive) {
     exit 1
 }
 if ($Mode -eq 'expect-fixed') {
-    if ($afterVeloState -eq 'Active') {
-        Write-Host 'RESULT: (expect-fixed) PASS - the endpoint survived the real uninstall with audio in use; the shipped fix works (exit 0).'
+    if ($afterVeloState -eq 'Active' -and $registryClean) {
+        Write-Host 'RESULT: (expect-fixed) PASS - the endpoint survived the real uninstall with audio in use AND the registry is clean; the shipped fixes work (exit 0).'
         exit 0
     }
-    Write-Host 'RESULT: (expect-fixed) FAIL - the endpoint went inactive after the uninstall; the fix is absent or ineffective in this build (exit 2). Inspect the snapshots.'
+    if ($afterVeloState -ne 'Active') {
+        Write-Host 'RESULT: (expect-fixed) FAIL - the endpoint went inactive after the uninstall; the fix is absent or ineffective in this build (exit 2). Inspect the snapshots.'
+    }
+    else {
+        Write-Host 'RESULT: (expect-fixed) FAIL - the uninstall left an EQ APO GUID dangling in FxProperties (26100+ NOKEY deleteKey regression, issue #189) (exit 2). Inspect the snapshots.'
+    }
     exit 2
 }
 # reproduce mode

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -239,15 +239,29 @@ jobs:
               Pop-Location
           }
           Log "devcon exited with $devconRc"
+          # devcon returns 0 on success and 1 when a reboot is required; anything
+          # else is a real install failure. Assert HERE, and never let devcon's
+          # code linger in $LASTEXITCODE: GitHub's pwsh wrapper appends
+          # "exit $LASTEXITCODE" to the script, so a stale native exit code
+          # becomes a silent step failure at the end.
+          if ($devconRc -ne 0 -and $devconRc -ne 1) {
+              Write-Error "devcon install failed (rc=$devconRc)"; exit 1
+          }
 
           # --- Make sure the audio services are up after the device add --------
           # Start them, then force an AudioEndpointBuilder restart so the freshly
           # installed Scream device is enumerated into the live endpoint graph
           # (this is SETUP, not the bug under test - the uninstall is what must
           # never restart AudioEndpointBuilder).
+          # NOTE: this must NOT shell out to "net start audiosrv". On images where
+          # AudioSrv is already running (windows-2025 starts it; windows-2022 does
+          # not) net exits non-zero for the benign "already been started" case,
+          # and that code leaks into the appended "exit $LASTEXITCODE" wrapper -
+          # the step then fails after all the real work succeeded, with no error
+          # text. Start-Service is idempotent and sets no native exit code.
           Log "Ensuring AudioEndpointBuilder + AudioSrv are running"
           try { Start-Service AudioEndpointBuilder -ErrorAction Stop } catch { Log "Start AudioEndpointBuilder: $($_.Exception.Message)" }
-          cmd /c "net start audiosrv" 2>&1 | ForEach-Object { Log $_ }
+          try { Start-Service AudioSrv -ErrorAction Stop } catch { Log "Start AudioSrv: $($_.Exception.Message)" }
           Log "Forcing AudioEndpointBuilder restart to enumerate the new device"
           try { Restart-Service -Force AudioEndpointBuilder -ErrorAction Stop } catch { Log "Restart AudioEndpointBuilder: $($_.Exception.Message)" }
           try { Start-Service AudioSrv -ErrorAction Stop } catch { Log "Start AudioSrv: $($_.Exception.Message)" }
@@ -271,15 +285,26 @@ jobs:
           } while (-not $screamSeen -and (Get-Date) -lt $deadline)
           Log "Scream endpoint visible in MMDevices: $screamSeen"
 
-          # Forensic enumeration into the log.
+          # Forensic enumeration into the log (best effort - never fails the step).
           Log "Win32_SoundDevice:"
-          Get-CimInstance Win32_SoundDevice | Select-Object Name, Status, StatusInfo |
-              Format-Table -AutoSize | Out-String | ForEach-Object { Add-Content -Path $log -Value $_ }
+          try {
+              Get-CimInstance Win32_SoundDevice -ErrorAction Stop | Select-Object Name, Status, StatusInfo |
+                  Format-Table -AutoSize | Out-String | ForEach-Object { Add-Content -Path $log -Value $_ }
+          } catch { Log "Get-CimInstance failed: $($_.Exception.Message)" }
           Log "Get-PnpDevice -Class AudioEndpoint:"
           try {
               Get-PnpDevice -Class AudioEndpoint -ErrorAction Stop | Select-Object Status, FriendlyName, InstanceId |
                   Format-Table -AutoSize | Out-String | ForEach-Object { Add-Content -Path $log -Value $_ }
           } catch { Log "Get-PnpDevice failed: $($_.Exception.Message)" }
+
+          # Deterministic step verdict: the endpoint must have appeared. Exit
+          # explicitly so no stale $LASTEXITCODE from a native tool above can
+          # decide this step's outcome via the appended wrapper.
+          if (-not $screamSeen) {
+              Write-Error "Scream endpoint never appeared in MMDevices within the wait window"
+              exit 1
+          }
+          exit 0
 
       # -----------------------------------------------------------------------
       # STEP 2: Discover the Scream Render endpoint's GUID at runtime.

--- a/.github/workflows/audio-live-repro.yml
+++ b/.github/workflows/audio-live-repro.yml
@@ -52,9 +52,14 @@
 #     driver, writes HKLM, runs an uninstaller, and cycles audio services. It is
 #     a deliberate, manually-triggered diagnostic on a DISPOSABLE GitHub runner,
 #     never a developer machine.
-#   - runs-on: windows-2022 (NOT windows-latest). windows-latest migrated to
-#     Server 2025; the Scream self-signed-driver recipe is only confirmed on
-#     Server 2022. Pin it so the experiment stays reproducible.
+#   - runs-on: selectable via the "runner" input, default windows-2022 (NOT
+#     windows-latest, which migrated to Server 2025). The Scream
+#     self-signed-driver recipe was originally confirmed on Server 2022, so
+#     that stays the default for reproducibility. windows-2025 (Server 2025,
+#     OS build 26100 - the same codebase as Windows 11 24H2) can be selected
+#     to prove the APO registers, loads into audiodg and keeps the endpoint
+#     alive on the 24H2-era audio stack, where upstream Equalizer APO has
+#     many "stopped working after 24H2/25H2" field reports.
 #
 # EXIT-CODE CONVENTION (see Diagnose-LiveEndpoint.ps1 for the full rationale)
 #   exit 0 = bug REPRODUCED (endpoint went inactive after the AudioSrv-only
@@ -84,6 +89,14 @@ on:
           - reproduce
           - expect-fixed
         default: reproduce
+      runner:
+        description: "Runner image: windows-2022 = Server 2022 (recipe-proven baseline); windows-2025 = Server 2025, build 26100 = Windows 11 24H2 codebase"
+        required: false
+        type: choice
+        options:
+          - windows-2022
+          - windows-2025
+        default: windows-2022
 
 permissions:
   contents: read
@@ -113,7 +126,7 @@ env:
 
 jobs:
   live-repro:
-    runs-on: windows-2022
+    runs-on: ${{ inputs.runner || 'windows-2022' }}
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## 목적

이슈 #189의 CI 재현 테스트입니다. 라이브 하네스를 24H2 코드베이스에서 돌릴 수 있게 하고, expect-fixed 판정에 '제거 후 레지스트리 청결'을 추가해 26100 제거 회귀를 게이트로 만듭니다.

## 변경

- `audio-live-repro.yml`에 `runner` dispatch 입력 추가: `windows-2022`(기본, 기존 레시피 검증 이미지) / `windows-2025`(build 26100 = Windows 11 24H2 코드베이스).
- Scream 설치 스텝의 종료 코드 누수 수정: windows-2025 이미지는 AudioSrv가 이미 실행 중이라 `net start`가 비0을 반환했고, GitHub pwsh 래퍼의 `exit $LASTEXITCODE` 때문에 실작업이 전부 성공한 스텝이 오류 문구 없이 실패했습니다. Start-Service(멱등)로 교체하고 devcon 반환값을 그 자리에서 단언하며 스텝을 명시적 exit로 끝냅니다.
- `Diagnose-LiveEndpoint.ps1` expect-fixed 모드: 엔드포인트 생존에 더해 **registryClean(제거 후 EQ CLSID 잔존 없음)** 을 요구합니다. 수정 전 릴리스는 `runner=windows-2025`에서 exit 2(재현), windows-2022에서는 exit 0이어야 합니다.

## 실측

- windows-2025 재현(구 판정 기준으로도 레지스트리 오염 확인): https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29151710023
- windows-2022 대조(청결): https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29151891591

버전 영향 없음(ci:). 수정 자체는 별도 fix PR로 이어집니다.

Closes 없음 — #189 은 fix PR이 닫습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)