### PR TITLE
refactor(editor): decouple Copy channel propagation from GUI

### DIFF
--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -34,6 +34,7 @@
 #include <QSettings>
 
 #include "MainWindow.h"
+#include "SkinManager.h"
 #include "FilterTableRow.h"
 #include "FilterTableMimeData.h"
 #include "FilterGUIFactoryRegistry.h"
@@ -312,6 +313,19 @@ IFilterGUI* FilterTable::createRowGui(const QString& line)
 	// still gets a real editor; the legacy path stays frozen (raw row).
 	if (renderMode == ModernCards && FilterCardModel::isPureCommentLine(line))
 		return new CommentCardEditor(line);
+
+	// Copy's maintained card editor is the skin routing view built directly by
+	// FilterCardRow. Channel propagation is handled by the row's Qt-free Copy
+	// domain logic, so a normal Copy row no longer needs a hidden heritage GUI.
+	// Dynamic Copy parameters still fall through: routing editors must not
+	// parse and rewrite inline expressions.
+	QString cardParameters;
+	FilterCardModel::commandForLine(line, &cardParameters);
+	if (renderMode == ModernCards
+		&& FilterCardModel::describeLine(line, 0).type == QStringLiteral("copy")
+		&& !FilterCardModel::hasInlineExpressions(cardParameters)
+		&& SkinManager::instance()->routingRenderer() != nullptr)
+		return nullptr;
 
 	int pos = line.indexOf(':');
 	if (pos == -1)

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -77,8 +77,20 @@ void FilterTable::propagateChannels()
 {
 	vector<wstring> channelNames = getChannelNames();
 
-	for (Item* item : model.items())
+	for (int row = 0; row < model.items().size(); row++)
 	{
+		Item* item = model.items()[row];
+		if (renderMode == ModernCards && gridLayout != nullptr)
+		{
+			QLayoutItem* cell = gridLayout->itemAtPosition(row, 0);
+			FilterCardRow* cardRow = cell != nullptr ? qobject_cast<FilterCardRow*>(cell->widget()) : nullptr;
+			if (cardRow != nullptr)
+			{
+				cardRow->configureChannels(channelNames);
+				continue;
+			}
+		}
+
 		if (item->gui != nullptr)
 			item->gui->configureChannels(channelNames);
 	}

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -13,6 +13,8 @@
 #include <QEnterEvent>
 #include <QFile>
 #include <QFrame>
+#include <QGraphicsScene>
+#include <QGraphicsView>
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QImage>
@@ -20,6 +22,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QPixmap>
+#include <QPointer>
 #include <QToolButton>
 #include <QScrollArea>
 #include <QScrollBar>
@@ -31,6 +34,7 @@
 
 #include "Editor/FilterTable.h"
 #include "Editor/SkinManager.h"
+#include "Editor/guis/CopyFilterGUI.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "Editor/skins/ISkin.h"
 #include "Editor/skins/Skins.h"
@@ -1004,6 +1008,26 @@ int runSwitchTest(const QStringList& arguments)
 		limitMs = 8000;
 
 	int failures = 0;
+	{
+		// LegacyRows still uses CopyFilterGUI. Its QGraphicsView does not own
+		// the scene, so the GUI must parent it explicitly; allWidgets() cannot
+		// detect this leak because QGraphicsScene is not a QWidget.
+		CopyFilterGUI* legacyCopy = new CopyFilterGUI({}, table);
+		QGraphicsView* graphicsView = legacyCopy->findChild<QGraphicsView*>();
+		QPointer<QGraphicsScene> scene = graphicsView != nullptr ? graphicsView->scene() : nullptr;
+		if (scene.isNull())
+		{
+			qWarning("SkinSwitchTest: legacy CopyFilterGUI scene was not created");
+			failures++;
+		}
+		delete legacyCopy;
+		if (!scene.isNull())
+		{
+			qWarning("SkinSwitchTest: deleting CopyFilterGUI did not delete its scene");
+			delete scene.data();
+			failures++;
+		}
+	}
 	qint64 worstMs = 0;
 	QString worstName;
 	const int rounds = 3;
@@ -1101,6 +1125,12 @@ int runSwitchTest(const QStringList& arguments)
 		QHash<QByteArray, int> histogram;
 		for (QWidget* widget : QApplication::allWidgets())
 			histogram[widget->metaObject()->className()]++;
+		const int legacyCopyWidgets = histogram.value(QByteArrayLiteral("CopyFilterGUI"));
+		if (legacyCopyWidgets != 0)
+		{
+			qWarning("SkinSwitchTest: modern cards retained %d CopyFilterGUI widgets", legacyCopyWidgets);
+			failures++;
+		}
 		QList<QPair<int, QByteArray>> ranked;
 		for (auto it = histogram.constBegin(); it != histogram.constEnd(); ++it)
 			ranked.append({ it.value(), it.key() });

--- a/Editor/guis/CopyFilterGUI.cpp
+++ b/Editor/guis/CopyFilterGUI.cpp
@@ -19,7 +19,6 @@
 
 #include "Editor/widgets/ResizeCorner.h"
 #include "Editor/helpers/GUIHelper.h"
-#include "helpers/ChannelHelper.h"
 #include "CopyFilterGUIForm.h"
 #include "CopyFilterGUI.h"
 #include "ui_CopyFilterGUI.h"
@@ -35,6 +34,7 @@ CopyFilterGUI::CopyFilterGUI(const std::vector<Assignment>& assignments, FilterT
 	ui->setupUi(this);
 
 	scene = new CopyFilterGUIScene;
+	scene->setParent(this);
 	ui->graphicsView->setScene(scene);
 	ui->graphicsView->setBackgroundRole(QPalette::Window);
 
@@ -76,26 +76,7 @@ void CopyFilterGUI::configureChannels(vector<wstring>& channelNames)
 		ui->form->setChannelNames(channelNames);
 	}
 
-	for (Assignment assignment : assignments)
-	{
-		if (assignment.targetChannel == L"")
-			continue;
-		bool hasSummand = false;
-		for (Assignment::Summand summand : assignment.sourceSum)
-		{
-			if (summand.channel != L" ")
-			{
-				hasSummand = true;
-				break;
-			}
-		}
-		if (!hasSummand)
-			continue;
-
-		int channelIndex = ChannelHelper::getChannelIndex(assignment.targetChannel, channelNames, true);
-		if (channelIndex == -1)
-			channelNames.push_back(assignment.targetChannel);
-	}
+	propagateCopyChannels(assignments, channelNames);
 }
 
 void CopyFilterGUI::store(QString& command, QString& parameters)

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -201,22 +201,8 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 		bodyStack->addWidget(editorContainer);
 		bodyStack->setCurrentWidget(editorContainer);
 		connect(routingView, SIGNAL(routingChanged()), this, SLOT(routingEdited()));
+		connect(routingView, SIGNAL(routingChanged()), table, SLOT(updateChannels()));
 
-		// The legacy CopyFilterGUI never appears in this card (the routing
-		// view is the editor), but it still owns Copy's channel-propagation
-		// behaviour: FilterTable::propagateChannels walks the row GUIs, and
-		// this one is what hands the Copy line's virtual channels to every
-		// row below. It must keep existing - but parentless it is a
-		// top-level zombie: clearRows() only nulls item->gui, so every
-		// rebuild (skin switch, paste, drag) would leak a CopyFilterGUI per
-		// Copy row and each later applySkin repolishes the growing zombie
-		// population (SkinGallery::runSwitchTest guards this). Adopt it as
-		// a hidden child so it dies with the row.
-		if (QWidget* legacyCopyGui = qobject_cast<QWidget*>(gui))
-		{
-			legacyCopyGui->setParent(this);
-			legacyCopyGui->hide();
-		}
 		// The expand default above keys off the gui the body shows; routing
 		// rows are their own editor and start open.
 		expandButton->setChecked(true);
@@ -308,6 +294,23 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	// the active skin to tag or extend this row.
 	SkinManager::instance()->prepareCommandRow(currentRowInfo(), cardFrame, headerWidget, bodyStack);
 	rebuildSummary();
+}
+
+void FilterCardRow::configureChannels(std::vector<std::wstring>& channelNames)
+{
+	if (routingView != nullptr && descriptor.type == QStringLiteral("copy"))
+	{
+		if (descriptor.enabled)
+		{
+			QString parameters;
+			FilterCardModel::commandForLine(item->text, &parameters);
+			propagateCopyChannels(CopyRoutingAdapter::parse(parameters), channelNames);
+		}
+		return;
+	}
+
+	if (gui != nullptr)
+		gui->configureChannels(channelNames);
 }
 
 CommandRowInfo FilterCardRow::currentRowInfo() const

--- a/Editor/widgets/FilterCardRow.h
+++ b/Editor/widgets/FilterCardRow.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -21,6 +24,7 @@ class FilterCardRow : public QWidget
 
 public:
 	FilterCardRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui, FilterCardRowScope scope, QWidget* parent = nullptr);
+	void configureChannels(std::vector<std::wstring>& channelNames);
 
 	QRect getHeaderRect() const;
 	void editText();

--- a/Tests/HybridConvTests/CopyCommandTests.cpp
+++ b/Tests/HybridConvTests/CopyCommandTests.cpp
@@ -192,6 +192,37 @@ void testEmptySumAssignmentsSerializeToNothing()
 	harness.expectTrue(serializeCopyAssignments(onlySeeded) == L"",
 		"a lone empty-sum assignment serializes to an empty string");
 }
+void testPropagateChannels()
+{
+	vector<wstring> channels = {L"L", L"R", L"LFE"};
+	vector<Assignment> assignments = parseCopyAssignments(L"V1=L V2=0 SUB=R");
+
+	Assignment unfinished;
+	unfinished.targetChannel = L"UNFINISHED";
+	Assignment::Summand sentinel;
+	sentinel.channel = L" ";
+	unfinished.sourceSum.push_back(sentinel);
+	assignments.push_back(unfinished);
+
+	Assignment empty;
+	empty.targetChannel = L"EMPTY";
+	assignments.push_back(empty);
+
+	propagateCopyChannels(assignments, channels);
+	harness.expectTrue(channels == vector<wstring>({L"L", L"R", L"LFE", L"V1", L"V2"}),
+		"Copy channel propagation appends valid targets in order, keeps LFE/SUB aliases unique, and skips unfinished rows");
+
+	propagateCopyChannels(assignments, channels);
+	harness.expectTrue(channels == vector<wstring>({L"L", L"R", L"LFE", L"V1", L"V2"}),
+		"Copy channel propagation is idempotent");
+
+	vector<wstring> chained = {L"L", L"R"};
+	propagateCopyChannels(parseCopyAssignments(L"V1=L"), chained);
+	propagateCopyChannels(parseCopyAssignments(L"V2=V1"), chained);
+	harness.expectTrue(chained == vector<wstring>({L"L", L"R", L"V1", L"V2"}),
+		"successive Copy commands expose virtual targets to the commands below them");
+}
+
 }
 
 void runCopyCommandTests()
@@ -204,5 +235,6 @@ void runCopyCommandTests()
 	testMalformedChunkDropped();
 	testSerializeRoundTrip();
 	testEmptySumAssignmentsSerializeToNothing();
+	testPropagateChannels();
 	harness.report();
 }

--- a/filters/CopyFilter.cpp
+++ b/filters/CopyFilter.cpp
@@ -311,3 +311,31 @@ std::wstring serializeCopyAssignments(const vector<Assignment>& assignments)
 
 	return result;
 }
+
+
+void propagateCopyChannels(const vector<Assignment>& assignments, vector<wstring>& channelNames)
+{
+	for (const Assignment& assignment : assignments)
+	{
+		if (assignment.targetChannel.empty())
+			continue;
+
+		bool hasSummand = false;
+		for (const Assignment::Summand& summand : assignment.sourceSum)
+		{
+			// A single space is the legacy form's unfinished-row sentinel.
+			// An empty channel is a constant summand and therefore still
+			// produces the target channel.
+			if (summand.channel != L" ")
+			{
+				hasSummand = true;
+				break;
+			}
+		}
+		if (!hasSummand)
+			continue;
+
+		if (ChannelHelper::getChannelIndex(assignment.targetChannel, channelNames, true) == -1)
+			channelNames.push_back(assignment.targetChannel);
+	}
+}

--- a/filters/CopyFilter.h
+++ b/filters/CopyFilter.h
@@ -56,6 +56,13 @@ std::vector<Assignment> parseCopyAssignments(const std::wstring& parameters);
 // assignments with an empty target are skipped.
 std::wstring serializeCopyAssignments(const std::vector<Assignment>& assignments);
 
+// Applies Copy's channel-flow semantics without constructing an Editor GUI.
+// Every assignment that has at least one real summand makes its target
+// available to the commands below it. Existing names and aliases are kept in
+// their canonical spelling through ChannelHelper::getChannelIndex().
+void propagateCopyChannels(const std::vector<Assignment>& assignments,
+	std::vector<std::wstring>& channelNames);
+
 #pragma AVRT_VTABLES_BEGIN
 class CopyFilter : public IFilter
 {


### PR DESCRIPTION
## Summary

- move Copy channel propagation into Qt-free domain logic shared by the engine-facing model and heritage GUI
- stop constructing hidden CopyFilterGUI trees for ModernCards; the visible routing row now owns propagation
- parent the heritage CopyFilterGUIScene and add CI gates for both lifetime regressions
- add channel-flow characterization tests for aliases, constants, sentinels, idempotence, and chained virtual channels

## Validation

- HybridConvTests CopyCommandTests exercise the new backend helper
- SkinGallery switch test fails if ModernCards retain any CopyFilterGUI or if deleting a heritage CopyFilterGUI leaves its QGraphicsScene alive
- GitHub Actions is the authoritative build/test validation for this Windows/Qt change