### PR TITLE
fix(security): CodeQL 실결함 6건 수정 — 할당 크기 오버플로 검증과 COM 경계 예외 차단

### DIFF
--- a/EqualizerAPO/ClassFactory.cpp
+++ b/EqualizerAPO/ClassFactory.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "stdafx.h"
+#include <new>
 #include "EqualizerAPO.h"
 #include "../helpers/LogHelper.h"
 #include "ClassFactory.h"
@@ -64,14 +65,27 @@ HRESULT __stdcall ClassFactory::CreateInstance(IUnknown* pUnknownOuter, const II
 	if (pUnknownOuter != nullptr && iid != __uuidof(IUnknown))
 		return E_NOINTERFACE;
 
-	EqualizerAPO* apo = new EqualizerAPO(pUnknownOuter);
-	if (apo == nullptr)
+	// The throwing operator new never returns null, so the old null check was
+	// dead code; the EqualizerAPO constructor (or a member constructor) can
+	// throw instead, and no C++ exception may cross this COM boundary into
+	// audiodg.exe. Translate to HRESULTs.
+	try
+	{
+		EqualizerAPO* apo = new EqualizerAPO(pUnknownOuter);
+
+		HRESULT hr = apo->NonDelegatingQueryInterface(iid, ppv);
+
+		apo->NonDelegatingRelease();
+		return hr;
+	}
+	catch (const std::bad_alloc&)
+	{
 		return E_OUTOFMEMORY;
-
-	HRESULT hr = apo->NonDelegatingQueryInterface(iid, ppv);
-
-	apo->NonDelegatingRelease();
-	return hr;
+	}
+	catch (...)
+	{
+		return E_FAIL;
+	}
 }
 
 HRESULT __stdcall ClassFactory::LockServer(BOOL bLock)

--- a/EqualizerAPO/DllMain.cpp
+++ b/EqualizerAPO/DllMain.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "stdafx.h"
+#include <new>
 #include <string>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -54,14 +55,26 @@ STDAPI DllGetClassObject(const CLSID& clsid, const IID& iid, void** ppv)
 	if (clsid != EQUALIZERAPO_POST_MIX_GUID && clsid != EQUALIZERAPO_PRE_MIX_GUID)
 		return CLASS_E_CLASSNOTAVAILABLE;
 
-	ClassFactory* factory = new ClassFactory();
-	if (factory == nullptr)
+	// The throwing operator new never returns null, so the old null check was
+	// dead code; what actually escapes on failure is a C++ exception, which
+	// must not cross this COM boundary into audiodg.exe. Translate to HRESULTs.
+	try
+	{
+		ClassFactory* factory = new ClassFactory();
+
+		HRESULT hr = factory->QueryInterface(iid, ppv);
+		factory->Release();
+
+		return hr;
+	}
+	catch (const std::bad_alloc&)
+	{
 		return E_OUTOFMEMORY;
-
-	HRESULT hr = factory->QueryInterface(iid, ppv);
-	factory->Release();
-
-	return hr;
+	}
+	catch (...)
+	{
+		return E_FAIL;
+	}
 }
 
 STDAPI DllRegisterServer()

--- a/filters/IIRFilter.cpp
+++ b/filters/IIRFilter.cpp
@@ -18,6 +18,8 @@
 */
 
 #include "stdafx.h"
+#include <limits>
+#include <new>
 #include "helpers/MemoryHelper.h"
 #include "IIRFilter.h"
 #include "helpers/PerfProfile.h"
@@ -60,15 +62,27 @@ vector<wstring> IIRFilter::initialize(float sampleRate, unsigned maxFrameCount, 
 {
 	channelCount = (unsigned)channelNames.size();
 
+	// The unsigned multiplications could wrap before widening to size_t
+	// (CodeQL cpp/integer-multiplication-cast-to-long); validate in size_t and
+	// use the same element count for allocation and initialization. Checked
+	// before freeing the old buffers so a failure cannot leave x/y dangling.
+	const size_t maxSize = (std::numeric_limits<size_t>::max)();
+	if (channelCount != 0 && static_cast<size_t>(order) > maxSize / channelCount)
+		throw std::bad_alloc();
+
+	const size_t stateCount = static_cast<size_t>(order) * channelCount;
+	if (stateCount > maxSize / sizeof *x)
+		throw std::bad_alloc();
+
 	if (x != nullptr)
 		MemoryHelper::free(x);
 	if (y != nullptr)
 		MemoryHelper::free(y);
 
-	x = static_cast<double*>(MemoryHelper::alloc(order * channelCount * sizeof *x));
-	y = static_cast<double*>(MemoryHelper::alloc(order * channelCount * sizeof *y));
-	std::fill_n(x, order * channelCount, 0.0);
-	std::fill_n(y, order * channelCount, 0.0);
+	x = static_cast<double*>(MemoryHelper::alloc(stateCount * sizeof *x));
+	y = static_cast<double*>(MemoryHelper::alloc(stateCount * sizeof *y));
+	std::fill_n(x, stateCount, 0.0);
+	std::fill_n(y, stateCount, 0.0);
 
 	return channelNames;
 }

--- a/filters/VSTPluginFilter.cpp
+++ b/filters/VSTPluginFilter.cpp
@@ -18,6 +18,8 @@
 */
 
 #include "stdafx.h"
+#include <limits>
+#include <new>
 #include "helpers/StringHelper.h"
 #include "helpers/LogHelper.h"
 #include "VSTPluginFilter.h"
@@ -142,8 +144,18 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 
 	// Allocate float buffers for conversion
 	if (firstEffect->numInputs() > 0) {
-		floatInputs = (float**)MemoryHelper::alloc(firstEffect->numInputs() * sizeof(float*));
-		_floatInputBuffer = static_cast<float*>(MemoryHelper::alloc(firstEffect->numInputs() * maxFrameCount * sizeof *_floatInputBuffer));
+		// A hostile or broken plugin can report a bus count whose product with
+		// maxFrameCount wraps before widening to size_t (CodeQL
+		// cpp/integer-multiplication-cast-to-long); validate in size_t first.
+		const size_t inputCount = static_cast<size_t>(firstEffect->numInputs());
+		const size_t maxSize = (std::numeric_limits<size_t>::max)();
+		if (inputCount > maxSize / sizeof(float*) ||
+			(maxFrameCount != 0 &&
+				inputCount > maxSize / maxFrameCount / sizeof *_floatInputBuffer))
+			throw std::bad_alloc();
+
+		floatInputs = (float**)MemoryHelper::alloc(inputCount * sizeof(float*));
+		_floatInputBuffer = static_cast<float*>(MemoryHelper::alloc(inputCount * maxFrameCount * sizeof *_floatInputBuffer));
 		if (floatInputs == nullptr || _floatInputBuffer == nullptr)
 		{
 			LogF(L"The VST plugin %s could not allocate float input buffers; passing audio through.", libPath.c_str());
@@ -156,8 +168,16 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	}
 
 	if (firstEffect->numOutputs() > 0) {
-		floatOutputs = (float**)MemoryHelper::alloc(firstEffect->numOutputs() * sizeof(float*));
-		_floatOutputBuffer = static_cast<float*>(MemoryHelper::alloc(firstEffect->numOutputs() * maxFrameCount * sizeof *_floatOutputBuffer));
+		// Same wrap-before-widening hazard as the input buffers above.
+		const size_t outputCount = static_cast<size_t>(firstEffect->numOutputs());
+		const size_t maxSize = (std::numeric_limits<size_t>::max)();
+		if (outputCount > maxSize / sizeof(float*) ||
+			(maxFrameCount != 0 &&
+				outputCount > maxSize / maxFrameCount / sizeof *_floatOutputBuffer))
+			throw std::bad_alloc();
+
+		floatOutputs = (float**)MemoryHelper::alloc(outputCount * sizeof(float*));
+		_floatOutputBuffer = static_cast<float*>(MemoryHelper::alloc(outputCount * maxFrameCount * sizeof *_floatOutputBuffer));
 		if (floatOutputs == nullptr || _floatOutputBuffer == nullptr)
 		{
 			LogF(L"The VST plugin %s could not allocate float output buffers; passing audio through.", libPath.c_str());


### PR DESCRIPTION
## 요약

CodeQL security-extended 첫 유효 스캔의 8건을 GPT-5.6 SOL(high) 검토로 판정해 처분했습니다. 실결함 6건은 이 PR로 수정, 오탐 2건은 근거 코멘트와 함께 dismiss했습니다. 오디오 수치는 변하지 않습니다(AudioRegressionTests 20/20 유지).

## 수정 (6건)

- **`cpp/integer-multiplication-cast-to-long` ×4** — `IIRFilter.cpp:68-69`, `VSTPluginFilter.cpp:146,160`: 할당 크기 곱셈(`order*channelCount`, `busCount*maxFrameCount`)이 `size_t`로 넓혀지기 전에 unsigned에서 랩될 수 있었습니다. `size_t` 범위에서 사전 검증하고 같은 원소 수를 할당·초기화에 사용합니다. IIR 쪽 검증은 기존 버퍼 해제 앞에 두어 실패 시 dangling을 막습니다. VST 쪽은 악성/비정상 플러그인이 보고하는 버스 수까지 방어합니다.
- **`cpp/incorrect-allocation-error-handling` ×2** — `DllMain.cpp:57`, `ClassFactory.cpp:67`: throwing `new` 뒤의 null 체크는 죽은 코드였고, 실제 실패 모드인 C++ 예외(`bad_alloc`, 생성자 예외)가 COM 경계를 넘어 audiodg.exe로 전파될 수 있었습니다. try/catch로 `E_OUTOFMEMORY`/`E_FAIL` 변환합니다.

## Dismiss (2건, false positive)

- **`cpp/suspicious-pointer-scaling` ×2** — `libHybridConv_eapo.cpp:193,432`: `fftw_complex`는 `double[2]`이고, interleaved `[re,im]` 저장소를 Highway `LoadInterleaved2`(순수 셔플)용 double 배열로 의도적으로 재해석하는 코드입니다. `j*2`는 복소수 인덱스 j의 올바른 double 단위 오프셋입니다. 경보에 근거 코멘트를 남기고 dismiss 완료.

## 검증

- 이 브랜치에서 CodeQL 재실행([run 29200599117](https://github.com/115dkk/EqualizerAPO-XT/actions/runs/29200599117)): 수정 6건은 더 이상 검출되지 않고(fixed), 오탐 2건만 남아 dismiss 처리.
- 로컬(VS18, avx2): Common·EqualizerAPO DLL 빌드 GREEN, HybridConvTests 1623·EngineOrchestrationTests 617·AudioRegressionTests 20/20 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)