### PR TITLE
fix(devices): Windows 11 24H2+에서 APO 제거가 OS 생성 FxProperties 하위 키에 걸려 실패하는 회귀 수정

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,18 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- Windows 11 24H2/25H2(그리고 Server 2025, 빌드 26100 이상)에서 제거가
+  실패하던 문제를 고쳤습니다. 이 설치가 `FxProperties` 키를 만들었던
+  장치에서, 24H2부터는 OS가 그 아래에 자체 하위 키를 만들어 넣기 때문에
+  키 통삭제가 레지스트리 오류를 던졌습니다. 그 결과 `DeviceSelector /u`는
+  모달 오류 창에 걸려 멎고(무인 실행에서는 영구 대기), 앱 제거는 조용히
+  넘어가 삭제된 EQ APO CLSID가 장치의 `FxProperties`에 매달린 채
+  남았습니다. 이제 제거는 자신이 쓴 값만 지우고 키는 다른 내용물이 전혀
+  없을 때만 삭제하며, `/u`는 오류를 대화상자 대신 stderr와 종료 코드로
+  보고합니다. 라이브 CI 하네스(`audio-live-repro.yml`의
+  `runner=windows-2025`)로 재현하고 회귀 게이트를 남겼습니다(이슈
+  [#189](https://github.com/115dkk/EqualizerAPO-XT/issues/189)).
+  ([#191](https://github.com/115dkk/EqualizerAPO-XT/pull/191))
 - `MultiConvolution` 매핑의 각 파일 채널에 `Copy:`와 같은 문법으로 배율을
   붙일 수 있습니다. `L=0.5*0+1`은 파일 채널 0의 컨볼루션 결과를 절반으로
   줄여 합산하고, `-1`은 역위상, `-0.5`는 둘 다이며, `-6dB*0` 같은 dB 값도

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Uninstalling on Windows 11 24H2/25H2 (and Server 2025, OS build 26100+)
+  no longer fails on endpoints whose `FxProperties` key this installation
+  created. The OS now puts its own subkeys below `FxProperties`, so the old
+  whole-key delete threw a registry error: `DeviceSelector /u` blocked on a
+  modal error dialog (forever when run unattended) and the app uninstall
+  silently left the removed EQ APO CLSIDs dangling in the device's
+  `FxProperties`. The uninstall now removes only the values it wrote and
+  deletes the key only when nothing else lives in it, and `/u` reports
+  registry errors through stderr and the exit code instead of a dialog.
+  Reproduced and guarded by the live CI harness
+  (`audio-live-repro.yml` with `runner=windows-2025`, issue
+  [#189](https://github.com/115dkk/EqualizerAPO-XT/issues/189)).
+  ([#191](https://github.com/115dkk/EqualizerAPO-XT/pull/191))
 - `MultiConvolution` mappings now take a per-file-channel factor with
   `Copy:`'s grammar: `L=0.5*0+1` halves file channel 0's convolution
   result before the sum, `-1` inverts the phase, `-0.5` does both, and dB

--- a/DeviceSelector/main.cpp
+++ b/DeviceSelector/main.cpp
@@ -215,10 +215,12 @@ int main(int argc, char* argv[])
 				}
 				catch (const RegistryException& e)
 				{
-					QMessageBox::critical(nullptr,
-						DeviceSelector::tr(
-							"Error while accessing the registry"),
-						QString::fromStdWString(e.getMessage()));
+					// /u is the unattended uninstall entry point (installer
+					// hooks, scripts, CI). A modal dialog here blocks forever
+					// when nobody can dismiss it (observed as a 120s hang on
+					// build 26100 runners, issue #189), so report through
+					// stderr and the exit code instead.
+					fwprintf(stderr, L"DeviceSelector /u: %ls\n", e.getMessage().c_str());
 					result = -1;
 				}
 			}

--- a/devices/DeviceAPOInfo.Uninstall.cpp
+++ b/devices/DeviceAPOInfo.Uninstall.cpp
@@ -73,7 +73,31 @@ void DeviceAPOInfo::uninstall()
 
 	if (originalApoGuids[0] == APOGUID_NOKEY)
 	{
-		RegistryHelper::deleteKey(keyPath + L"\\FxProperties");
+		// This installation created FxProperties, but since Windows 11 24H2
+		// (build 26100) the OS puts its own subkeys below it, and
+		// RegDeleteKeyExW refuses to delete a key that has subkeys - a
+		// whole-key delete therefore throws on such systems and the uninstall
+		// leaves the EQ CLSIDs dangling (issue #189). Delete the values this
+		// installation wrote and remove the key itself only when nothing else
+		// lives in it.
+		wstring fxPath = keyPath + L"\\FxProperties";
+		if (RegistryHelper::keyExists(fxPath))
+		{
+			static const wchar_t* ownedValueNames[] = {
+				lfxGuidValueName, gfxGuidValueName, sfxGuidValueName,
+				mfxGuidValueName, efxGuidValueName,
+				sfxProcessingModesValueName, mfxProcessingModesValueName,
+				efxProcessingModesValueName, fxTitleValueName
+			};
+			for (const wchar_t* valueName : ownedValueNames)
+			{
+				if (RegistryHelper::valueExists(fxPath, valueName))
+					RegistryHelper::deleteValue(fxPath, valueName);
+			}
+
+			if (RegistryHelper::keyEmpty(fxPath))
+				RegistryHelper::deleteKey(fxPath);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
## 문제 (#189)

build 26100+(Windows 11 24H2/25H2, Server 2025)에서는 OS가 엔드포인트의 `FxProperties` 아래에 자체 하위 키를 만듭니다. NOKEY 제거 분기가 비재귀 `RegDeleteKeyExW`로 키를 통삭제하려다 예외를 던져, DeviceSelector /u는 모달 오류로 멎고(무인 환경에선 영구 대기) Velopack 제거는 조용히 넘어가 삭제된 EQ CLSID가 FxProperties에 매달린 채 남았습니다. 장치별 복원이 첫 연산에서 죽으므로 해당 장치의 Child APOs 정리도 건너뛰었습니다.

## 수정

- `DeviceAPOInfo::uninstall` NOKEY 분기: 이 설치가 쓴 값(APO GUID 5종, processing modes 3종, FX title)만 삭제하고, 키는 값·하위 키가 전혀 없을 때만 삭제합니다. 24H2 이전 시스템에서는 종전과 동일한 최종 상태가 됩니다.
- `DeviceSelector /u`: 무인 경로에서 모달 금지 — 레지스트리 오류를 stderr와 종료 코드로 보고합니다.

## 검증

- 로컬: Common.vcxproj (v145, x64 Release) 빌드 통과.
- 재현·판정 근거: windows-2025 run https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29151710023 (오염) vs windows-2022 run https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29151891591 (청결).
- 머지 후: 릴리스가 만들어지면 `gh workflow run audio-live-repro.yml --ref main -f mode=expect-fixed -f runner=windows-2025`가 exit 0이 되는 것으로 종결 검증합니다(재현 게이트는 ci PR로 선행 머지).

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)