### PR TITLE
ci(codeql): 깨진 빌드 스텁 수정 — 실제로 컴파일·분석되게 하고 Node 20 제거

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,47 +55,48 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
-      # 출하되는 C++ 표면을 빌드한다. build.yml의 프로퍼티 집합을 그대로 쓰되,
-      # 보안 표면이 아닌 테스트 프로젝트는 빼고 핵심(엔진·파서·필터·헬퍼가 든
-      # Common 정적 라이브러리, APO DLL, 보조 exe)만 빌드해 분석 잡음을 줄인다.
-      # Common이 다른 프로젝트의 링크 의존이므로 먼저 빌드한다.
+      # 출하되는 C++ 표면을 컴파일해 CodeQL 트레이서에 태운다. CodeQL은 링크가
+      # 아니라 컴파일만 필요하므로(추출기가 cl.exe 호출을 후킹) APO DLL·보조
+      # exe는 /t:ClCompile로 컴파일만 한다. 이렇게 하면 표준 GitHub 러너의
+      # VS(현재 VS 2026/"18")에 ATL 컴포넌트가 없어 링크 단계에서 atls.lib를
+      # 못 찾던 문제(build.yml이 커스텀 windows-2025-vs2026 러너를 쓰는 이유)를
+      # 링크 자체를 건너뛰어 피한다. Common은 다른 프로젝트가 참조하는 정적
+      # 라이브러리라 먼저 정식 빌드한다(lib.exe는 외부 lib를 링크하지 않는다).
+      # 보안 표면이 아닌 테스트 프로젝트는 분석 잡음이라 뺀다.
       - name: Build C++ core (MSVC)
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           $deps = "${{ github.workspace }}\deps"
 
-          # 링커가 우리 .lib를 찾도록 LIB에 검색 경로를 앞세운다(build.yml과 동일).
-          $env:LIB = "$deps\libsndfile\build\Release;$deps\muparserx\build\Release;$deps\fftw\Release;$env:LIB"
-
-          $projects = @(
-            "Common.vcxproj",
-            "EqualizerAPO\EqualizerAPO.vcxproj",
-            "VoicemeeterClient\VoicemeeterClient.vcxproj",
-            "Benchmark\Benchmark.vcxproj"
-          )
-
-          $buildParams = @(
+          # 헤더 경로만 있으면 컴파일된다(링크는 하지 않으므로 lib 경로 불필요).
+          $includeParams = @(
             "/m",
             "/p:Configuration=Release",
             "/p:Platform=x64",
-            "/t:rebuild",
-            "/p:PlatformToolset=v143",  # windows-2025 = VS 2022; .vcxproj 기본 v145는 이 이미지에 없다
+            "/p:PlatformToolset=v143",  # windows-2025 이미지의 VS는 v143 툴셋; .vcxproj 기본 v145는 없다
             "/p:EnableEnhancedInstructionSet=AdvancedVectorExtensions2",  # 출하되는 avx2 코드경로를 분석
             "/p:FFTW_INCLUDE=$deps\fftw\include",
-            "/p:FFTW_LIB=$deps\fftw\Release",
             "/p:MUPARSERX_INCLUDE=$deps\muparserx\parser",
-            "/p:MUPARSERX_LIB=$deps\muparserx\build\Release",
             "/p:LIBSNDFILE_INCLUDE=$deps\libsndfile\include",
-            "/p:LIBSNDFILE_LIB=$deps\libsndfile\build\Release",
             "/p:TCLAP_ROOT=$deps\tclap",
             "/p:VST3_SDK=$deps\vst3sdk",
             "/p:HIGHWAY_INCLUDE=$deps\highway"
           )
 
-          foreach ($project in $projects) {
-            Write-Host "`n=== Building $project ==="
-            msbuild $project @buildParams
+          # 프로젝트별 빌드 대상: Common은 정식 빌드(정적 lib 생성 + 컴파일),
+          # 나머지는 컴파일 전용.
+          $targets = [ordered]@{
+            "Common.vcxproj"                              = "Build"
+            "EqualizerAPO\EqualizerAPO.vcxproj"           = "ClCompile"
+            "VoicemeeterClient\VoicemeeterClient.vcxproj" = "ClCompile"
+            "Benchmark\Benchmark.vcxproj"                 = "ClCompile"
+          }
+
+          foreach ($project in $targets.Keys) {
+            $target = $targets[$project]
+            Write-Host "`n=== $target $project ==="
+            msbuild $project "/t:$target" @includeParams
             if ($LASTEXITCODE -ne 0) {
               Write-Error "Build failed for $project"
               exit $LASTEXITCODE

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,16 +20,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── C++ 코어 (MSVC) ──
-          # MacType DLL은 Windows + MSVC 빌드가 필수.
-          # 자기 프로젝트의 빌드 명령에 맞게 수정할 것.
+          # C++ 코어를 MSVC로 직접 빌드해 CodeQL 트레이서에 컴파일 과정을 태운다.
+          # 표준 GitHub 호스티드 windows-2025(VS 2022 Enterprise)에서 돌린다.
+          # build.yml의 x64 러너(windows-2025-vs2026, VS 2026/v145)는 커스텀
+          # 라벨이라 CodeQL 번들이 없어 쓰지 않는다. 그래서 아래 빌드는 이
+          # 이미지의 v143 툴셋으로 강제한다(.vcxproj 기본값은 v145).
           - language: c-cpp
-            os: windows-latest
+            os: windows-2025
             build-mode: manual
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      # build.yml과 동일하게 MSBuild를 PATH에 올린다. 깨진 vcvarsall cmd
+      # 스텁을 대체한다(그 스텁은 msbuild를 PATH에 못 올려 곧바로 실패했다).
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v3
+        with:
+          msbuild-architecture: x64
+
+      # 정본 프로비저너를 재사용한다(Provisioning.psm1을 build.yml과 공유).
+      # avx2/x64 의존성(FFTW·muparserx·libsndfile·TCLAP·VST3·Highway)을 내려받고
+      # 검증한다. 아래 MSBuild 프로젝트들은 Qt를 링크하지 않으므로 -SkipQt로
+      # 무거운 Qt 설치를 건너뛴다. init 앞에 두어 다운로드는 트레이싱하지 않는다.
+      - name: Provision C++ dependencies (no Qt)
+        shell: pwsh
+        run: ./setup-build.ps1 -SkipQt
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -38,15 +55,54 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
 
-      # C++ 수동 빌드 — 프로젝트에 맞게 수정 필요
-      - if: matrix.build-mode == 'manual'
-        name: Build C++ (MSVC)
-        shell: cmd
+      # 출하되는 C++ 표면을 빌드한다. build.yml의 프로퍼티 집합을 그대로 쓰되,
+      # 보안 표면이 아닌 테스트 프로젝트는 빼고 핵심(엔진·파서·필터·헬퍼가 든
+      # Common 정적 라이브러리, APO DLL, 보조 exe)만 빌드해 분석 잡음을 줄인다.
+      # Common이 다른 프로젝트의 링크 의존이므로 먼저 빌드한다.
+      - name: Build C++ core (MSVC)
+        shell: pwsh
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          msbuild EqualizerAPO.sln /p:Configuration=Release /p:Platform=x64
+          $ErrorActionPreference = "Stop"
+          $deps = "${{ github.workspace }}\deps"
+
+          # 링커가 우리 .lib를 찾도록 LIB에 검색 경로를 앞세운다(build.yml과 동일).
+          $env:LIB = "$deps\libsndfile\build\Release;$deps\muparserx\build\Release;$deps\fftw\Release;$env:LIB"
+
+          $projects = @(
+            "Common.vcxproj",
+            "EqualizerAPO\EqualizerAPO.vcxproj",
+            "VoicemeeterClient\VoicemeeterClient.vcxproj",
+            "Benchmark\Benchmark.vcxproj"
+          )
+
+          $buildParams = @(
+            "/m",
+            "/p:Configuration=Release",
+            "/p:Platform=x64",
+            "/t:rebuild",
+            "/p:PlatformToolset=v143",  # windows-2025 = VS 2022; .vcxproj 기본 v145는 이 이미지에 없다
+            "/p:EnableEnhancedInstructionSet=AdvancedVectorExtensions2",  # 출하되는 avx2 코드경로를 분석
+            "/p:FFTW_INCLUDE=$deps\fftw\include",
+            "/p:FFTW_LIB=$deps\fftw\Release",
+            "/p:MUPARSERX_INCLUDE=$deps\muparserx\parser",
+            "/p:MUPARSERX_LIB=$deps\muparserx\build\Release",
+            "/p:LIBSNDFILE_INCLUDE=$deps\libsndfile\include",
+            "/p:LIBSNDFILE_LIB=$deps\libsndfile\build\Release",
+            "/p:TCLAP_ROOT=$deps\tclap",
+            "/p:VST3_SDK=$deps\vst3sdk",
+            "/p:HIGHWAY_INCLUDE=$deps\highway"
+          )
+
+          foreach ($project in $projects) {
+            Write-Host "`n=== Building $project ==="
+            msbuild $project @buildParams
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Build failed for $project"
+              exit $LASTEXITCODE
+            }
+          }
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## 배경

CodeQL 워크플로우의 최근 수동 실행([run 29183116969](https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29183116969))이 `Build C++ (MSVC)` 스텝에서 `'msbuild' is not recognized`로 즉시 실패했습니다. 빌드 스텝이 다른 프로젝트에서 복붙한 미완성 스텁이었습니다("MacType DLL" 주석, "프로젝트에 맞게 수정할 것" 흔적).

세 가지가 겹쳐 있었습니다:
1. `cmd` 스텝의 `call vcvarsall.bat`가 `msbuild`를 PATH에 못 올림.
2. 의존성 프로비저닝·프로퍼티 오버라이드가 전혀 없이 `msbuild EqualizerAPO.sln`만 호출(그 `.sln`은 Qt VS Tools 프로젝트를 포함해 qmake 없이는 빌드조차 안 됨).
3. `analyze@v3`이 `init@v4`와 짝이 안 맞아 Node 20으로 돌며 폐기 경고(첨부된 경고의 원인).

## 수정

- **MSBuild PATH**: build.yml과 동일하게 `microsoft/setup-msbuild@v3`.
- **의존성**: 정본 프로비저너 `setup-build.ps1 -SkipQt`(build.yml과 `Provisioning.psm1` 공유). 핵심 MSBuild 프로젝트는 Qt를 링크하지 않아 Qt 설치는 건너뜀.
- **빌드**: 보안 표면(엔진·파서·필터·헬퍼가 든 Common, APO DLL, 보조 exe)만 컴파일. **CodeQL은 링크가 아니라 컴파일만 필요**하므로 APO DLL·보조 exe는 `/t:ClCompile`로 컴파일만 함. 이렇게 하면 표준 GitHub 러너의 VS(현재 VS 2026 Enterprise)에 ATL 컴포넌트가 없어 링크 단계에서 `atls.lib`를 못 찾던 문제(build.yml이 커스텀 `windows-2025-vs2026` 러너를 쓰는 이유)를 링크 자체를 건너뛰어 피함. 표준 windows-2025 이미지의 VS는 v143 툴셋이라 `.vcxproj` 기본 v145 대신 v143을 강제. 테스트 프로젝트는 분석 잡음이라 제외.
- **Node 20 제거**: 다른 워크플로우와 맞춰 `checkout@v4→v6`, `init@v4`와 짝을 맞춰 `analyze@v3→v4`.

## 검증

이 브랜치에서 CodeQL을 두 번 수동 실행하며 실패를 실측으로 잡고 고쳤습니다:
- 1차([run 29183467221](https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29183467221)): 프로비저닝·컴파일은 통과, APO DLL 링크만 `atls.lib`로 실패 → 위 ClCompile 전환.
- 2차([run 29183774254](https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29183774254)): **성공**. 로그에 소스 추출(`parser/RegexFunctions.cpp` 등)·TRAP import 완료·결과 해석이 찍혀 빈 데이터베이스가 아님을 확인.
- 로컬에서 VS 2022 v143 + avx2로 네 프로젝트 전부 exit 0 컴파일, `/t:ClCompile`이 링크를 건너뜀을 확인.

첨부해 주신 Node 20 폐기 경고는 이 변경으로 사라집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)