### PR TITLE
Harden resource ownership and failure handling

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,14 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 설정 저장을 원자적으로 바꾸고, 일부만 읽힌 설정은 정상 오디오 그래프로
+  적용하지 않게 했습니다. 필터 팩터리, HybridConv/FFTW 플랜, IR 데이터,
+  Copy/IIR 상태, VST 인스턴스, COM 아파트먼트와 VST3 DLL 팩터리에 명시적인
+  RAII 소유권과 외부 크기 검증을 적용했습니다. 필터 초기화가 실패하면 설정
+  재로딩 전체를 되돌리고 기존 설정을 유지하므로, 할당 실패나 손상된
+  플러그인의 예외가 로더 밖으로 빠져나가 Windows 오디오 서비스를 종료하지
+  않습니다. DSP 핫패스와 연산 순서는 바꾸지 않았습니다.
+  ([#198](https://github.com/115dkk/EqualizerAPO-XT/pull/198))
 - Soft 스킨의 필터 추가 목록이 각 템플릿을 삽입할 설정 줄 그대로
   ("피킹 필터" 밑에 `Filter: ON PK Fc 100 Hz Gain 0 dB Q 10`, "지연" 밑에
   `Delay: 0 ms`) 설명하던 것을 고쳤습니다. 문법을 직접 편집하지 않는

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Configuration saving is now atomic and partial reads are rejected instead
+  of being applied as valid audio graphs. Filter factories, HybridConv/FFTW
+  plans, IR data, Copy/IIR state, VST instances, COM apartments, and VST3 DLL
+  factories now have explicit RAII ownership and checked external sizes.
+  Failed filter initialization rolls back the whole reload and keeps the
+  active configuration, so an allocation failure or malformed plug-in cannot
+  escape the loader and terminate the Windows audio service. The DSP hot path
+  and its operation order are unchanged. ([#198](https://github.com/115dkk/EqualizerAPO-XT/pull/198))
 - The Soft skin's add-filter picker described each template with the raw
   config line it would insert (`Filter: ON PK Fc 100 Hz Gain 0 dB Q 10`
   under "Peaking filter", `Delay: 0 ms` under "Delay"), which is noise to

--- a/ConfigurationFileReader.cpp
+++ b/ConfigurationFileReader.cpp
@@ -8,6 +8,16 @@
 #include "helpers/LogHelper.h"
 #include "helpers/StringHelper.h"
 
+namespace
+{
+std::stringstream makeFailedStream()
+{
+	std::stringstream stream;
+	stream.setstate(std::ios::badbit);
+	return stream;
+}
+}
+
 std::stringstream ConfigurationFileReader::readWithRetry(const std::wstring& path)
 {
 	DWORD error = ERROR_SUCCESS;
@@ -15,14 +25,25 @@ std::stringstream ConfigurationFileReader::readWithRetry(const std::wstring& pat
 	if (hFile == INVALID_HANDLE_VALUE)
 	{
 		LogFStatic(L"Error while reading configuration file %s: %s", path.c_str(), StringHelper::getSystemErrorString(error).c_str());
-		return {};
+		return makeFailedStream();
 	}
 
 	std::stringstream inputStream;
 	char buf[8192];
-	unsigned long bytesRead = 0;
-	while (ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr) && bytesRead != 0)
+	for (;;)
+	{
+		DWORD bytesRead = 0;
+		if (!ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr))
+		{
+			error = GetLastError();
+			CloseHandle(hFile);
+			LogFStatic(L"Error while reading configuration file %s: %s", path.c_str(), StringHelper::getSystemErrorString(error).c_str());
+			return makeFailedStream();
+		}
+		if (bytesRead == 0)
+			break;
 		inputStream.write(buf, bytesRead);
+	}
 
 	CloseHandle(hFile);
 	inputStream.seekg(0);

--- a/DeviceAPOInfo.cpp
+++ b/DeviceAPOInfo.cpp
@@ -111,15 +111,16 @@ wstring DeviceAPOInfo::getDefaultDevice(bool input, int role)
 	wstring result;
 
 	winutil::ComPtr<IMMDeviceEnumerator> enumerator;
-	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&enumerator);
+	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+		__uuidof(IMMDeviceEnumerator), reinterpret_cast<void**>(enumerator.put()));
 	if (SUCCEEDED(hr))
 	{
 		winutil::ComPtr<IMMDevice> endPoint;
-		hr = enumerator->GetDefaultAudioEndpoint(input ? eCapture : eRender, (ERole)role, &endPoint);
+		hr = enumerator->GetDefaultAudioEndpoint(input ? eCapture : eRender, (ERole)role, endPoint.put());
 		if (SUCCEEDED(hr))
 		{
 			winutil::ComPtr<IPropertyStore> propertyStore;
-			hr = endPoint->OpenPropertyStore(STGM_READ, &propertyStore);
+			hr = endPoint->OpenPropertyStore(STGM_READ, propertyStore.put());
 			if (SUCCEEDED(hr))
 			{
 				winutil::PropVariant variant;

--- a/Editor/ConfigFileCodec.cpp
+++ b/Editor/ConfigFileCodec.cpp
@@ -19,6 +19,8 @@
 
 #include <sstream>
 
+#include <QSaveFile>
+
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
@@ -86,9 +88,19 @@ ConfigFileCodec::ReadResult ConfigFileCodec::readConfig(const QString& path)
 	string buffer;
 
 	char buf[8192];
-	unsigned long bytesRead = -1;
-	while (ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr) && bytesRead != 0)
+	for (;;)
 	{
+		DWORD bytesRead = 0;
+		if (!ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr))
+		{
+			error = GetLastError();
+			CloseHandle(hFile);
+			result.ok = false;
+			result.errorMessage = QString::fromStdWString(StringHelper::getSystemErrorString(error));
+			return result;
+		}
+		if (bytesRead == 0)
+			break;
 		buffer.append(buf, bytesRead);
 	}
 
@@ -106,21 +118,35 @@ ConfigFileCodec::WriteResult ConfigFileCodec::writeConfig(const QString& path, c
 	QByteArray byteArray = encodeLines(lines);
 	result.totalBytes = byteArray.length();
 
-	DWORD error = ERROR_SUCCESS;
-	HANDLE hFile = openFileWithSharingRetry(path.toStdWString().c_str(), GENERIC_WRITE, 0, CREATE_ALWAYS, error);
-	if (hFile == INVALID_HANDLE_VALUE)
+	QSaveFile file(path);
+	file.setDirectWriteFallback(false);
+	if (!file.open(QIODevice::WriteOnly))
 	{
 		result.opened = false;
-		result.errorMessage = QString::fromStdWString(StringHelper::getSystemErrorString(error));
+		result.errorMessage = file.errorString();
 		return result;
 	}
 
-	unsigned long bytesWritten;
-	WriteFile(hFile, byteArray.constData(), byteArray.length(), &bytesWritten, nullptr);
+	const qint64 bytesWritten = file.write(byteArray);
+	if (bytesWritten != byteArray.size())
+	{
+		file.cancelWriting();
+		result.opened = false;
+		result.bytesWritten = bytesWritten > 0 ? static_cast<unsigned long>(bytesWritten) : 0;
+		result.errorMessage = file.errorString();
+		if (result.errorMessage.isEmpty())
+			result.errorMessage = QStringLiteral("Only %1/%2 bytes could be written").arg(bytesWritten).arg(byteArray.size());
+		return result;
+	}
 
-	CloseHandle(hFile);
+	result.bytesWritten = static_cast<unsigned long>(bytesWritten);
+	if (!file.commit())
+	{
+		result.opened = false;
+		result.errorMessage = file.errorString();
+		return result;
+	}
 
 	result.opened = true;
-	result.bytesWritten = bytesWritten;
 	return result;
 }

--- a/Editor/ConfigFileCodec.h
+++ b/Editor/ConfigFileCodec.h
@@ -34,9 +34,9 @@ class ConfigFileCodec
 {
 public:
 	// Outcome of a read attempt. ok == false means the file could not be opened
-	// because of a non-sharing-violation error; errorMessage then holds the
-	// formatted system error string the caller should surface. A locked file is
-	// retried internally and never reported as a failure.
+	// or could not be read completely; errorMessage then holds the formatted
+	// system error string the caller should surface. A locked file is retried
+	// internally and never reported as a failure.
 	struct ReadResult
 	{
 		bool ok = false;
@@ -44,10 +44,10 @@ public:
 		QString errorMessage;
 	};
 
-	// Outcome of a write attempt. opened == false means CreateFile failed with a
-	// non-sharing-violation error (errorMessage set), so the caller should abort.
-	// When opened == true the file was written; comparing bytesWritten against
-	// totalBytes lets the caller detect a short write.
+	// Outcome of a write attempt. opened remains the compatibility success flag:
+	// it is true only after the complete temporary file has been atomically
+	// committed to path. Any open, write, flush, or replacement failure leaves
+	// it false and sets errorMessage.
 	struct WriteResult
 	{
 		bool opened = false;
@@ -61,8 +61,9 @@ public:
 	// separators (the caller converts it).
 	static ReadResult readConfig(const QString& path);
 
-	// Writes lines to path, retrying while the file is locked, joining lines with
-	// CRLF and encoding each line as UTF-8 (no trailing newline).
+	// Writes lines to a temporary file next to path, then atomically commits it.
+	// A failed write or replacement leaves an existing path unchanged. Lines are
+	// joined with CRLF and encoded as UTF-8 (no trailing newline).
 	static WriteResult writeConfig(const QString& path, const QList<QString>& lines);
 
 	// Pure, file-system-free transforms, exposed for reuse and testing.

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -81,14 +81,14 @@ int runVstRoundTripSelfTest()
 		VSTPluginFilterFactory factory;
 		std::wstring command = L"VSTPlugin";
 		std::wstring params = c.params;
-		std::vector<IFilter*> filters = factory.createFilter(L"", command, params);
+		FilterVector filters = factory.createFilter(L"", command, params);
 		if (filters.empty())
 		{
 			fprintf(stderr, "[VST selftest] %ls: parse produced no filter\n", c.name);
 			failures++;
 			continue;
 		}
-		VSTPluginFilter* f0 = static_cast<VSTPluginFilter*>(filters[0]);
+		VSTPluginFilter* f0 = static_cast<VSTPluginFilter*>(filters[0].get());
 		std::wstring chunk0 = f0->getChunkData();
 		std::unordered_map<std::wstring, float> map0 = f0->getParamMap();
 
@@ -96,22 +96,18 @@ int runVstRoundTripSelfTest()
 		QString outCommand, outParams;
 		gui.store(outCommand, outParams);
 
-		for (IFilter* f : filters) { f->~IFilter(); MemoryHelper::free(f); }
-
 		std::wstring command2 = outCommand.toStdWString();
 		std::wstring params2 = outParams.toStdWString();
-		std::vector<IFilter*> filters2 = factory.createFilter(L"", command2, params2);
+		FilterVector filters2 = factory.createFilter(L"", command2, params2);
 		if (filters2.empty())
 		{
 			fprintf(stderr, "[VST selftest] %ls: re-parse produced no filter (params='%ls')\n", c.name, params2.c_str());
 			failures++;
 			continue;
 		}
-		VSTPluginFilter* f1 = static_cast<VSTPluginFilter*>(filters2[0]);
+		VSTPluginFilter* f1 = static_cast<VSTPluginFilter*>(filters2[0].get());
 		std::wstring chunk1 = f1->getChunkData();
 		std::unordered_map<std::wstring, float> map1 = f1->getParamMap();
-		for (IFilter* f : filters2) { f->~IFilter(); MemoryHelper::free(f); }
-
 		bool ok = (chunk0 == chunk1) && (map0 == map1);
 		if (!ok)
 		{

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -590,7 +590,6 @@ void VSTCardEditor::updatePermissionWarning()
 #include "filters/VSTPluginFilter.h"
 #include "filters/VSTPluginFilterFactory.h"
 #include "helpers/VSTPluginLibrary.h"
-#include "helpers/MemoryHelper.h"
 
 REGISTER_FILTER_CARD_EDITOR(vstplugin, [](FilterTable*, const QString&, const QString& parameters) -> IFilterGUI* {
 	// Parse the line into the engine's VST filter (no plugin DLL is loaded
@@ -599,21 +598,16 @@ REGISTER_FILTER_CARD_EDITOR(vstplugin, [](FilterTable*, const QString&, const QS
 	VSTPluginFilterFactory factory;
 	std::wstring commandWStr = L"VSTPlugin";
 	std::wstring paramWStr = parameters.toStdWString();
-	std::vector<IFilter*> filters = factory.createFilter(L"", commandWStr, paramWStr);
+	FilterVector filters = factory.createFilter(L"", commandWStr, paramWStr);
 	VSTCardEditor* editor;
 	if (!filters.empty())
 	{
-		VSTPluginFilter* filter = static_cast<VSTPluginFilter*>(filters[0]);
+		VSTPluginFilter* filter = static_cast<VSTPluginFilter*>(filters[0].get());
 		editor = new VSTCardEditor(filter->getLibrary(), filter->getChunkData(), filter->getParamMap());
 	}
 	else
 	{
 		editor = new VSTCardEditor(VSTPluginLibrary::getInstance(L""), L"", std::unordered_map<std::wstring, float>());
-	}
-	for (IFilter* f : filters)
-	{
-		f->~IFilter();
-		MemoryHelper::free(f);
 	}
 	return editor;
 })

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -18,6 +18,8 @@
 */
 
 #include "stdafx.h"
+#include <exception>
+#include <new>
 #include <Unknwn.h>
 #define INITGUID
 #include <mmdeviceapi.h>
@@ -514,7 +516,28 @@ HRESULT EqualizerAPO::LockForProcess(UINT32 u32NumInputConnections,
 			channelMask = inFormat.dwChannelMask;
 	}
 
-	engine.initialize(outFormat.fFramesPerSecond, inFormat.dwSamplesPerFrame, realChannelCount, outFormat.dwSamplesPerFrame, channelMask, maxFrameCount);
+	try
+	{
+		engine.initialize(outFormat.fFramesPerSecond, inFormat.dwSamplesPerFrame, realChannelCount, outFormat.dwSamplesPerFrame, channelMask, maxFrameCount);
+	}
+	catch (const std::bad_alloc&)
+	{
+		LogF(L"Filter engine initialization ran out of memory; rejecting LockForProcess instead of terminating the audio service");
+		UnlockForProcess();
+		return E_OUTOFMEMORY;
+	}
+	catch (const std::exception& e)
+	{
+		LogF(L"Filter engine initialization failed; rejecting LockForProcess: %S", e.what());
+		UnlockForProcess();
+		return E_FAIL;
+	}
+	catch (...)
+	{
+		LogF(L"Filter engine initialization failed with an unknown exception; rejecting LockForProcess");
+		UnlockForProcess();
+		return E_FAIL;
+	}
 
 	return hr;
 }

--- a/FilterConfiguration.h
+++ b/FilterConfiguration.h
@@ -27,11 +27,6 @@
 
 class FilterEngine;
 
-struct FilterDeleter
-{
-	void operator()(IFilter* filter) const;
-};
-
 struct FilterInfo
 {
 	std::unique_ptr<IFilter, FilterDeleter> filter;

--- a/FilterEngine.h
+++ b/FilterEngine.h
@@ -53,7 +53,10 @@ public:
 	void setPreMix(bool preMix);
 	void setDeviceInfo(bool capture, bool postMixInstalled, const std::wstring& deviceName, const std::wstring& connectionName, const std::wstring& deviceGuid, const std::wstring& deviceString);
 	void initialize(float sampleRate, unsigned inputChannelCount, unsigned realChannelCount, unsigned outputChannelCount, unsigned channelMask, unsigned maxFrameCount, const std::wstring& customPath = L"");
-	void loadConfig(const std::wstring& customPath = L"");
+	// Builds a complete configuration before publishing it. A failed load keeps
+	// the active configuration and returns false; no initialization exception is
+	// allowed to escape the configuration-loading boundary.
+	bool loadConfig(const std::wstring& customPath = L"");
 	void loadConfigFile(const std::wstring& path);
 	void watchRegistryKey(const std::wstring& key);
 	void process(float* output, float* input, unsigned frameCount);
@@ -100,7 +103,7 @@ private:
 	};
 	using FilterConfigurationPtr = std::unique_ptr<FilterConfiguration, FilterConfigurationDeleter>;
 
-	void addFilters(const std::vector<IFilter*>& filters);
+	void addFilters(FilterVector filters);
 	void cleanupConfigurations();
 	static void notificationThread(FilterEngine* engine);
 	bool acquireLoadPermit();

--- a/IFilter.h
+++ b/IFilter.h
@@ -19,7 +19,9 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "helpers/MemoryHelper.h"
@@ -49,3 +51,24 @@ public:
 protected:
 };
 #pragma AVRT_VTABLES_END
+
+struct FilterDeleter
+{
+	void operator()(IFilter* filter) const;
+};
+
+using FilterPtr = std::unique_ptr<IFilter, FilterDeleter>;
+using FilterVector = std::vector<FilterPtr>;
+
+template<class T, class... Args>
+FilterPtr makeFilter(Args&&... args)
+{
+	return FilterPtr(MemoryHelper::construct<T>(std::forward<Args>(args)...));
+}
+
+inline FilterVector singleFilter(FilterPtr filter)
+{
+	FilterVector filters;
+	filters.push_back(std::move(filter));
+	return filters;
+}

--- a/IFilterFactory.h
+++ b/IFilterFactory.h
@@ -34,8 +34,8 @@ public:
 	virtual ~IFilterFactory() {}
 
 	virtual void initialize(FilterEngine* engine) {}
-	virtual std::vector<IFilter*> startOfConfiguration() {return std::vector<IFilter*>();}
-	virtual std::vector<IFilter*> startOfFile(const std::wstring& configPath) {return std::vector<IFilter*>();}
+	virtual FilterVector startOfConfiguration() {return {};}
+	virtual FilterVector startOfFile(const std::wstring& configPath) {return {};}
 	// Contract (see the dispatch loop in engine/FilterEngine.Configuration.cpp):
 	// the engine offers each config line to every factory in priority order.
 	// - Returning one or more filters consumes the line; iteration stops.
@@ -46,8 +46,8 @@ public:
 	//   the next factory.
 	// `parameters` may be normalized in place (e.g. decimal-comma fixes); the
 	// engine does not read it back after the call.
-	virtual std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) = 0;
-	virtual std::vector<IFilter*> endOfFile(const std::wstring& configPath) {return std::vector<IFilter*>();}
-	virtual std::vector<IFilter*> endOfConfiguration() {return std::vector<IFilter*>();}
+	virtual FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) = 0;
+	virtual FilterVector endOfFile(const std::wstring& configPath) {return {};}
+	virtual FilterVector endOfConfiguration() {return {};}
 };
 #pragma AVRT_VTABLES_END

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -1345,7 +1345,7 @@ void testConfigFileCodecRejectsPartialRead()
 	expectTrue(result.lines.isEmpty(), "readConfig does not expose a partial configuration");
 }
 
-void testMemoryHelperConstructReleasesStorageWhenConstructorThrows()
+void testMemoryHelperConstructReleasesStorageWhenConstructorThrows() noexcept
 {
 	struct ThrowingConstructor
 	{

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -1,5 +1,14 @@
 #include <cstdio>
 #include <cstdlib>
+#include <malloc.h>
+#include <stdexcept>
+#include <thread>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 
 #include <QCoreApplication>
 #include <QDir>
@@ -28,10 +37,29 @@
 #include "Editor/widgets/routing/MultiConvolutionRoutingAdapter.h"
 #include "Editor/widgets/routing/RoutingFold.h"
 #include "Editor/widgets/routing/StudioRoutingModel.h"
+#include "helpers/MemoryHelper.h"
 #include "UpdateChecker/UpdateInfoFormatter.h"
 #include "UpdateChecker/VelopackUpdateInfo.h"
 
 #include "Tests/TestHarness.h"
+
+namespace
+{
+int memoryHelperAllocations = 0;
+int memoryHelperFrees = 0;
+}
+
+void* MemoryHelper::alloc(size_t size)
+{
+	++memoryHelperAllocations;
+	return _aligned_malloc(size, 16);
+}
+
+void MemoryHelper::free(void* ptr)
+{
+	++memoryHelperFrees;
+	_aligned_free(ptr);
+}
 
 namespace
 {
@@ -1249,6 +1277,100 @@ void testConfigFileCodec()
 	requireEqual((int)roundTrip.size(), 2, "encodeLines output decodes back to the same line count");
 	expectEqual(roundTrip[1], QString::fromUtf8("caf\xC3\xA9"), "decode(encode(lines)) round-trips non-ASCII text");
 }
+
+void testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails()
+{
+	QTemporaryDir dir;
+	requireTrue(dir.isValid(), "atomic-save test creates a temporary directory");
+
+	QString path = QDir::toNativeSeparators(dir.filePath("config.txt"));
+	QFile original(path);
+	requireTrue(original.open(QIODevice::WriteOnly), "atomic-save test creates the original file");
+	requireTrue(original.write("original") == 8, "atomic-save test writes the original contents");
+	original.close();
+
+	// Access 0 with read/write sharing still permits in-place writes, while
+	// omitting FILE_SHARE_DELETE prevents replacement while this handle lives.
+	HANDLE replacementBlocker = CreateFileW(
+		path.toStdWString().c_str(),
+		0,
+		FILE_SHARE_READ | FILE_SHARE_WRITE,
+		nullptr,
+		OPEN_EXISTING,
+		FILE_ATTRIBUTE_NORMAL,
+		nullptr);
+	requireTrue(replacementBlocker != INVALID_HANDLE_VALUE, "atomic-save test locks replacement of the original file");
+
+	ConfigFileCodec::WriteResult result = ConfigFileCodec::writeConfig(path, QList<QString>() << "replacement");
+	CloseHandle(replacementBlocker);
+
+	expectFalse(result.opened, "writeConfig reports an atomic replacement failure");
+
+	QFile preserved(path);
+	requireTrue(preserved.open(QIODevice::ReadOnly), "atomic-save test reopens the original file");
+	expectEqual(QString::fromUtf8(preserved.readAll()), "original", "failed atomic replacement preserves the original contents");
+}
+
+void testConfigFileCodecRejectsPartialRead()
+{
+	const std::wstring pipeName = L"\\\\.\\pipe\\EditorLogicTests-ConfigRead-" + std::to_wstring(GetCurrentProcessId());
+	HANDLE pipe = CreateNamedPipeW(
+		pipeName.c_str(),
+		PIPE_ACCESS_OUTBOUND,
+		PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+		1,
+		4096,
+		4096,
+		0,
+		nullptr);
+	requireTrue(pipe != INVALID_HANDLE_VALUE, "partial-read test creates a named pipe");
+
+	bool serverSucceeded = false;
+	std::thread server([&]() {
+		BOOL connected = ConnectNamedPipe(pipe, nullptr);
+		if (!connected && GetLastError() == ERROR_PIPE_CONNECTED)
+			connected = TRUE;
+		const char prefix[] = "Preamp: -6 dB\r\n";
+		DWORD written = 0;
+		if (connected && WriteFile(pipe, prefix, sizeof(prefix) - 1, &written, nullptr) && written == sizeof(prefix) - 1)
+			serverSucceeded = FlushFileBuffers(pipe) != FALSE;
+		DisconnectNamedPipe(pipe);
+		CloseHandle(pipe);
+	});
+
+	ConfigFileCodec::ReadResult result = ConfigFileCodec::readConfig(QString::fromStdWString(pipeName));
+	server.join();
+	requireTrue(serverSucceeded, "partial-read test sends the configuration prefix");
+	expectFalse(result.ok, "readConfig rejects bytes followed by a ReadFile failure");
+	expectTrue(result.lines.isEmpty(), "readConfig does not expose a partial configuration");
+}
+
+void testMemoryHelperConstructReleasesStorageWhenConstructorThrows()
+{
+	struct ThrowingConstructor
+	{
+		ThrowingConstructor()
+		{
+			throw std::runtime_error("constructor failure");
+		}
+	};
+
+	memoryHelperAllocations = 0;
+	memoryHelperFrees = 0;
+	bool threw = false;
+	try
+	{
+		MemoryHelper::construct<ThrowingConstructor>();
+	}
+	catch (const std::runtime_error&)
+	{
+		threw = true;
+	}
+
+	expectTrue(threw, "construct propagates a constructor exception");
+	expectEqual(memoryHelperAllocations, 1, "construct allocates storage once");
+	expectEqual(memoryHelperFrees, 1, "construct releases storage when construction fails");
+}
 }
 
 int main(int argc, char** argv)
@@ -1270,6 +1392,9 @@ int main(int argc, char** argv)
 	testStudioRoutingModel();
 	testRoutingFold();
 	testConfigFileCodec();
+	testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails();
+	testConfigFileCodecRejectsPartialRead();
+	testMemoryHelperConstructReleasesStorageWhenConstructorThrows();
 	testFilterListModel();
 	testFilterListUndo();
 

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -1345,7 +1345,7 @@ void testConfigFileCodecRejectsPartialRead()
 	expectTrue(result.lines.isEmpty(), "readConfig does not expose a partial configuration");
 }
 
-void testMemoryHelperConstructReleasesStorageWhenConstructorThrows() noexcept
+void testMemoryHelperConstructReleasesStorageWhenConstructorThrows()
 {
 	struct ThrowingConstructor
 	{
@@ -1394,6 +1394,9 @@ int main(int argc, char** argv)
 	testConfigFileCodec();
 	testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails();
 	testConfigFileCodecRejectsPartialRead();
+	// The constructor exception is deliberately caught inside the test; cppcheck
+	// does not propagate that catch back through MemoryHelper::construct.
+	// cppcheck-suppress throwInEntryPoint
 	testMemoryHelperConstructReleasesStorageWhenConstructorThrows();
 	testFilterListModel();
 	testFilterListUndo();

--- a/Tests/EngineOrchestrationTests/ConfigurationFileReaderTests.cpp
+++ b/Tests/EngineOrchestrationTests/ConfigurationFileReaderTests.cpp
@@ -1,0 +1,62 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	ConfigurationFileReader failure-path tests. A named pipe provides real
+	ReadFile behavior: the first read succeeds, then the server disconnects so
+	the next read fails with ERROR_BROKEN_PIPE.
+*/
+
+#include <sstream>
+#include <string>
+#include <thread>
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "ConfigurationFileReader.h"
+#include "Tests/TestHarness.h"
+
+void runConfigurationFileReaderTests(test::Harness& harness)
+{
+	wchar_t tempPath[MAX_PATH] = {};
+	DWORD tempLength = GetTempPathW(MAX_PATH, tempPath);
+	harness.require(tempLength > 0 && tempLength < MAX_PATH, "open-failure test obtains the temporary directory");
+	const std::wstring missingPath = std::wstring(tempPath) + L"EapoMissingConfig-" + std::to_wstring(GetCurrentProcessId()) + L".txt";
+	DeleteFileW(missingPath.c_str());
+	std::stringstream missing = ConfigurationFileReader::readWithRetry(missingPath);
+	harness.expectFalse(missing.good(), "readWithRetry reports an open failure");
+
+	const std::wstring pipeName = L"\\\\.\\pipe\\EngineOrchestrationTests-ConfigRead-" + std::to_wstring(GetCurrentProcessId());
+	HANDLE pipe = CreateNamedPipeW(
+		pipeName.c_str(),
+		PIPE_ACCESS_OUTBOUND,
+		PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+		1,
+		4096,
+		4096,
+		0,
+		nullptr);
+	harness.require(pipe != INVALID_HANDLE_VALUE, "partial configuration read creates a named pipe");
+
+	bool serverSucceeded = false;
+	std::thread server([&]() {
+		BOOL connected = ConnectNamedPipe(pipe, nullptr);
+		if (!connected && GetLastError() == ERROR_PIPE_CONNECTED)
+			connected = TRUE;
+		const char prefix[] = "Preamp: -6 dB\r\n";
+		DWORD written = 0;
+		if (connected && WriteFile(pipe, prefix, sizeof(prefix) - 1, &written, nullptr) && written == sizeof(prefix) - 1)
+			serverSucceeded = FlushFileBuffers(pipe) != FALSE;
+		DisconnectNamedPipe(pipe);
+		CloseHandle(pipe);
+	});
+
+	std::stringstream input = ConfigurationFileReader::readWithRetry(pipeName);
+	server.join();
+	harness.require(serverSucceeded, "partial configuration read sends the prefix");
+	harness.expectFalse(input.good(), "readWithRetry reports a ReadFile failure");
+	harness.expectTrue(input.str().empty(), "readWithRetry does not expose a partial configuration");
+}

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -430,6 +430,30 @@ void testConfigSwapCrossfades(test::Harness& harness)
 	harness.expect(std::fabs(finalRight - target) < 1e-4f, "right channel did not converge to the new config gain");
 }
 
+// A reload is one transaction: filters may have been constructed and
+// initialized, but the active configuration must not change unless the final
+// FilterConfiguration allocation also succeeds. This injects failure at that
+// exact allocation (one PreampFilter allocation succeeds first).
+void testFailedConfigLoadKeepsActiveConfiguration(test::Harness& harness)
+{
+	std::wstring configA = writeConfig(harness, L"transaction_a.txt", "Preamp: -6.0206 dB\n");
+	std::wstring configB = writeConfig(harness, L"transaction_b.txt", "Preamp: -20 dB\n");
+
+	FilterEngine engine;
+	initializeEngine(engine, 48000, 2, 480, configA);
+	std::vector<float> before = processDcBlock(engine, 1.0f, 1.0f, 480);
+	harness.expect(std::fabs(before[0] - 0.5f) < 1e-3f, "transaction test did not establish config A");
+
+	MemoryHelper::failAllocationAfterForTesting(1);
+	bool loaded = engine.loadConfig(configB);
+	MemoryHelper::resetAllocationFailureForTesting();
+	harness.expectFalse(loaded, "reload reported success after injected FilterConfiguration allocation failure");
+
+	std::vector<float> after = processDcBlock(engine, 1.0f, 1.0f, 480);
+	harness.expect(std::fabs(after[0] - 0.5f) < 1e-3f,
+		"failed reload replaced or damaged the active configuration");
+}
+
 // process() can arrive before initialize(), and initialize() can finish
 // without loading any configuration (unreadable ConfigPath and no custom
 // path). Both leave currentConfig null; every overload must pass audio
@@ -542,6 +566,7 @@ void testConfigLoadTrace(test::Harness& harness)
 
 // Defined in SampleIoTests.cpp next to this file.
 void runSampleIoTests(test::Harness& harness);
+void runConfigurationFileReaderTests(test::Harness& harness);
 
 int main()
 {
@@ -550,11 +575,13 @@ int main()
 	test::Harness harness("EngineOrchestrationTests");
 
 	testProcessWithoutConfigurationDoesNotCrash(harness);
+	runConfigurationFileReaderTests(harness);
 	runSampleIoTests(harness);
 	testChannelSelectorRouting(harness);
 	testCopySwapsChannels(harness);
 	testMultiConvolutionIgnoresChannelSelection(harness);
 	testConfigSwapCrossfades(harness);
+	testFailedConfigLoadKeepsActiveConfiguration(harness);
 	testRealBrirCrossfeed(harness);
 	testConfigLoadTrace(harness);
 

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj
@@ -240,6 +240,7 @@ if exist "$(MUPARSERX_LIB)\*.dll" copy /Y "$(MUPARSERX_LIB)\*.dll" "$(OutDir)"</
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="ConfigurationFileReaderTests.cpp" />
     <ClCompile Include="EngineOrchestrationTests.cpp" />
     <ClCompile Include="SampleIoTests.cpp" />
   </ItemGroup>

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj.filters
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj.filters
@@ -11,6 +11,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ConfigurationFileReaderTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="EngineOrchestrationTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Tests/HybridConvTests/CommonLogicTests.cpp
+++ b/Tests/HybridConvTests/CommonLogicTests.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "IFilter.h"
 #include "helpers/StringHelper.h"
 #include "helpers/ChannelHelper.h"
 #include "Tests/TestHarness.h"
@@ -21,6 +22,42 @@ using std::vector;
 namespace
 {
 test::Harness harness("CommonLogicTests");
+
+class LifetimeProbeFilter : public IFilter
+{
+public:
+	LifetimeProbeFilter(bool* destroyed)
+		: destroyed(destroyed)
+	{
+	}
+
+	~LifetimeProbeFilter() override
+	{
+		*destroyed = true;
+	}
+
+	std::vector<std::wstring> initialize(float, unsigned, std::vector<std::wstring> channelNames) override
+	{
+		return channelNames;
+	}
+
+	void process(double**, double**, unsigned) override
+	{
+	}
+
+private:
+	bool* destroyed;
+};
+
+void testOwningFilterPointer()
+{
+	bool destroyed = false;
+	{
+		FilterPtr filter = makeFilter<LifetimeProbeFilter>(&destroyed);
+		harness.expectTrue(filter != nullptr, "makeFilter should return an owning filter pointer");
+	}
+	harness.expectTrue(destroyed, "FilterPtr should destroy and release the filter when ownership ends");
+}
 
 void testStringHelper()
 {
@@ -100,6 +137,7 @@ void testChannelHelper()
 
 void runCommonLogicTests()
 {
+	testOwningFilterPointer();
 	testStringHelper();
 	testChannelHelper();
 	harness.report();

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -318,6 +318,9 @@ void assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix()
 {
 	constexpr unsigned slotCount = 2;
 	HConvSingle* slots = static_cast<HConvSingle*>(MemoryHelper::alloc(sizeof(HConvSingle) * slotCount));
+	// cppcheck 2.21 reports a parser error on this ordinary null check after the
+	// templated/static_cast allocation expression; MSVC builds and runs the path.
+	// cppcheck-suppress syntaxError
 	if (slots == nullptr)
 		fail("could not allocate convolver slots for partial-initialization test");
 	memset(slots, 0xA5, sizeof(HConvSingle) * slotCount);

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -317,7 +317,7 @@ void assertInvalidConvolverArgumentsLeaveEmptyOutput()
 void assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix()
 {
 	constexpr unsigned slotCount = 2;
-	auto* slots = static_cast<HConvSingle*>(MemoryHelper::alloc(sizeof(HConvSingle) * slotCount));
+	HConvSingle* slots = static_cast<HConvSingle*>(MemoryHelper::alloc(sizeof(HConvSingle) * slotCount));
 	if (slots == nullptr)
 		fail("could not allocate convolver slots for partial-initialization test");
 	memset(slots, 0xA5, sizeof(HConvSingle) * slotCount);

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -10,7 +10,11 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
@@ -20,7 +24,9 @@
 
 #include "filters/ConvolutionFilter.h"
 #include "filters/ConvolutionFilePath.h"
+#include "filters/IrCache.h"
 #include "helpers/LogHelper.h"
+#include "helpers/MemoryHelper.h"
 #include "libHybridConv-0.1.1/libHybridConv_eapo.h"
 #include "Tests/TestHarness.h"
 
@@ -265,6 +271,68 @@ void assertPartitionBuffersFormOneSlab()
 	hcCloseSingle(&filter);
 }
 
+void assertEmptyConvolverCloseIsIdempotent()
+{
+	HConvSingle filter = {};
+	hcCloseSingle(nullptr);
+	hcCloseSingle(&filter);
+	vector<double> impulseResponse(1, 1.0);
+	hcInitSingle(&filter, impulseResponse.data(), 1, 8, 1);
+	hcCloseSingle(&filter);
+	hcCloseSingle(&filter);
+
+	harness.expect(filter.storage == nullptr, "closing an empty convolver should preserve its empty state");
+}
+
+void assertInvalidConvolverArgumentsLeaveEmptyOutput()
+{
+	vector<double> impulseResponse(1, 1.0);
+	HConvSingle filter = {};
+	bool rejected = false;
+	try
+	{
+		hcInitSingle(&filter, impulseResponse.data(), 1, 1, 0);
+	}
+	catch (const std::invalid_argument&)
+	{
+		rejected = true;
+	}
+
+	harness.expect(rejected, "hcInitSingle should reject a zero processing-step count");
+	harness.expect(filter.storage == nullptr, "failed hcInitSingle should leave a safely closable empty output");
+	hcCloseSingle(&filter);
+
+	rejected = false;
+	try
+	{
+		hcInitSingle(&filter, impulseResponse.data(), 1, (std::numeric_limits<int>::max)(), 1);
+	}
+	catch (const std::length_error&)
+	{
+		rejected = true;
+	}
+	harness.expect(rejected, "hcInitSingle should reject a frame length that overflows FFTW's transform size");
+}
+
+void assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix()
+{
+	constexpr unsigned slotCount = 2;
+	auto* slots = static_cast<HConvSingle*>(MemoryHelper::alloc(sizeof(HConvSingle) * slotCount));
+	if (slots == nullptr)
+		fail("could not allocate convolver slots for partial-initialization test");
+	memset(slots, 0xA5, sizeof(HConvSingle) * slotCount);
+
+	HConvSingleArray pending;
+	pending.adoptUninitialized(slots, slotCount);
+	vector<double> impulseResponse(1, 1.0);
+	hcInitSingle(&pending[0], impulseResponse.data(), 1, 8, 1);
+	pending.markInitialized();
+
+	HConvSingleArray owner(std::move(pending));
+	owner.reset();
+	owner.reset();
+}
+
 void assertConvolutionPathParsing()
 {
 	_wputenv_s(L"EAPO_XT_TEST_IR_DIR", L"C:\\Impulse Responses");
@@ -282,6 +350,7 @@ void assertConvolutionPathParsing()
 		ConvolutionFilePath::resolve(L"C:\\EqualizerAPO\\config\\config.txt", L"") == L"",
 		"empty convolution path should remain empty");
 }
+
 }
 
 int main()
@@ -292,6 +361,9 @@ int main()
 	assertSparseImpulseResponseSurvivesPastOneSecond(137);
 	assertConvolutionFilterRecoversFromInitialShortFrame();
 	assertPartitionBuffersFormOneSlab();
+	assertEmptyConvolverCloseIsIdempotent();
+	assertInvalidConvolverArgumentsLeaveEmptyOutput();
+	assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix();
 	assertConvolutionPathParsing();
 
 	// Pure-logic helper, command-codec and parser-extension coverage that also

--- a/Tests/HybridConvTests/IIRCommandTests.cpp
+++ b/Tests/HybridConvTests/IIRCommandTests.cpp
@@ -64,6 +64,12 @@ void testParameterValidation()
 	harness.expectFalse(
 		IIRFilterFactory::parseCommand(L"Filter", L"ON IIR Order 1", cmd),
 		"a line without Coefficients is rejected");
+	harness.expectFalse(
+		IIRFilterFactory::parseCommand(L"Filter", L"ON IIR Order 1 Coefficients 1 0 0 0", cmd),
+		"a zero a0 coefficient is rejected");
+	harness.expectFalse(
+		IIRFilterFactory::parseCommand(L"Filter", L"ON IIR Order 1 Coefficients 1e999 0 1 0", cmd),
+		"non-finite coefficients are rejected");
 }
 
 void testRoundTrip()

--- a/Tests/HybridConvTests/VstHostTests.cpp
+++ b/Tests/HybridConvTests/VstHostTests.cpp
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -45,6 +46,8 @@
 
 #include "helpers/VSTPluginLibrary.h"
 #include "helpers/VSTPluginInstance.h"
+#include "filters/VSTPluginFilter.h"
+#include "filters/loudnessCorrection/VolumeController.h"
 #include "Tests/TestHarness.h"
 
 using std::shared_ptr;
@@ -55,6 +58,41 @@ using std::wstring;
 namespace
 {
 test::Harness harness("VstHostTests");
+
+class RejectingLibrary : public AbstractLibrary
+{
+public:
+	explicit RejectingLibrary(wstring path)
+		: path(std::move(path))
+	{
+	}
+
+	wstring getLibPath() override
+	{
+		return path;
+	}
+
+	int getCustomInitializeCount() const
+	{
+		return customInitializeCount;
+	}
+
+protected:
+	bool loadFunctions() override
+	{
+		return true;
+	}
+
+	int customInitialize() override
+	{
+		++customInitializeCount;
+		return FUNCTIONS_MISSING;
+	}
+
+private:
+	wstring path;
+	int customInitializeCount = 0;
+};
 
 // Must match TestVst2Plugin.cpp's ChunkBlob layout and magic exactly so we can
 // build a chunk the plugin will accept and predict what it emits.
@@ -131,10 +169,65 @@ bool closeEnough(double a, double b)
 {
 	return std::fabs(a - b) <= 1.0e-9;
 }
+
+void expectRejectedMetadataPassesThrough(const shared_ptr<VSTPluginLibrary>& library,
+	const wchar_t* mode, const std::string& label)
+{
+	SetEnvironmentVariableW(L"EAPO_TEST_VST_METADATA", mode);
+
+	ChunkBlob gainBlob = {};
+	gainBlob.magic = kChunkMagic;
+	gainBlob.version = kChunkVersion;
+	gainBlob.gain = 0.5f;
+
+	{
+		VSTPluginFilter filter(library, encodeChunk(gainBlob), unordered_map<wstring, float>());
+		filter.initialize(48000.0f, 4, {L"L", L"R"});
+
+		double inLeft[4] = {0.25, 0.5, 0.75, 1.0};
+		double inRight[4] = {-0.25, -0.5, -0.75, -1.0};
+		double outLeft[4] = {};
+		double outRight[4] = {};
+		double* input[2] = {inLeft, inRight};
+		double* output[2] = {outLeft, outRight};
+		filter.process(output, input, 4);
+
+		bool unchanged = true;
+		for (int i = 0; i < 4; ++i)
+		{
+			if (!closeEnough(outLeft[i], inLeft[i]) || !closeEnough(outRight[i], inRight[i]))
+				unchanged = false;
+		}
+		harness.expectTrue(unchanged, label + ": malformed plugin is bypassed");
+	}
+
+	SetEnvironmentVariableW(L"EAPO_TEST_VST_METADATA", nullptr);
+}
+
+void testVolumeControllerBalancesComInitialization()
+{
+	bool threadStartedUninitialized = false;
+	bool threadEndedUninitialized = false;
+	std::thread worker([&]()
+	{
+		ULONG_PTR token = 0;
+		threadStartedUninitialized = CoGetContextToken(&token) == CO_E_NOTINITIALIZED;
+		{
+			VolumeController controller;
+		}
+		threadEndedUninitialized = CoGetContextToken(&token) == CO_E_NOTINITIALIZED;
+	});
+	worker.join();
+
+	harness.expectTrue(threadStartedUninitialized, "COM balance test starts on an uninitialized thread");
+	harness.expectTrue(threadEndedUninitialized, "VolumeController balances COM initialization");
+}
 } // namespace
 
 void runVstHostTests()
 {
+	testVolumeControllerBalancesComInitialization();
+
 	const wstring dir = exeDirectory();
 	if (dir.empty())
 	{
@@ -151,6 +244,17 @@ void runVstHostTests()
 		return;
 	}
 
+	// A failed subclass initialization must roll the DLL load back completely.
+	// Otherwise the second call sees a non-null module and returns 0 (already
+	// initialized), turning the original failure into a false success.
+	RejectingLibrary rejectingLibrary(dllPath);
+	harness.expectEqual(rejectingLibrary.initialize(), AbstractLibrary::FUNCTIONS_MISSING,
+		"custom initialization failure is reported");
+	harness.expectEqual(rejectingLibrary.initialize(), AbstractLibrary::FUNCTIONS_MISSING,
+		"custom initialization failure is reported again after rollback");
+	harness.expectEqual(rejectingLibrary.getCustomInitializeCount(), 2,
+		"custom initialization is retried after rollback");
+
 	// Load the library through the engine's loader (LoadLibrary +
 	// GetProcAddress(VSTPluginMain)). initialize() returns >0 on the first
 	// successful load (1) and 0 if already loaded; negative values are the
@@ -162,6 +266,13 @@ void runVstHostTests()
 	int loadResult = library->initialize();
 	harness.expectTrue(loadResult >= 0, "library initialize did not return an error code");
 	harness.expectTrue(library->VSTPluginMain != nullptr, "VSTPluginMain symbol resolved");
+
+	expectRejectedMetadataPassesThrough(library, L"huge-inputs", "unrealistic input count");
+	expectRejectedMetadataPassesThrough(library, L"negative-inputs", "negative input count");
+	expectRejectedMetadataPassesThrough(library, L"huge-outputs", "unrealistic output count");
+	expectRejectedMetadataPassesThrough(library, L"negative-outputs", "negative output count");
+	expectRejectedMetadataPassesThrough(library, L"negative-delay", "negative initial delay");
+	expectRejectedMetadataPassesThrough(library, L"huge-delay", "unrealistic initial delay");
 
 	// Construct and initialize the instance the way the engine does (heap
 	// allocated, owned here). processLevel mirrors a realtime audio thread.

--- a/Tests/TestVst2Plugin/TestVst2Plugin.cpp
+++ b/Tests/TestVst2Plugin/TestVst2Plugin.cpp
@@ -32,6 +32,9 @@
 #include <cstdint>
 #include <cstring>
 
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
 #include "helpers/aeffectx.h"
 
 namespace
@@ -289,6 +292,27 @@ vst_effect_t* createEffect()
 	effect->version = 1;
 	effect->process_float = &processReplacing;
 	effect->process_double = &processDoubleReplacing;
+
+	// Host robustness tests select malformed metadata before creating an
+	// instance. Normal test runs leave the variable unset and retain the fixed
+	// two-channel contract documented above.
+	wchar_t metadataMode[32] = {};
+	if (GetEnvironmentVariableW(L"EAPO_TEST_VST_METADATA", metadataMode,
+		static_cast<DWORD>(sizeof(metadataMode) / sizeof(metadataMode[0]))) > 0)
+	{
+		if (wcscmp(metadataMode, L"huge-inputs") == 0)
+			effect->num_inputs = 2048;
+		else if (wcscmp(metadataMode, L"negative-inputs") == 0)
+			effect->num_inputs = -1;
+		else if (wcscmp(metadataMode, L"huge-outputs") == 0)
+			effect->num_outputs = 2048;
+		else if (wcscmp(metadataMode, L"negative-outputs") == 0)
+			effect->num_outputs = -1;
+		else if (wcscmp(metadataMode, L"negative-delay") == 0)
+			effect->delay = -1;
+		else if (wcscmp(metadataMode, L"huge-delay") == 0)
+			effect->delay = INT32_MAX;
+	}
 
 	return effect;
 }

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -60,58 +60,100 @@ using std::wstring;
 using namespace mup;
 
 
-void FilterEngine::loadConfig(const wstring& customPath)
+bool FilterEngine::loadConfig(const wstring& customPath)
 {
 	lock_guard<mutex> lock(loadMutex);
 	timer.start();
-	previousConfig.reset();
 
-	allChannelNames = ChannelHelper::getChannelNames(max(realChannelCount, outputChannelCount), channelMask);
+	// The factories build through these engine-owned scratch fields. Move the
+	// previous idle state aside so the whole load is transactional: any exception
+	// discards the partial filters/channel routing and restores registry watches,
+	// while currentConfig remains untouched.
+	auto savedFilterInfos = move(filterInfos);
+	auto savedCurrentChannelNames = move(currentChannelNames);
+	auto savedLastChannelNames = move(lastChannelNames);
+	auto savedLastNewChannelNames = move(lastNewChannelNames);
+	auto savedAllChannelNames = move(allChannelNames);
+	auto savedWatchRegistryKeys = move(watchRegistryKeys);
+	auto savedTraceFile = move(traceFile);
+	const int savedTraceLine = traceLine;
+	const bool savedLastInPlace = lastInPlace;
 
-	currentChannelNames = allChannelNames;
-	lastChannelNames.clear();
-	lastNewChannelNames.clear();
-	watchRegistryKeys.clear();
-	parser->ClearVar();
+	auto rollback = [&]() noexcept {
+		filterInfos = move(savedFilterInfos);
+		currentChannelNames = move(savedCurrentChannelNames);
+		lastChannelNames = move(savedLastChannelNames);
+		lastNewChannelNames = move(savedLastNewChannelNames);
+		allChannelNames = move(savedAllChannelNames);
+		watchRegistryKeys = move(savedWatchRegistryKeys);
+		traceFile = move(savedTraceFile);
+		traceLine = savedTraceLine;
+		lastInPlace = savedLastInPlace;
+	};
 
-	for (auto it = factories.cbegin(); it != factories.cend(); it++)
+	try
 	{
-		IFilterFactory* factory = it->get();
-		vector<IFilter*> newFilters = factory->startOfConfiguration();
-		if (!newFilters.empty())
-			addFilters(newFilters);
+		allChannelNames = ChannelHelper::getChannelNames(max(realChannelCount, outputChannelCount), channelMask);
+
+		currentChannelNames = allChannelNames;
+		lastChannelNames.clear();
+		lastNewChannelNames.clear();
+		watchRegistryKeys.clear();
+		parser->ClearVar();
+
+		for (auto it = factories.cbegin(); it != factories.cend(); it++)
+		{
+			IFilterFactory* factory = it->get();
+			FilterVector newFilters = factory->startOfConfiguration();
+			if (!newFilters.empty())
+				addFilters(move(newFilters));
+		}
+
+		if (customPath.empty())
+			loadConfigFile(configPath + L"\\config.txt");
+		else
+			loadConfigFile(customPath);
+
+		for (auto it = factories.cbegin(); it != factories.cend(); it++)
+		{
+			IFilterFactory* factory = it->get();
+			FilterVector newFilters = factory->endOfConfiguration();
+			if (!newFilters.empty())
+				addFilters(move(newFilters));
+		}
+
+		FilterConfigurationPtr config(MemoryHelper::construct<FilterConfiguration>(this, move(filterInfos), (unsigned)allChannelNames.size()));
+
+		filterInfos.clear();
+
+		double loadTime = timer.stop();
+		TraceF(L"Finished loading configuration after %lf milliseconds", loadTime * 1000.0);
+
+		previousConfig.reset();
+		if (!currentConfig)
+			currentConfig = move(config);
+		else
+		{
+			nextConfig = move(config);
+			// Release: publish the fully-constructed FilterConfiguration to the RT
+			// thread. Pairs with the acquire loads in process()/finishTransitionIfReady.
+			nextConfigReady.store(true, std::memory_order_release);
+		}
+		return true;
 	}
-
-	if (customPath.empty())
-		loadConfigFile(configPath + L"\\config.txt");
-	else
-		loadConfigFile(customPath);
-
-	for (auto it = factories.cbegin(); it != factories.cend(); it++)
+	catch (const exception& e)
 	{
-		IFilterFactory* factory = it->get();
-		vector<IFilter*> newFilters = factory->endOfConfiguration();
-		if (!newFilters.empty())
-			addFilters(newFilters);
+		rollback();
+		timer.stop();
+		LogF(L"Configuration load failed; keeping the active configuration: %S", e.what());
 	}
-
-	void* mem = MemoryHelper::alloc(sizeof(FilterConfiguration));
-	FilterConfigurationPtr config(new(mem) FilterConfiguration(this, move(filterInfos), (unsigned)allChannelNames.size()));
-
-	filterInfos.clear();
-
-	double loadTime = timer.stop();
-	TraceF(L"Finished loading configuration after %lf milliseconds", loadTime * 1000.0);
-
-	if (!currentConfig)
-		currentConfig = move(config);
-	else
+	catch (...)
 	{
-		nextConfig = move(config);
-		// Release: publish the fully-constructed FilterConfiguration to the RT
-		// thread. Pairs with the acquire loads in process()/finishTransitionIfReady.
-		nextConfigReady.store(true, std::memory_order_release);
+		rollback();
+		timer.stop();
+		LogF(L"Configuration load failed with an unknown exception; keeping the active configuration");
 	}
+	return false;
 }
 
 void FilterEngine::loadConfigFile(const wstring& path)
@@ -134,9 +176,9 @@ void FilterEngine::loadConfigFile(const wstring& path)
 	for (auto it = factories.cbegin(); it != factories.cend(); it++)
 	{
 		IFilterFactory* factory = it->get();
-		vector<IFilter*> newFilters = factory->startOfFile(path);
+		FilterVector newFilters = factory->startOfFile(path);
 		if (!newFilters.empty())
-			addFilters(newFilters);
+			addFilters(move(newFilters));
 	}
 
 	while (inputStream.good())
@@ -165,15 +207,9 @@ void FilterEngine::loadConfigFile(const wstring& path)
 			{
 				IFilterFactory* factory = it->get();
 
-				vector<IFilter*> newFilters;
+				FilterVector newFilters;
 				try
 				{
-					// A factory that throws after constructing some filters leaks
-					// those IFilter*s: partial results live inside the factory and
-					// cannot be reclaimed here. The leak is bounded by config-reload
-					// frequency and accepted; factories that allocate more than
-					// trivially should own partials via a scope guard before
-					// returning.
 					newFilters = factory->createFilter(path, key, value);
 				}
 				catch (const exception& e)
@@ -185,7 +221,7 @@ void FilterEngine::loadConfigFile(const wstring& path)
 					break;
 				if (!newFilters.empty())
 				{
-					addFilters(newFilters);
+					addFilters(move(newFilters));
 					producedFilter = true;
 					break;
 				}
@@ -224,9 +260,9 @@ void FilterEngine::loadConfigFile(const wstring& path)
 	for (auto it = factories.cbegin(); it != factories.cend(); it++)
 	{
 		IFilterFactory* factory = it->get();
-		vector<IFilter*> newFilters = factory->endOfFile(path);
+		FilterVector newFilters = factory->endOfFile(path);
 		if (!newFilters.empty())
-			addFilters(newFilters);
+			addFilters(move(newFilters));
 	}
 
 	// restore channels selected in outer configuration file

--- a/engine/FilterEngine.Runtime.cpp
+++ b/engine/FilterEngine.Runtime.cpp
@@ -54,13 +54,13 @@ using std::vector;
 using std::wstring;
 
 
-void FilterEngine::addFilters(const vector<IFilter*>& filters)
+void FilterEngine::addFilters(FilterVector filters)
 {
-	for (vector<IFilter*>::const_iterator it = filters.begin(); it != filters.end(); it++)
+	for (FilterPtr& ownedFilter : filters)
 	{
-		IFilter* filter = *it;
 		auto filterInfo = make_unique<FilterInfo>();
-		filterInfo->filter.reset(filter);
+		filterInfo->filter = move(ownedFilter);
+		IFilter* filter = filterInfo->filter.get();
 		filterInfo->inPlace = filter->getInPlace();
 		vector<wstring> savedChannelNames = currentChannelNames;
 		bool allChannels = filter->getAllChannels();
@@ -247,7 +247,13 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 				break;
 			}
 
-			engine->loadConfig();
+			const bool loaded = engine->loadConfig();
+			// A successful reload normally keeps the permit until the RT thread
+			// finishes the crossfade. Failed loads publish nothing, and a recovery
+			// load after an initially missing configuration installs currentConfig
+			// directly; both cases must return the permit here.
+			if (!loaded || !engine->nextConfigReady.load(std::memory_order_acquire))
+				engine->releaseLoadPermit();
 			FindNextChangeNotification(notificationHandle);
 			registryEvent.reset();
 		}

--- a/filters/BiQuadFilterFactory.cpp
+++ b/filters/BiQuadFilterFactory.cpp
@@ -232,15 +232,14 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	return true;
 }
 
-vector<IFilter*> BiQuadFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector BiQuadFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	BiQuadCommand cmd;
 	if (!parseCommand(command, parameters, cmd))
-		return vector<IFilter*>(0);
+		return {};
 
-	BiQuadFilter* filter = MemoryHelper::construct<BiQuadFilter>(
-		cmd.type, cmd.dbGain, cmd.freq, cmd.bandwidthOrQOrS, cmd.isBandwidthOrS, cmd.isCornerFreq);
-	return vector<IFilter*>(1, filter);
+	return singleFilter(makeFilter<BiQuadFilter>(
+		cmd.type, cmd.dbGain, cmd.freq, cmd.bandwidthOrQOrS, cmd.isBandwidthOrS, cmd.isCornerFreq));
 }
 
 double BiQuadFilterFactory::getFreq(const wstring& freqString)

--- a/filters/BiQuadFilterFactory.h
+++ b/filters/BiQuadFilterFactory.h
@@ -30,7 +30,7 @@ class BiQuadFilterFactory : public IFilterFactory
 {
 public:
 	BiQuadFilterFactory();
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 	// Parses a "Filter:" config line into a BiQuadCommand. This is the single
 	// owner of the BiQuad config-line grammar: createFilter() uses it to build

--- a/filters/ChannelFilterFactory.cpp
+++ b/filters/ChannelFilterFactory.cpp
@@ -31,12 +31,11 @@ REGISTER_FILTER_FACTORY(FilterFactoryPriority::Channel, ChannelFilterFactory, fa
 using std::vector;
 using std::wstring;
 
-vector<IFilter*> ChannelFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector ChannelFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	ChannelCommand cmd;
 	if (!ChannelCommand::parse(command, parameters, cmd))
-		return vector<IFilter*>(0);
+		return {};
 
-	ChannelFilter* filter = MemoryHelper::construct<ChannelFilter>(cmd.channels);
-	return vector<IFilter*>(1, filter);
+	return singleFilter(makeFilter<ChannelFilter>(cmd.channels));
 }

--- a/filters/ChannelFilterFactory.h
+++ b/filters/ChannelFilterFactory.h
@@ -27,5 +27,5 @@
 class ChannelFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <cmath>
 #include <memory>
+#include <utility>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <fftw3.h>
@@ -152,12 +153,15 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 		LogF(L"ConvolutionFilter: could not allocate %u filter slots", channelCount);
 		return;
 	}
-	filters.adopt(allocated, channelCount);
+	HConvSingleArray pendingFilters;
+	pendingFilters.adoptUninitialized(allocated, channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		// hcInitSingle reads the IR samples during planning but does not retain
 		// the pointer, so it is safe to feed it the shared cache buffer.
 		const std::vector<double>& src = ir->buffers[i % ir->channels];
-		hcInitSingle(&filters[i], const_cast<double*>(src.data()), static_cast<int>(ir->frames), static_cast<int>(frameCount), 1);
+		hcInitSingle(&pendingFilters[i], const_cast<double*>(src.data()), static_cast<int>(ir->frames), static_cast<int>(frameCount), 1);
+		pendingFilters.markInitialized();
 	}
+	filters = std::move(pendingFilters);
 }

--- a/filters/ConvolutionFilterFactory.cpp
+++ b/filters/ConvolutionFilterFactory.cpp
@@ -32,16 +32,15 @@ REGISTER_FILTER_FACTORY(FilterFactoryPriority::Convolution, ConvolutionFilterFac
 using std::vector;
 using std::wstring;
 
-vector<IFilter*> ConvolutionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector ConvolutionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	ConvolutionCommand cmd;
 	if (!ConvolutionCommand::parse(command, parameters, cmd))
-		return vector<IFilter*>(0);
+		return {};
 
 	wstring absolutePath = ConvolutionFilePath::resolve(configPath, cmd.path);
 	if (absolutePath.empty())
-		return vector<IFilter*>(0);
+		return {};
 
-	ConvolutionFilter* filter = MemoryHelper::construct<ConvolutionFilter>(absolutePath);
-	return vector<IFilter*>(1, filter);
+	return singleFilter(makeFilter<ConvolutionFilter>(absolutePath));
 }

--- a/filters/ConvolutionFilterFactory.h
+++ b/filters/ConvolutionFilterFactory.h
@@ -27,5 +27,5 @@
 class ConvolutionFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/CopyFilter.cpp
+++ b/filters/CopyFilter.cpp
@@ -40,8 +40,6 @@ CopyFilter::CopyFilter(const vector<Assignment>& assignments)
 {
 	this->assignments = assignments;
 
-	internalAssignments = nullptr;
-	assignmentCount = 0;
 }
 
 CopyFilter::~CopyFilter()
@@ -51,17 +49,13 @@ CopyFilter::~CopyFilter()
 
 vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount, vector<wstring> channelNames)
 {
-	cleanup();
-
-	assignmentCount = (unsigned)assignments.size();
-	internalAssignments = (InternalAssignment*)MemoryHelper::alloc(assignmentCount * sizeof(InternalAssignment));
-
+	vector<InternalAssignment> preparedAssignments;
+	preparedAssignments.reserve(assignments.size());
 	vector<wstring> outChannelNames;
 
-	for (unsigned i = 0; i < assignmentCount; i++)
+	for (Assignment& a : assignments)
 	{
-		InternalAssignment& ia = internalAssignments[i];
-		Assignment& a = assignments[i];
+		InternalAssignment ia;
 
 		wstring channelName = a.targetChannel;
 		int channelIndex = ChannelHelper::getChannelIndex(a.targetChannel, channelNames, true);
@@ -72,13 +66,11 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 		if (it == outChannelNames.end())
 			outChannelNames.push_back(channelName);
 
-		ia.sourceCount = (unsigned)a.sourceSum.size();
-		ia.sourceSum = (InternalAssignment::InternalSummand*)MemoryHelper::alloc(ia.sourceCount * sizeof(InternalAssignment::InternalSummand));
+		ia.sourceSum.reserve(a.sourceSum.size());
 
-		for (unsigned j = 0; j < ia.sourceCount; j++)
+		for (Assignment::Summand& s : a.sourceSum)
 		{
-			InternalAssignment::InternalSummand& is = ia.sourceSum[j];
-			Assignment::Summand& s = a.sourceSum[j];
+			InternalAssignment::InternalSummand is;
 
 			if (s.channel != L"")
 				is.channel = ChannelHelper::getChannelIndex(s.channel, channelNames);
@@ -89,18 +81,22 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 				is.factor = pow(10.0, s.factor / 20.0);
 			else
 				is.factor = s.factor;
+
+			ia.sourceSum.push_back(is);
 		}
+
+		preparedAssignments.push_back(std::move(ia));
 	}
 
 	wstringstream stream;
 	stream << "Copying ";
-	for (unsigned i = 0; i < assignmentCount; i++)
+	for (size_t i = 0; i < preparedAssignments.size(); i++)
 	{
-		InternalAssignment& ia = internalAssignments[i];
+		InternalAssignment& ia = preparedAssignments[i];
 		if (i > 0)
 			stream << ", ";
 		stream << L"to channel " << outChannelNames[ia.targetChannel].c_str() << " ";
-		for (unsigned j = 0; j < ia.sourceCount; j++)
+		for (size_t j = 0; j < ia.sourceSum.size(); j++)
 		{
 			const InternalAssignment::InternalSummand& is = ia.sourceSum[j];
 			if (j > 0)
@@ -112,6 +108,7 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 		}
 	}
 	TraceF(L"%s", stream.str().c_str());
+	internalAssignments = std::move(preparedAssignments);
 
 	return outChannelNames;
 }
@@ -120,11 +117,9 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 void CopyFilter::process(double** output, double** input, unsigned frameCount)
 {
 	PerfScope _ps("CopyFilter::process");
-	for (unsigned i = 0; i < assignmentCount; i++)
+	for (InternalAssignment& ia : internalAssignments)
 	{
-		InternalAssignment& ia = internalAssignments[i];
-
-		if (ia.targetChannel == -1 || ia.sourceCount == 0)
+		if (ia.targetChannel == -1 || ia.sourceSum.empty())
 			continue;
 
 		{
@@ -140,7 +135,7 @@ void CopyFilter::process(double** output, double** input, unsigned frameCount)
 					output[ia.targetChannel][f] = is.factor * input[is.channel][f];
 		}
 
-		for (unsigned j = 1; j < ia.sourceCount; j++)
+		for (size_t j = 1; j < ia.sourceSum.size(); j++)
 		{
 			const InternalAssignment::InternalSummand& is = ia.sourceSum[j];
 
@@ -160,21 +155,7 @@ void CopyFilter::process(double** output, double** input, unsigned frameCount)
 
 void CopyFilter::cleanup()
 {
-	if (internalAssignments != nullptr)
-	{
-		for (unsigned i = 0; i < assignmentCount; i++)
-		{
-			InternalAssignment& ia = internalAssignments[i];
-			if (ia.sourceSum != nullptr)
-			{
-				MemoryHelper::free(ia.sourceSum);
-				ia.sourceSum = nullptr;
-			}
-		}
-
-		MemoryHelper::free(internalAssignments);
-		internalAssignments = nullptr;
-	}
+	internalAssignments.clear();
 }
 
 const std::vector<Assignment>& CopyFilter::getAssignments() const

--- a/filters/CopyFilter.h
+++ b/filters/CopyFilter.h
@@ -84,12 +84,12 @@ private:
 
 	struct InternalAssignment
 	{
-		int targetChannel;
+		int targetChannel = 0;
 
 		struct InternalSummand
 		{
-			double factor;
-			int channel;
+			double factor = 0.0;
+			int channel = 0;
 		};
 
 		std::vector<InternalSummand> sourceSum;

--- a/filters/CopyFilter.h
+++ b/filters/CopyFilter.h
@@ -92,11 +92,9 @@ private:
 			int channel;
 		};
 
-		InternalSummand* sourceSum;
-		unsigned sourceCount;
+		std::vector<InternalSummand> sourceSum;
 	};
 
-	InternalAssignment* internalAssignments;
-	unsigned assignmentCount;
+	std::vector<InternalAssignment> internalAssignments;
 };
 #pragma AVRT_VTABLES_END

--- a/filters/CopyFilterFactory.cpp
+++ b/filters/CopyFilterFactory.cpp
@@ -31,20 +31,16 @@ using std::find;
 using std::vector;
 using std::wstring;
 
-vector<IFilter*> CopyFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector CopyFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	CopyFilter* filter = nullptr;
-
 	if (command == L"Copy")
 	{
 		// Parse the routing via the shared parser (parseCopyAssignments), the
 		// same routine the Editor GUI factory uses.
 		vector<Assignment> assignments = parseCopyAssignments(parameters);
 
-		filter = MemoryHelper::construct<CopyFilter>(assignments);
+		return singleFilter(makeFilter<CopyFilter>(assignments));
 	}
 
-	if (filter == nullptr)
-		return vector<IFilter*>(0);
-	return vector<IFilter*>(1, filter);
+	return {};
 }

--- a/filters/CopyFilterFactory.h
+++ b/filters/CopyFilterFactory.h
@@ -27,5 +27,5 @@
 class CopyFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/DelayFilterFactory.cpp
+++ b/filters/DelayFilterFactory.cpp
@@ -77,12 +77,11 @@ bool DelayFilterFactory::parseCommand(const wstring& command, wstring& parameter
 	return false;
 }
 
-vector<IFilter*> DelayFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector DelayFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	DelayCommand cmd;
 	if (!parseCommand(command, parameters, cmd))
-		return vector<IFilter*>(0);
+		return {};
 
-	DelayFilter* filter = MemoryHelper::construct<DelayFilter>(cmd.delay, cmd.isMs);
-	return vector<IFilter*>(1, filter);
+	return singleFilter(makeFilter<DelayFilter>(cmd.delay, cmd.isMs));
 }

--- a/filters/DelayFilterFactory.h
+++ b/filters/DelayFilterFactory.h
@@ -28,7 +28,7 @@
 class DelayFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 	// Parses a "Delay:" config line into a DelayCommand. This is the single owner
 	// of the Delay config-line grammar: createFilter() uses it to build the

--- a/filters/DeviceFilterFactory.cpp
+++ b/filters/DeviceFilterFactory.cpp
@@ -45,14 +45,14 @@ void DeviceFilterFactory::initialize(FilterEngine* engine)
 }
 #endif
 
-vector<IFilter*> DeviceFilterFactory::startOfConfiguration()
+FilterVector DeviceFilterFactory::startOfConfiguration()
 {
 	deviceMatches = true;
 
-	return vector<IFilter*>();
+	return {};
 }
 
-vector<IFilter*> DeviceFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector DeviceFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	DeviceCommand cmd;
 	if (DeviceCommand::parse(command, parameters, cmd))
@@ -67,13 +67,13 @@ vector<IFilter*> DeviceFilterFactory::createFilter(const wstring& configPath, ws
 		// skip line for further factories
 		command = L"";
 
-	return vector<IFilter*>();
+	return {};
 }
 
-std::vector<IFilter*> DeviceFilterFactory::endOfFile(const std::wstring& configPath)
+FilterVector DeviceFilterFactory::endOfFile(const std::wstring& configPath)
 {
 	// in outer file, the device must have matched, otherwise the inner file would not have been included
 	deviceMatches = true;
 
-	return vector<IFilter*>();
+	return {};
 }

--- a/filters/DeviceFilterFactory.h
+++ b/filters/DeviceFilterFactory.h
@@ -30,9 +30,9 @@ public:
 #ifndef NO_FILTERENGINE
 	void initialize(FilterEngine* engine) override;
 #endif
-	std::vector<IFilter*> startOfConfiguration() override;
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
-	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
+	FilterVector startOfConfiguration() override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector endOfFile(const std::wstring& configPath) override;
 
 private:
 	bool deviceMatches = false;

--- a/filters/ExpressionFilterFactory.cpp
+++ b/filters/ExpressionFilterFactory.cpp
@@ -52,10 +52,10 @@ void ExpressionFilterFactory::initialize(FilterEngine* engine)
 	registerEngineFreeParserExtensions(*parser);
 }
 
-vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector ExpressionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	if (command.length() > 0 && command[0] == L'#')
-		return vector<IFilter*>();
+		return {};
 
 	// Lex through the shared codec, then evaluate the expression segments in
 	// place so the other factories see the substituted parameter text.
@@ -132,5 +132,5 @@ vector<IFilter*> ExpressionFilterFactory::createFilter(const wstring& configPath
 		command = L"";
 	}
 
-	return vector<IFilter*>();
+	return {};
 }

--- a/filters/ExpressionFilterFactory.h
+++ b/filters/ExpressionFilterFactory.h
@@ -29,7 +29,7 @@ class ExpressionFilterFactory : public IFilterFactory
 {
 public:
 	void initialize(FilterEngine* engine) override;
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 private:
 	mup::ParserX* parser = nullptr;

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -20,8 +20,11 @@
 #include "stdafx.h"
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <mutex>
+#include <new>
+#include <stdexcept>
 #include <unordered_map>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -77,10 +80,25 @@ namespace
 		}
 	};
 
-	struct EqIrCacheEntry
+	struct FftwComplexDeleter
 	{
-		std::vector<double> ir;
+		void operator()(fftw_complex* value) const noexcept
+		{
+			fftw_free(value);
+		}
 	};
+
+	struct FftwPlanDeleter
+	{
+		void operator()(fftw_plan_s* value) const noexcept
+		{
+			if (value != nullptr)
+				fftw_destroy_plan(value);
+		}
+	};
+
+	using FftwComplexPtr = std::unique_ptr<fftw_complex, FftwComplexDeleter>;
+	using FftwPlanPtr = std::unique_ptr<fftw_plan_s, FftwPlanDeleter>;
 
 	std::mutex& eqIrCacheMutex()
 	{
@@ -88,9 +106,9 @@ namespace
 		return m;
 	}
 
-	std::unordered_map<EqIrCacheKey, std::shared_ptr<const EqIrCacheEntry>, EqIrCacheKeyHash>& eqIrCache()
+	std::unordered_map<EqIrCacheKey, std::weak_ptr<const std::vector<double>>, EqIrCacheKeyHash>& eqIrCache()
 	{
-		static std::unordered_map<EqIrCacheKey, std::shared_ptr<const EqIrCacheEntry>, EqIrCacheKeyHash> c;
+		static std::unordered_map<EqIrCacheKey, std::weak_ptr<const std::vector<double>>, EqIrCacheKeyHash> c;
 		return c;
 	}
 }
@@ -108,24 +126,31 @@ const std::vector<FilterNode>& GraphicEQFilter::getNodes()
 void GraphicEQFilter::initializeFilters(unsigned frameCount)
 {
 	EqIrCacheKey key{ nodes, static_cast<int>(sampleRate), filterLength };
-	std::shared_ptr<const EqIrCacheEntry> cached;
+	std::shared_ptr<const std::vector<double>> cached;
 	{
 		std::lock_guard<std::mutex> lock(eqIrCacheMutex());
 		auto it = eqIrCache().find(key);
 		if (it != eqIrCache().end())
-			cached = it->second;
+			cached = it->second.lock();
 	}
 
 	if (!cached)
 	{
-		auto entry = std::make_shared<EqIrCacheEntry>();
-		entry->ir.resize(filterLength);
+		if (filterLength == 0 || filterLength > static_cast<unsigned>((std::numeric_limits<int>::max)() / 2))
+			throw std::invalid_argument("GraphicEQ filter length is out of range");
+
+		auto entry = std::make_shared<std::vector<double>>(filterLength);
+		const size_t fftLength = static_cast<size_t>(filterLength) * 2;
 
 		fftw_make_planner_thread_safe();
-		fftw_complex* timeData = fftw_alloc_complex(filterLength * 2);
-		fftw_complex* freqData = fftw_alloc_complex(filterLength * 2);
-		fftw_plan planForward = fftw_plan_dft_1d(filterLength * 2, timeData, freqData, FFTW_FORWARD, FFTW_ESTIMATE);
-		fftw_plan planReverse = fftw_plan_dft_1d(filterLength * 2, freqData, timeData, FFTW_BACKWARD, FFTW_ESTIMATE);
+		FftwComplexPtr timeData(fftw_alloc_complex(fftLength));
+		FftwComplexPtr freqData(fftw_alloc_complex(fftLength));
+		if (!timeData || !freqData)
+			throw std::bad_alloc();
+		FftwPlanPtr planForward(fftw_plan_dft_1d(static_cast<int>(fftLength), timeData.get(), freqData.get(), FFTW_FORWARD, FFTW_ESTIMATE));
+		FftwPlanPtr planReverse(fftw_plan_dft_1d(static_cast<int>(fftLength), freqData.get(), timeData.get(), FFTW_BACKWARD, FFTW_ESTIMATE));
+		if (!planForward || !planReverse)
+			throw std::runtime_error("Could not create GraphicEQ FFTW plans");
 
 		GainIterator gainIterator(nodes);
 		for (unsigned i = 0; i < filterLength; i++)
@@ -134,43 +159,46 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 			double dbGain = gainIterator.gainAt(freq);
 			double gain = pow(10.0, dbGain / 20.0);
 
-			freqData[i][0] = gain;
-			freqData[i][1] = 0;
-			freqData[2 * filterLength - i - 1][0] = gain;
-			freqData[2 * filterLength - i - 1][1] = 0;
+			freqData.get()[i][0] = gain;
+			freqData.get()[i][1] = 0;
+			freqData.get()[2 * filterLength - i - 1][0] = gain;
+			freqData.get()[2 * filterLength - i - 1][1] = 0;
 		}
 
-		mps(timeData, freqData, planForward, planReverse);
+		mps(timeData.get(), freqData.get(), planForward.get(), planReverse.get());
 
-		fftw_execute(planReverse);
+		fftw_execute(planReverse.get());
 
 		for (unsigned i = 0; i < 2 * filterLength; i++)
 		{
-			timeData[i][0] /= 2 * filterLength;
-			timeData[i][1] /= 2 * filterLength;
+			timeData.get()[i][0] /= 2 * filterLength;
+			timeData.get()[i][1] /= 2 * filterLength;
 		}
 
 		for (unsigned i = 0; i < filterLength; i++)
 		{
 			double factor = 0.5 * (1 + cos(2 * M_PI * i * 1.0 / (2 * filterLength)));
-			timeData[i][0] *= factor;
-			timeData[i][1] *= factor;
+			timeData.get()[i][0] *= factor;
+			timeData.get()[i][1] *= factor;
 		}
 
 		for (unsigned i = 0; i < filterLength; i++)
-			entry->ir[i] = timeData[i][0];
-
-		fftw_free(timeData);
-		fftw_free(freqData);
-		fftw_destroy_plan(planForward);
-		fftw_destroy_plan(planReverse);
+			(*entry)[i] = timeData.get()[i][0];
 
 		{
 			std::lock_guard<std::mutex> lock(eqIrCacheMutex());
-			eqIrCache().emplace(std::move(key), entry);
+			for (auto it = eqIrCache().begin(); it != eqIrCache().end();)
+			{
+				if (it->second.expired())
+					it = eqIrCache().erase(it);
+				else
+					++it;
+			}
+			eqIrCache()[std::move(key)] = entry;
 		}
 		cached = entry;
 	}
+	synthesizedIr = cached;
 
 	fftw_make_planner_thread_safe();
 	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
@@ -181,11 +209,14 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 		LogF(L"GraphicEQFilter: could not allocate %u filter slots", channelCount);
 		return;
 	}
-	filters.adopt(allocated, channelCount);
+	HConvSingleArray pendingFilters;
+	pendingFilters.adoptUninitialized(allocated, channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
-		hcInitSingle(&filters[i], const_cast<double*>(cached->ir.data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);
+		hcInitSingle(&pendingFilters[i], const_cast<double*>(cached->data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);
+		pendingFilters.markInitialized();
 	}
+	filters = std::move(pendingFilters);
 }
 
 // Minimum phase spectrum from coefficients

--- a/filters/GraphicEQFilter.h
+++ b/filters/GraphicEQFilter.h
@@ -41,5 +41,6 @@ private:
 
 	std::vector<FilterNode> nodes;
 	unsigned filterLength;
+	std::shared_ptr<const std::vector<double>> synthesizedIr;
 };
 #pragma AVRT_VTABLES_END

--- a/filters/GraphicEQFilterFactory.cpp
+++ b/filters/GraphicEQFilterFactory.cpp
@@ -31,10 +31,8 @@ REGISTER_FILTER_FACTORY(FilterFactoryPriority::GraphicEQ, GraphicEQFilterFactory
 using std::vector;
 using std::wstring;
 
-vector<IFilter*> GraphicEQFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector GraphicEQFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	GraphicEQFilter* filter = nullptr;
-
 	if (command == L"GraphicEQ")
 	{
 		// Parse the node list into the shared, Qt-free struct so the engine and the
@@ -44,10 +42,8 @@ vector<IFilter*> GraphicEQFilterFactory::createFilter(const wstring& configPath,
 
 		TraceF(L"Graphic equalizer with %d nodes", cmd.nodes.size());
 
-		filter = MemoryHelper::construct<GraphicEQFilter>(cmd.nodes, 16384);
+		return singleFilter(makeFilter<GraphicEQFilter>(cmd.nodes, 16384));
 	}
 
-	if (filter == nullptr)
-		return vector<IFilter*>(0);
-	return vector<IFilter*>(1, filter);
+	return {};
 }

--- a/filters/GraphicEQFilterFactory.h
+++ b/filters/GraphicEQFilterFactory.h
@@ -27,5 +27,5 @@
 class GraphicEQFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/IIRFilter.cpp
+++ b/filters/IIRFilter.cpp
@@ -18,8 +18,10 @@
 */
 
 #include "stdafx.h"
+#include <cmath>
 #include <limits>
 #include <new>
+#include <stdexcept>
 #include "helpers/MemoryHelper.h"
 #include "IIRFilter.h"
 #include "helpers/PerfProfile.h"
@@ -32,13 +34,19 @@ using std::wstring;
 
 IIRFilter::IIRFilter(const vector<double>& coefficients)
 {
-	order = (unsigned)coefficients.size() / 2 - 1;
-	a = static_cast<double*>(MemoryHelper::alloc(order * sizeof *a));
-	b = static_cast<double*>(MemoryHelper::alloc(order * sizeof *b));
-	x = nullptr;
-	y = nullptr;
+	if (coefficients.size() < 4 || coefficients.size() % 2 != 0)
+		throw std::invalid_argument("IIR coefficients must contain matching b and a terms");
+	for (double coefficient : coefficients)
+		if (!std::isfinite(coefficient))
+			throw std::invalid_argument("IIR coefficients must be finite");
+
+	order = static_cast<unsigned>(coefficients.size() / 2 - 1);
+	a.resize(order);
+	b.resize(order);
 
 	double a0 = coefficients[order + 1];
+	if (a0 == 0.0)
+		throw std::invalid_argument("IIR a0 coefficient must not be zero");
 	b0 = coefficients[0] / a0;
 	for (unsigned i = 0; i < order; i++)
 	{
@@ -49,13 +57,6 @@ IIRFilter::IIRFilter(const vector<double>& coefficients)
 
 IIRFilter::~IIRFilter()
 {
-	MemoryHelper::free(a);
-	MemoryHelper::free(b);
-
-	if (x != nullptr)
-		MemoryHelper::free(x);
-	if (y != nullptr)
-		MemoryHelper::free(y);
 }
 
 vector<wstring> IIRFilter::initialize(float sampleRate, unsigned maxFrameCount, vector<wstring> channelNames)
@@ -71,18 +72,13 @@ vector<wstring> IIRFilter::initialize(float sampleRate, unsigned maxFrameCount, 
 		throw std::bad_alloc();
 
 	const size_t stateCount = static_cast<size_t>(order) * channelCount;
-	if (stateCount > maxSize / sizeof *x)
+	if (stateCount > maxSize / sizeof(double))
 		throw std::bad_alloc();
 
-	if (x != nullptr)
-		MemoryHelper::free(x);
-	if (y != nullptr)
-		MemoryHelper::free(y);
-
-	x = static_cast<double*>(MemoryHelper::alloc(stateCount * sizeof *x));
-	y = static_cast<double*>(MemoryHelper::alloc(stateCount * sizeof *y));
-	std::fill_n(x, stateCount, 0.0);
-	std::fill_n(y, stateCount, 0.0);
+	vector<double> newX(stateCount, 0.0);
+	vector<double> newY(stateCount, 0.0);
+	x.swap(newX);
+	y.swap(newY);
 
 	return channelNames;
 }
@@ -97,8 +93,8 @@ void IIRFilter::process(double** output, double** input, unsigned frameCount)
 		double* outputChannel = output[i];
 
 		unsigned channelOffset = i * order;
-		double* xo = x + channelOffset;
-		double* yo = y + channelOffset;
+		double* xo = x.data() + channelOffset;
+		double* yo = y.data() + channelOffset;
 		for (unsigned j = 0; j < frameCount; j++)
 		{
 			double sample = inputChannel[j];

--- a/filters/IIRFilter.h
+++ b/filters/IIRFilter.h
@@ -34,10 +34,10 @@ public:
 private:
 	unsigned order;
 	double b0;
-	double* a;
-	double* b;
+	std::vector<double> a;
+	std::vector<double> b;
 	unsigned channelCount = 0;
-	double* x;
-	double* y;
+	std::vector<double> x;
+	std::vector<double> y;
 };
 #pragma AVRT_VTABLES_END

--- a/filters/IIRFilterFactory.cpp
+++ b/filters/IIRFilterFactory.cpp
@@ -83,16 +83,29 @@ bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& param
 	out.order = order;
 	out.coefficients.clear();
 	for (const wstring& coefficientString : coefficientStrings)
-		out.coefficients.push_back(StringHelper::parseDouble(coefficientString));
+	{
+		double coefficient = StringHelper::parseDouble(coefficientString);
+		if (!std::isfinite(coefficient))
+		{
+			LogFStatic(L"IIR coefficients must be finite");
+			return false;
+		}
+		out.coefficients.push_back(coefficient);
+	}
+	if (out.coefficients[order + 1] == 0.0)
+	{
+		LogFStatic(L"IIR a0 coefficient must not be zero");
+		return false;
+	}
 
 	return true;
 }
 
-vector<IFilter*> IIRFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector IIRFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	IIRCommand cmd;
 	if (!parseCommand(command, parameters, cmd))
-		return vector<IFilter*>(0);
+		return {};
 
 	wstringstream stream;
 	stream << L"Adding IIR filter of order " << cmd.order << " with coefficients";
@@ -103,6 +116,5 @@ vector<IFilter*> IIRFilterFactory::createFilter(const wstring& configPath, wstri
 
 	TraceF(L"%s", stream.str().c_str());
 
-	IIRFilter* filter = MemoryHelper::construct<IIRFilter>(cmd.coefficients);
-	return vector<IFilter*>(1, filter);
+	return singleFilter(makeFilter<IIRFilter>(cmd.coefficients));
 }

--- a/filters/IIRFilterFactory.h
+++ b/filters/IIRFilterFactory.h
@@ -29,7 +29,7 @@ class IIRFilterFactory : public IFilterFactory
 {
 public:
 	IIRFilterFactory();
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 	// Parses a "Filter:" IIR config line into an IIRCommand. This is the single
 	// owner of the IIR grammar; grammar errors (order below 1, wrong coefficient

--- a/filters/IfFilterFactory.cpp
+++ b/filters/IfFilterFactory.cpp
@@ -40,17 +40,17 @@ void IfFilterFactory::initialize(FilterEngine* engine)
 	this->engine = engine;
 }
 
-vector<IFilter*> IfFilterFactory::startOfConfiguration()
+FilterVector IfFilterFactory::startOfConfiguration()
 {
 	trueCount = 0;
 	falseCount = 0;
 	while (!trueCountStack.empty())
 		trueCountStack.pop();
 
-	return vector<IFilter*>();
+	return {};
 }
 
-std::vector<IFilter*> IfFilterFactory::startOfFile(const std::wstring& configPath)
+FilterVector IfFilterFactory::startOfFile(const std::wstring& configPath)
 {
 	trueCountStack.push(trueCount);
 	trueCount = 0;
@@ -61,10 +61,10 @@ std::vector<IFilter*> IfFilterFactory::startOfFile(const std::wstring& configPat
 		falseCount = 0;
 	}
 
-	return vector<IFilter*>();
+	return {};
 }
 
-vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector IfFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	IfCommand cmd;
 	bool isIfFamily = IfCommand::parse(command, parameters, cmd);
@@ -231,10 +231,10 @@ vector<IFilter*> IfFilterFactory::createFilter(const wstring& configPath, wstrin
 		command = L"";
 	}
 
-	return vector<IFilter*>();
+	return {};
 }
 
-std::vector<IFilter*> IfFilterFactory::endOfFile(const std::wstring& configPath)
+FilterVector IfFilterFactory::endOfFile(const std::wstring& configPath)
 {
 	if (trueCount != 0 || falseCount != 0)
 	{
@@ -244,7 +244,7 @@ std::vector<IFilter*> IfFilterFactory::endOfFile(const std::wstring& configPath)
 	trueCount = trueCountStack.top();
 	trueCountStack.pop();
 
-	return vector<IFilter*>();
+	return {};
 }
 
 bool IfFilterFactory::toBoolean(const Value& value)

--- a/filters/IfFilterFactory.h
+++ b/filters/IfFilterFactory.h
@@ -29,10 +29,10 @@ class IfFilterFactory : public IFilterFactory
 {
 public:
 	void initialize(FilterEngine* engine) override;
-	std::vector<IFilter*> startOfConfiguration() override;
-	std::vector<IFilter*> startOfFile(const std::wstring& configPath) override;
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
-	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
+	FilterVector startOfConfiguration() override;
+	FilterVector startOfFile(const std::wstring& configPath) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector endOfFile(const std::wstring& configPath) override;
 
 private:
 	mup::ParserX* parser = nullptr;

--- a/filters/IncludeFilterFactory.cpp
+++ b/filters/IncludeFilterFactory.cpp
@@ -39,21 +39,21 @@ void IncludeFilterFactory::initialize(FilterEngine* engine)
 	this->engine = engine;
 }
 
-vector<IFilter*> IncludeFilterFactory::startOfConfiguration()
+FilterVector IncludeFilterFactory::startOfConfiguration()
 {
 	recursionDepth = -1;
 
-	return vector<IFilter*>();
+	return {};
 }
 
-vector<IFilter*> IncludeFilterFactory::startOfFile(const wstring& configPath)
+FilterVector IncludeFilterFactory::startOfFile(const wstring& configPath)
 {
 	recursionDepth++;
 
-	return vector<IFilter*>();
+	return {};
 }
 
-vector<IFilter*> IncludeFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector IncludeFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	IncludeCommand cmd;
 	if (IncludeCommand::parse(command, parameters, cmd))
@@ -81,12 +81,12 @@ vector<IFilter*> IncludeFilterFactory::createFilter(const wstring& configPath, w
 		command = L"";
 	}
 
-	return vector<IFilter*>();
+	return {};
 }
 
-std::vector<IFilter*> IncludeFilterFactory::endOfFile(const wstring& configPath)
+FilterVector IncludeFilterFactory::endOfFile(const wstring& configPath)
 {
 	recursionDepth--;
 
-	return vector<IFilter*>();
+	return {};
 }

--- a/filters/IncludeFilterFactory.h
+++ b/filters/IncludeFilterFactory.h
@@ -29,10 +29,10 @@ class IncludeFilterFactory : public IFilterFactory
 public:
 	void initialize(FilterEngine* engine) override;
 
-	std::vector<IFilter*> startOfConfiguration() override;
-	std::vector<IFilter*> startOfFile(const std::wstring& configPath) override;
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
-	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
+	FilterVector startOfConfiguration() override;
+	FilterVector startOfFile(const std::wstring& configPath) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector endOfFile(const std::wstring& configPath) override;
 
 private:
 	FilterEngine* engine = nullptr;

--- a/filters/IrCache.cpp
+++ b/filters/IrCache.cpp
@@ -20,6 +20,7 @@
 #include "stdafx.h"
 #include <cmath>
 #include <climits>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -36,6 +37,9 @@ using std::abs;
 
 namespace
 {
+	constexpr unsigned kMaxIrChannels = 1024;
+	using SndFilePtr = std::unique_ptr<SNDFILE, decltype(&sf_close)>;
+
 	// Cache of decoded impulse-response PCM, keyed by path + mtime + sample rate.
 	// Lets a config reload (or a second filter using the same IR) skip the
 	// libsndfile read + interleave-to-planar pass. File I/O and the per-channel
@@ -111,16 +115,16 @@ std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, d
 	}
 
 	SF_INFO info{};
-	SNDFILE* in = sf_wchar_open(filename.c_str(), SFM_READ, &info);
-	if (in == nullptr)
+	SNDFILE* opened = sf_wchar_open(filename.c_str(), SFM_READ, &info);
+	if (opened == nullptr)
 	{
-		LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(in));
+		LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(opened));
 		return nullptr;
 	}
+	SndFilePtr in(opened, &sf_close);
 	if (abs(sampleRate - info.samplerate) > 1.0)
 	{
 		LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
-		sf_close(in);
 		return nullptr;
 	}
 
@@ -129,26 +133,37 @@ std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, d
 	// filter-pointer array (crash); channels == 0 divides by zero in the
 	// channel map; and frames > INT_MAX would wrap negative when cast to int.
 	// All three are reachable from a user-writable config plus a crafted IR.
-	if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX)
+	if (info.frames <= 0 || info.channels <= 0 || info.frames > INT_MAX
+		|| static_cast<unsigned>(info.channels) > kMaxIrChannels)
 	{
 		LogFStatic(L"Impulse response has no usable audio (frames=%lld, channels=%d); ignoring %s",
 			static_cast<long long>(info.frames), info.channels, filename.c_str());
-		sf_close(in);
 		return nullptr;
 	}
 
 	const unsigned channels = static_cast<unsigned>(info.channels);
 	const unsigned frames = static_cast<unsigned>(info.frames);
+	if (static_cast<size_t>(frames) > (std::numeric_limits<size_t>::max)() / channels)
+	{
+		LogFStatic(L"Impulse response dimensions are too large (frames=%u, channels=%u); ignoring %s",
+			frames, channels, filename.c_str());
+		return nullptr;
+	}
 	std::vector<double> interleaved(static_cast<size_t>(frames) * channels);
 	sf_count_t numRead = 0;
 	while (numRead < info.frames)
 	{
-		sf_count_t got = sf_readf_double(in, interleaved.data() + numRead * channels, info.frames - numRead);
+		sf_count_t got = sf_readf_double(in.get(), interleaved.data() + numRead * channels, info.frames - numRead);
 		if (got <= 0)
-			break; // truncated or unreadable file: stop instead of spinning forever
+			break;
 		numRead += got;
 	}
-	sf_close(in);
+	if (numRead != info.frames)
+	{
+		LogFStatic(L"Impulse response ended early (expected %lld frames, read %lld); ignoring %s",
+			static_cast<long long>(info.frames), static_cast<long long>(numRead), filename.c_str());
+		return nullptr;
+	}
 
 	auto entry = std::make_shared<IrCacheEntry>();
 	entry->channels = channels;
@@ -185,11 +200,12 @@ void HConvSingleArray::reset()
 {
 	if (ptr != nullptr)
 	{
-		for (unsigned i = 0; i < count; i++)
+		for (unsigned i = 0; i < initializedCount; i++)
 			hcCloseSingle(&ptr[i]);
 
 		MemoryHelper::free(ptr);
 		ptr = nullptr;
 	}
-	count = 0;
+	capacity = 0;
+	initializedCount = 0;
 }

--- a/filters/IrCache.h
+++ b/filters/IrCache.h
@@ -19,9 +19,11 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "libHybridConv-0.1.1/libHybridConv_eapo.h"
@@ -49,10 +51,10 @@ std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, d
 
 // RAII owner for a flat HConvSingle array. The array is a single block
 // allocated with MemoryHelper::alloc(sizeof(HConvSingle) * count) and must be
-// torn down by closing every element (hcCloseSingle) before freeing the block.
-// Wrapping it makes that teardown automatic and idempotent. The element count
-// is stored by value at adopt() time rather than read from an owner member,
-// so it does not depend on member declaration order.
+// torn down by closing every successfully initialized element (hcCloseSingle)
+// before freeing the block. Wrapping it makes partial-initialization rollback
+// automatic and idempotent. Counts are stored in the owner rather than read
+// from a filter member, so teardown does not depend on declaration order.
 class HConvSingleArray
 {
 public:
@@ -61,6 +63,27 @@ public:
 
 	HConvSingleArray(const HConvSingleArray&) = delete;
 	HConvSingleArray& operator=(const HConvSingleArray&) = delete;
+	HConvSingleArray(HConvSingleArray&& other) noexcept
+		: ptr(other.ptr), capacity(other.capacity), initializedCount(other.initializedCount)
+	{
+		other.ptr = nullptr;
+		other.capacity = 0;
+		other.initializedCount = 0;
+	}
+	HConvSingleArray& operator=(HConvSingleArray&& other) noexcept
+	{
+		if (this != &other)
+		{
+			reset();
+			ptr = other.ptr;
+			capacity = other.capacity;
+			initializedCount = other.initializedCount;
+			other.ptr = nullptr;
+			other.capacity = 0;
+			other.initializedCount = 0;
+		}
+		return *this;
+	}
 
 	// Take ownership of a freshly allocated block holding `newCount` elements.
 	// Any previously held block is torn down first using the same
@@ -70,7 +93,27 @@ public:
 		if (newPtr != ptr)
 			reset();
 		ptr = newPtr;
-		count = newCount;
+		capacity = newCount;
+		initializedCount = newCount;
+	}
+
+	// Take ownership before initialization starts, then register each element
+	// only after hcInitSingle has committed it. If a later initialization
+	// throws, reset() closes the completed prefix and never reads untouched
+	// allocation bytes.
+	void adoptUninitialized(HConvSingle* newPtr, unsigned newCapacity)
+	{
+		if (newPtr != ptr)
+			reset();
+		ptr = newPtr;
+		capacity = newCapacity;
+		initializedCount = 0;
+	}
+
+	void markInitialized() noexcept
+	{
+		assert(initializedCount < capacity);
+		initializedCount++;
 	}
 
 	HConvSingleArray& operator=(std::nullptr_t)
@@ -84,10 +127,11 @@ public:
 	// (filters[i], &filters[i], filters == nullptr, hcInitSingle(&filters[i], ...)).
 	operator HConvSingle*() const { return ptr; }
 
-	// Close every element (hcCloseSingle), then free the block.
+	// Close the successfully initialized prefix, then free the whole block.
 	void reset();
 
 private:
 	HConvSingle* ptr = nullptr;
-	unsigned count = 0;
+	unsigned capacity = 0;
+	unsigned initializedCount = 0;
 };

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <utility>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <fftw3.h>
@@ -131,6 +132,8 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		LogF(L"MultiConvolutionFilter: could not allocate %u convolution units", totalUnits);
 		return outChannelNames;
 	}
+	HConvSingleArray pendingFilters;
+	pendingFilters.adoptUninitialized(allocated, totalUnits);
 
 	tempBuffer.assign(maxFrameCount, 0.0);
 	unitFactors.assign(totalUnits, 1.0);
@@ -142,13 +145,14 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		{
 			// hcInitSingle reads the IR samples during planning but does not
 			// retain the pointer, so the shared cache buffer is safe to feed.
-			hcInitSingle(&allocated[next], const_cast<double*>(ir->buffers[ref.channel].data()), (int)irFrames, (int)maxFrameCount, 1);
+			hcInitSingle(&pendingFilters[next], const_cast<double*>(ir->buffers[ref.channel].data()), (int)irFrames, (int)maxFrameCount, 1);
+			pendingFilters.markInitialized();
 			unitFactors[next] = ref.isDecibel ? pow(10.0, ref.factor / 20.0) : ref.factor;
 			next++;
 		}
 		plans[i].unitCount = next - plans[i].firstUnit;
 	}
-	filters.adopt(allocated, next);
+	filters = std::move(pendingFilters);
 	unitCount = next;
 	filterFrameCount = maxFrameCount;
 

--- a/filters/MultiConvolutionFilterFactory.cpp
+++ b/filters/MultiConvolutionFilterFactory.cpp
@@ -32,16 +32,15 @@ REGISTER_FILTER_FACTORY(FilterFactoryPriority::Convolution, MultiConvolutionFilt
 using std::vector;
 using std::wstring;
 
-vector<IFilter*> MultiConvolutionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector MultiConvolutionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	MultiConvolutionCommand cmd;
 	if (!MultiConvolutionCommand::parse(command, parameters, cmd))
-		return vector<IFilter*>(0);
+		return {};
 
 	wstring absolutePath = ConvolutionFilePath::resolve(configPath, cmd.path);
 	if (absolutePath.empty())
-		return vector<IFilter*>(0);
+		return {};
 
-	MultiConvolutionFilter* filter = MemoryHelper::construct<MultiConvolutionFilter>(cmd.mappings, absolutePath);
-	return vector<IFilter*>(1, filter);
+	return singleFilter(makeFilter<MultiConvolutionFilter>(cmd.mappings, absolutePath));
 }

--- a/filters/MultiConvolutionFilterFactory.h
+++ b/filters/MultiConvolutionFilterFactory.h
@@ -26,5 +26,5 @@
 class MultiConvolutionFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/PreampFilterFactory.cpp
+++ b/filters/PreampFilterFactory.cpp
@@ -61,9 +61,9 @@ bool PreampFilterFactory::parseCommand(const wstring& command, const wstring& pa
 	return true;
 }
 
-vector<IFilter*> PreampFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector PreampFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	PreampFilter* filter = nullptr;
+	FilterPtr filter;
 
 	PreampCommand cmd;
 	if (parseCommand(command, parameters, cmd))
@@ -78,7 +78,7 @@ vector<IFilter*> PreampFilterFactory::createFilter(const wstring& configPath, ws
 			{
 				TraceF(L"Adjusting preamp by %g dB", cmd.dbGain);
 
-				filter = MemoryHelper::construct<PreampFilter>(cmd.dbGain);
+				filter = makeFilter<PreampFilter>(cmd.dbGain);
 			}
 		}
 		else
@@ -88,6 +88,6 @@ vector<IFilter*> PreampFilterFactory::createFilter(const wstring& configPath, ws
 	}
 
 	if (filter == nullptr)
-		return vector<IFilter*>(0);
-	return vector<IFilter*>(1, filter);
+		return {};
+	return singleFilter(std::move(filter));
 }

--- a/filters/PreampFilterFactory.h
+++ b/filters/PreampFilterFactory.h
@@ -28,7 +28,7 @@
 class PreampFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 	// Parses a "Preamp:" config line into a PreampCommand. This is the single
 	// owner of the preamp grammar: createFilter() uses it to decide whether to

--- a/filters/StageFilterFactory.cpp
+++ b/filters/StageFilterFactory.cpp
@@ -40,23 +40,23 @@ void StageFilterFactory::initialize(FilterEngine* engine)
 	engine->getParser()->DefineConst(L"stage", engine->isCapture() ? L"capture" : engine->isPreMix() ? L"pre-mix" : L"post-mix");
 }
 
-vector<IFilter*> StageFilterFactory::startOfConfiguration()
+FilterVector StageFilterFactory::startOfConfiguration()
 {
 	stageMatches = engineCapture || !enginePreMix || !enginePostMixInstalled;
 	while (!stageMatchesStack.empty())
 		stageMatchesStack.pop();
 
-	return vector<IFilter*>();
+	return {};
 }
 
-std::vector<IFilter*> StageFilterFactory::startOfFile(const std::wstring& configPath)
+FilterVector StageFilterFactory::startOfFile(const std::wstring& configPath)
 {
 	stageMatchesStack.push(stageMatches);
 
-	return vector<IFilter*>();
+	return {};
 }
 
-vector<IFilter*> StageFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector StageFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	StageCommand cmd;
 	if (StageCommand::parse(command, parameters, cmd))
@@ -108,13 +108,13 @@ vector<IFilter*> StageFilterFactory::createFilter(const wstring& configPath, wst
 		// skip line for further factories
 		command = L"";
 
-	return vector<IFilter*>();
+	return {};
 }
 
-std::vector<IFilter*> StageFilterFactory::endOfFile(const std::wstring& configPath)
+FilterVector StageFilterFactory::endOfFile(const std::wstring& configPath)
 {
 	stageMatches = stageMatchesStack.top();
 	stageMatchesStack.pop();
 
-	return vector<IFilter*>();
+	return {};
 }

--- a/filters/StageFilterFactory.h
+++ b/filters/StageFilterFactory.h
@@ -29,10 +29,10 @@ class StageFilterFactory : public IFilterFactory
 {
 public:
 	void initialize(FilterEngine* engine) override;
-	std::vector<IFilter*> startOfConfiguration() override;
-	std::vector<IFilter*> startOfFile(const std::wstring& configPath) override;
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
-	std::vector<IFilter*> endOfFile(const std::wstring& configPath) override;
+	FilterVector startOfConfiguration() override;
+	FilterVector startOfFile(const std::wstring& configPath) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector endOfFile(const std::wstring& configPath) override;
 
 private:
 	// Named with an engine prefix so they cannot be confused with the

--- a/filters/VSTPluginFilter.cpp
+++ b/filters/VSTPluginFilter.cpp
@@ -26,6 +26,20 @@
 
 using std::max;
 
+namespace
+{
+constexpr unsigned kMaxPluginChannelCount = 1024;
+constexpr unsigned kMaxPluginLatencySamples = 16 * 1024 * 1024;
+
+bool checkedMultiply(size_t left, size_t right, size_t& result) noexcept
+{
+	if (left != 0 && right > (std::numeric_limits<size_t>::max)() / left)
+		return false;
+	result = left * right;
+	return true;
+}
+}
+
 VSTPluginFilter::VSTPluginFilter(std::shared_ptr<VSTPluginLibrary> library, std::wstring chunkData, const std::unordered_map<std::wstring, float>& paramMap)
 	: library(library), libPath(library->getLibPath()), chunkData(chunkData), paramMap(paramMap)
 {
@@ -64,7 +78,28 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 		skipProcessing = true;
 	}
 
-	effectChannelCount = max(firstEffect->numInputs(), firstEffect->numOutputs());
+	// Metadata is plugin-controlled. Snapshot it once, validate the signed
+	// values, and use only the cached values for every allocation and processing
+	// loop below. Re-reading allows a broken plugin to change the loop bounds
+	// after the corresponding buffers were sized.
+	const int reportedInputCount = firstEffect->numInputs();
+	const int reportedOutputCount = firstEffect->numOutputs();
+	const int reportedLatency = firstEffect->getInitialDelay();
+	if (reportedInputCount < 0 || reportedOutputCount < 0 || reportedLatency < 0
+		|| reportedInputCount > static_cast<int>(kMaxPluginChannelCount)
+		|| reportedOutputCount > static_cast<int>(kMaxPluginChannelCount)
+		|| reportedLatency > static_cast<int>(kMaxPluginLatencySamples))
+	{
+		LogF(L"The VST plugin %s reported invalid channel or latency metadata; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		firstEffect->~VSTPluginInstance();
+		MemoryHelper::free(firstEffect);
+		return channelNames;
+	}
+
+	effectInputCount = static_cast<unsigned>(reportedInputCount);
+	effectOutputCount = static_cast<unsigned>(reportedOutputCount);
+	effectChannelCount = max(effectInputCount, effectOutputCount);
 	if (effectChannelCount == 0)
 	{
 		skipProcessing = true;
@@ -74,8 +109,18 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	}
 
 	// round up
-	effectCount = (channelCount + (effectChannelCount - 1)) / effectChannelCount;
-	effects = (VSTPluginInstance**)MemoryHelper::alloc(effectCount * sizeof(VSTPluginInstance*));
+	effectCount = channelCount / effectChannelCount + (channelCount % effectChannelCount != 0 ? 1 : 0);
+	size_t allocationBytes = 0;
+	if (!checkedMultiply(effectCount, sizeof(VSTPluginInstance*), allocationBytes))
+	{
+		LogF(L"The VST plugin %s reported metadata that overflows its instance table; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		effectCount = 0;
+		firstEffect->~VSTPluginInstance();
+		MemoryHelper::free(firstEffect);
+		return channelNames;
+	}
+	effects = (VSTPluginInstance**)MemoryHelper::alloc(allocationBytes);
 	if (effects == nullptr)
 	{
 		LogF(L"The VST plugin %s could not allocate its instance table; passing audio through.", libPath.c_str());
@@ -109,8 +154,26 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	prepareForProcessing(sampleRate, maxFrameCount);
 
 	// 2 times for input and output
-	emptyChannelCount = 2 * (effectCount * effectChannelCount - channelCount);
-	emptyChannels = (double**)MemoryHelper::alloc(emptyChannelCount * sizeof(double*));
+	size_t paddedChannelCount = 0;
+	if (!checkedMultiply(effectCount, effectChannelCount, paddedChannelCount)
+		|| paddedChannelCount < channelCount
+		|| paddedChannelCount - channelCount > (std::numeric_limits<size_t>::max)() / 2)
+	{
+		LogF(L"The VST plugin %s reported metadata that overflows its padding count; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		return channelNames;
+	}
+	emptyChannelCount = 2 * (paddedChannelCount - channelCount);
+	if (!checkedMultiply(emptyChannelCount, sizeof(double*), allocationBytes))
+	{
+		LogF(L"The VST plugin %s reported metadata that overflows its padding table; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		emptyChannelCount = 0;
+		return channelNames;
+	}
+	emptyChannels = emptyChannelCount > 0
+		? (double**)MemoryHelper::alloc(allocationBytes)
+		: nullptr;
 	if (emptyChannels == nullptr && emptyChannelCount > 0)
 	{
 		LogF(L"The VST plugin %s could not allocate padding channels; passing audio through.", libPath.c_str());
@@ -120,7 +183,13 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	}
 	for (unsigned i = 0; i < emptyChannelCount; i++)
 	{
-		emptyChannels[i] = static_cast<double*>(MemoryHelper::alloc(maxFrameCount * sizeof *emptyChannels[i]));
+		if (!checkedMultiply(maxFrameCount, sizeof *emptyChannels[i], allocationBytes))
+		{
+			skipProcessing = true;
+			emptyChannelCount = i;
+			return channelNames;
+		}
+		emptyChannels[i] = static_cast<double*>(MemoryHelper::alloc(allocationBytes));
 		if (emptyChannels[i] == nullptr)
 		{
 			LogF(L"The VST plugin %s could not allocate padding channel %u; passing audio through.", libPath.c_str(), i);
@@ -133,9 +202,22 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 		std::fill_n(emptyChannels[i], maxFrameCount, 0.0);
 	}
 
-	inputArray = (double**)MemoryHelper::alloc(firstEffect->numInputs() * sizeof(double*));
-	outputArray = (double**)MemoryHelper::alloc(firstEffect->numOutputs() * sizeof(double*));
-	if (inputArray == nullptr || outputArray == nullptr)
+	if (!checkedMultiply(effectInputCount, sizeof(double*), allocationBytes))
+	{
+		LogF(L"The VST plugin %s reported an input count that overflows its bus table; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		return channelNames;
+	}
+	inputArray = effectInputCount > 0 ? (double**)MemoryHelper::alloc(allocationBytes) : nullptr;
+	if (!checkedMultiply(effectOutputCount, sizeof(double*), allocationBytes))
+	{
+		LogF(L"The VST plugin %s reported an output count that overflows its bus table; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		return channelNames;
+	}
+	outputArray = effectOutputCount > 0 ? (double**)MemoryHelper::alloc(allocationBytes) : nullptr;
+	if ((effectInputCount > 0 && inputArray == nullptr)
+		|| (effectOutputCount > 0 && outputArray == nullptr))
 	{
 		LogF(L"The VST plugin %s could not allocate its bus arrays; passing audio through.", libPath.c_str());
 		skipProcessing = true;
@@ -143,11 +225,11 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	}
 
 	// Allocate float buffers for conversion
-	if (firstEffect->numInputs() > 0) {
+	if (effectInputCount > 0) {
 		// A hostile or broken plugin can report a bus count whose product with
 		// maxFrameCount wraps before widening to size_t (CodeQL
 		// cpp/integer-multiplication-cast-to-long); validate in size_t first.
-		const size_t inputCount = static_cast<size_t>(firstEffect->numInputs());
+		const size_t inputCount = effectInputCount;
 		const size_t maxSize = (std::numeric_limits<size_t>::max)();
 		if (inputCount > maxSize / sizeof(float*) ||
 			(maxFrameCount != 0 &&
@@ -162,14 +244,14 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 			skipProcessing = true;
 			return channelNames;
 		}
-		for (int i = 0; i < firstEffect->numInputs(); ++i) {
+		for (unsigned i = 0; i < effectInputCount; ++i) {
 			floatInputs[i] = _floatInputBuffer + i * maxFrameCount;
 		}
 	}
 
-	if (firstEffect->numOutputs() > 0) {
+	if (effectOutputCount > 0) {
 		// Same wrap-before-widening hazard as the input buffers above.
-		const size_t outputCount = static_cast<size_t>(firstEffect->numOutputs());
+		const size_t outputCount = effectOutputCount;
 		const size_t maxSize = (std::numeric_limits<size_t>::max)();
 		if (outputCount > maxSize / sizeof(float*) ||
 			(maxFrameCount != 0 &&
@@ -184,16 +266,23 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 			skipProcessing = true;
 			return channelNames;
 		}
-		for (int i = 0; i < firstEffect->numOutputs(); ++i) {
+		for (unsigned i = 0; i < effectOutputCount; ++i) {
 			floatOutputs[i] = _floatOutputBuffer + i * maxFrameCount;
 		}
 	}
 
 	// Allocate delay compensation buffers
-	delayBufferLength = firstEffect->getInitialDelay();
+	delayBufferLength = static_cast<unsigned>(reportedLatency);
 	if (delayBufferLength > 0)
 	{
-		delayBuffers = (double**)MemoryHelper::alloc(channelCount * sizeof(double*));
+		if (!checkedMultiply(channelCount, sizeof(double*), allocationBytes))
+		{
+			LogF(L"The VST plugin %s reported a latency whose channel table overflows; passing audio through.", libPath.c_str());
+			skipProcessing = true;
+			delayBufferLength = 0;
+			return channelNames;
+		}
+		delayBuffers = (double**)MemoryHelper::alloc(allocationBytes);
 		if (delayBuffers == nullptr)
 		{
 			LogF(L"The VST plugin %s could not allocate delay buffers; passing audio through.", libPath.c_str());
@@ -203,7 +292,17 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 		}
 		for (unsigned i = 0; i < channelCount; i++)
 		{
-			delayBuffers[i] = static_cast<double*>(MemoryHelper::alloc(delayBufferLength * sizeof *delayBuffers[i]));
+			if (!checkedMultiply(delayBufferLength, sizeof *delayBuffers[i], allocationBytes))
+			{
+				for (unsigned j = 0; j < i; j++)
+					MemoryHelper::free(delayBuffers[j]);
+				MemoryHelper::free(delayBuffers);
+				delayBuffers = nullptr;
+				delayBufferLength = 0;
+				skipProcessing = true;
+				return channelNames;
+			}
+			delayBuffers[i] = static_cast<double*>(MemoryHelper::alloc(allocationBytes));
 			if (delayBuffers[i] == nullptr)
 			{
 				LogF(L"The VST plugin %s could not allocate delay buffer %u; passing audio through.", libPath.c_str(), i);
@@ -219,7 +318,13 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 			}
 			std::fill_n(delayBuffers[i], delayBufferLength, 0.0);
 		}
-		delayTempBuffer = static_cast<double*>(MemoryHelper::alloc(maxFrameCount * sizeof *delayTempBuffer));
+		if (!checkedMultiply(maxFrameCount, sizeof *delayTempBuffer, allocationBytes))
+		{
+			skipProcessing = true;
+			delayBufferLength = 0;
+			return channelNames;
+		}
+		delayTempBuffer = static_cast<double*>(MemoryHelper::alloc(allocationBytes));
 		if (delayTempBuffer == nullptr)
 		{
 			LogF(L"The VST plugin %s could not allocate its delay scratch buffer; passing audio through.", libPath.c_str());
@@ -280,7 +385,7 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 		{
 			VSTPluginInstance* effect = effects[i];
 			// Setup double pointer arrays to point to the correct source/destination double buffers
-			for (int j = 0; j < effect->numInputs(); j++)
+			for (unsigned j = 0; j < effectInputCount; j++)
 			{
 				if (channelOffset + j < channelCount)
 					inputArray[j] = input[channelOffset + j];
@@ -288,7 +393,7 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 					inputArray[j] = emptyChannels[emptyChannelIndex++];
 			}
 
-			for (int j = 0; j < effect->numOutputs(); j++)
+			for (unsigned j = 0; j < effectOutputCount; j++)
 			{
 				if (channelOffset + j < channelCount)
 					outputArray[j] = output[channelOffset + j];
@@ -301,7 +406,7 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 			}
 			else {
 				// Convert input from double** to float** using pre-allocated buffers
-				for (int j = 0; j < effect->numInputs(); j++)
+				for (unsigned j = 0; j < effectInputCount; j++)
 				{
 					convertDoubleToFloat(floatInputs[j], inputArray[j], frameCount);
 				}
@@ -313,21 +418,21 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 				else
 				{
 					// For non-replacing, VST expects to add to the output. Clear float buffer first.
-					for (int j = 0; j < effect->numOutputs(); j++)
+					for (unsigned j = 0; j < effectOutputCount; j++)
 						std::fill_n(floatOutputs[j], frameCount, 0.0f);
 					effect->process(floatInputs, floatOutputs, frameCount);
 				}
 
 				// Convert output from float** back to double** into the final destination
-				for (int j = 0; j < effect->numOutputs(); j++)
+				for (unsigned j = 0; j < effectOutputCount; j++)
 				{
 					convertFloatToDouble(outputArray[j], floatOutputs[j], frameCount);
 				}
 			}
 
-			if (effect->numOutputs() < effect->numInputs())
+			if (effectOutputCount < effectInputCount)
 			{
-				for (int j = effect->numOutputs(); j < effect->numInputs(); j++)
+				for (unsigned j = effectOutputCount; j < effectInputCount; j++)
 				{
 					if (channelOffset + j < channelCount)
 						std::fill_n(output[channelOffset + j], frameCount, 0.0);
@@ -425,6 +530,9 @@ void VSTPluginFilter::cleanup()
 		effects = nullptr;
 	}
 	effectCount = 0;
+	effectInputCount = 0;
+	effectOutputCount = 0;
+	effectChannelCount = 0;
 
 	if (emptyChannels != nullptr)
 	{

--- a/filters/VSTPluginFilter.h
+++ b/filters/VSTPluginFilter.h
@@ -46,6 +46,8 @@ private:
 	std::wstring chunkData;
 	std::unordered_map<std::wstring, float> paramMap;
 	size_t channelCount = 0;
+	unsigned effectInputCount = 0;
+	unsigned effectOutputCount = 0;
 	unsigned effectChannelCount = 0;
 	size_t effectCount = 0;
 	VSTPluginInstance** effects = nullptr;

--- a/filters/VSTPluginFilterFactory.cpp
+++ b/filters/VSTPluginFilterFactory.cpp
@@ -33,9 +33,9 @@ using std::unordered_map;
 using std::vector;
 using std::wstring;
 
-vector<IFilter*> VSTPluginFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector VSTPluginFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	VSTPluginFilter* filter = nullptr;
+	FilterPtr filter;
 
 	if (command == L"VSTPlugin")
 	{
@@ -81,12 +81,12 @@ vector<IFilter*> VSTPluginFilterFactory::createFilter(const wstring& configPath,
 
 			if (create)
 			{
-				filter = MemoryHelper::construct<VSTPluginFilter>(library, chunkData, paramMap);
+				filter = makeFilter<VSTPluginFilter>(library, chunkData, paramMap);
 			}
 		}
 	}
 
 	if (filter == nullptr)
-		return vector<IFilter*>(0);
-	return vector<IFilter*>(1, filter);
+		return {};
+	return singleFilter(std::move(filter));
 }

--- a/filters/VSTPluginFilterFactory.h
+++ b/filters/VSTPluginFilterFactory.h
@@ -27,5 +27,5 @@
 class VSTPluginFilterFactory : public IFilterFactory
 {
 public:
-	std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.cpp
+++ b/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.cpp
@@ -41,9 +41,9 @@ LoudnessCorrectionFilterFactory::LoudnessCorrectionFilterFactory()
 {
 }
 
-vector<IFilter*> LoudnessCorrectionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
+FilterVector LoudnessCorrectionFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
-	vector<IFilter*> allFilter(0);
+	FilterVector allFilters;
 
 	LoudnessCorrectionCommand cmd;
 	if (LoudnessCorrectionCommand::parse(command, parameters, cmd))
@@ -54,9 +54,8 @@ vector<IFilter*> LoudnessCorrectionFilterFactory::createFilter(const wstring& co
 		filterParameters.referenceLevel = cmd.referenceLevel;
 		filterParameters.referenceOffset = cmd.referenceOffset;
 		filterParameters.attenuation = cmd.attenuation;
-		void* mem = MemoryHelper::alloc(sizeof(LoudnessCorrectionFilter));
-		allFilter.push_back(new(mem) LoudnessCorrectionFilter(filterParameters));
+		allFilters.push_back(makeFilter<LoudnessCorrectionFilter>(filterParameters));
 	}
 
-	return allFilter;
+	return allFilters;
 }

--- a/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.h
+++ b/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.h
@@ -28,5 +28,5 @@ class LoudnessCorrectionFilterFactory : public IFilterFactory
 {
 public:
 	LoudnessCorrectionFilterFactory();
-	virtual std::vector<IFilter*> createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters);
+	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 };

--- a/filters/loudnessCorrection/VolumeController.cpp
+++ b/filters/loudnessCorrection/VolumeController.cpp
@@ -23,19 +23,19 @@
 
 VolumeController::VolumeController()
 {
-	CoInitialize(nullptr);
-
 	winutil::ComPtr<IMMDeviceEnumerator> deviceEnumerator;
-	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER, __uuidof(IMMDeviceEnumerator), (LPVOID*)&deviceEnumerator);
+	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER,
+		__uuidof(IMMDeviceEnumerator), reinterpret_cast<void**>(deviceEnumerator.put()));
 	if (FAILED(hr) || !deviceEnumerator)
 		return;
 
 	winutil::ComPtr<IMMDevice> defaultDevice;
-	hr = deviceEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, &defaultDevice);
+	hr = deviceEnumerator->GetDefaultAudioEndpoint(eRender, eMultimedia, defaultDevice.put());
 	if (FAILED(hr) || !defaultDevice)
 		return;
 
-	hr = defaultDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_INPROC_SERVER, nullptr, (LPVOID*)&_endpointVolume);
+	hr = defaultDevice->Activate(__uuidof(IAudioEndpointVolume), CLSCTX_INPROC_SERVER,
+		nullptr, reinterpret_cast<void**>(_endpointVolume.put()));
 	if (FAILED(hr) || !_endpointVolume)
 		return;
 

--- a/filters/loudnessCorrection/VolumeController.h
+++ b/filters/loudnessCorrection/VolumeController.h
@@ -32,6 +32,7 @@ public:
 	HRESULT getVolume(double& currentVolume);
 	HRESULT setVolume(double volume);
 private:
+	winutil::ComApartment _comApartment;
 	winutil::ComPtr<IAudioEndpointVolume> _endpointVolume;
 	float _minVol = 0.0f;
 	float _maxVol = 0.0f;

--- a/helpers/AbstractLibrary.cpp
+++ b/helpers/AbstractLibrary.cpp
@@ -73,7 +73,12 @@ int AbstractLibrary::initialize()
 
 		int res = customInitialize();
 		if (res < 0)
+		{
+			customUninitialize();
+			FreeLibrary(module);
+			module = nullptr;
 			return res;
+		}
 
 		TraceF(L"Loaded library %s", libPath.c_str());
 
@@ -87,6 +92,11 @@ int AbstractLibrary::customInitialize()
 {
 	// overwrite if needed
 	return 0;
+}
+
+void AbstractLibrary::customUninitialize() noexcept
+{
+	// overwrite if needed
 }
 
 wstring AbstractLibrary::getLoadPath()

--- a/helpers/AbstractLibrary.h
+++ b/helpers/AbstractLibrary.h
@@ -39,6 +39,7 @@ public:
 protected:
 	virtual bool loadFunctions() = 0;
 	virtual int customInitialize();
+	virtual void customUninitialize() noexcept;
 
 	HMODULE module = nullptr;
 

--- a/helpers/AudioFormatProbe.cpp
+++ b/helpers/AudioFormatProbe.cpp
@@ -47,23 +47,24 @@ Result probe(const std::wstring& deviceGuid)
 	// (Qt does this implicitly via the GUI event loop).
 	ComPtr<IMMDeviceEnumerator> enumerator;
 	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr,
-		CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&enumerator));
+		CLSCTX_INPROC_SERVER, __uuidof(IMMDeviceEnumerator),
+		reinterpret_cast<void**>(enumerator.put()));
 	if (FAILED(hr) || !enumerator)
 		return result;
 
 	ComPtr<IMMDevice> device;
-	hr = enumerator->GetDevice(deviceGuid.c_str(), &device);
+	hr = enumerator->GetDevice(deviceGuid.c_str(), device.put());
 	if (FAILED(hr) || !device)
 		return result;
 
 	ComPtr<IAudioClient> client;
 	hr = device->Activate(__uuidof(IAudioClient), CLSCTX_INPROC_SERVER, nullptr,
-		reinterpret_cast<void**>(&client));
+		reinterpret_cast<void**>(client.put()));
 	if (FAILED(hr) || !client)
 		return result;
 
 	CoTaskMem<WAVEFORMATEX> mixFormat;
-	hr = client->GetMixFormat(&mixFormat);
+	hr = client->GetMixFormat(mixFormat.put());
 	if (FAILED(hr) || !mixFormat)
 		return result;
 

--- a/helpers/ComPtr.h
+++ b/helpers/ComPtr.h
@@ -24,7 +24,7 @@
 
 namespace winutil
 {
-	// Move-only COM smart pointer. Copying performs AddRef so the reference
+	// Copyable COM smart pointer. Copying performs AddRef so the reference
 	// count stays balanced; the previous hand-rolled local versions relied on
 	// never being copied and would have double-released on an accidental copy.
 	template<typename T>
@@ -78,15 +78,12 @@ namespace winutil
 		explicit operator bool() const noexcept { return ptr != nullptr; }
 
 		// Releases any held interface and hands back the address of the
-		// internal pointer for use as an out-parameter, e.g.
-		// CoCreateInstance(..., &p) or IID_PPV_ARGS(&p).
+		// internal pointer for use as an out-parameter.
 		T** put() noexcept
 		{
 			reset();
 			return &ptr;
 		}
-
-		T** operator&() noexcept { return put(); }
 
 		void reset() noexcept
 		{
@@ -99,6 +96,32 @@ namespace winutil
 
 	private:
 		T* ptr = nullptr;
+	};
+
+	// Balances CoInitialize on the constructing thread. Declare this before any
+	// ComPtr members so those interfaces are released before CoUninitialize runs
+	// during reverse-order member destruction.
+	class ComApartment
+	{
+	public:
+		ComApartment() noexcept
+			: result(CoInitialize(nullptr))
+		{
+		}
+
+		~ComApartment()
+		{
+			if (SUCCEEDED(result))
+				CoUninitialize();
+		}
+
+		ComApartment(const ComApartment&) = delete;
+		ComApartment& operator=(const ComApartment&) = delete;
+		ComApartment(ComApartment&&) = delete;
+		ComApartment& operator=(ComApartment&&) = delete;
+
+	private:
+		HRESULT result;
 	};
 
 	// RAII wrapper for a PROPVARIANT: PropVariantInit on construction,
@@ -142,8 +165,6 @@ namespace winutil
 			reset();
 			return &ptr;
 		}
-
-		T** operator&() noexcept { return put(); }
 
 		void reset() noexcept
 		{

--- a/helpers/MemoryHelper.cpp
+++ b/helpers/MemoryHelper.cpp
@@ -18,6 +18,8 @@
 */
 
 #include "stdafx.h"
+#include <atomic>
+#include <limits>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <malloc.h>
@@ -28,8 +30,27 @@
 #include "LogHelper.h"
 #include "MemoryHelper.h"
 
+namespace
+{
+	constexpr size_t allocationFailureDisabled = (std::numeric_limits<size_t>::max)();
+	std::atomic<size_t> allocationFailureCountdown{ allocationFailureDisabled };
+}
+
 void* MemoryHelper::alloc(size_t size)
 {
+	size_t remaining = allocationFailureCountdown.load(std::memory_order_relaxed);
+	while (remaining != allocationFailureDisabled)
+	{
+		if (remaining == 0)
+		{
+			LogFStatic(L"Injected allocation failure for %Iu bytes.", size);
+			return nullptr;
+		}
+		if (allocationFailureCountdown.compare_exchange_weak(
+			remaining, remaining - 1, std::memory_order_relaxed, std::memory_order_relaxed))
+			break;
+	}
+
 #ifdef _DEBUG
 	void* memory = _aligned_malloc_dbg(size, 16, __FILE__, __LINE__);
 #else
@@ -42,6 +63,16 @@ void* MemoryHelper::alloc(size_t size)
 	}
 
 	return memory;
+}
+
+void MemoryHelper::failAllocationAfterForTesting(size_t successfulAllocations) noexcept
+{
+	allocationFailureCountdown.store(successfulAllocations, std::memory_order_relaxed);
+}
+
+void MemoryHelper::resetAllocationFailureForTesting() noexcept
+{
+	allocationFailureCountdown.store(allocationFailureDisabled, std::memory_order_relaxed);
 }
 
 void MemoryHelper::free(void* ptr)

--- a/helpers/MemoryHelper.h
+++ b/helpers/MemoryHelper.h
@@ -36,6 +36,12 @@ class MemoryHelper
 public:
 	static void* alloc(size_t size);
 	static void free(void* ptr);
+	// Deterministic failure injection for allocation-path tests. Passing N lets
+	// N subsequent allocations succeed and makes the following allocation fail;
+	// resetAllocationFailureForTesting() restores normal operation. MemoryHelper
+	// is used only while filters/configurations are prepared, never in AVRT_CODE.
+	static void failAllocationAfterForTesting(size_t successfulAllocations) noexcept;
+	static void resetAllocationFailureForTesting() noexcept;
 
 	// Typed, checked construction over alloc()/free().
 	//
@@ -51,7 +57,15 @@ public:
 		void* mem = alloc(sizeof(T));
 		if (mem == nullptr)
 			throw std::bad_alloc();
-		return new(mem) T(std::forward<Args>(args)...);
+		try
+		{
+			return ::new(mem) T(std::forward<Args>(args)...);
+		}
+		catch (...)
+		{
+			free(mem);
+			throw;
+		}
 	}
 
 	template<class T>

--- a/helpers/ServiceHelper.cpp
+++ b/helpers/ServiceHelper.cpp
@@ -105,7 +105,7 @@ Service::Service(SC_HANDLE scManager, const std::wstring& serviceName, bool allo
 	DWORD desiredAccess = SERVICE_START | SERVICE_STOP | SERVICE_QUERY_STATUS;
 	if (allowEnumerate)
 		desiredAccess |= SERVICE_ENUMERATE_DEPENDENTS;
-	serviceHandle = OpenServiceW(scManager, serviceName.c_str(), SERVICE_START | SERVICE_STOP | SERVICE_QUERY_STATUS | SERVICE_ENUMERATE_DEPENDENTS);
+	serviceHandle = OpenServiceW(scManager, serviceName.c_str(), desiredAccess);
 	if (serviceHandle == nullptr)
 		fail(L"OpenService", GetLastError());
 }

--- a/helpers/VSTPluginLibrary.cpp
+++ b/helpers/VSTPluginLibrary.cpp
@@ -159,6 +159,25 @@ int VSTPluginLibrary::customInitialize()
 	return FUNCTIONS_MISSING;
 }
 
+void VSTPluginLibrary::customUninitialize() noexcept
+{
+	if (factory != nullptr)
+	{
+		factory->release();
+		factory = nullptr;
+	}
+	GetPluginFactory = nullptr;
+	VSTPluginMain = nullptr;
+}
+
+VSTPluginLibrary::~VSTPluginLibrary()
+{
+	// AbstractLibrary's base destructor unloads the module after this derived
+	// destructor returns. Release module-owned VST3 objects while their code is
+	// still resident.
+	customUninitialize();
+}
+
 VSTPluginLibrary::VSTPluginLibrary(const wstring& libPath)
 	: libPath(libPath), loadPath(libPath)
 {

--- a/helpers/VSTPluginLibrary.cpp
+++ b/helpers/VSTPluginLibrary.cpp
@@ -161,6 +161,11 @@ int VSTPluginLibrary::customInitialize()
 
 void VSTPluginLibrary::customUninitialize() noexcept
 {
+	releasePluginFactory();
+}
+
+void VSTPluginLibrary::releasePluginFactory() noexcept
+{
 	if (factory != nullptr)
 	{
 		factory->release();
@@ -175,7 +180,7 @@ VSTPluginLibrary::~VSTPluginLibrary()
 	// AbstractLibrary's base destructor unloads the module after this derived
 	// destructor returns. Release module-owned VST3 objects while their code is
 	// still resident.
-	customUninitialize();
+	releasePluginFactory();
 }
 
 VSTPluginLibrary::VSTPluginLibrary(const wstring& libPath)

--- a/helpers/VSTPluginLibrary.h
+++ b/helpers/VSTPluginLibrary.h
@@ -31,6 +31,8 @@
 class VSTPluginLibrary : public AbstractLibrary
 {
 public:
+	~VSTPluginLibrary() override;
+
 	static std::shared_ptr<VSTPluginLibrary> getInstance(const std::wstring& libPath);
 	static std::wstring getDefaultPluginPath();
 
@@ -48,6 +50,7 @@ public:
 protected:
 	bool loadFunctions() override;
 	int customInitialize() override;
+	void customUninitialize() noexcept override;
 
 private:
 	VSTPluginLibrary(const std::wstring& libPath);

--- a/helpers/VSTPluginLibrary.h
+++ b/helpers/VSTPluginLibrary.h
@@ -54,6 +54,7 @@ protected:
 
 private:
 	VSTPluginLibrary(const std::wstring& libPath);
+	void releasePluginFactory() noexcept;
 	static std::wstring resolveVST3ModulePath(const std::wstring& libPath);
 	static std::unordered_map<std::wstring, std::weak_ptr<VSTPluginLibrary>> instanceMap;
 	static std::wstring defaultPluginPath;

--- a/helpers/Win32Event.h
+++ b/helpers/Win32Event.h
@@ -3,6 +3,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include <system_error>
 #include <utility>
 
 class Win32Event
@@ -11,6 +12,8 @@ public:
 	Win32Event(bool manualReset, bool initialState)
 		: handle(CreateEventW(nullptr, manualReset, initialState, nullptr))
 	{
+		if (handle == nullptr)
+			throw std::system_error(static_cast<int>(GetLastError()), std::system_category(), "CreateEventW");
 	}
 
 	~Win32Event()

--- a/libHybridConv-0.1.1/HcAlignedStorage.h
+++ b/libHybridConv-0.1.1/HcAlignedStorage.h
@@ -4,7 +4,17 @@
 #include <malloc.h>
 
 #include <cstddef>
+#include <limits>
 #include <memory>
+#include <new>
+
+inline std::size_t checkedHcMultiply(std::size_t left, std::size_t right)
+{
+	const std::size_t maxSize = (std::numeric_limits<std::size_t>::max)();
+	if (left != 0 && right > maxSize / left)
+		throw std::bad_array_new_length();
+	return left * right;
+}
 
 template<typename T>
 struct HcAlignedRelease
@@ -21,7 +31,10 @@ using HcAlignedPtr = std::unique_ptr<T, HcAlignedRelease<T>>;
 template<typename T>
 HcAlignedPtr<T> makeHcAlignedArray(std::size_t count)
 {
-	return HcAlignedPtr<T>(static_cast<T*>(fftw_malloc(sizeof(T) * count)));
+	HcAlignedPtr<T> result(static_cast<T*>(fftw_malloc(checkedHcMultiply(sizeof(T), count))));
+	if (!result)
+		throw std::bad_alloc();
+	return result;
 }
 
 // 64-byte-aligned single allocation for buffers FFTW plans never touch (the
@@ -43,5 +56,8 @@ using HcSlabPtr = std::unique_ptr<T, HcSlabRelease<T>>;
 template<typename T>
 HcSlabPtr<T> makeHcSlab(std::size_t count)
 {
-	return HcSlabPtr<T>(static_cast<T*>(_aligned_malloc(sizeof(T) * count, 64)));
+	HcSlabPtr<T> result(static_cast<T*>(_aligned_malloc(checkedHcMultiply(sizeof(T), count), 64)));
+	if (!result)
+		throw std::bad_alloc();
+	return result;
 }

--- a/libHybridConv-0.1.1/libHybridConv_eapo.cpp
+++ b/libHybridConv-0.1.1/libHybridConv_eapo.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <string.h>
 #include <unordered_map>
@@ -77,6 +78,34 @@ struct HConvSingleStorage
 	std::vector<double*> mixImagPtrs;
 	HcAlignedPtr<double> historyTime;
 };
+
+namespace
+{
+class HcPlanOwner
+{
+public:
+	explicit HcPlanOwner(fftw_plan plan = nullptr) noexcept : plan(plan) {}
+	~HcPlanOwner()
+	{
+		if (plan != nullptr)
+			fftw_destroy_plan(plan);
+	}
+
+	HcPlanOwner(const HcPlanOwner&) = delete;
+	HcPlanOwner& operator=(const HcPlanOwner&) = delete;
+
+	fftw_plan get() const noexcept { return plan; }
+	fftw_plan release() noexcept
+	{
+		fftw_plan result = plan;
+		plan = nullptr;
+		return result;
+	}
+
+private:
+	fftw_plan plan;
+};
+}
 
 
 
@@ -441,83 +470,96 @@ static inline void copy_split_complex_vec(const fftw_complex* __restrict src,
 }
 void hcInitSingle(HConvSingle * filter, double* h, int hlen, int flen, int steps)
 {
-	int i, j, size, num, pos;
+	if (filter == nullptr)
+		throw std::invalid_argument("hcInitSingle requires an output filter");
+
+	if (h == nullptr)
+		throw std::invalid_argument("hcInitSingle requires impulse-response samples");
+	if (hlen <= 0 || flen <= 0 || steps <= 0)
+		throw std::invalid_argument("hcInitSingle lengths and step count must be positive");
+	if (flen > (std::numeric_limits<int>::max)() / 2)
+		throw std::length_error("hcInitSingle frame length is too large");
+	if (steps == (std::numeric_limits<int>::max)())
+		throw std::length_error("hcInitSingle step count is too large");
+
+	int i, j, num, pos;
 	double gain;
-	// The struct may come from uninitialized stack or heap memory, so the old
-	// storage pointer must not be read here. Every init pairs with a
-	// hcCloseSingle, which frees it.
-	filter->storage = new HConvSingleStorage();
-	auto& storage = *filter->storage;
+	const size_t frameLength = static_cast<size_t>(flen);
+	const size_t dftLength = checkedHcMultiply(frameLength, 2);
+	const size_t complexLength = frameLength + 1;
+	const size_t filterSegmentCount =
+		(static_cast<size_t>(hlen) + frameLength - 1) / frameLength;
+	if (filterSegmentCount >= static_cast<size_t>((std::numeric_limits<int>::max)()))
+		throw std::length_error("hcInitSingle requires too many partitions");
 
-	filter->step = 0;
-	filter->maxstep = steps;
-	filter->mixpos = 0;
-	filter->framelength = flen;
+	const size_t planeStride = (complexLength + 7) & ~static_cast<size_t>(7);
+	const size_t partitionStride = checkedHcMultiply(planeStride, 2);
+	const size_t filterSlabElements = checkedHcMultiply(filterSegmentCount, partitionStride);
+	const size_t mixSegmentCount = filterSegmentCount + 1;
+	const size_t mixSlabElements = checkedHcMultiply(mixSegmentCount, partitionStride);
 
-	size = sizeof *filter->dft_time * 2 * flen;
-	storage.dftTime = makeHcAlignedArray<double>(2 * (size_t)flen);
-	filter->dft_time = storage.dftTime.get();
+	HConvSingle temp = {};
+	auto storageOwner = std::make_unique<HConvSingleStorage>();
+	auto& storage = *storageOwner;
 
-	size = sizeof(fftw_complex) * (flen + 1);
-	storage.dftFreq = makeHcAlignedArray<fftw_complex>((size_t)flen + 1);
-	filter->dft_freq = storage.dftFreq.get();
+	temp.step = 0;
+	temp.maxstep = steps;
+	temp.mixpos = 0;
+	temp.framelength = flen;
 
-	size = sizeof *filter->in_freq_real * (flen + 1);
-	storage.inFreqReal = makeHcAlignedArray<double>((size_t)flen + 1);
-	storage.inFreqImag = makeHcAlignedArray<double>((size_t)flen + 1);
-	filter->in_freq_real = storage.inFreqReal.get();
-	filter->in_freq_imag = storage.inFreqImag.get();
+	storage.dftTime = makeHcAlignedArray<double>(dftLength);
+	temp.dft_time = storage.dftTime.get();
+	storage.dftFreq = makeHcAlignedArray<fftw_complex>(complexLength);
+	temp.dft_freq = storage.dftFreq.get();
+	storage.inFreqReal = makeHcAlignedArray<double>(complexLength);
+	storage.inFreqImag = makeHcAlignedArray<double>(complexLength);
+	temp.in_freq_real = storage.inFreqReal.get();
+	temp.in_freq_imag = storage.inFreqImag.get();
 
-	filter->num_filterbuf = (hlen + flen - 1) / flen;
-
-	size = sizeof *filter->steptask * (steps + 1);
-	storage.stepTask.resize((size_t)steps + 1);
-	filter->steptask = storage.stepTask.data();
-	num = filter->num_filterbuf / steps;
+	temp.num_filterbuf = static_cast<int>(filterSegmentCount);
+	storage.stepTask.resize(static_cast<size_t>(steps) + 1);
+	temp.steptask = storage.stepTask.data();
+	num = temp.num_filterbuf / steps;
 	for (i = 0; i <= steps; i++)
-		filter->steptask[i] = i * num;
-	pos = (filter->steptask[1] == 0) ? 1 : 2;
-	num = filter->num_filterbuf % steps;
+		temp.steptask[i] = i * num;
+	pos = (temp.steptask[1] == 0) ? 1 : 2;
+	num = temp.num_filterbuf % steps;
 	for (j = pos; j < pos + num; j++) {
 		for (i = j; i <= steps; i++)
-			filter->steptask[i]++;
+			temp.steptask[i]++;
 	}
 
 	// Each plane is padded to a whole number of cache lines so every real and
 	// imag plane starts 64-byte aligned; a partition is [real|imag]. The
 	// memset doubles as a pre-touch so first use on the audio thread does not
 	// take the soft page faults.
-	const size_t planeStride = ((size_t)flen + 1 + 7) & ~(size_t)7;
-	const size_t partitionStride = 2 * planeStride;
-
-	storage.filterSlab = makeHcSlab<double>((size_t)filter->num_filterbuf * partitionStride);
-	storage.filterRealPtrs.resize(filter->num_filterbuf);
-	storage.filterImagPtrs.resize(filter->num_filterbuf);
-	filter->filterbuf_freq_real = storage.filterRealPtrs.data();
-	filter->filterbuf_freq_imag = storage.filterImagPtrs.data();
-	for (i = 0; i < filter->num_filterbuf; i++) {
-		filter->filterbuf_freq_real[i] = storage.filterSlab.get() + (size_t)i * partitionStride;
-		filter->filterbuf_freq_imag[i] = filter->filterbuf_freq_real[i] + planeStride;
+	storage.filterSlab = makeHcSlab<double>(filterSlabElements);
+	storage.filterRealPtrs.resize(filterSegmentCount);
+	storage.filterImagPtrs.resize(filterSegmentCount);
+	temp.filterbuf_freq_real = storage.filterRealPtrs.data();
+	temp.filterbuf_freq_imag = storage.filterImagPtrs.data();
+	for (i = 0; i < temp.num_filterbuf; i++) {
+		temp.filterbuf_freq_real[i] = storage.filterSlab.get() + (size_t)i * partitionStride;
+		temp.filterbuf_freq_imag[i] = temp.filterbuf_freq_real[i] + planeStride;
 	}
-	memset(storage.filterSlab.get(), 0, (size_t)filter->num_filterbuf * partitionStride * sizeof(double));
+	memset(storage.filterSlab.get(), 0, checkedHcMultiply(filterSlabElements, sizeof(double)));
 
-	filter->num_mixbuf = filter->num_filterbuf + 1;
+	temp.num_mixbuf = static_cast<int>(mixSegmentCount);
 
-	storage.mixSlab = makeHcSlab<double>((size_t)filter->num_mixbuf * partitionStride);
-	storage.mixRealPtrs.resize(filter->num_mixbuf);
-	storage.mixImagPtrs.resize(filter->num_mixbuf);
-	filter->mixbuf_freq_real = storage.mixRealPtrs.data();
-	filter->mixbuf_freq_imag = storage.mixImagPtrs.data();
-	for (i = 0; i < filter->num_mixbuf; i++) {
-		filter->mixbuf_freq_real[i] = storage.mixSlab.get() + (size_t)i * partitionStride;
-		filter->mixbuf_freq_imag[i] = filter->mixbuf_freq_real[i] + planeStride;
+	storage.mixSlab = makeHcSlab<double>(mixSlabElements);
+	storage.mixRealPtrs.resize(mixSegmentCount);
+	storage.mixImagPtrs.resize(mixSegmentCount);
+	temp.mixbuf_freq_real = storage.mixRealPtrs.data();
+	temp.mixbuf_freq_imag = storage.mixImagPtrs.data();
+	for (i = 0; i < temp.num_mixbuf; i++) {
+		temp.mixbuf_freq_real[i] = storage.mixSlab.get() + (size_t)i * partitionStride;
+		temp.mixbuf_freq_imag[i] = temp.mixbuf_freq_real[i] + planeStride;
 	}
-	memset(storage.mixSlab.get(), 0, (size_t)filter->num_mixbuf * partitionStride * sizeof(double));
+	memset(storage.mixSlab.get(), 0, checkedHcMultiply(mixSlabElements, sizeof(double)));
 
-	size = sizeof *filter->history_time * flen;
-	storage.historyTime = makeHcAlignedArray<double>(flen);
-	filter->history_time = storage.historyTime.get();
-	memset(filter->history_time, 0, size);
+	storage.historyTime = makeHcAlignedArray<double>(frameLength);
+	temp.history_time = storage.historyTime.get();
+	memset(temp.history_time, 0, checkedHcMultiply(frameLength, sizeof(double)));
 
 	// When a cached wisdom file exists we use FFTW_MEASURE — planner returns immediately from the cache,
 	// giving the optimized plan without the multi-second learning cost. Without wisdom we fall back to
@@ -542,54 +584,76 @@ void hcInitSingle(HConvSingle * filter, double* h, int hlen, int flen, int steps
 			});
 		}
 		unsigned fftw_flags = (wisdomAvailable ? FFTW_MEASURE : FFTW_ESTIMATE) | FFTW_PRESERVE_INPUT;
-		filter->fft = fftw_plan_dft_r2c_1d(2 * flen, filter->dft_time, filter->dft_freq, fftw_flags);
-		filter->ifft = fftw_plan_dft_c2r_1d(2 * flen, filter->dft_freq, filter->dft_time, fftw_flags);
+		HcPlanOwner fft(fftw_plan_dft_r2c_1d(2 * flen, temp.dft_time, temp.dft_freq, fftw_flags));
+		if (fft.get() == nullptr)
+			throw std::runtime_error("FFTW could not create the forward convolution plan");
+		HcPlanOwner ifft(fftw_plan_dft_c2r_1d(2 * flen, temp.dft_freq, temp.dft_time, fftw_flags));
+		if (ifft.get() == nullptr)
+			throw std::runtime_error("FFTW could not create the inverse convolution plan");
+
+		temp.fft = fft.release();
+		temp.ifft = ifft.release();
 	}
+	HcPlanOwner fft(temp.fft);
+	HcPlanOwner ifft(temp.ifft);
+	temp.fft = nullptr;
+	temp.ifft = nullptr;
 
 	gain = 0.5 / flen;
 
-	memset(filter->dft_time, 0, sizeof *filter->dft_time * 2 * flen);
+	memset(temp.dft_time, 0, checkedHcMultiply(dftLength, sizeof(double)));
 
 	// Full-length segments
-	for (i = 0; i < filter->num_filterbuf - 1; i++) {
+	for (i = 0; i < temp.num_filterbuf - 1; i++) {
 		// dft_time[0:flen] = gain * h[i * flen + 0 : + flen]
-		mul_store_gain_double(filter->dft_time, h + (size_t)i * flen, flen, gain);
+		mul_store_gain_double(temp.dft_time, h + (size_t)i * flen, flen, gain);
 
-		fftw_execute(filter->fft);
+		fftw_execute(fft.get());
 
 		// Split complex to separate real/imag buffers
-		copy_split_complex_vec((const fftw_complex*)filter->dft_freq,
-			filter->filterbuf_freq_real[i],
-			filter->filterbuf_freq_imag[i],
+		copy_split_complex_vec((const fftw_complex*)temp.dft_freq,
+			temp.filterbuf_freq_real[i],
+			temp.filterbuf_freq_imag[i],
 			flen + 1);
 	}
 
 	// Tail (possibly partial) segment
 	int last_segment_len = hlen - i * flen;
 	if (last_segment_len > 0) {
-		mul_store_gain_double(filter->dft_time, h + (size_t)i * flen, last_segment_len, gain);
+		mul_store_gain_double(temp.dft_time, h + (size_t)i * flen, last_segment_len, gain);
 		// zero the remainder up to 2*flen
-		memset(&filter->dft_time[last_segment_len], 0,
-			sizeof *filter->dft_time * (2 * (size_t)flen - (size_t)last_segment_len));
+		memset(&temp.dft_time[last_segment_len], 0,
+			checkedHcMultiply(dftLength - (size_t)last_segment_len, sizeof(double)));
 	}
 	else {
 		// No tail data: ensure the time buffer is zeroed
-		memset(filter->dft_time, 0, sizeof *filter->dft_time * 2 * flen);
+		memset(temp.dft_time, 0, checkedHcMultiply(dftLength, sizeof(double)));
 	}
 
-	fftw_execute(filter->fft);
-	copy_split_complex_vec((const fftw_complex*)filter->dft_freq,
-		filter->filterbuf_freq_real[i],
-		filter->filterbuf_freq_imag[i],
+	fftw_execute(fft.get());
+	copy_split_complex_vec((const fftw_complex*)temp.dft_freq,
+		temp.filterbuf_freq_real[i],
+		temp.filterbuf_freq_imag[i],
 		flen + 1);
+
+	temp.fft = fft.release();
+	temp.ifft = ifft.release();
+	temp.storage = storageOwner.release();
+	// Publish only after every allocation, plan, and initial transform has
+	// succeeded. A throwing path never exposes partial ownership to the caller.
+	*filter = temp;
 }
 
 void hcCloseSingle(HConvSingle* filter)
 {
-	fftw_destroy_plan(filter->ifft);
-	fftw_destroy_plan(filter->fft);
+	if (filter == nullptr)
+		return;
+	if (filter->ifft != nullptr)
+		fftw_destroy_plan(filter->ifft);
+	if (filter->fft != nullptr)
+		fftw_destroy_plan(filter->fft);
 	delete filter->storage;
-	memset(filter, 0, sizeof(HConvSingle));
+	*filter = {};
 }
 
 // The dual/triple-segment (low-latency) API lives in


### PR DESCRIPTION
## Summary
- make configuration reads fail closed and editor saves atomic
- move filter, HybridConv, FFTW, IR, Copy, and IIR ownership into RAII containers
- validate VST metadata and balance COM, DLL, event, and service lifetimes
- make configuration reload transactional so initialization failures keep the active audio graph

## Root cause
Several initialization paths published ownership before construction completed, trusted external sizes, or treated partial I/O as success. Those paths could leak resources, corrupt state, or let an exception escape into audiodg.exe.

## Validation
- EqualizerAPO Release x64 build (0 warnings)
- Qt Editor qmake/nmake build and --selftest-vst
- EditorLogicTests: 337 checks
- EngineOrchestrationTests: 626 checks
- HybridConvTests: 1,627 checks
- MultiConvolutionTests: 5,355 checks
- AudioRegressionTests: 20/20
- Bump-Version.ps1 -Check
- git diff --check

The Visual Studio whole-solution command still cannot locate QtMsBuild in this local environment; the Qt targets were validated through the repository's qmake/nmake build instead.