### PR TITLE
Refactor resource ownership with RAII

### DIFF
--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -23,6 +23,7 @@
 #include <crtdbg.h>
 #endif
 #include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <fstream>
 #include <algorithm>
@@ -31,7 +32,6 @@
 #include <cmath>
 #include <string>
 #include <vector>
-#include <sndfile.h>
 #include <tclap/CmdLine.h>
 
 #include "../version.h"
@@ -41,6 +41,7 @@
 #include "../helpers/PrecisionTimer.h"
 #include "../helpers/MemoryHelper.h"
 #include "../helpers/PerfProfile.h"
+#include "../helpers/SndfileRAII.h"
 
 using std::cerr;
 using std::cout;
@@ -114,10 +115,10 @@ int main(int argc, char** argv)
 			timer.start();
 
 			SF_INFO info;
-			SNDFILE* inFile = sf_open(input.c_str(), SFM_READ, &info);
-			if (inFile == nullptr)
+			sndfile::Handle inFile(sf_open(input.c_str(), SFM_READ, &info));
+			if (!inFile)
 			{
-				cerr << sf_strerror(inFile);
+				cerr << sf_strerror(nullptr);
 				return 1;
 			}
 
@@ -131,10 +132,7 @@ int main(int argc, char** argv)
 
 			sf_count_t numRead = 0;
 			while (numRead < frameCount)
-				numRead += sf_readf_float(inFile, buf.data() + numRead * channelCount, frameCount - numRead);
-
-			sf_close(inFile);
-			inFile = nullptr;
+				numRead += sf_readf_float(inFile.get(), buf.data() + numRead * channelCount, frameCount - numRead);
 
 			double readTime = timer.stop();
 			cout << "Reading input file took " << readTime << " seconds\n";
@@ -301,19 +299,16 @@ int main(int argc, char** argv)
 			cout << "\nWriting output to " << output << "\n";
 
 			SF_INFO info = {frameCount, static_cast<int>(sampleRate), static_cast<int>(channelCount), SF_FORMAT_WAV | SF_FORMAT_PCM_16, 0};
-			SNDFILE* outFile = sf_open(output.c_str(), SFM_WRITE, &info);
-			if (outFile == nullptr)
+			sndfile::Handle outFile(sf_open(output.c_str(), SFM_WRITE, &info));
+			if (!outFile)
 			{
-				cerr << sf_strerror(outFile);
+				cerr << sf_strerror(nullptr);
 				return 1;
 			}
 
 			sf_count_t numWritten = 0;
 			while (numWritten < frameCount)
-				numWritten += sf_writef_float(outFile, buf2.data() + numWritten * channelCount, frameCount - numWritten);
-
-			sf_close(outFile);
-			outFile = nullptr;
+				numWritten += sf_writef_float(outFile.get(), buf2.data() + numWritten * channelCount, frameCount - numWritten);
 		}
 
 		if (!noPauseArg.getValue())
@@ -325,5 +320,15 @@ int main(int argc, char** argv)
 	{
 		cerr << "Error: " << e.error() << " for arg " << e.argId() << "\n";
 		return -1;
+	}
+	catch (const std::exception& error)
+	{
+		cerr << "Unhandled exception: " << error.what() << "\n";
+		return EXIT_FAILURE;
+	}
+	catch (...)
+	{
+		cerr << "Unhandled non-standard exception\n";
+		return EXIT_FAILURE;
 	}
 }

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -358,11 +358,14 @@
     <ClInclude Include="helpers\FileSharingRetry.h" />
     <ClInclude Include="helpers\GainIterator.h" />
     <ClInclude Include="helpers\LogHelper.h" />
+    <ClInclude Include="helpers\FftwRAII.h" />
     <ClInclude Include="helpers\MemoryHelper.h" />
+    <ClInclude Include="helpers\Win32Resource.h" />
     <ClInclude Include="helpers\PerfProfile.h" />
     <ClInclude Include="helpers\PrecisionTimer.h" />
     <ClInclude Include="helpers\RegistryHelper.h" />
     <ClInclude Include="helpers\ScopeGuard.h" />
+    <ClInclude Include="helpers\SndfileRAII.h" />
     <ClInclude Include="helpers\StringHelper.h" />
     <ClInclude Include="helpers\UncaughtExceptions.h" />
     <ClInclude Include="helpers\VSTPluginInstance.h" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -140,8 +140,14 @@
     <ClInclude Include="helpers\LogHelper.h">
       <Filter>helpers</Filter>
     </ClInclude>
+    <ClInclude Include="helpers\FftwRAII.h">
+      <Filter>helpers</Filter>
+    </ClInclude>
     <ClInclude Include="helpers\MemoryHelper.h">
       <Filter>helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="helpers\Win32Resource.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="helpers\PerfProfile.h">
       <Filter>helpers</Filter>
@@ -153,6 +159,9 @@
       <Filter>helpers</Filter>
     </ClInclude>
     <ClInclude Include="helpers\ScopeGuard.h">
+      <Filter>helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="helpers\SndfileRAII.h">
       <Filter>helpers</Filter>
     </ClInclude>
     <ClInclude Include="helpers\StringHelper.h">

--- a/ConfigurationFileReader.cpp
+++ b/ConfigurationFileReader.cpp
@@ -21,8 +21,9 @@ std::stringstream makeFailedStream()
 std::stringstream ConfigurationFileReader::readWithRetry(const std::wstring& path)
 {
 	DWORD error = ERROR_SUCCESS;
-	HANDLE hFile = openFileWithSharingRetry(path.c_str(), GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, error);
-	if (hFile == INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle file = openFileWithSharingRetry(
+		path.c_str(), GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, error);
+	if (!file)
 	{
 		LogFStatic(L"Error while reading configuration file %s: %s", path.c_str(), StringHelper::getSystemErrorString(error).c_str());
 		return makeFailedStream();
@@ -33,10 +34,9 @@ std::stringstream ConfigurationFileReader::readWithRetry(const std::wstring& pat
 	for (;;)
 	{
 		DWORD bytesRead = 0;
-		if (!ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr))
+		if (!ReadFile(file.get(), buf, sizeof(buf), &bytesRead, nullptr))
 		{
 			error = GetLastError();
-			CloseHandle(hFile);
 			LogFStatic(L"Error while reading configuration file %s: %s", path.c_str(), StringHelper::getSystemErrorString(error).c_str());
 			return makeFailedStream();
 		}
@@ -45,7 +45,6 @@ std::stringstream ConfigurationFileReader::readWithRetry(const std::wstring& pat
 		inputStream.write(buf, bytesRead);
 	}
 
-	CloseHandle(hFile);
 	inputStream.seekg(0);
 	return inputStream;
 }

--- a/DeviceAPOInfo.cpp
+++ b/DeviceAPOInfo.cpp
@@ -30,6 +30,7 @@
 #include "helpers/StringHelper.h"
 #include "helpers/RegistryHelper.h"
 #include "helpers/ComPtr.h"
+#include "helpers/Win32Resource.h"
 
 using std::make_shared;
 using std::move;
@@ -173,14 +174,13 @@ bool DeviceAPOInfo::checkAPORegistration(bool fix)
 				// regsvr32.exe (no extra process, no transient window).
 				// LOAD_WITH_ALTERED_SEARCH_PATH resolves the DLL's own
 				// dependencies relative to its directory.
-				HMODULE module = LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
-				if (module != nullptr)
+				winutil::UniqueModule module(LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH));
+				if (module)
 				{
 					using DllServerProc = HRESULT(__stdcall*)();
-					DllServerProc registerProc = reinterpret_cast<DllServerProc>(GetProcAddress(module, "DllRegisterServer"));
+					DllServerProc registerProc = reinterpret_cast<DllServerProc>(GetProcAddress(module.get(), "DllRegisterServer"));
 					if (registerProc != nullptr)
 						registerProc();
-					FreeLibrary(module);
 				}
 			}
 		}

--- a/DeviceSelector/DeviceSelector.cpp
+++ b/DeviceSelector/DeviceSelector.cpp
@@ -21,6 +21,7 @@
 #include <DeviceAPOInfo.h>
 #include <helpers/RegistryHelper.h>
 #include <helpers/ServiceHelper.h>
+#include <helpers/Win32Resource.h>
 #include <QPropertyAnimation>
 #include <VoicemeeterAPOInfo.h>
 #include "DeviceTestDialog.h"
@@ -322,8 +323,9 @@ void DeviceSelector::finish(bool deviceUpdated)
 	{
 		if (QMessageBox::question(this, tr("Reboot"), tr("To apply the changes, Windows should be rebooted. Reboot now?")) == QMessageBox::Yes)
 		{
-			HANDLE tokenHandle;
-			if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tokenHandle))
+			winutil::UniqueHandle tokenHandle;
+			if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+				tokenHandle.put()))
 			{
 				LUID luid;
 				if (LookupPrivilegeValue(nullptr, SE_SHUTDOWN_NAME, &luid))
@@ -333,11 +335,10 @@ void DeviceSelector::finish(bool deviceUpdated)
 					tp.Privileges[0].Luid = luid;
 					tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-					if (AdjustTokenPrivileges(tokenHandle, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
+					if (AdjustTokenPrivileges(tokenHandle.get(), FALSE, &tp,
+						sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
 						InitiateShutdownW(nullptr, nullptr, 0, SHUTDOWN_RESTART | SHUTDOWN_GRACE_OVERRIDE, SHTDN_REASON_MAJOR_APPLICATION | SHTDN_REASON_MINOR_MAINTENANCE);
 				}
-
-				CloseHandle(tokenHandle);
 			}
 		}
 	}

--- a/DeviceSelector/DeviceTestThread.cpp
+++ b/DeviceSelector/DeviceTestThread.cpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <helpers/RegistryHelper.h>
 #include <helpers/ServiceHelper.h>
+#include <helpers/ComPtr.h>
 #include <ObjBase.h>
 #include "DeviceTestThread.h"
 
@@ -62,8 +63,15 @@ void DeviceTestThread::run()
 {
 	SCOPE_EXIT{emit finished(); };
 
-	CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-	SCOPE_EXIT{CoUninitialize(); };
+	winutil::ComApartment apartment(COINIT_MULTITHREADED);
+	if (!apartment.isUsable())
+	{
+		emit logError(tr("Could not initialize COM for device testing."));
+		emit abort(tr("COM initialization failed (0x%1).")
+			.arg(static_cast<qulonglong>(apartment.status()), 8, 16, QLatin1Char('0')), -1);
+		return;
+	}
+
 	try
 	{
 		emit log(tr("Restarting audio service..."));

--- a/DeviceSelector/DeviceTestThread.h
+++ b/DeviceSelector/DeviceTestThread.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <DeviceAPOInfo.h>
+#include <QHash>
 #include <QThread>
 #include "ReceiveThread.h"
 

--- a/DeviceSelector/ReceiveThread.cpp
+++ b/DeviceSelector/ReceiveThread.cpp
@@ -20,6 +20,7 @@
 #include "stdafx.h"
 #include "helpers/LogHelper.h"
 #include "helpers/StringHelper.h"
+#include "helpers/Win32Resource.h"
 #include "ReceiveThread.h"
 
 ReceiveThread::ReceiveThread(const std::wstring& pipeName)
@@ -37,18 +38,19 @@ void ReceiveThread::stop()
 {
 	if (pipeName != L"")
 	{
-		HANDLE pipe = CreateFileW((L"\\\\.\\pipe\\" + pipeName).c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
-		if (pipe == INVALID_HANDLE_VALUE)
+		winutil::UniqueHandle pipe(CreateFileW((L"\\\\.\\pipe\\" + pipeName).c_str(),
+			GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr));
+		if (!pipe)
 		{
 			if (WaitNamedPipeW((L"\\\\.\\pipe\\" + pipeName).c_str(), 1000))
-				pipe = CreateFileW((L"\\\\.\\pipe\\" + pipeName).c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+				pipe.reset(CreateFileW((L"\\\\.\\pipe\\" + pipeName).c_str(),
+					GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr));
 		}
-		if (pipe != INVALID_HANDLE_VALUE)
+		if (pipe)
 		{
 			DWORD bytesWritten;
-			WriteFile(pipe, "stop", 4, &bytesWritten, nullptr);
-			FlushFileBuffers(pipe);
-			CloseHandle(pipe);
+			WriteFile(pipe.get(), "stop", 4, &bytesWritten, nullptr);
+			FlushFileBuffers(pipe.get());
 		}
 		pipeName = L"";
 	}
@@ -61,42 +63,41 @@ void ReceiveThread::run()
 {
 	try
 	{
-		PSECURITY_DESCRIPTOR pSD = (PSECURITY_DESCRIPTOR)LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH);
+		winutil::UniqueLocalPtr<void> pSD(LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH));
 		if (!pSD)
 			throw ReceiveException(L"Could not allocate security descriptor: " + StringHelper::getSystemErrorString(GetLastError()));
-		SCOPE_EXIT{LocalFree(pSD);};
 
-		if (!InitializeSecurityDescriptor(pSD, SECURITY_DESCRIPTOR_REVISION))
+		if (!InitializeSecurityDescriptor(pSD.get(), SECURITY_DESCRIPTOR_REVISION))
 			throw ReceiveException(L"Could not initialize security descriptor: " + StringHelper::getSystemErrorString(GetLastError()));
 
-		if (!SetSecurityDescriptorDacl(pSD, TRUE, nullptr, FALSE))
+		if (!SetSecurityDescriptorDacl(pSD.get(), TRUE, nullptr, FALSE))
 			throw ReceiveException(L"Could not set security descriptor DACL: " + StringHelper::getSystemErrorString(GetLastError()));
 
 		SECURITY_ATTRIBUTES sa;
 		sa.nLength = sizeof(sa);
-		sa.lpSecurityDescriptor = pSD;
+		sa.lpSecurityDescriptor = pSD.get();
 		sa.bInheritHandle = FALSE;
 
 		char buf[1024];
 		while (true)
 		{
-			HANDLE pipe = CreateNamedPipeW((L"\\\\.\\pipe\\" + pipeName).c_str(), PIPE_ACCESS_INBOUND, PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
-				PIPE_UNLIMITED_INSTANCES, 0, sizeof(buf), 0, &sa);
-			if (pipe == INVALID_HANDLE_VALUE)
+			winutil::UniqueHandle pipe(CreateNamedPipeW((L"\\\\.\\pipe\\" + pipeName).c_str(),
+				PIPE_ACCESS_INBOUND, PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+				PIPE_UNLIMITED_INSTANCES, 0, sizeof(buf), 0, &sa));
+			if (!pipe)
 				throw ReceiveException(L"Could not create named pipe: " + StringHelper::getSystemErrorString(GetLastError()));
-			SCOPE_EXIT{CloseHandle(pipe);};
 
-			bool connected = ConnectNamedPipe(pipe, nullptr);
+			bool connected = ConnectNamedPipe(pipe.get(), nullptr);
 			if (!connected)
 				connected = GetLastError() == ERROR_PIPE_CONNECTED;
 
 			if (!connected)
 				continue;
 
-			SCOPE_EXIT{DisconnectNamedPipe(pipe);};
+			SCOPE_EXIT{DisconnectNamedPipe(pipe.get());};
 
 			DWORD bytesRead;
-			bool ok = ReadFile(pipe, buf, sizeof(buf), &bytesRead, nullptr);
+			bool ok = ReadFile(pipe.get(), buf, sizeof(buf), &bytesRead, nullptr);
 			if (!ok || bytesRead == 0)
 				throw ReceiveException(L"Could not read from pipe: " + StringHelper::getSystemErrorString(GetLastError()));
 

--- a/Editor/AnalysisThread.cpp
+++ b/Editor/AnalysisThread.cpp
@@ -19,6 +19,8 @@
 
 #include <QElapsedTimer>
 
+#include <stdexcept>
+
 #include "FilterEngine.h"
 #include "AnalysisThread.h"
 
@@ -35,26 +37,13 @@ AnalysisThread::AnalysisThread()
 
 AnalysisThread::~AnalysisThread()
 {
-	mutex.lock();
-	quit = true;
-	condition.wakeAll();
-	mutex.unlock();
+	{
+		QMutexLocker locker(&mutex);
+		quit = true;
+		condition.wakeAll();
+	}
 
 	wait();
-
-	if (resultFreqData != nullptr)
-		fftw_free(resultFreqData);
-
-	if (buf != nullptr)
-		delete[] buf;
-	if (buf2 != nullptr)
-		delete[] buf2;
-	if (timeData != nullptr)
-		fftw_free(timeData);
-	if (freqData != nullptr)
-		fftw_free(freqData);
-	if (planForward != nullptr)
-		fftw_destroy_plan(planForward);
 }
 
 void AnalysisThread::setParameters(shared_ptr<AbstractAPOInfo> device, int channelMask, int channelIndex, const QString& configPath, int frameCount)
@@ -69,81 +58,91 @@ void AnalysisThread::setParameters(shared_ptr<AbstractAPOInfo> device, int chann
 	condition.wakeAll();
 }
 
-void AnalysisThread::beginGetResult()
+AnalysisThread::ResultLock AnalysisThread::lockResult()
 {
-	mutex.lock();
+	return ResultLock(*this);
 }
 
-void AnalysisThread::endGetResult()
+AnalysisThread::ResultLock::ResultLock(AnalysisThread& owner)
+	: owner(owner), locker(&owner.mutex)
 {
-	mutex.unlock();
 }
 
-fftw_complex* AnalysisThread::getFreqData() const
+fftw_complex* AnalysisThread::ResultLock::freqData() const
 {
-	return resultFreqData;
+	return owner.resultFreqData.get();
 }
 
-int AnalysisThread::getFreqDataLength() const
+int AnalysisThread::ResultLock::freqDataLength() const
 {
-	return freqDataLength;
+	return owner.freqDataLength;
 }
 
-int AnalysisThread::getFreqDataSampleRate() const
+int AnalysisThread::ResultLock::freqDataSampleRate() const
 {
-	return freqDataSampleRate;
+	return owner.freqDataSampleRate;
 }
 
-double AnalysisThread::getPeakGain() const
+double AnalysisThread::ResultLock::peakGain() const
 {
-	return peakGain;
+	return owner.peakGain;
 }
 
-int AnalysisThread::getLatency() const
+int AnalysisThread::ResultLock::latency() const
 {
-	return latency;
+	return owner.latency;
 }
 
-double AnalysisThread::getInitializationTime() const
+double AnalysisThread::ResultLock::initializationTime() const
 {
-	return initializationTime;
+	return owner.initializationTime;
 }
 
-double AnalysisThread::getProcessingTime() const
+double AnalysisThread::ResultLock::processingTime() const
 {
-	return processingTime;
+	return owner.processingTime;
 }
 
-unsigned AnalysisThread::getProcessedFrames() const
+unsigned AnalysisThread::ResultLock::processedFrames() const
 {
-	return processedFrames;
+	return owner.processedFrames;
 }
 
-const std::vector<ConfigLoadTraceEntry>& AnalysisThread::getLoadTrace() const
+const std::vector<ConfigLoadTraceEntry>& AnalysisThread::ResultLock::loadTrace() const
 {
-	return resultLoadTrace;
+	return owner.resultLoadTrace;
 }
 
 void AnalysisThread::run()
+try
 {
 	while (true)
 	{
-		mutex.lock();
-		if (!quit && this->frameCount == 0)
-			condition.wait(&mutex);
-		if (quit)
+		shared_ptr<AbstractAPOInfo> device;
+		int channelMask;
+		int channelIndex;
+		QString configPath;
+		int frameCount;
 		{
-			mutex.unlock();
-			break;
+			QMutexLocker locker(&mutex);
+			while (!quit && this->frameCount == 0)
+				condition.wait(&mutex);
+			if (quit)
+				break;
+
+			device = this->device;
+			channelMask = this->channelMask;
+			channelIndex = this->channelIndex;
+			configPath = this->configPath;
+			frameCount = this->frameCount;
+			this->frameCount = 0;
 		}
 
-		shared_ptr<AbstractAPOInfo> device = this->device;
-		int channelMask = this->channelMask;
-		int channelIndex = this->channelIndex;
-		QString configPath = this->configPath;
-		int frameCount = this->frameCount;
-		this->frameCount = 0;
-		mutex.unlock();
+		if (frameCount <= 0)
+		{
+			qWarning("Analysis skipped an invalid frame count: %d", frameCount);
+			continue;
+		}
 
 		QElapsedTimer timer;
 		timer.start();
@@ -194,31 +193,29 @@ void AnalysisThread::run()
 
 		if (frameCount != lastFrameCount || channelCount != lastChannelCount)
 		{
-			if (buf != nullptr)
-				delete[] buf;
-			buf = new double[frameCount * channelCount];
-			std::fill_n(buf, frameCount * channelCount, 0.0);
-
-			if (buf2 != nullptr)
-				delete[] buf2;
-			buf2 = new double[frameCount * channelCount];
+			if (channelCount != 0
+				&& static_cast<size_t>(frameCount) > (numeric_limits<size_t>::max)() / channelCount)
+			{
+				throw std::length_error("Analysis buffer size overflow");
+			}
+			const size_t sampleCount = static_cast<size_t>(frameCount) * channelCount;
+			std::vector<double> newBuf(sampleCount, 0.0);
+			std::vector<double> newBuf2(sampleCount);
+			buf = std::move(newBuf);
+			buf2 = std::move(newBuf2);
 		}
 		for (unsigned i = 0; i < channelCount; i++)
 			buf[i] = 1.0f;
 
 		if (frameCount != lastFrameCount)
 		{
-			if (timeData != nullptr)
-				fftw_free(timeData);
-			timeData = fftw_alloc_real(frameCount);
-
-			if (freqData != nullptr)
-				fftw_free(freqData);
-			freqData = fftw_alloc_complex(frameCount);
-
-			if (planForward != nullptr)
-				fftw_destroy_plan(planForward);
-			planForward = fftw_plan_dft_r2c_1d(frameCount, timeData, freqData, FFTW_ESTIMATE);
+			auto newTimeData = fftw::allocateReal(frameCount);
+			auto newFreqData = fftw::allocateComplex(frameCount);
+			auto newPlan = fftw::makeRealToComplexPlan(frameCount, newTimeData.get(), newFreqData.get());
+			planForward.reset();
+			timeData = std::move(newTimeData);
+			freqData = std::move(newFreqData);
+			planForward = std::move(newPlan);
 		}
 
 		lastFrameCount = frameCount;
@@ -232,7 +229,7 @@ void AnalysisThread::run()
 		while (processedFrames < 10 * sampleRate)
 		{
 			qint64 startTime = timer.nsecsElapsed();
-			engine.process(buf2, buf, frameCount);
+			engine.process(buf2.data(), buf.data(), frameCount);
 			processingTime += (timer.nsecsElapsed() - startTime) / 1e6;
 			processedFrames += frameCount;
 
@@ -240,7 +237,7 @@ void AnalysisThread::run()
 			{
 				for (int i = 0; i < startFrame; i++)
 				{
-					timeData[frameCount - startFrame + i] = buf2[i * channelCount + channelIndex];
+					timeData.get()[frameCount - startFrame + i] = buf2[i * channelCount + channelIndex];
 				}
 				break;
 			}
@@ -259,7 +256,7 @@ void AnalysisThread::run()
 			{
 				for (int i = 0; i < frameCount - startFrame; i++)
 				{
-					timeData[i] = buf2[(startFrame + i) * channelCount + channelIndex];
+						timeData.get()[i] = buf2[(startFrame + i) * channelCount + channelIndex];
 				}
 
 				if (startFrame == 0)
@@ -281,13 +278,13 @@ void AnalysisThread::run()
 		{
 			latency += startFrame;
 
-			fftw_execute(planForward);
+			fftw_execute(planForward.get());
 
 			peakGain = -DBL_MAX;
 
 			for (int i = 0; i < frameCount / 2; i++)
 			{
-				double sqrGain = freqData[i][0] * freqData[i][0] + freqData[i][1] * freqData[i][1];
+				double sqrGain = freqData.get()[i][0] * freqData.get()[i][0] + freqData.get()[i][1] * freqData.get()[i][1];
 				if (sqrGain > peakGain)
 					peakGain = sqrGain;
 			}
@@ -298,29 +295,34 @@ void AnalysisThread::run()
 		{
 			latency = 0;
 			peakGain = -numeric_limits<double>::infinity();
-			std::fill_n(&freqData[0][0], frameCount * 2, 0.0);
+			std::fill_n(&freqData.get()[0][0], frameCount * 2, 0.0);
 		}
 
-		mutex.lock();
-		if (this->freqDataLength != frameCount)
 		{
-			if (resultFreqData != nullptr)
-				fftw_free(resultFreqData);
-			resultFreqData = fftw_alloc_complex(frameCount);
+			QMutexLocker locker(&mutex);
+			if (this->freqDataLength != frameCount)
+				resultFreqData = fftw::allocateComplex(frameCount);
+			std::copy_n(&freqData.get()[0][0], frameCount * 2, &resultFreqData.get()[0][0]);
+			this->freqDataLength = frameCount;
+			this->freqDataSampleRate = sampleRate;
+			this->latency = latency;
+			this->peakGain = peakGain;
+			this->initializationTime = initializationTime;
+			this->processingTime = processingTime;
+			this->processedFrames = processedFrames;
+			this->resultLoadTrace = std::move(traceCollector.entries);
 		}
-		std::copy_n(&freqData[0][0], frameCount * 2, &resultFreqData[0][0]);
-		this->freqDataLength = frameCount;
-		this->freqDataSampleRate = sampleRate;
-		this->latency = latency;
-		this->peakGain = peakGain;
-		this->initializationTime = initializationTime;
-		this->processingTime = processingTime;
-		this->processedFrames = processedFrames;
-		this->resultLoadTrace = std::move(traceCollector.entries);
-		mutex.unlock();
 
 		qDebug("Analysis took %.1f ms", timer.nsecsElapsed() / 1e6);
 
 		emit analysisFinished();
 	}
+}
+catch (const std::exception& error)
+{
+	qCritical("Analysis thread stopped after an exception: %s", error.what());
+}
+catch (...)
+{
+	qCritical("Analysis thread stopped after a non-standard exception");
 }

--- a/Editor/AnalysisThread.h
+++ b/Editor/AnalysisThread.h
@@ -23,35 +23,47 @@
 
 #include <QThread>
 #include <QMutex>
+#include <QMutexLocker>
 #include <QWaitCondition>
 #include <fftw3.h>
 
 #include "ConfigLoadTrace.h"
 #include "DeviceAPOInfo.h"
+#include "helpers/FftwRAII.h"
 
 class AnalysisThread : public QThread
 {
 	Q_OBJECT
 
 public:
+	class ResultLock
+	{
+	public:
+		ResultLock(const ResultLock&) = delete;
+		ResultLock& operator=(const ResultLock&) = delete;
+
+		fftw_complex* freqData() const;
+		int freqDataLength() const;
+		int freqDataSampleRate() const;
+		double peakGain() const;
+		int latency() const;
+		double initializationTime() const;
+		double processingTime() const;
+		unsigned processedFrames() const;
+		const std::vector<ConfigLoadTraceEntry>& loadTrace() const;
+
+	private:
+		friend class AnalysisThread;
+		explicit ResultLock(AnalysisThread& owner);
+
+		AnalysisThread& owner;
+		QMutexLocker<QMutex> locker;
+	};
+
 	AnalysisThread();
 	~AnalysisThread();
 	void setParameters(std::shared_ptr<AbstractAPOInfo> device, int channelMask, int channelIndex, const QString& configPath, int frameCount);
-	void beginGetResult();
-	void endGetResult();
-
-	fftw_complex* getFreqData() const;
-	int getFreqDataLength() const;
-	int getFreqDataSampleRate() const;
-	double getPeakGain() const;
-	int getLatency() const;
-	double getInitializationTime() const;
-	double getProcessingTime() const;
-	unsigned getProcessedFrames() const;
-	// Per-line facts the engine reported while loading the analyzed config
-	// (branch decisions, Eval values, skipped lines). Like the other getters,
-	// only valid between beginGetResult() and endGetResult().
-	const std::vector<ConfigLoadTraceEntry>& getLoadTrace() const;
+	ResultLock lockResult();
 
 signals:
 	void analysisFinished();
@@ -72,7 +84,7 @@ private:
 	int frameCount = 0;
 
 	// output
-	fftw_complex* resultFreqData = nullptr;
+	fftw::ComplexBuffer resultFreqData;
 	int freqDataLength = 0;
 	int freqDataSampleRate = 0;
 	double peakGain = 0.0;
@@ -85,9 +97,9 @@ private:
 	// internal (not protected by mutex)
 	int lastFrameCount = -1;
 	int lastChannelCount = -1;
-	double* buf = nullptr;
-	double* buf2 = nullptr;
-	double* timeData = nullptr;
-	fftw_complex* freqData = nullptr;
-	fftw_plan planForward = nullptr;
+	std::vector<double> buf;
+	std::vector<double> buf2;
+	fftw::RealBuffer timeData;
+	fftw::ComplexBuffer freqData;
+	fftw::Plan planForward;
 };

--- a/Editor/ConfigFileCodec.cpp
+++ b/Editor/ConfigFileCodec.cpp
@@ -77,8 +77,9 @@ ConfigFileCodec::ReadResult ConfigFileCodec::readConfig(const QString& path)
 	ReadResult result;
 
 	DWORD error = ERROR_SUCCESS;
-	HANDLE hFile = openFileWithSharingRetry(path.toStdWString().c_str(), GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, error);
-	if (hFile == INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle file = openFileWithSharingRetry(
+		path.toStdWString().c_str(), GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, error);
+	if (!file)
 	{
 		result.ok = false;
 		result.errorMessage = QString::fromStdWString(StringHelper::getSystemErrorString(error));
@@ -91,10 +92,9 @@ ConfigFileCodec::ReadResult ConfigFileCodec::readConfig(const QString& path)
 	for (;;)
 	{
 		DWORD bytesRead = 0;
-		if (!ReadFile(hFile, buf, sizeof(buf), &bytesRead, nullptr))
+		if (!ReadFile(file.get(), buf, sizeof(buf), &bytesRead, nullptr))
 		{
 			error = GetLastError();
-			CloseHandle(hFile);
 			result.ok = false;
 			result.errorMessage = QString::fromStdWString(StringHelper::getSystemErrorString(error));
 			return result;
@@ -103,8 +103,6 @@ ConfigFileCodec::ReadResult ConfigFileCodec::readConfig(const QString& path)
 			break;
 		buffer.append(buf, bytesRead);
 	}
-
-	CloseHandle(hFile);
 
 	result.ok = true;
 	result.lines = decodeLines(buffer);

--- a/Editor/FilterGUIFactoryRegistry.cpp
+++ b/Editor/FilterGUIFactoryRegistry.cpp
@@ -18,6 +18,8 @@
 */
 
 #include <algorithm>
+#include <memory>
+#include <vector>
 
 #include "FilterGUIFactoryRegistry.h"
 #include "IFilterGUIFactory.h"
@@ -45,17 +47,17 @@ bool FilterGUIFactoryRegistry::registerFactory(int order, FilterGUIFactoryCreato
 	return true;
 }
 
-QList<IFilterGUIFactory*> FilterGUIFactoryRegistry::createFactories()
+std::vector<std::unique_ptr<IFilterGUIFactory>> FilterGUIFactoryRegistry::createFactories()
 {
 	QList<FilterGUIFactoryRegistration> sortedRegistrations = registrations();
 	std::stable_sort(sortedRegistrations.begin(), sortedRegistrations.end(), [](const FilterGUIFactoryRegistration& left, const FilterGUIFactoryRegistration& right) {
 		return left.order < right.order;
 	});
 
-	QList<IFilterGUIFactory*> factories;
+	std::vector<std::unique_ptr<IFilterGUIFactory>> factories;
 	factories.reserve(sortedRegistrations.size());
 	for (const FilterGUIFactoryRegistration& registration : sortedRegistrations)
-		factories.append(registration.creator());
+		factories.push_back(registration.creator());
 
 	return factories;
 }

--- a/Editor/FilterGUIFactoryRegistry.h
+++ b/Editor/FilterGUIFactoryRegistry.h
@@ -19,11 +19,14 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include <QList>
 
 class IFilterGUIFactory;
 
-using FilterGUIFactoryCreator = IFilterGUIFactory* (*)();
+using FilterGUIFactoryCreator = std::unique_ptr<IFilterGUIFactory>(*)();
 
 // Single source of truth for the order in which FilterTable offers each parsed
 // configuration line to the GUI factories. Factories are sorted by ascending
@@ -59,9 +62,9 @@ class FilterGUIFactoryRegistry
 public:
 	static bool registerFactory(int order, FilterGUIFactoryCreator creator);
 
-	// Fresh factory instances in ascending order. The caller (FilterTable) takes
-	// ownership and deletes them.
-	static QList<IFilterGUIFactory*> createFactories();
+	// Fresh factory instances in ascending order. Ownership is explicit in the
+	// returned collection and transfers to FilterTable by move.
+	static std::vector<std::unique_ptr<IFilterGUIFactory>> createFactories();
 };
 
 // Registers a GUI factory with its matching order. The factory's .cpp is compiled
@@ -71,5 +74,5 @@ public:
 #define REGISTER_FILTER_GUI_FACTORY(order, factoryType) \
 	namespace \
 	{ \
-		const bool factoryType##Registered = FilterGUIFactoryRegistry::registerFactory(order, []() -> IFilterGUIFactory* { return new factoryType; }); \
+		const bool factoryType##Registered = FilterGUIFactoryRegistry::registerFactory(order, []() -> std::unique_ptr<IFilterGUIFactory> { return std::make_unique<factoryType>(); }); \
 	}

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -73,7 +73,7 @@ FilterTable::FilterTable(MainWindow* mainWindow, QWidget* parent)
 
 	// The roster and its matching order live in the factory translation units
 	// themselves via REGISTER_FILTER_GUI_FACTORY (see FilterGUIFactoryRegistry).
-	// FilterTable owns the returned instances and deletes them in its destructor.
+	// FilterTable owns the returned instances through the collection.
 	factories = FilterGUIFactoryRegistry::createFactories();
 
 	// Every mutation - structural (add/delete/paste/drop) or in-row (knob
@@ -93,9 +93,6 @@ FilterTable::~FilterTable()
 
 	// The items themselves are owned and deleted by the FilterListModel member.
 
-	for (IFilterGUIFactory* factory : factories)
-		delete factory;
-	factories.clear();
 }
 
 void FilterTable::initialize(QScrollArea* scrollArea, const QList<shared_ptr<AbstractAPOInfo>>& outputDevices, const QList<shared_ptr<AbstractAPOInfo>>& inputDevices)
@@ -110,7 +107,7 @@ void FilterTable::initialize(QScrollArea* scrollArea, const QList<shared_ptr<Abs
 	// per scroll gesture in wheelEvent().
 	scrollArea->installEventFilter(this);
 
-	for (IFilterGUIFactory* factory : factories)
+	for (const auto& factory : factories)
 		factory->initialize(this);
 }
 
@@ -171,7 +168,7 @@ void FilterTable::updateGuis()
 	gridLayout->setColumnStretch(0, 0);
 	gridLayout->setColumnStretch(1, 1);
 
-	for (IFilterGUIFactory* factory : factories)
+	for (const auto& factory : factories)
 		factory->startOfFile(configPath);
 
 	QVector<FilterCardRowScope> rowScopes = FilterCardModel::calculateScopes(getLines());
@@ -201,7 +198,7 @@ void FilterTable::updateGuis()
 		row++;
 	}
 
-	for (IFilterGUIFactory* factory : factories)
+	for (const auto& factory : factories)
 		factory->endOfFile(configPath);
 
 	propagateChannels();
@@ -350,10 +347,13 @@ IFilterGUI* FilterTable::createRowGui(const QString& line)
 			return cardGui;
 	}
 
-	IFilterGUI* gui = nullptr;
-	for (IFilterGUIFactory* factory : factories)
+	// Factory results are parentless until the selected row adopts them. Keep
+	// the temporary legacy GUI scoped while card-mode replacement is decided,
+	// so a card constructor failure cannot strand it.
+	std::unique_ptr<IFilterGUI> gui;
+	for (const auto& factory : factories)
 	{
-		gui = factory->createFilterGUI(factoryKey, factoryValue);
+		gui.reset(factory->createFilterGUI(factoryKey, factoryValue));
 		if (gui != nullptr || factoryKey == "")
 			break;
 	}
@@ -370,20 +370,20 @@ IFilterGUI* FilterTable::createRowGui(const QString& line)
 		// fall back to the legacy GUI.
 		IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
 		if (cardGui != nullptr)
-		{
-			delete gui;
 			return cardGui;
-		}
 		// In Modern Cards we skip the legacy CommentFilterGUI decorator on
 		// purpose: the card row already owns the enable/disable affordance
 		// and a second power toolbar inside the body editor only produces
 		// rules that disagree with the card header.
-		return gui;
+		return gui.release();
 	}
 
-	for (IFilterGUIFactory* factory : factories)
-		gui = factory->decorateFilterGUI(gui);
-	return gui;
+	// The legacy decorator Interface accepts and may adopt a raw child pointer.
+	// Release at that established ownership-transfer seam.
+	IFilterGUI* decoratedGui = gui.release();
+	for (const auto& factory : factories)
+		decoratedGui = factory->decorateFilterGUI(decoratedGui);
+	return decoratedGui;
 }
 
 void FilterTable::updateSingleRowGui(Item* item)

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include <QLabel>
 #include <QListWidget>
 #include <QTableWidget>
@@ -243,7 +246,7 @@ private:
 	// True while applyHistoryState replays a snapshot, so the resulting
 	// linesChanged marks the tab dirty without re-recording the step.
 	bool restoringHistory = false;
-	QList<IFilterGUIFactory*> factories;
+	std::vector<std::unique_ptr<IFilterGUIFactory>> factories;
 	bool scrollingNow = false;
 	// True while the app-global wheel-redirect filter is installed; see
 	// wheelEvent()/eventFilter().

--- a/Editor/FilterTableParts/FilterTable.Model.cpp
+++ b/Editor/FilterTableParts/FilterTable.Model.cpp
@@ -277,7 +277,7 @@ QList<FilterTemplate> FilterTable::pickerFilterTemplates() const
 {
 	QList<FilterTemplate> templates;
 	QList<QStringList> trailingSections;
-	for (IFilterGUIFactory* factory : factories)
+	for (const auto& factory : factories)
 	{
 		const QList<FilterTemplate> factoryTemplates = factory->createFilterTemplates();
 		// A factory can ask for its sections to close the catalog

--- a/Editor/FilterTableRow.cpp
+++ b/Editor/FilterTableRow.cpp
@@ -36,7 +36,7 @@
 
 FilterTableRow::FilterTableRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui)
 	: QWidget(table),
-	ui(new Ui::FilterTableRow)
+	ui(std::make_unique<Ui::FilterTableRow>())
 {
 	ui->setupUi(this);
 	ui->labelNumber->setMinimumWidth(GUIHelper::scale(25));
@@ -66,10 +66,7 @@ FilterTableRow::FilterTableRow(FilterTable* table, int number, FilterTable::Item
 	ui->stackedWidget->setCurrentIndex(1);
 }
 
-FilterTableRow::~FilterTableRow()
-{
-	delete ui;
-}
+FilterTableRow::~FilterTableRow() = default;
 
 QRect FilterTableRow::getHeaderRect()
 {

--- a/Editor/FilterTableRow.h
+++ b/Editor/FilterTableRow.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QWidget>
 #include <QTime>
 
@@ -55,7 +57,7 @@ private slots:
 	void on_lineEdit_editingCanceled();
 
 private:
-	Ui::FilterTableRow* ui;
+	std::unique_ptr<Ui::FilterTableRow> ui;
 	FilterTable* table;
 	FilterTable::Item* item;
 	IFilterGUI* gui;

--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -72,7 +72,7 @@ template<class T> QList<T> MainWindow::toQList(const std::vector<T>& vector)
 }
 
 MainWindow::MainWindow(QDir configDir, QWidget* parent)
-	: QMainWindow(parent), ui(new Ui::MainWindow), configDir(configDir)
+	: QMainWindow(parent), ui(std::make_unique<Ui::MainWindow>()), configDir(configDir)
 {
 	outputDevices = toQList(DeviceAPOInfo::loadAllInfos(false));
 	inputDevices = toQList(DeviceAPOInfo::loadAllInfos(true));
@@ -220,9 +220,9 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 	}
 	ui->tabWidget->setObjectName(QStringLiteral("MainTabWidget"));
 
-	analysisThread = new AnalysisThread;
+	analysisThread = std::make_unique<AnalysisThread>();
 	analysisThread->start();
-	connect(analysisThread, SIGNAL(analysisFinished()), this, SLOT(updateAnalysisPanel()));
+	connect(analysisThread.get(), SIGNAL(analysisFinished()), this, SLOT(updateAnalysisPanel()));
 
 	// Derive the language roster from the catalogs that actually shipped
 	// (:/translations/Editor_<code>.qm) instead of a hand-maintained list, so
@@ -298,11 +298,7 @@ void MainWindow::watchForPendingUpdate()
 }
 
 MainWindow::~MainWindow()
-{
-	delete ui;
-
-	delete analysisThread;
-}
+= default;
 
 void MainWindow::doChecks()
 {

--- a/Editor/MainWindow.h
+++ b/Editor/MainWindow.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <QMainWindow>
@@ -147,7 +148,7 @@ private:
 	void updateDirtyStatus();
 	template<class T> QList<T> toQList(const std::vector<T>& vector);
 
-	Ui::MainWindow* ui;
+	std::unique_ptr<Ui::MainWindow> ui;
 
 	QDir configDir;
 	QCheckBox* instantModeCheckBox;
@@ -160,7 +161,7 @@ private:
 	std::shared_ptr<AbstractAPOInfo> defaultOutputDevice;
 	AnalysisPlotScene* analysisPlotScene;
 	EqGraphView* eqGraphView = nullptr;
-	AnalysisThread* analysisThread = nullptr;
+	std::unique_ptr<AnalysisThread> analysisThread;
 	QTimer* analysisDebounceTimer = nullptr;
 	bool restart = false;
 	bool noSavePreferences = false;

--- a/Editor/MainWindowParts/MainWindow.Analysis.cpp
+++ b/Editor/MainWindowParts/MainWindow.Analysis.cpp
@@ -84,10 +84,10 @@ void MainWindow::on_resolutionSpinBox_valueChanged(int value)
 
 void MainWindow::updateAnalysisPanel()
 {
-	analysisThread->beginGetResult();
-	int sampleRate = analysisThread->getFreqDataSampleRate();
-	int latency = analysisThread->getLatency();
-	analysisPlotScene->setFreqData(analysisThread->getFreqData(), analysisThread->getFreqDataLength(), sampleRate);
+	auto result = analysisThread->lockResult();
+	int sampleRate = result.freqDataSampleRate();
+	int latency = result.latency();
+	analysisPlotScene->setFreqData(result.freqData(), result.freqDataLength(), sampleRate);
 	if (eqGraphView != nullptr)
 		eqGraphView->setNodes(analysisPlotScene->getNodes(), static_cast<unsigned>(sampleRate), ui->analysisChannelComboBox->currentText());
 
@@ -96,7 +96,7 @@ void MainWindow::updateAnalysisPanel()
 	// not part of the analyzed chain receives an empty set, which clears any
 	// stale facts from a previous device/config selection.
 	{
-		const std::vector<ConfigLoadTraceEntry>& trace = analysisThread->getLoadTrace();
+		const std::vector<ConfigLoadTraceEntry>& trace = result.loadTrace();
 		for (int i = 0; i < ui->tabWidget->count(); i++)
 		{
 			QScrollArea* scrollArea = qobject_cast<QScrollArea*>(ui->tabWidget->widget(i));
@@ -125,30 +125,28 @@ void MainWindow::updateAnalysisPanel()
 		label->update();
 	};
 
-	double peakGain = analysisThread->getPeakGain();
+	double peakGain = result.peakGain();
 	ui->peakGainValueLabel->setText(tr("%0 dB").arg(peakGain, 0, 'f', 1));
 	setSeverity(ui->peakGainValueLabel, peakGain > 0 ? "critical" : "normal");
 
-	int processedFrames = analysisThread->getProcessedFrames();
+	int processedFrames = result.processedFrames();
 	if (sampleRate <= 0 || processedFrames <= 0)
 	{
 		ui->latencyValueLabel->setText(QString::fromUtf8("\xE2\x80\x94"));
 		ui->cpuUsageValueLabel->setText(QString::fromUtf8("\xE2\x80\x94"));
 		setSeverity(ui->cpuUsageValueLabel, "normal");
-		ui->initTimeValueLabel->setText(tr("%0 ms").arg(analysisThread->getInitializationTime(), 0, 'f', 1));
-		analysisThread->endGetResult();
+		ui->initTimeValueLabel->setText(tr("%0 ms").arg(result.initializationTime(), 0, 'f', 1));
 		return;
 	}
 
 	ui->latencyValueLabel->setText(tr("%0 ms (%1 s.)").arg(latency * 1000.0 / sampleRate, 0, 'f', 1).arg(latency));
 
-	ui->initTimeValueLabel->setText(tr("%0 ms").arg(analysisThread->getInitializationTime(), 0, 'f', 1));
+	ui->initTimeValueLabel->setText(tr("%0 ms").arg(result.initializationTime(), 0, 'f', 1));
 
-	double cpuUsage = analysisThread->getProcessingTime() * 100.0 / (processedFrames * 1000.0 / sampleRate);
+	double cpuUsage = result.processingTime() * 100.0 / (processedFrames * 1000.0 / sampleRate);
 	ui->cpuUsageValueLabel->setText(tr("%0 %").arg(cpuUsage, 0, 'f', 1));
 	setSeverity(ui->cpuUsageValueLabel, cpuUsage >= 50 ? "critical" : (cpuUsage >= 20 ? "warning" : "normal"));
 
-	analysisThread->endGetResult();
 }
 
 

--- a/Editor/guis/BiQuadFilterGUI.cpp
+++ b/Editor/guis/BiQuadFilterGUI.cpp
@@ -33,7 +33,7 @@ static const double dialQMin = 0.3333;
 static const double dialQMax = 33.3333;
 
 BiQuadFilterGUI::BiQuadFilterGUI(const BiQuadCommand& command)
-	: ui(new Ui::BiQuadFilterGUI)
+	: ui(std::make_unique<Ui::BiQuadFilterGUI>())
 {
 	ui->setupUi(this);
 
@@ -95,10 +95,7 @@ BiQuadFilterGUI::BiQuadFilterGUI(const BiQuadCommand& command)
 	ui->gainSpinBox->setValue(command.dbGain);
 }
 
-BiQuadFilterGUI::~BiQuadFilterGUI()
-{
-	delete ui;
-}
+BiQuadFilterGUI::~BiQuadFilterGUI() = default;
 
 // This is the sole BiQuad serializer; the engine only parses. It emits from the
 // combo-box mode selectors (Fixed/Q/BW/Slope, centre/corner) rather than from a

--- a/Editor/guis/BiQuadFilterGUI.h
+++ b/Editor/guis/BiQuadFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 #include <filters/BiQuad.h>
 #include <filters/BiQuadCommand.h>
@@ -50,7 +52,7 @@ private slots:
 private:
 	int getTypeCategory(BiQuad::Type type);
 
-	Ui::BiQuadFilterGUI* ui;
+	std::unique_ptr<Ui::BiQuadFilterGUI> ui;
 	BiQuad::Type previousType = BiQuad::PEAKING;
 	bool qIsBwOrS = false;
 };

--- a/Editor/guis/ChannelFilterGUI.cpp
+++ b/Editor/guis/ChannelFilterGUI.cpp
@@ -26,13 +26,14 @@ using std::vector;
 using std::wstring;
 
 ChannelFilterGUI::ChannelFilterGUI(const QString& parameters, int selectedChannelMask)
-	: ui(new Ui::ChannelFilterGUI)
+	: ui(std::make_unique<Ui::ChannelFilterGUI>())
 {
 	ui->setupUi(this);
 
 	this->selectedChannelMask = selectedChannelMask;
 
 	scene = new ChannelFilterGUIScene;
+	scene->setParent(this);
 	ui->graphicsView->setScene(scene);
 	ui->graphicsView->setBackgroundRole(QPalette::Window);
 	connect(scene, SIGNAL(selectionChanged()), this, SLOT(updateSelectedChannels()));
@@ -47,10 +48,7 @@ ChannelFilterGUI::ChannelFilterGUI(const QString& parameters, int selectedChanne
 		selectedChannels.append(QString::fromStdWString(channel));
 }
 
-ChannelFilterGUI::~ChannelFilterGUI()
-{
-	delete ui;
-}
+ChannelFilterGUI::~ChannelFilterGUI() = default;
 
 void ChannelFilterGUI::configureChannels(vector<wstring>& channelNames)
 {

--- a/Editor/guis/ChannelFilterGUI.h
+++ b/Editor/guis/ChannelFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 #include "ChannelFilterGUIScene.h"
 
@@ -43,7 +45,7 @@ private slots:
 private:
 	void refreshGui();
 
-	Ui::ChannelFilterGUI* ui;
+	std::unique_ptr<Ui::ChannelFilterGUI> ui;
 	QStringList selectedChannels;
 	int selectedChannelMask;
 	std::vector<std::wstring> channelNames;

--- a/Editor/guis/ChannelFilterGUIDialog.cpp
+++ b/Editor/guis/ChannelFilterGUIDialog.cpp
@@ -34,7 +34,7 @@ using std::wstring;
 
 ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, const QStringList& selectedChannels, int selectedChannelMask, const vector<wstring>& channelNames)
 	: QDialog(parent),
-	ui(new Ui::ChannelFilterGUIDialog)
+	ui(std::make_unique<Ui::ChannelFilterGUIDialog>())
 {
 	ui->setupUi(this);
 	resize(GUIHelper::scale(QSize(355, 329)));
@@ -126,10 +126,7 @@ ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, const QStringLis
 	ui->stackedWidget->setCurrentIndex((selectedChannelMask & SPEAKER_BACK_CENTER) ? 1 : 0);
 }
 
-ChannelFilterGUIDialog::~ChannelFilterGUIDialog()
-{
-	delete ui;
-}
+ChannelFilterGUIDialog::~ChannelFilterGUIDialog() = default;
 
 void ChannelFilterGUIDialog::on_addButton_clicked()
 {

--- a/Editor/guis/ChannelFilterGUIDialog.h
+++ b/Editor/guis/ChannelFilterGUIDialog.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QCheckBox>
 #include <QDialog>
 
@@ -44,6 +46,6 @@ private slots:
 	void on_allChannelsCheckBox_toggled(bool checked);
 
 private:
-	Ui::ChannelFilterGUIDialog* ui;
+	std::unique_ptr<Ui::ChannelFilterGUIDialog> ui;
 	QList<QCheckBox*> checkBoxes;
 };

--- a/Editor/guis/CommentFilterGUI.cpp
+++ b/Editor/guis/CommentFilterGUI.cpp
@@ -25,11 +25,10 @@ using std::vector;
 using std::wstring;
 
 CommentFilterGUI::CommentFilterGUI(IFilterGUI* child, bool isComment)
+	: ui(std::make_unique<Ui::CommentFilterGUI>()), child(child)
 {
-	ui = new Ui::CommentFilterGUI;
 	ui->setupUi(this);
 
-	this->child = child;
 	connect(child, SIGNAL(updateModel()), this, SIGNAL(updateModel()));
 	connect(child, SIGNAL(updateChannels()), this, SIGNAL(updateChannels()));
 
@@ -44,10 +43,7 @@ CommentFilterGUI::CommentFilterGUI(IFilterGUI* child, bool isComment)
 	child->setEnabled(!isComment);
 }
 
-CommentFilterGUI::~CommentFilterGUI()
-{
-	delete ui;
-}
+CommentFilterGUI::~CommentFilterGUI() = default;
 
 void CommentFilterGUI::configureChannels(vector<wstring>& channelNames)
 {

--- a/Editor/guis/CommentFilterGUI.h
+++ b/Editor/guis/CommentFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 
 namespace Ui {
@@ -42,6 +44,6 @@ private slots:
 	void on_actionPowerOn_toggled(bool checked);
 
 private:
-	Ui::CommentFilterGUI* ui;
+	std::unique_ptr<Ui::CommentFilterGUI> ui;
 	IFilterGUI* child;
 };

--- a/Editor/guis/ConvolutionFilterGUI.cpp
+++ b/Editor/guis/ConvolutionFilterGUI.cpp
@@ -18,18 +18,17 @@
 */
 
 #include <QFileDialog>
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
 
 #include "Editor/helpers/ConvolutionPathHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "filters/ConvolutionCommand.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/SndfileRAII.h"
 #include "ConvolutionFilterGUI.h"
 #include "ui_ConvolutionFilterGUI.h"
 
 ConvolutionFilterGUI::ConvolutionFilterGUI(const QString& configPath, unsigned deviceSampleRate, const QString& path)
-	: ui(new Ui::ConvolutionFilterGUI), deviceSampleRate(deviceSampleRate)
+	: ui(std::make_unique<Ui::ConvolutionFilterGUI>()), deviceSampleRate(deviceSampleRate)
 {
 	ui->setupUi(this);
 
@@ -46,10 +45,7 @@ ConvolutionFilterGUI::ConvolutionFilterGUI(const QString& configPath, unsigned d
 	updateFileInfo();
 }
 
-ConvolutionFilterGUI::~ConvolutionFilterGUI()
-{
-	delete ui;
-}
+ConvolutionFilterGUI::~ConvolutionFilterGUI() = default;
 
 void ConvolutionFilterGUI::store(QString& command, QString& parameters)
 {
@@ -132,8 +128,8 @@ void ConvolutionFilterGUI::updateFileInfo()
 			else
 			{
 				SF_INFO info = {};
-				SNDFILE* file = sf_wchar_open(path.toStdWString().c_str(), SFM_READ, &info);
-				if (file == nullptr)
+				sndfile::Handle file(sf_wchar_open(path.toStdWString().c_str(), SFM_READ, &info));
+				if (!file)
 				{
 					error = tr("Unsupported file format");
 					labelsVisible = false;
@@ -145,8 +141,6 @@ void ConvolutionFilterGUI::updateFileInfo()
 
 					ui->labelLengthValue->setText(tr("%0 ms (%1 samples)").arg(length).arg(info.frames));
 					ui->labelSampleRateValue->setText(tr("%0 Hz").arg(sampleRate));
-					sf_close(file);
-
 					if (sampleRate != deviceSampleRate)
 					{
 						error = tr("The file sample rate does not match the device sample rate (%0 Hz)!\nSelect a different file or change the device configuration.").arg(deviceSampleRate);

--- a/Editor/guis/ConvolutionFilterGUI.h
+++ b/Editor/guis/ConvolutionFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 
 namespace Ui {
@@ -43,7 +45,7 @@ private slots:
 private:
 	void updateFileInfo();
 
-	Ui::ConvolutionFilterGUI* ui;
+	std::unique_ptr<Ui::ConvolutionFilterGUI> ui;
 	QString configPath;
 	unsigned deviceSampleRate;
 };

--- a/Editor/guis/CopyFilterGUI.cpp
+++ b/Editor/guis/CopyFilterGUI.cpp
@@ -29,7 +29,7 @@ using std::vector;
 using std::wstring;
 
 CopyFilterGUI::CopyFilterGUI(const std::vector<Assignment>& assignments, FilterTable* filterTable)
-	: ui(new Ui::CopyFilterGUI)
+	: ui(std::make_unique<Ui::CopyFilterGUI>())
 {
 	ui->setupUi(this);
 
@@ -59,10 +59,7 @@ CopyFilterGUI::CopyFilterGUI(const std::vector<Assignment>& assignments, FilterT
 	connect(ui->form, SIGNAL(updateChannels()), this, SIGNAL(updateChannels()));
 }
 
-CopyFilterGUI::~CopyFilterGUI()
-{
-	delete ui;
-}
+CopyFilterGUI::~CopyFilterGUI() = default;
 
 void CopyFilterGUI::configureChannels(vector<wstring>& channelNames)
 {

--- a/Editor/guis/CopyFilterGUI.h
+++ b/Editor/guis/CopyFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "filters/CopyFilter.h"
 #include "Editor/IFilterGUI.h"
 #include "CopyFilterGUIScene.h"
@@ -46,7 +48,7 @@ public:
 	void storePreferences(QVariantMap& prefs) override;
 
 private:
-	Ui::CopyFilterGUI* ui;
+	std::unique_ptr<Ui::CopyFilterGUI> ui;
 	CopyFilterGUIScene* scene;
 
 	std::vector<std::wstring> inputChannelNames;

--- a/Editor/guis/CopyFilterGUIRow.cpp
+++ b/Editor/guis/CopyFilterGUIRow.cpp
@@ -26,7 +26,7 @@ using std::wstring;
 
 CopyFilterGUIRow::CopyFilterGUIRow(Assignment::Summand summand, const std::vector<wstring>& channelNames, QWidget* parent)
 	: QWidget(parent),
-	ui(new Ui::CopyFilterGUIRow)
+	ui(std::make_unique<Ui::CopyFilterGUIRow>())
 {
 	ui->setupUi(this);
 
@@ -59,10 +59,7 @@ CopyFilterGUIRow::CopyFilterGUIRow(Assignment::Summand summand, const std::vecto
 	connect(ui->channelComboBox, SIGNAL(editTextChanged(QString)), this, SIGNAL(updateChannels()));
 }
 
-CopyFilterGUIRow::~CopyFilterGUIRow()
-{
-	delete ui;
-}
+CopyFilterGUIRow::~CopyFilterGUIRow() = default;
 
 void CopyFilterGUIRow::setChannelNames(const vector<wstring>& channelNames)
 {

--- a/Editor/guis/CopyFilterGUIRow.h
+++ b/Editor/guis/CopyFilterGUIRow.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QWidget>
 
 #include "filters/CopyFilter.h"
@@ -46,5 +48,5 @@ private slots:
 	void on_modeComboBox_currentIndexChanged(int index);
 
 private:
-	Ui::CopyFilterGUIRow* ui;
+	std::unique_ptr<Ui::CopyFilterGUIRow> ui;
 };

--- a/Editor/guis/DelayFilterGUI.cpp
+++ b/Editor/guis/DelayFilterGUI.cpp
@@ -27,7 +27,7 @@ static const double dialMin = 1.0;
 static const double dialMax = 10000.0;
 
 DelayFilterGUI::DelayFilterGUI(double delay, bool isMs)
-	: ui(new Ui::DelayFilterGUI)
+	: ui(std::make_unique<Ui::DelayFilterGUI>())
 {
 	ui->setupUi(this);
 
@@ -36,10 +36,7 @@ DelayFilterGUI::DelayFilterGUI(double delay, bool isMs)
 	ui->delaySpinBox->setValue(delay);
 }
 
-DelayFilterGUI::~DelayFilterGUI()
-{
-	delete ui;
-}
+DelayFilterGUI::~DelayFilterGUI() = default;
 
 void DelayFilterGUI::store(QString& command, QString& parameters)
 {

--- a/Editor/guis/DelayFilterGUI.h
+++ b/Editor/guis/DelayFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 
 namespace Ui {
@@ -43,5 +45,5 @@ private slots:
 	void on_delaySpinBox_valueChanged(double value);
 
 private:
-	Ui::DelayFilterGUI* ui;
+	std::unique_ptr<Ui::DelayFilterGUI> ui;
 };

--- a/Editor/guis/DeviceFilterGUI.cpp
+++ b/Editor/guis/DeviceFilterGUI.cpp
@@ -28,16 +28,13 @@ using std::shared_ptr;
 using std::string;
 
 DeviceFilterGUI::DeviceFilterGUI(DeviceFilterGUIFactory* factory)
-	: ui(new Ui::DeviceFilterGUI)
+	: ui(std::make_unique<Ui::DeviceFilterGUI>())
 {
 	ui->setupUi(this);
 	this->factory = factory;
 }
 
-DeviceFilterGUI::~DeviceFilterGUI()
-{
-	delete ui;
-}
+DeviceFilterGUI::~DeviceFilterGUI() = default;
 
 void DeviceFilterGUI::load(const QString& parameters)
 {

--- a/Editor/guis/DeviceFilterGUI.h
+++ b/Editor/guis/DeviceFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 #include "DeviceFilterGUIFactory.h"
 
@@ -40,7 +42,7 @@ private slots:
 	void on_pushButton_clicked();
 
 private:
-	Ui::DeviceFilterGUI* ui;
+	std::unique_ptr<Ui::DeviceFilterGUI> ui;
 	DeviceFilterGUIFactory* factory;
 	QString pattern;
 };

--- a/Editor/guis/DeviceFilterGUIDialog.cpp
+++ b/Editor/guis/DeviceFilterGUIDialog.cpp
@@ -28,7 +28,7 @@ using std::shared_ptr;
 
 DeviceFilterGUIDialog::DeviceFilterGUIDialog(DeviceFilterGUI* gui, DeviceFilterGUIFactory* factory, const QString& pattern)
 	: QDialog(gui),
-	ui(new Ui::DeviceFilterGUIDialog)
+	ui(std::make_unique<Ui::DeviceFilterGUIDialog>())
 {
 	ui->setupUi(this);
 	resize(GUIHelper::scale(QSize(500, 350)));
@@ -79,10 +79,7 @@ DeviceFilterGUIDialog::DeviceFilterGUIDialog(DeviceFilterGUI* gui, DeviceFilterG
 		ui->treeWidget->resizeColumnToContents(i);
 }
 
-DeviceFilterGUIDialog::~DeviceFilterGUIDialog()
-{
-	delete ui;
-}
+DeviceFilterGUIDialog::~DeviceFilterGUIDialog() = default;
 
 QString DeviceFilterGUIDialog::getPattern()
 {

--- a/Editor/guis/DeviceFilterGUIDialog.h
+++ b/Editor/guis/DeviceFilterGUIDialog.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QDialog>
 
 #include "DeviceFilterGUI.h"
@@ -44,7 +46,7 @@ private slots:
 	void on_showOnlyInstalledCheckBox_toggled(bool checked);
 
 private:
-	Ui::DeviceFilterGUIDialog* ui;
+	std::unique_ptr<Ui::DeviceFilterGUIDialog> ui;
 };
 
 Q_DECLARE_METATYPE(std::shared_ptr<AbstractAPOInfo>)

--- a/Editor/guis/GraphicEQFilterGUI.cpp
+++ b/Editor/guis/GraphicEQFilterGUI.cpp
@@ -41,7 +41,7 @@ using std::vector;
 QRegularExpression GraphicEQFilterGUI::numberRegEx("[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?");
 
 GraphicEQFilterGUI::GraphicEQFilterGUI(const std::vector<FilterNode>& nodes, const QString& configPath, FilterTable* filterTable)
-	: ui(new Ui::GraphicEQFilterGUI), configPath(configPath)
+	: ui(std::make_unique<Ui::GraphicEQFilterGUI>()), configPath(configPath)
 {
 	ui->setupUi(this);
 	if(GUIHelper::isDarkMode())
@@ -100,10 +100,7 @@ GraphicEQFilterGUI::GraphicEQFilterGUI(const std::vector<FilterNode>& nodes, con
 	ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 }
 
-GraphicEQFilterGUI::~GraphicEQFilterGUI()
-{
-	delete ui;
-}
+GraphicEQFilterGUI::~GraphicEQFilterGUI() = default;
 
 void GraphicEQFilterGUI::store(QString& command, QString& parameters)
 {

--- a/Editor/guis/GraphicEQFilterGUI.h
+++ b/Editor/guis/GraphicEQFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <vector>
 
 #include <QRegularExpression>
@@ -69,7 +71,7 @@ private slots:
 private:
 	void setFreqEditable(bool editable);
 
-	Ui::GraphicEQFilterGUI* ui;
+	std::unique_ptr<Ui::GraphicEQFilterGUI> ui;
 	GraphicEQFilterGUIScene* scene;
 	QString configPath;
 	static QRegularExpression numberRegEx;

--- a/Editor/guis/IncludeFilterGUI.cpp
+++ b/Editor/guis/IncludeFilterGUI.cpp
@@ -26,7 +26,7 @@
 #include "ui_IncludeFilterGUI.h"
 
 IncludeFilterGUI::IncludeFilterGUI(FilterTable* filterTable, const QString& path)
-	: ui(new Ui::IncludeFilterGUI), filterTable(filterTable)
+	: ui(std::make_unique<Ui::IncludeFilterGUI>()), filterTable(filterTable)
 {
 	ui->setupUi(this);
 
@@ -44,10 +44,7 @@ IncludeFilterGUI::IncludeFilterGUI(FilterTable* filterTable, const QString& path
 	updateFileInfo();
 }
 
-IncludeFilterGUI::~IncludeFilterGUI()
-{
-	delete ui;
-}
+IncludeFilterGUI::~IncludeFilterGUI() = default;
 
 void IncludeFilterGUI::store(QString& command, QString& parameters)
 {

--- a/Editor/guis/IncludeFilterGUI.h
+++ b/Editor/guis/IncludeFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 #include "Editor/FilterTable.h"
 
@@ -44,6 +46,6 @@ private slots:
 private:
 	void updateFileInfo();
 
-	Ui::IncludeFilterGUI* ui;
+	std::unique_ptr<Ui::IncludeFilterGUI> ui;
 	FilterTable* filterTable;
 };

--- a/Editor/guis/LoudnessCorrectionFilterGUI.cpp
+++ b/Editor/guis/LoudnessCorrectionFilterGUI.cpp
@@ -25,7 +25,7 @@
 
 LoudnessCorrectionFilterGUI::LoudnessCorrectionFilterGUI(double refLevel, double refOffset, double att)
 	: IFilterGUI(),
-	ui(new Ui::LoudnessCorrectionFilterGUI)
+	ui(std::make_unique<Ui::LoudnessCorrectionFilterGUI>())
 {
 	ui->setupUi(this);
 
@@ -41,10 +41,7 @@ LoudnessCorrectionFilterGUI::LoudnessCorrectionFilterGUI(double refLevel, double
 	timer.start(10);
 }
 
-LoudnessCorrectionFilterGUI::~LoudnessCorrectionFilterGUI()
-{
-	delete ui;
-}
+LoudnessCorrectionFilterGUI::~LoudnessCorrectionFilterGUI() = default;
 
 void LoudnessCorrectionFilterGUI::store(QString& command, QString& parameters)
 {

--- a/Editor/guis/LoudnessCorrectionFilterGUI.h
+++ b/Editor/guis/LoudnessCorrectionFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QTimer>
 
 #include "Editor/IFilterGUI.h"
@@ -47,7 +49,7 @@ private slots:
 	void updateVolume();
 
 private:
-	Ui::LoudnessCorrectionFilterGUI* ui;
+	std::unique_ptr<Ui::LoudnessCorrectionFilterGUI> ui;
 	bool state = true;
 	QTimer timer;
 	VolumeController volumeController;

--- a/Editor/guis/LoudnessCorrectionFilterGUIDialog.cpp
+++ b/Editor/guis/LoudnessCorrectionFilterGUIDialog.cpp
@@ -28,7 +28,7 @@
 
 LoudnessCorrectionFilterGUIDialog::LoudnessCorrectionFilterGUIDialog(QWidget* parent)
 	: QDialog(parent),
-	ui(new Ui::LoudnessCorrectionFilterGUIDialog)
+	ui(std::make_unique<Ui::LoudnessCorrectionFilterGUIDialog>())
 {
 	ui->setupUi(this);
 }
@@ -36,7 +36,6 @@ LoudnessCorrectionFilterGUIDialog::LoudnessCorrectionFilterGUIDialog(QWidget* pa
 LoudnessCorrectionFilterGUIDialog::~LoudnessCorrectionFilterGUIDialog()
 {
 	on_stopButton_clicked();
-	delete ui;
 }
 
 int LoudnessCorrectionFilterGUIDialog::getMeasuredLevel()

--- a/Editor/guis/LoudnessCorrectionFilterGUIDialog.h
+++ b/Editor/guis/LoudnessCorrectionFilterGUIDialog.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QDialog>
 #include <QBuffer>
 
@@ -45,6 +47,6 @@ private slots:
 	void on_bothRadioButton_toggled(bool checked);
 
 private:
-	Ui::LoudnessCorrectionFilterGUIDialog* ui;
+	std::unique_ptr<Ui::LoudnessCorrectionFilterGUIDialog> ui;
 	QBuffer buffer;
 };

--- a/Editor/guis/LoudnessCorrectionFilterGUIFactory.cpp
+++ b/Editor/guis/LoudnessCorrectionFilterGUIFactory.cpp
@@ -33,11 +33,6 @@ LoudnessCorrectionFilterGUIFactory::~LoudnessCorrectionFilterGUIFactory()
 	if (timer != nullptr)
 		timer->stop();
 
-	if (volumeController != nullptr)
-	{
-		delete volumeController;
-		volumeController = nullptr;
-	}
 }
 
 void LoudnessCorrectionFilterGUIFactory::initialize(FilterTable* filterTable)
@@ -78,7 +73,7 @@ void LoudnessCorrectionFilterGUIFactory::checkVolume()
 {
 	if (volumeController == nullptr)
 	{
-		volumeController = new VolumeController();
+		volumeController = std::make_unique<VolumeController>();
 		volumeController->getVolume(lastVolume);
 	}
 	else

--- a/Editor/guis/LoudnessCorrectionFilterGUIFactory.h
+++ b/Editor/guis/LoudnessCorrectionFilterGUIFactory.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QTimer>
 #include "Editor/IFilterGUIFactory.h"
 #include "Editor/FilterTable.h"
@@ -42,6 +44,6 @@ private slots:
 private:
 	FilterTable* filterTable = nullptr;
 	QTimer* timer = nullptr;
-	VolumeController* volumeController = nullptr;
+	std::unique_ptr<VolumeController> volumeController;
 	double lastVolume = -1;
 };

--- a/Editor/guis/PreampFilterGUI.cpp
+++ b/Editor/guis/PreampFilterGUI.cpp
@@ -27,7 +27,7 @@
 
 
 PreampFilterGUI::PreampFilterGUI(double dbGain)
-	: ui(new Ui::PreampFilterGUI)
+	: ui(std::make_unique<Ui::PreampFilterGUI>())
 {
 	ui->setupUi(this);
 
@@ -35,10 +35,7 @@ PreampFilterGUI::PreampFilterGUI(double dbGain)
 	ui->doubleSpinBox->setValue(dbGain);
 }
 
-PreampFilterGUI::~PreampFilterGUI()
-{
-	delete ui;
-}
+PreampFilterGUI::~PreampFilterGUI() = default;
 
 void PreampFilterGUI::store(QString& command, QString& parameters)
 {

--- a/Editor/guis/PreampFilterGUI.h
+++ b/Editor/guis/PreampFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 #include <filters/PreampFilter.h>
 
@@ -41,5 +43,5 @@ private slots:
 	void on_dial_valueChanged(int value);
 
 private:
-	Ui::PreampFilterGUI* ui;
+	std::unique_ptr<Ui::PreampFilterGUI> ui;
 };

--- a/Editor/guis/StageFilterGUI.cpp
+++ b/Editor/guis/StageFilterGUI.cpp
@@ -22,7 +22,7 @@
 #include "ui_StageFilterGUI.h"
 
 StageFilterGUI::StageFilterGUI(const QString& parameters)
-	: ui(new Ui::StageFilterGUI)
+	: ui(std::make_unique<Ui::StageFilterGUI>())
 {
 	ui->setupUi(this);
 
@@ -35,10 +35,7 @@ StageFilterGUI::StageFilterGUI(const QString& parameters)
 	ui->captureCheckBox->setChecked(cmd.contains(StageCommand::capture));
 }
 
-StageFilterGUI::~StageFilterGUI()
-{
-	delete ui;
-}
+StageFilterGUI::~StageFilterGUI() = default;
 
 void StageFilterGUI::store(QString& command, QString& parameters)
 {

--- a/Editor/guis/StageFilterGUI.h
+++ b/Editor/guis/StageFilterGUI.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Editor/IFilterGUI.h"
 
 namespace Ui {
@@ -43,5 +45,5 @@ private slots:
 	void on_captureCheckBox_toggled(bool checked);
 
 private:
-	Ui::StageFilterGUI* ui;
+	std::unique_ptr<Ui::StageFilterGUI> ui;
 };

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -45,7 +45,7 @@ using std::placeholders::_1;
 using std::placeholders::_2;
 
 VSTPluginFilterGUI::VSTPluginFilterGUI(std::shared_ptr<VSTPluginLibrary> library, const std::wstring& chunkData, const std::unordered_map<std::wstring, float>& paramMap)
-	: ui(new Ui::VSTPluginFilterGUI), library(library), chunkData(chunkData), paramMap(paramMap)
+	: ui(std::make_unique<Ui::VSTPluginFilterGUI>()), library(library), chunkData(chunkData), paramMap(paramMap)
 {
 	ui->setupUi(this);
 	ui->frame->setVisible(false);
@@ -78,11 +78,7 @@ VSTPluginFilterGUI::~VSTPluginFilterGUI()
 	{
 		if (embedded)
 			on_embedAction_toggled(false);
-		delete effect;
-		effect = nullptr;
 	}
-
-	delete ui;
 }
 
 void VSTPluginFilterGUI::store(QString& command, QString& parameters)
@@ -133,7 +129,7 @@ void VSTPluginFilterGUI::on_openPanelButton_clicked()
 	{
 		effect->writeToEffect(chunkData, paramMap);
 
-		VSTPluginFilterGUIDialog dialog(this, effect, autoApplyDialog);
+		VSTPluginFilterGUIDialog dialog(this, effect.get(), autoApplyDialog);
 		connect(dialog.getApplyButton(), SIGNAL(pressed()), SLOT(applyDialog()));
 		connect(dialog.getAutoApplyCheckBox(), SIGNAL(toggled(bool)), SLOT(autoApplyToggled(bool)));
 		connect(QAbstractEventDispatcher::instance(), SIGNAL(aboutToBlock()), SLOT(on_idle()));
@@ -202,7 +198,7 @@ void VSTPluginFilterGUI::initPlugin()
 		}
 		else
 		{
-			effect = new VSTPluginInstance(library, 1);
+			effect = std::make_unique<VSTPluginInstance>(library, 1);
 			if (effect->initialize())
 			{
 				effect->setLanguage(QLocale().language() == QLocale::German ? 2 : 1);
@@ -213,8 +209,7 @@ void VSTPluginFilterGUI::initPlugin()
 			}
 			else
 			{
-				delete effect;
-				effect = nullptr;
+				effect.reset();
 
 				color = Qt::red;
 				text = tr("Plugin crashed during initialization.");
@@ -239,8 +234,7 @@ void VSTPluginFilterGUI::on_pathLineEdit_editingFinished()
 			oldId = effect->uniqueID();
 			if (ui->embedAction->isChecked())
 				on_embedAction_toggled(false);
-			delete effect;
-			effect = nullptr;
+			effect.reset();
 		}
 
 		QDir pluginsDir(QString::fromStdWString(VSTPluginLibrary::getDefaultPluginPath()));

--- a/Editor/guis/VSTPluginFilterGUI.h
+++ b/Editor/guis/VSTPluginFilterGUI.h
@@ -56,9 +56,9 @@ private:
 	bool embedPlugin();
 	void updatePermissionWarning();
 
-	Ui::VSTPluginFilterGUI* ui;
+	std::unique_ptr<Ui::VSTPluginFilterGUI> ui;
 	std::shared_ptr<VSTPluginLibrary> library;
-	VSTPluginInstance* effect = nullptr;
+	std::unique_ptr<VSTPluginInstance> effect;
 	std::wstring chunkData;
 	std::unordered_map<std::wstring, float> paramMap;
 	bool embedded = false;

--- a/Editor/guis/VSTPluginFilterGUIDialog.cpp
+++ b/Editor/guis/VSTPluginFilterGUIDialog.cpp
@@ -27,7 +27,7 @@ using std::placeholders::_2;
 
 VSTPluginFilterGUIDialog::VSTPluginFilterGUIDialog(QWidget* parent, VSTPluginInstance* effect, bool autoApply)
 	: QDialog(parent, Qt::WindowCloseButtonHint),
-	ui(new Ui::VSTPluginFilterGUIDialog),
+	ui(std::make_unique<Ui::VSTPluginFilterGUIDialog>()),
 	effect(effect)
 {
 	ui->setupUi(this);
@@ -53,8 +53,6 @@ VSTPluginFilterGUIDialog::~VSTPluginFilterGUIDialog()
 {
 	effect->stopEditing();
 	effect->setSizeWindowFunc(nullptr);
-
-	delete ui;
 }
 
 QPushButton* VSTPluginFilterGUIDialog::getApplyButton()

--- a/Editor/guis/VSTPluginFilterGUIDialog.h
+++ b/Editor/guis/VSTPluginFilterGUIDialog.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <QDialog>
 #include <QCheckBox>
 #include "helpers/VSTPluginInstance.h"
@@ -44,6 +46,7 @@ private slots:
 	void on_autoApplyCheckBox_clicked(bool checked);
 
 private:
-	Ui::VSTPluginFilterGUIDialog* ui;
+	std::unique_ptr<Ui::VSTPluginFilterGUIDialog> ui;
+	// Non-owning: the dialog is stack-bound inside the effect owner's method.
 	VSTPluginInstance* effect;
 };

--- a/Editor/helpers/CrashHandler.cpp
+++ b/Editor/helpers/CrashHandler.cpp
@@ -11,6 +11,7 @@
 #include <dbghelp.h>
 #include <shlobj.h>
 
+#include "helpers/Win32Resource.h"
 #include "version.h"
 
 namespace
@@ -51,24 +52,25 @@ void writeReport(EXCEPTION_POINTERS* pointers, const wchar_t* reason)
 	swprintf_s(dumpPath, L"%s\\Editor-%d.%d.%d-%lu-%lu.dmp", dumpDirectory,
 		MAJOR, MINOR, REVISION, pid, tick);
 
-	HANDLE dumpFile = CreateFileW(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-	if (dumpFile != INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle dumpFile(
+		CreateFileW(dumpPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+	if (dumpFile)
 	{
 		MINIDUMP_EXCEPTION_INFORMATION info;
 		info.ThreadId = GetCurrentThreadId();
 		info.ExceptionPointers = pointers;
 		info.ClientPointers = FALSE;
-		MiniDumpWriteDump(GetCurrentProcess(), pid, dumpFile,
+		MiniDumpWriteDump(GetCurrentProcess(), pid, dumpFile.get(),
 			static_cast<MINIDUMP_TYPE>(MiniDumpWithIndirectlyReferencedMemory | MiniDumpScanMemory),
 			pointers != nullptr ? &info : nullptr, nullptr, nullptr);
-		CloseHandle(dumpFile);
 	}
 
 	wchar_t textPath[MAX_PATH];
 	swprintf_s(textPath, L"%s\\Editor-%d.%d.%d-%lu-%lu.txt", dumpDirectory,
 		MAJOR, MINOR, REVISION, pid, tick);
-	HANDLE textFile = CreateFileW(textPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-	if (textFile != INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle textFile(
+		CreateFileW(textPath, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+	if (textFile)
 	{
 		wchar_t line[768];
 		const DWORD code = (pointers != nullptr && pointers->ExceptionRecord != nullptr)
@@ -84,9 +86,8 @@ void writeReport(EXCEPTION_POINTERS* pointers, const wchar_t* reason)
 		if (length > 0)
 		{
 			DWORD written = 0;
-			WriteFile(textFile, line, length * sizeof(wchar_t), &written, nullptr);
+			WriteFile(textFile.get(), line, length * sizeof(wchar_t), &written, nullptr);
 		}
-		CloseHandle(textFile);
 	}
 }
 

--- a/Editor/helpers/GUIChannelHelper.cpp
+++ b/Editor/helpers/GUIChannelHelper.cpp
@@ -22,14 +22,10 @@
 
 #include "GUIChannelHelper.h"
 
-GUIChannelHelper* GUIChannelHelper::instance = nullptr;
-
 GUIChannelHelper* GUIChannelHelper::getInstance()
 {
-	if (instance == nullptr)
-		instance = new GUIChannelHelper();
-
-	return instance;
+	static GUIChannelHelper instance;
+	return &instance;
 }
 
 GUIChannelHelper::GUIChannelHelper()

--- a/Editor/helpers/GUIChannelHelper.h
+++ b/Editor/helpers/GUIChannelHelper.h
@@ -39,7 +39,6 @@ public:
 
 private:
 	GUIChannelHelper();
-	static GUIChannelHelper* instance;
 
 	QList<ChannelConfigurationInfo> channelConfigurationInfos;
 };

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -53,6 +53,7 @@
 #include "helpers/MemoryHelper.h"
 #include "helpers/ApoRegistration.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/Win32Resource.h"
 #include "helpers/VelopackBootstrap.h"
 #include "version.h"
 #include "helpers/QtAppBootstrap.h"
@@ -164,14 +165,13 @@ bool isHookArgument(const char* arg)
 bool isCurrentProcessElevated()
 {
 	BOOL elevated = FALSE;
-	HANDLE token = nullptr;
-	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+	winutil::UniqueHandle token;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, token.put()))
 		return false;
 	TOKEN_ELEVATION elevation;
 	DWORD size = sizeof(elevation);
-	if (GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &size))
+	if (GetTokenInformation(token.get(), TokenElevation, &elevation, sizeof(elevation), &size))
 		elevated = elevation.TokenIsElevated;
-	CloseHandle(token);
 	return elevated == TRUE;
 }
 
@@ -251,10 +251,10 @@ int relaunchElevatedAndWait(int argc, char* argv[])
 	if (info.hProcess == nullptr)
 		return 1;
 
-	WaitForSingleObject(info.hProcess, INFINITE);
+	winutil::UniqueHandle process(info.hProcess);
+	WaitForSingleObject(process.get(), INFINITE);
 	DWORD exitCode = 1;
-	GetExitCodeProcess(info.hProcess, &exitCode);
-	CloseHandle(info.hProcess);
+	GetExitCodeProcess(process.get(), &exitCode);
 	return static_cast<int>(exitCode);
 }
 

--- a/Editor/widgets/FilterListModel.cpp
+++ b/Editor/widgets/FilterListModel.cpp
@@ -1,4 +1,8 @@
-#include <QtAlgorithms>
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "FilterListModel.h"
 
@@ -6,9 +10,18 @@
 // (FilterTable.Clipboard.cpp / FilterTable.Model.cpp / FilterTable.Mouse.cpp)
 // and live here so they can be unit-tested.
 
-FilterListModel::~FilterListModel()
+namespace
 {
-	qDeleteAll(itemList);
+	using OwnedFilterListItem = std::unique_ptr<FilterListItem>;
+
+	QList<FilterListItem*> buildItemView(const std::vector<OwnedFilterListItem>& ownedItems)
+	{
+		QList<FilterListItem*> result;
+		result.reserve(static_cast<qsizetype>(ownedItems.size()));
+		for (const auto& item : ownedItems)
+			result.append(item.get());
+		return result;
+	}
 }
 
 QList<QString> FilterListModel::lines() const
@@ -22,43 +35,48 @@ QList<QString> FilterListModel::lines() const
 
 void FilterListModel::setLines(const QList<QString>& lines)
 {
-	qDeleteAll(itemList);
-	itemList.clear();
-	// FilterTable::setLines never cleared the selection set, leaving it full
-	// of pointers into the deleted document; clear it so a reused address in
-	// the new document can never appear pre-selected.
-	selectedSet.clear();
-
+	std::vector<OwnedFilterListItem> newOwnedItems;
+	newOwnedItems.reserve(static_cast<size_t>(lines.size()));
 	for (const QString& line : lines)
-		itemList.append(new FilterListItem(line));
+		newOwnedItems.push_back(std::make_unique<FilterListItem>(line));
 
-	if (!itemList.isEmpty())
-	{
-		focusedItem = itemList[0];
-		selectionStartItem = itemList[0];
-	}
-	else
-	{
-		focusedItem = nullptr;
-		selectionStartItem = nullptr;
-	}
+	QList<FilterListItem*> newItemList = buildItemView(newOwnedItems);
+	QSet<FilterListItem*> newSelectedSet;
+	FilterListItem* newFocusedItem = newItemList.isEmpty() ? nullptr : newItemList[0];
+
+	// All potentially-throwing work is complete. These swaps form one
+	// no-throw commit, so the old document remains coherent on allocation
+	// failure and is destroyed only after no raw observer references it.
+	ownedItems.swap(newOwnedItems);
+	itemList.swap(newItemList);
+	selectedSet.swap(newSelectedSet);
+	focusedItem = newFocusedItem;
+	selectionStartItem = newFocusedItem;
 }
 
 FilterListItem* FilterListModel::addLine(const QString& line, const FilterListItem* before)
 {
-	FilterListItem* newItem = new FilterListItem(line);
+	auto newItem = std::make_unique<FilterListItem>(line);
+	FilterListItem* result = newItem.get();
+	int index = before == nullptr ? itemList.size() : itemList.indexOf(before);
+	if (index < 0)
+		index = itemList.size();
 
-	if (before != nullptr)
+	QList<FilterListItem*> newItemList;
+	newItemList.reserve(itemList.size() + 1);
+	for (int i = 0; i <= itemList.size(); i++)
 	{
-		int index = itemList.indexOf(before);
-		itemList.insert(index, newItem);
-	}
-	else
-	{
-		itemList.append(newItem);
+		if (i == index)
+			newItemList.append(result);
+		if (i < itemList.size())
+			newItemList.append(itemList[i]);
 	}
 
-	return newItem;
+	ownedItems.reserve(ownedItems.size() + 1);
+	ownedItems.insert(ownedItems.begin() + index, std::move(newItem));
+	itemList.swap(newItemList);
+
+	return result;
 }
 
 bool FilterListModel::removeItem(FilterListItem* item)
@@ -67,94 +85,149 @@ bool FilterListModel::removeItem(FilterListItem* item)
 	if (index == -1)
 		return false;
 
-	itemList.removeAt(index);
 	FilterListItem* replacement = nullptr;
-	if (!itemList.isEmpty())
-		replacement = itemList[qMin(index, int(itemList.size()) - 1)];
+	if (itemList.size() > 1)
+		replacement = itemList[index + 1 < itemList.size() ? index + 1 : index - 1];
 
-	if (selectedSet.remove(item) && replacement != nullptr)
-		selectedSet.insert(replacement);
-	if (focusedItem == item)
-		focusedItem = replacement;
-	if (selectionStartItem == item)
-		selectionStartItem = replacement;
+	QList<FilterListItem*> newItemList;
+	newItemList.reserve(itemList.size() - 1);
+	for (FilterListItem* existingItem : itemList)
+	{
+		if (existingItem != item)
+			newItemList.append(existingItem);
+	}
 
-	delete item;
+	QSet<FilterListItem*> newSelectedSet = selectedSet;
+	if (newSelectedSet.remove(item) && replacement != nullptr)
+		newSelectedSet.insert(replacement);
+	FilterListItem* newFocusedItem = focusedItem == item ? replacement : focusedItem;
+	FilterListItem* newSelectionStartItem = selectionStartItem == item ? replacement : selectionStartItem;
+
+	itemList.swap(newItemList);
+	selectedSet.swap(newSelectedSet);
+	focusedItem = newFocusedItem;
+	selectionStartItem = newSelectionStartItem;
+	ownedItems.erase(ownedItems.begin() + index);
 	return true;
 }
 
 void FilterListModel::removeItems(const QSet<FilterListItem*>& itemsToRemove)
 {
-	for (FilterListItem* item : itemsToRemove)
+	std::vector<FilterListItem*> removedItems;
+	removedItems.reserve(ownedItems.size());
+	QList<FilterListItem*> newItemList;
+	newItemList.reserve(itemList.size());
+	for (const auto& ownedItem : ownedItems)
 	{
-		itemList.removeOne(item);
-		if (focusedItem == item)
-			focusedItem = nullptr;
-		if (selectionStartItem == item)
-			selectionStartItem = nullptr;
-		selectedSet.remove(item);
-		delete item;
+		FilterListItem* item = ownedItem.get();
+		if (itemsToRemove.contains(item))
+			removedItems.push_back(item);
+		else
+			newItemList.append(item);
 	}
+	if (removedItems.empty())
+		return;
+
+	QSet<FilterListItem*> newSelectedSet = selectedSet;
+	for (FilterListItem* item : removedItems)
+		newSelectedSet.remove(item);
+	const auto wasRemoved = [&removedItems](FilterListItem* item) {
+		return std::find(removedItems.begin(), removedItems.end(), item) != removedItems.end();
+	};
+	FilterListItem* newFocusedItem = wasRemoved(focusedItem) ? nullptr : focusedItem;
+	FilterListItem* newSelectionStartItem = wasRemoved(selectionStartItem) ? nullptr : selectionStartItem;
+
+	itemList.swap(newItemList);
+	selectedSet.swap(newSelectedSet);
+	focusedItem = newFocusedItem;
+	selectionStartItem = newSelectionStartItem;
+	ownedItems.erase(std::remove_if(ownedItems.begin(), ownedItems.end(), [&itemsToRemove](const auto& ownedItem) {
+		return itemsToRemove.contains(ownedItem.get());
+	}), ownedItems.end());
 }
 
 QList<FilterListItem*> FilterListModel::insertLines(const QStringList& lines, const QList<QVariantMap>& prefsList, int dropRow)
 {
+	dropRow = qBound(0, dropRow, itemList.size());
+	std::vector<OwnedFilterListItem> newOwnedItems;
+	newOwnedItems.reserve(static_cast<size_t>(lines.size()));
 	QList<FilterListItem*> inserted;
-
-	selectedSet.clear();
-	focusedItem = nullptr;
-	selectionStartItem = nullptr;
+	inserted.reserve(lines.size());
 	for (int i = 0; i < lines.size(); i++)
 	{
-		FilterListItem* item = new FilterListItem(lines[i]);
+		auto ownedItem = std::make_unique<FilterListItem>(lines[i]);
 		if (i < prefsList.size())
-			item->prefs = prefsList[i];
-		selectedSet.insert(item);
-		itemList.insert(dropRow++, item);
-		if (focusedItem == nullptr)
-		{
-			focusedItem = item;
-			selectionStartItem = item;
-		}
-		inserted.append(item);
+			ownedItem->prefs = prefsList[i];
+		inserted.append(ownedItem.get());
+		newOwnedItems.push_back(std::move(ownedItem));
 	}
+
+	QList<FilterListItem*> newItemList;
+	newItemList.reserve(itemList.size() + inserted.size());
+	for (int i = 0; i < dropRow; i++)
+		newItemList.append(itemList[i]);
+	for (FilterListItem* item : inserted)
+		newItemList.append(item);
+	for (int i = dropRow; i < itemList.size(); i++)
+		newItemList.append(itemList[i]);
+
+	QSet<FilterListItem*> newSelectedSet;
+	newSelectedSet.reserve(inserted.size());
+	for (FilterListItem* item : inserted)
+		newSelectedSet.insert(item);
+	FilterListItem* newFocusedItem = inserted.isEmpty() ? nullptr : inserted[0];
+
+	ownedItems.reserve(ownedItems.size() + newOwnedItems.size());
+	ownedItems.insert(ownedItems.begin() + dropRow,
+		std::make_move_iterator(newOwnedItems.begin()),
+		std::make_move_iterator(newOwnedItems.end()));
+	itemList.swap(newItemList);
+	selectedSet.swap(newSelectedSet);
+	focusedItem = newFocusedItem;
+	selectionStartItem = newFocusedItem;
 
 	return inserted;
 }
 
 void FilterListModel::deleteSelected()
 {
-	QList<FilterListItem*> newItems;
+	QList<FilterListItem*> newItemList;
+	// selectedSet is normally a subset of the document, but reserving the
+	// current view size keeps this transaction safe even if a caller supplied
+	// an external observer through the public selection Interface.
+	newItemList.reserve(itemList.size());
 	for (FilterListItem* item : itemList)
 	{
-		if (selectedSet.contains(item))
-		{
-			if (item == focusedItem)
-				focusedItem = nullptr;
-			if (item == selectionStartItem)
-				selectionStartItem = nullptr;
-			delete item;
-		}
-		else
-		{
-			newItems.append(item);
-		}
+		if (!selectedSet.contains(item))
+			newItemList.append(item);
 	}
-	selectedSet.clear();
-	itemList = newItems;
+	FilterListItem* newFocusedItem = selectedSet.contains(focusedItem) ? nullptr : focusedItem;
+	FilterListItem* newSelectionStartItem = selectedSet.contains(selectionStartItem) ? nullptr : selectionStartItem;
+
+	QSet<FilterListItem*> removedItems;
+	removedItems.swap(selectedSet);
+	itemList.swap(newItemList);
+	focusedItem = newFocusedItem;
+	selectionStartItem = newSelectionStartItem;
+	ownedItems.erase(std::remove_if(ownedItems.begin(), ownedItems.end(), [&removedItems](const auto& ownedItem) {
+		return removedItems.contains(ownedItem.get());
+	}), ownedItems.end());
 }
 
 void FilterListModel::selectOnly(FilterListItem* item)
 {
-	selectedSet.clear();
-	selectedSet.insert(item);
+	QSet<FilterListItem*> newSelectedSet;
+	newSelectedSet.insert(item);
+	selectedSet.swap(newSelectedSet);
 }
 
 void FilterListModel::selectAll()
 {
-	selectedSet.clear();
+	QSet<FilterListItem*> newSelectedSet;
+	newSelectedSet.reserve(itemList.size());
 	for (FilterListItem* item : itemList)
-		selectedSet.insert(item);
+		newSelectedSet.insert(item);
+	selectedSet.swap(newSelectedSet);
 }
 
 void FilterListModel::selectRangeFromAnchor(const FilterListItem* target)
@@ -164,9 +237,11 @@ void FilterListModel::selectRangeFromAnchor(const FilterListItem* target)
 	if (startRow == -1 || targetRow == -1)
 		return;
 
-	selectedSet.clear();
+	QSet<FilterListItem*> newSelectedSet;
+	newSelectedSet.reserve(qAbs(targetRow - startRow) + 1);
 	for (int i = qMin(startRow, targetRow); i <= qMax(startRow, targetRow); i++)
-		selectedSet.insert(itemList[i]);
+		newSelectedSet.insert(itemList[i]);
+	selectedSet.swap(newSelectedSet);
 }
 
 int FilterListModel::firstSelectedIndex() const

--- a/Editor/widgets/FilterListModel.h
+++ b/Editor/widgets/FilterListModel.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include <QList>
 #include <QSet>
 #include <QString>
@@ -39,7 +42,7 @@ class FilterListModel
 {
 public:
 	FilterListModel() = default;
-	~FilterListModel();
+	~FilterListModel() = default;
 
 	FilterListModel(const FilterListModel&) = delete;
 	FilterListModel& operator=(const FilterListModel&) = delete;
@@ -160,6 +163,9 @@ public:
 	CopyPayload copyPayload() const;
 
 private:
+	std::vector<std::unique_ptr<FilterListItem>> ownedItems;
+	// Stable, non-owning projection retained as the readable caller Interface.
+	// Mutations prepare its replacement before swapping owner and view state.
 	QList<FilterListItem*> itemList;
 	QSet<FilterListItem*> selectedSet;
 	FilterListItem* focusedItem = nullptr;

--- a/Editor/widgets/cards/ConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/ConvolutionCardEditor.cpp
@@ -12,9 +12,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
-
 #include "AbstractAPOInfo.h"
 #include "Editor/FilterTable.h"
 #include "Editor/SkinManager.h"
@@ -27,6 +24,7 @@
 #include "ReferenceCardView.h"
 #include "filters/ConvolutionCommand.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/SndfileRAII.h"
 
 ConvolutionCardEditor::ConvolutionCardEditor(FilterTable* filterTable, const QString& path, QWidget* parent)
 	: IFilterGUI(parent), filterTable(filterTable), path(path.trimmed())
@@ -208,8 +206,8 @@ void ConvolutionCardEditor::updateFileInfo()
 			// so it usually reads the file even when the audio service cannot;
 			// the readout stays visible next to any permission status below.
 			SF_INFO sfInfo = {};
-			SNDFILE* file = sf_wchar_open(state.fullPath.toStdWString().c_str(), SFM_READ, &sfInfo);
-			if (file == nullptr)
+			sndfile::Handle file(sf_wchar_open(state.fullPath.toStdWString().c_str(), SFM_READ, &sfInfo));
+			if (!file)
 			{
 				state.statusText = tr("Unsupported file format");
 				state.statusSeverity = ReferenceCardState::Severity::Critical;
@@ -221,8 +219,6 @@ void ConvolutionCardEditor::updateFileInfo()
 				state.readout << tr("%1 ms").arg(QString::number(lengthMs, 'f', 1))
 					<< tr("%1 samples").arg(static_cast<qlonglong>(sfInfo.frames))
 					<< tr("%1 Hz").arg(sampleRate);
-				sf_close(file);
-
 				const unsigned deviceRate = currentDeviceSampleRate();
 				if (deviceRate != 0 && static_cast<unsigned>(sampleRate) != deviceRate)
 				{

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
@@ -34,9 +34,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
-
 #include "AbstractAPOInfo.h"
 #include "Editor/FilterTable.h"
 #include "Editor/SkinManager.h"
@@ -50,6 +47,7 @@
 #include "Editor/widgets/routing/MultiConvolutionRoutingAdapter.h"
 #include "ReferenceCardView.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/SndfileRAII.h"
 
 MultiConvolutionCardEditor::MultiConvolutionCardEditor(FilterTable* filterTable,
 	const std::vector<MultiConvolutionCommand::Mapping>& mappings,
@@ -355,8 +353,8 @@ void MultiConvolutionCardEditor::updateFileInfo()
 				state.directory = QDir::toNativeSeparators(asWritten.path());
 
 			SF_INFO sfInfo = {};
-			SNDFILE* file = sf_wchar_open(state.fullPath.toStdWString().c_str(), SFM_READ, &sfInfo);
-			if (file == nullptr)
+			sndfile::Handle file(sf_wchar_open(state.fullPath.toStdWString().c_str(), SFM_READ, &sfInfo));
+			if (!file)
 			{
 				state.statusText = tr("Unsupported file format");
 				state.statusSeverity = ReferenceCardState::Severity::Critical;
@@ -372,8 +370,6 @@ void MultiConvolutionCardEditor::updateFileInfo()
 					<< tr("%1 Hz").arg(sampleRate)
 					<< tr("%1 ch").arg(sfInfo.channels);
 				fileChannelCount = sfInfo.channels;
-				sf_close(file);
-
 				const unsigned deviceRate = currentDeviceSampleRate();
 				if (deviceRate != 0 && static_cast<unsigned>(sampleRate) != deviceRate)
 				{

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -135,8 +135,6 @@ VSTCardEditor::~VSTCardEditor()
 	{
 		if (embedded)
 			embedToggled(false);
-		delete effect;
-		effect = nullptr;
 	}
 }
 
@@ -192,7 +190,7 @@ void VSTCardEditor::openPanel()
 	{
 		effect->writeToEffect(chunkData, paramMap);
 
-		VSTPluginFilterGUIDialog dialog(this, effect, autoApplyDialog);
+		VSTPluginFilterGUIDialog dialog(this, effect.get(), autoApplyDialog);
 		connect(dialog.getApplyButton(), SIGNAL(pressed()), SLOT(applyDialog()));
 		connect(dialog.getAutoApplyCheckBox(), SIGNAL(toggled(bool)), SLOT(autoApplyToggled(bool)));
 		connect(QAbstractEventDispatcher::instance(), SIGNAL(aboutToBlock()), SLOT(onIdle()));
@@ -259,7 +257,7 @@ void VSTCardEditor::initPlugin()
 		}
 		else
 		{
-			effect = new VSTPluginInstance(library, 1);
+			effect = std::make_unique<VSTPluginInstance>(library, 1);
 			if (effect->initialize())
 			{
 				effect->setLanguage(QLocale().language() == QLocale::German ? 2 : 1);
@@ -267,8 +265,7 @@ void VSTCardEditor::initPlugin()
 			}
 			else
 			{
-				delete effect;
-				effect = nullptr;
+				effect.reset();
 				initErrorText = tr("Plugin crashed during initialization.");
 			}
 		}
@@ -348,8 +345,7 @@ void VSTCardEditor::pathCommitted(const QString& text)
 			oldId = effect->uniqueID();
 			if (embedAction->isChecked())
 				embedToggled(false);
-			delete effect;
-			effect = nullptr;
+			effect.reset();
 		}
 
 		QDir pluginsDir(QString::fromStdWString(VSTPluginLibrary::getDefaultPluginPath()));

--- a/Editor/widgets/cards/VSTCardEditor.h
+++ b/Editor/widgets/cards/VSTCardEditor.h
@@ -64,7 +64,7 @@ private:
 	void onSizeWindow(int w, int h);
 
 	std::shared_ptr<VSTPluginLibrary> library;
-	VSTPluginInstance* effect = nullptr;
+	std::unique_ptr<VSTPluginInstance> effect;
 	std::wstring chunkData;
 	std::unordered_map<std::wstring, float> paramMap;
 	bool embedded = false;

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -30,6 +30,7 @@
 #include "../helpers/RegistryHelper.h"
 #include "../helpers/StringHelper.h"
 #include "../helpers/ComPtr.h"
+#include "../helpers/Win32Resource.h"
 #include "../DeviceAPOInfo.h"
 #include "EqualizerAPO.h"
 
@@ -582,20 +583,21 @@ void EqualizerAPO::sendMessage(std::wstring& deviceTestPipeName, const std::wstr
 {
 	string message = "{\"deviceGuid\":\"" + StringHelper::toString(deviceGuid, CP_UTF8) + "\", \"stage\":\"" + (apoGuid == EQUALIZERAPO_PRE_MIX_GUID ? "PreMix" : "PostMix") + "\", \"phase\":\"" + phase + "\"}";
 
-	HANDLE pipe = CreateFileW((L"\\\\.\\pipe\\" + deviceTestPipeName).c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
-	if (pipe == INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle pipe(CreateFileW((L"\\\\.\\pipe\\" + deviceTestPipeName).c_str(),
+		GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr));
+	if (!pipe)
 	{
 		if (WaitNamedPipeW((L"\\\\.\\pipe\\" + deviceTestPipeName).c_str(), 1000))
-			pipe = CreateFileW((L"\\\\.\\pipe\\" + deviceTestPipeName).c_str(), GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+			pipe.reset(CreateFileW((L"\\\\.\\pipe\\" + deviceTestPipeName).c_str(),
+				GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr));
 	}
-	if (pipe != INVALID_HANDLE_VALUE)
+	if (pipe)
 	{
 		DWORD bytesWritten;
-		if (!WriteFile(pipe, message.c_str(), static_cast<int>(message.length()), &bytesWritten, nullptr))
+		if (!WriteFile(pipe.get(), message.c_str(), static_cast<int>(message.length()), &bytesWritten, nullptr))
 			LogF(L"Could not write to pipe: %s", StringHelper::getSystemErrorString(GetLastError()).c_str());
 
-		FlushFileBuffers(pipe);
-		CloseHandle(pipe);
+		FlushFileBuffers(pipe.get());
 	}
 	else
 	{

--- a/Installer/AutoInstaller.cpp
+++ b/Installer/AutoInstaller.cpp
@@ -37,6 +37,8 @@
 #include <intrin.h>      // __cpuid, __cpuidex, _xgetbv
 #include <string>
 
+#include "../helpers/ComPtr.h"
+#include "../helpers/Win32Resource.h"
 #include "../version.h"
 
 #pragma comment(lib, "winhttp.lib")
@@ -46,6 +48,25 @@
 
 namespace
 {
+struct BCryptAlgorithmTraits
+{
+    using resource_type = BCRYPT_ALG_HANDLE;
+    static resource_type invalid() noexcept { return nullptr; }
+    static bool isValid(resource_type value) noexcept { return value != nullptr; }
+    static void close(resource_type value) noexcept { BCryptCloseAlgorithmProvider(value, 0); }
+};
+
+struct BCryptHashTraits
+{
+    using resource_type = BCRYPT_HASH_HANDLE;
+    static resource_type invalid() noexcept { return nullptr; }
+    static bool isValid(resource_type value) noexcept { return value != nullptr; }
+    static void close(resource_type value) noexcept { BCryptDestroyHash(value); }
+};
+
+using UniqueBCryptAlgorithm = winutil::UniqueResource<BCryptAlgorithmTraits>;
+using UniqueBCryptHash = winutil::UniqueResource<BCryptHashTraits>;
+
 // GitHub repository that hosts the releases. Matches the GithubSource URL used by
 // the in-app updater (Editor/main.cpp).
 const wchar_t* kRepoOwner = L"115dkk";
@@ -216,37 +237,37 @@ std::wstring tempFilePath(const std::wstring& fileName)
 bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::wstring& error)
 {
     bool ok = false;
-    HINTERNET session = nullptr;
-    HINTERNET connect = nullptr;
-    HINTERNET request = nullptr;
-    HANDLE file = INVALID_HANDLE_VALUE;
+    winutil::UniqueWinHttpHandle session;
+    winutil::UniqueWinHttpHandle connect;
+    winutil::UniqueWinHttpHandle request;
+    winutil::UniqueHandle file;
 
-    session = WinHttpOpen(kUserAgent, WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
-        WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
-    if (session == nullptr)
+    session.reset(WinHttpOpen(kUserAgent, WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+        WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0));
+    if (!session)
     {
         error = L"Could not initialise WinHTTP.";
         goto cleanup;
     }
 
-    connect = WinHttpConnect(session, L"github.com", INTERNET_DEFAULT_HTTPS_PORT, 0);
-    if (connect == nullptr)
+    connect.reset(WinHttpConnect(session.get(), L"github.com", INTERNET_DEFAULT_HTTPS_PORT, 0));
+    if (!connect)
     {
         error = L"Could not connect to github.com.";
         goto cleanup;
     }
 
-    request = WinHttpOpenRequest(connect, L"GET", path.c_str(), nullptr,
-        WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
-    if (request == nullptr)
+    request.reset(WinHttpOpenRequest(connect.get(), L"GET", path.c_str(), nullptr,
+        WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE));
+    if (!request)
     {
         error = L"Could not create the download request.";
         goto cleanup;
     }
 
-    if (!WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+    if (!WinHttpSendRequest(request.get(), WINHTTP_NO_ADDITIONAL_HEADERS, 0,
             WINHTTP_NO_REQUEST_DATA, 0, 0, 0) ||
-        !WinHttpReceiveResponse(request, nullptr))
+        !WinHttpReceiveResponse(request.get(), nullptr))
     {
         error = L"No response from the download server. Check your internet connection.";
         goto cleanup;
@@ -255,7 +276,7 @@ bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::
     {
         DWORD statusCode = 0;
         DWORD size = sizeof(statusCode);
-        WinHttpQueryHeaders(request,
+        WinHttpQueryHeaders(request.get(),
             WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
             WINHTTP_HEADER_NAME_BY_INDEX, &statusCode, &size, WINHTTP_NO_HEADER_INDEX);
         if (statusCode != 200)
@@ -266,9 +287,9 @@ bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::
         }
     }
 
-    file = CreateFileW(outFile.c_str(), GENERIC_WRITE, 0, nullptr,
-        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file == INVALID_HANDLE_VALUE)
+    file.reset(CreateFileW(outFile.c_str(), GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!file)
     {
         error = L"Could not create a temporary file for the download.";
         goto cleanup;
@@ -277,7 +298,7 @@ bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::
     for (;;)
     {
         DWORD available = 0;
-        if (!WinHttpQueryDataAvailable(request, &available))
+        if (!WinHttpQueryDataAvailable(request.get(), &available))
         {
             error = L"The download was interrupted.";
             goto cleanup;
@@ -288,14 +309,14 @@ bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::
         std::string buffer;
         buffer.resize(available);
         DWORD read = 0;
-        if (!WinHttpReadData(request, &buffer[0], available, &read) || read == 0)
+        if (!WinHttpReadData(request.get(), &buffer[0], available, &read) || read == 0)
         {
             error = L"The download was interrupted.";
             goto cleanup;
         }
 
         DWORD written = 0;
-        if (!WriteFile(file, buffer.data(), read, &written, nullptr) || written != read)
+        if (!WriteFile(file.get(), buffer.data(), read, &written, nullptr) || written != read)
         {
             error = L"Could not write the downloaded installer to disk.";
             goto cleanup;
@@ -305,16 +326,12 @@ bool downloadToFile(const std::wstring& path, const std::wstring& outFile, std::
     ok = true;
 
 cleanup:
-    if (file != INVALID_HANDLE_VALUE)
-        CloseHandle(file);
-    if (request != nullptr)
-        WinHttpCloseHandle(request);
-    if (connect != nullptr)
-        WinHttpCloseHandle(connect);
-    if (session != nullptr)
-        WinHttpCloseHandle(session);
-    if (!ok && file != INVALID_HANDLE_VALUE)
-        DeleteFileW(outFile.c_str());
+    {
+        const bool removePartialFile = !ok && static_cast<bool>(file);
+        file.reset();
+        if (removePartialFile)
+            DeleteFileW(outFile.c_str());
+    }
     return ok;
 }
 
@@ -325,27 +342,27 @@ cleanup:
 bool sha256OfFile(const std::wstring& path, std::wstring& outHexLower, std::wstring& error)
 {
     bool ok = false;
-    BCRYPT_ALG_HANDLE algorithm = nullptr;
-    BCRYPT_HASH_HANDLE hash = nullptr;
-    HANDLE file = INVALID_HANDLE_VALUE;
+    UniqueBCryptAlgorithm algorithm;
+    UniqueBCryptHash hash;
+    winutil::UniqueHandle file;
     UCHAR digest[32] = {};
     std::string buffer;
     buffer.resize(64 * 1024);
 
-    if (BCryptOpenAlgorithmProvider(&algorithm, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0)
+    if (BCryptOpenAlgorithmProvider(algorithm.put(), BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0)
     {
         error = L"Could not initialise the SHA-256 provider.";
         goto cleanup;
     }
-    if (BCryptCreateHash(algorithm, &hash, nullptr, 0, nullptr, 0, 0) != 0)
+    if (BCryptCreateHash(algorithm.get(), hash.put(), nullptr, 0, nullptr, 0, 0) != 0)
     {
         error = L"Could not create a SHA-256 hash object.";
         goto cleanup;
     }
 
-    file = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file == INVALID_HANDLE_VALUE)
+    file.reset(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!file)
     {
         error = L"Could not open the downloaded installer for verification.";
         goto cleanup;
@@ -354,21 +371,21 @@ bool sha256OfFile(const std::wstring& path, std::wstring& outHexLower, std::wstr
     for (;;)
     {
         DWORD read = 0;
-        if (!ReadFile(file, &buffer[0], static_cast<DWORD>(buffer.size()), &read, nullptr))
+        if (!ReadFile(file.get(), &buffer[0], static_cast<DWORD>(buffer.size()), &read, nullptr))
         {
             error = L"Could not read the downloaded installer for verification.";
             goto cleanup;
         }
         if (read == 0)
             break;
-        if (BCryptHashData(hash, reinterpret_cast<PUCHAR>(&buffer[0]), read, 0) != 0)
+        if (BCryptHashData(hash.get(), reinterpret_cast<PUCHAR>(&buffer[0]), read, 0) != 0)
         {
             error = L"Could not hash the downloaded installer.";
             goto cleanup;
         }
     }
 
-    if (BCryptFinishHash(hash, digest, sizeof(digest), 0) != 0)
+    if (BCryptFinishHash(hash.get(), digest, sizeof(digest), 0) != 0)
     {
         error = L"Could not finish hashing the downloaded installer.";
         goto cleanup;
@@ -388,12 +405,6 @@ bool sha256OfFile(const std::wstring& path, std::wstring& outHexLower, std::wstr
     ok = true;
 
 cleanup:
-    if (file != INVALID_HANDLE_VALUE)
-        CloseHandle(file);
-    if (hash != nullptr)
-        BCryptDestroyHash(hash);
-    if (algorithm != nullptr)
-        BCryptCloseAlgorithmProvider(algorithm, 0);
     return ok;
 }
 
@@ -497,21 +508,20 @@ std::wstring expectedHashFromChecksums(const std::string& text, const std::wstri
 bool readSmallFile(const std::wstring& path, std::string& outData)
 {
     bool ok = false;
-    HANDLE file = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
-        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file == INVALID_HANDLE_VALUE)
+    winutil::UniqueHandle file(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!file)
         return false;
 
     LARGE_INTEGER size = {};
-    if (GetFileSizeEx(file, &size) && size.QuadPart > 0 && size.QuadPart <= 1024 * 1024)
+    if (GetFileSizeEx(file.get(), &size) && size.QuadPart > 0 && size.QuadPart <= 1024 * 1024)
     {
         outData.resize(static_cast<size_t>(size.QuadPart));
         DWORD read = 0;
-        ok = ReadFile(file, &outData[0], static_cast<DWORD>(outData.size()), &read, nullptr) &&
+        ok = ReadFile(file.get(), &outData[0], static_cast<DWORD>(outData.size()), &read, nullptr) &&
             read == outData.size();
     }
 
-    CloseHandle(file);
     if (!ok)
         outData.clear();
     return ok;
@@ -573,28 +583,26 @@ bool launchSetup(const std::wstring& setupPath, bool silent, DWORD& exitCode)
 
     STARTUPINFOW startup = {};
     startup.cb = sizeof(startup);
-    PROCESS_INFORMATION proc = {};
+    winutil::UniqueProcessInformation proc;
 
     // CreateProcessW may modify the command-line buffer, so pass a writable copy.
     std::wstring mutableCommand = commandLine;
     if (!CreateProcessW(setupPath.c_str(), &mutableCommand[0], nullptr, nullptr, FALSE,
-            0, nullptr, nullptr, &startup, &proc))
+            0, nullptr, nullptr, &startup, proc.put()))
     {
         return false;
     }
 
     if (silent)
     {
-        WaitForSingleObject(proc.hProcess, INFINITE);
-        GetExitCodeProcess(proc.hProcess, &exitCode);
+        WaitForSingleObject(proc.process(), INFINITE);
+        GetExitCodeProcess(proc.process(), &exitCode);
     }
     else
     {
         exitCode = 0;
     }
 
-    CloseHandle(proc.hThread);
-    CloseHandle(proc.hProcess);
     return true;
 }
 
@@ -620,9 +628,9 @@ const wchar_t* flagValue(int argc, wchar_t** argv, const wchar_t* flag)
 
 void writeTextFile(const wchar_t* path, const std::wstring& text)
 {
-    HANDLE file = CreateFileW(path, GENERIC_WRITE, 0, nullptr,
-        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file == INVALID_HANDLE_VALUE)
+    winutil::UniqueHandle file(CreateFileW(path, GENERIC_WRITE, 0, nullptr,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+    if (!file)
         return;
     std::string utf8;
     int needed = WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1, nullptr, 0, nullptr, nullptr);
@@ -631,9 +639,8 @@ void writeTextFile(const wchar_t* path, const std::wstring& text)
         utf8.resize(needed - 1);
         WideCharToMultiByte(CP_UTF8, 0, text.c_str(), -1, &utf8[0], needed - 1, nullptr, nullptr);
         DWORD written = 0;
-        WriteFile(file, utf8.data(), static_cast<DWORD>(utf8.size()), &written, nullptr);
+        WriteFile(file.get(), utf8.data(), static_cast<DWORD>(utf8.size()), &written, nullptr);
     }
-    CloseHandle(file);
 }
 
 // Print the detection result for --detect-only. Try the parent console first
@@ -646,13 +653,12 @@ int reportDetection(const std::wstring& channel, const std::wstring& url,
 
     if (AttachConsole(ATTACH_PARENT_PROCESS))
     {
-        HANDLE conout = CreateFileW(L"CONOUT$", GENERIC_WRITE,
-            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
-        if (conout != INVALID_HANDLE_VALUE)
+        winutil::UniqueHandle conout(CreateFileW(L"CONOUT$", GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr));
+        if (conout)
         {
             DWORD written = 0;
-            WriteConsoleW(conout, text.c_str(), static_cast<DWORD>(text.size()), &written, nullptr);
-            CloseHandle(conout);
+            WriteConsoleW(conout.get(), text.c_str(), static_cast<DWORD>(text.size()), &written, nullptr);
         }
         FreeConsole();
     }
@@ -672,33 +678,26 @@ int reportDetection(const std::wstring& channel, const std::wstring& url,
 int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
 {
     int argc = 0;
-    wchar_t** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-    const bool detectOnly = argv != nullptr && hasFlag(argc, argv, L"--detect-only");
-    const bool silent = argv != nullptr && hasFlag(argc, argv, L"--silent");
-    const wchar_t* outPath = argv != nullptr ? flagValue(argc, argv, L"--out") : nullptr;
+    winutil::UniqueLocalPtr<wchar_t*> argv(CommandLineToArgvW(GetCommandLineW(), &argc));
+    const bool detectOnly = argv && hasFlag(argc, argv.get(), L"--detect-only");
+    const bool silent = argv && hasFlag(argc, argv.get(), L"--silent");
+    const wchar_t* outPath = argv ? flagValue(argc, argv.get(), L"--out") : nullptr;
 
     int index = kAvx2;
     const std::wstring channel = detectChannel(&index);
     const std::wstring url = downloadUrl(channel);
 
     if (detectOnly)
-    {
-        const int code = reportDetection(channel, url, outPath, index);
-        if (argv != nullptr)
-            LocalFree(argv);
-        return code;
-    }
+        return reportDetection(channel, url, outPath, index);
 
-    if (argv != nullptr)
-        LocalFree(argv);
-
-    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    winutil::ComApartment apartment(COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
 
     // A marquee shell progress dialog covers the detect+download gap so the user
     // is not left staring at nothing before Velopack's installer appears.
-    IProgressDialog* progress = nullptr;
-    if (SUCCEEDED(CoCreateInstance(CLSID_ProgressDialog, nullptr, CLSCTX_INPROC_SERVER,
-            IID_PPV_ARGS(&progress))) && progress != nullptr)
+    winutil::ComPtr<IProgressDialog> progress;
+    if (apartment.isUsable()
+        && SUCCEEDED(CoCreateInstance(CLSID_ProgressDialog, nullptr, CLSCTX_INPROC_SERVER,
+            IID_PPV_ARGS(progress.put()))) && progress)
     {
         progress->SetTitle(L"EqualizerAPO-XT");
         progress->SetLine(1, L"Selecting the best build for your CPU...", FALSE, nullptr);
@@ -716,16 +715,15 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
     bool verified = false;
     if (downloaded)
     {
-        if (progress != nullptr)
+        if (progress)
             progress->SetLine(1, L"Verifying the downloaded installer...", FALSE, nullptr);
         verified = verifySetupChecksum(outFile, assetName(channel), error);
     }
 
-    if (progress != nullptr)
+    if (progress)
     {
         progress->StopProgressDialog();
-        progress->Release();
-        progress = nullptr;
+        progress.reset();
     }
 
     int result = 0;
@@ -762,6 +760,5 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
         }
     }
 
-    CoUninitialize();
     return result;
 }

--- a/Tests/AudioRegressionTests/AudioRegressionTests.cpp
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.cpp
@@ -12,7 +12,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <limits>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -23,18 +25,36 @@
 #include <windows.h>
 #include <bcrypt.h>
 
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
-
 #include "FilterEngine.h"
 #include "helpers/LogHelper.h"
+#include "helpers/SndfileRAII.h"
 #include "helpers/StringHelper.h"
+#include "helpers/Win32Resource.h"
 #include "Tests/TestHarness.h"
 
 #pragma comment(lib, "bcrypt.lib")
 
 namespace
 {
+
+struct BCryptAlgorithmTraits
+{
+	using resource_type = BCRYPT_ALG_HANDLE;
+	static resource_type invalid() noexcept { return nullptr; }
+	static bool isValid(resource_type value) noexcept { return value != nullptr; }
+	static void close(resource_type value) noexcept { BCryptCloseAlgorithmProvider(value, 0); }
+};
+
+struct BCryptHashTraits
+{
+	using resource_type = BCRYPT_HASH_HANDLE;
+	static resource_type invalid() noexcept { return nullptr; }
+	static bool isValid(resource_type value) noexcept { return value != nullptr; }
+	static void close(resource_type value) noexcept { BCryptDestroyHash(value); }
+};
+
+using UniqueBCryptAlgorithm = winutil::UniqueResource<BCryptAlgorithmTraits>;
+using UniqueBCryptHash = winutil::UniqueResource<BCryptHashTraits>;
 
 enum class SignalType
 {
@@ -221,25 +241,24 @@ std::vector<float> generateSignal(SignalType type, unsigned sampleRate, unsigned
 
 bool writeRawFloat(const std::wstring& path, const std::vector<float>& data)
 {
-	HANDLE h = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-	if (h == INVALID_HANDLE_VALUE) return false;
+	winutil::UniqueHandle file(CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,
+		CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+	if (!file) return false;
 	DWORD written = 0;
-	BOOL ok = WriteFile(h, data.data(), (DWORD)(data.size() * sizeof(float)), &written, nullptr);
-	CloseHandle(h);
+	BOOL ok = WriteFile(file.get(), data.data(), (DWORD)(data.size() * sizeof(float)), &written, nullptr);
 	return ok && written == data.size() * sizeof(float);
 }
 
 bool readRawFloat(const std::wstring& path, std::vector<float>& out)
 {
-	HANDLE h = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-	if (h == INVALID_HANDLE_VALUE) return false;
+	winutil::UniqueHandle file(CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+		OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+	if (!file) return false;
 	LARGE_INTEGER size;
-	GetFileSizeEx(h, &size);
-	if (size.QuadPart % sizeof(float) != 0) { CloseHandle(h); return false; }
+	if (!GetFileSizeEx(file.get(), &size) || size.QuadPart % sizeof(float) != 0) return false;
 	out.resize((size_t)(size.QuadPart / sizeof(float)));
 	DWORD readBytes = 0;
-	BOOL ok = ReadFile(h, out.data(), (DWORD)(out.size() * sizeof(float)), &readBytes, nullptr);
-	CloseHandle(h);
+	BOOL ok = ReadFile(file.get(), out.data(), (DWORD)(out.size() * sizeof(float)), &readBytes, nullptr);
 	return ok && readBytes == out.size() * sizeof(float);
 }
 
@@ -311,17 +330,16 @@ CompareResult compareBuffers(const std::vector<float>& out, const std::vector<fl
 
 std::string sha256Hex(const void* data, size_t size)
 {
-	BCRYPT_ALG_HANDLE alg = nullptr;
-	BCRYPT_HASH_HANDLE hash = nullptr;
+	UniqueBCryptAlgorithm algorithm;
+	UniqueBCryptHash hash;
 	UCHAR digest[32] = {};
 	std::string hex;
-	if (BCryptOpenAlgorithmProvider(&alg, BCRYPT_SHA256_ALGORITHM, nullptr, 0) == 0)
+	if (BCryptOpenAlgorithmProvider(algorithm.put(), BCRYPT_SHA256_ALGORITHM, nullptr, 0) == 0)
 	{
-		if (BCryptCreateHash(alg, &hash, nullptr, 0, nullptr, 0, 0) == 0)
+		if (BCryptCreateHash(algorithm.get(), hash.put(), nullptr, 0, nullptr, 0, 0) == 0)
 		{
-			BCryptHashData(hash, (PUCHAR)data, (ULONG)size, 0);
-			BCryptFinishHash(hash, digest, sizeof(digest), 0);
-			BCryptDestroyHash(hash);
+			BCryptHashData(hash.get(), (PUCHAR)data, (ULONG)size, 0);
+			BCryptFinishHash(hash.get(), digest, sizeof(digest), 0);
 			char buf[3];
 			for (UCHAR b : digest)
 			{
@@ -329,7 +347,6 @@ std::string sha256Hex(const void* data, size_t size)
 				hex += buf;
 			}
 		}
-		BCryptCloseAlgorithmProvider(alg, 0);
 	}
 	return hex;
 }
@@ -366,11 +383,10 @@ bool writeIrWav(const std::wstring& path, const std::vector<std::vector<double>>
 	info.samplerate = (int)sampleRate;
 	info.channels = (int)numCh;
 	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
-	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_WRITE, &info);
-	if (file == nullptr)
+	sndfile::Handle file(sf_wchar_open(path.c_str(), SFM_WRITE, &info));
+	if (!file)
 		return false;
-	sf_writef_double(file, interleaved.data(), (sf_count_t)frames);
-	sf_close(file);
+	sf_writef_double(file.get(), interleaved.data(), (sf_count_t)frames);
 	return true;
 }
 
@@ -383,12 +399,12 @@ bool writeTextFile(const std::wstring& path, const std::wstring& text)
 		utf8.resize((size_t)n);
 		WideCharToMultiByte(CP_UTF8, 0, text.data(), (int)text.size(), utf8.data(), n, nullptr, nullptr);
 	}
-	HANDLE h = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-	if (h == INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle file(CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr,
+		CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
+	if (!file)
 		return false;
 	DWORD written = 0;
-	BOOL ok = WriteFile(h, utf8.data(), (DWORD)utf8.size(), &written, nullptr);
-	CloseHandle(h);
+	BOOL ok = WriteFile(file.get(), utf8.data(), (DWORD)utf8.size(), &written, nullptr);
 	return ok && written == utf8.size();
 }
 
@@ -633,15 +649,14 @@ void runAllEquivalenceBatteries(const Options& opts, bool& outFailed, unsigned& 
 	{
 		++fileIndex;
 		SF_INFO info = {};
-		SNDFILE* file = sf_wchar_open(irPath.c_str(), SFM_READ, &info);
-		if (file == nullptr)
+		sndfile::Handle file(sf_wchar_open(irPath.c_str(), SFM_READ, &info));
+		if (!file)
 		{
 			fprintf(stderr, "ERROR: --equiv-ir file unreadable: %S\n", irPath.c_str());
 			outFailed = true;
 			++total;
 			continue;
 		}
-		sf_close(file);
 		const std::string label = "ir" + std::to_string(fileIndex);
 		printf("\n--equiv-ir %S: %d channels, %lld frames, %d Hz\n", irPath.c_str(), info.channels, (long long)info.frames, info.samplerate);
 		runEquivalenceBattery(label, irPath, (unsigned)info.channels, (unsigned)info.frames, (unsigned)info.samplerate, opts, outFailed, passed, total);
@@ -713,7 +728,7 @@ bool runCase(const TestCase& tc, const Options& opts, bool& outFailed)
 
 }
 
-int main(int argc, char** argv)
+int runAudioRegressionTests(int argc, char** argv)
 {
 	LogHelper::set(stderr, false, false, false);
 
@@ -755,4 +770,21 @@ int main(int argc, char** argv)
 	test::Harness harness("AudioRegressionTests");
 	harness.expect(!anyFailed, "one or more regression cases failed (drift beyond tolerance or I/O error)");
 	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	try
+	{
+		return runAudioRegressionTests(argc, argv);
+	}
+	catch (const std::exception& error)
+	{
+		fprintf(stderr, "AudioRegressionTests: unhandled exception: %s\n", error.what());
+	}
+	catch (...)
+	{
+		fprintf(stderr, "AudioRegressionTests: unhandled non-standard exception\n");
+	}
+	return EXIT_FAILURE;
 }

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -40,6 +40,7 @@
 #include "Editor/widgets/routing/RoutingFold.h"
 #include "Editor/widgets/routing/StudioRoutingModel.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/Win32Resource.h"
 #include "UpdateChecker/UpdateInfoFormatter.h"
 #include "UpdateChecker/VelopackUpdateInfo.h"
 
@@ -131,6 +132,26 @@ void requireTrue(bool value, const QString& message)
 // FilterListModel: the widget-free document/selection model behind
 // FilterTable, so its mutation and selection logic is testable without a
 // QWidget.
+static void requireFilterListModelInvariants(const FilterListModel& model, const char* stage)
+{
+	QSet<FilterListItem*> documentItems;
+	for (FilterListItem* item : model.items())
+	{
+		if (item == nullptr || documentItems.contains(item))
+			throw std::runtime_error(std::string("FilterListModel projection invariant failed after ") + stage);
+		documentItems.insert(item);
+	}
+	for (FilterListItem* item : model.selected())
+	{
+		if (!documentItems.contains(item))
+			throw std::runtime_error(std::string("FilterListModel selection invariant failed after ") + stage);
+	}
+	if (model.focused() != nullptr && !documentItems.contains(model.focused()))
+		throw std::runtime_error(std::string("FilterListModel focus invariant failed after ") + stage);
+	if (model.selectionStart() != nullptr && !documentItems.contains(model.selectionStart()))
+		throw std::runtime_error(std::string("FilterListModel anchor invariant failed after ") + stage);
+}
+
 static void testFilterListModel()
 {
 	FilterListModel model;
@@ -143,12 +164,14 @@ static void testFilterListModel()
 	expectTrue(model.focused() == model.items()[0], "setLines focuses the first line");
 	expectTrue(model.selectionStart() == model.items()[0], "setLines anchors the selection on the first line");
 	expectTrue(model.selected().isEmpty(), "setLines starts with an empty selection");
+	requireFilterListModelInvariants(model, "setLines");
 
 	// addLine inserts before an anchor item, or appends without one.
 	FilterListItem* added = model.addLine("Filter: ON PK Fc 1000 Hz Gain -3 dB Q 0.71", model.items()[1]);
 	expectEqual((int)model.items().indexOf(added), 1, "addLine inserts before the anchor");
 	FilterListItem* appended = model.addLine("GraphicEQ: 20 -1; 1000 2");
 	expectEqual((int)model.items().indexOf(appended), (int)model.items().size() - 1, "addLine without anchor appends");
+	requireFilterListModelInvariants(model, "addLine");
 
 	// Range selection math (the Shift-click/Shift-arrow logic): anchor..target
 	// in either direction; a missing anchor leaves the selection untouched.
@@ -196,6 +219,7 @@ static void testFilterListModel()
 	expectTrue(model.selectionStart() == inserted[0], "insertLines anchors on the first inserted line");
 	expectTrue(inserted[0]->prefs.value("expanded").toBool() && inserted[1]->prefs.isEmpty(),
 		"insertLines aligns prefs by index and leaves extra lines without prefs");
+	requireFilterListModelInvariants(model, "insertLines");
 
 	// deleteSelected removes exactly the selection, clears it and drops the
 	// focus/anchor when they pointed at deleted rows.
@@ -212,6 +236,7 @@ static void testFilterListModel()
 	expectTrue(model.selected().isEmpty(), "deleteSelected clears the selection");
 	expectTrue(model.focused() == nullptr && model.selectionStart() == nullptr,
 		"deleteSelected drops focus/anchor pointing at deleted rows");
+	requireFilterListModelInvariants(model, "deleteSelected");
 
 	// selectAll selects every row.
 	model.selectAll();
@@ -230,6 +255,36 @@ static void testFilterListModel()
 	expectTrue(model.focused() == replacement && model.selectionStart() == replacement,
 		"removeItem moves focus and anchor to the neighbouring row");
 	expectFalse(model.removeItem(nullptr), "removeItem rejects items outside the document");
+	requireFilterListModelInvariants(model, "removeItem");
+
+	// Batch removal has no individual replacement semantics, but must commit
+	// ownership, projection and observer state together.
+	FilterListModel batchModel;
+	batchModel.setLines(QList<QString>() << "one" << "two" << "three");
+	FilterListItem* removed = batchModel.items()[1];
+	batchModel.select(removed);
+	batchModel.setFocused(removed);
+	batchModel.setSelectionStart(removed);
+	batchModel.removeItems(QSet<FilterListItem*>() << removed);
+	requireFilterListModelInvariants(batchModel, "removeItems");
+	if (batchModel.lines() != (QList<QString>() << "one" << "three"))
+		throw std::runtime_error("FilterListModel removeItems order invariant failed");
+
+	// Invalid external anchors and drop rows must be normalized before the
+	// owner vector is indexed; this is both a public-API guard and a regression
+	// test for the former begin() - 1 undefined behavior.
+	FilterListModel boundaryModel;
+	boundaryModel.setLines(QList<QString>() << "middle");
+	FilterListItem externalAnchor("external");
+	const FilterListItem* appendedAtBoundary = boundaryModel.addLine("end", &externalAnchor);
+	boundaryModel.insertLines(QStringList() << "front", {}, -100);
+	boundaryModel.insertLines(QStringList() << "tail", {}, 100);
+	requireFilterListModelInvariants(boundaryModel, "boundary normalization");
+	if (boundaryModel.lines() != (QList<QString>() << "front" << "middle" << "end" << "tail")
+		|| boundaryModel.items()[2] != appendedAtBoundary)
+	{
+		throw std::runtime_error("FilterListModel boundary normalization failed");
+	}
 }
 
 // FilterListUndo: the widget-free undo/redo history FilterTable commits to on
@@ -1293,18 +1348,18 @@ void testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails()
 
 	// Access 0 with read/write sharing still permits in-place writes, while
 	// omitting FILE_SHARE_DELETE prevents replacement while this handle lives.
-	HANDLE replacementBlocker = CreateFileW(
+	winutil::UniqueHandle replacementBlocker(CreateFileW(
 		path.toStdWString().c_str(),
 		0,
 		FILE_SHARE_READ | FILE_SHARE_WRITE,
 		nullptr,
 		OPEN_EXISTING,
 		FILE_ATTRIBUTE_NORMAL,
-		nullptr);
-	requireTrue(replacementBlocker != INVALID_HANDLE_VALUE, "atomic-save test locks replacement of the original file");
+		nullptr));
+	requireTrue(static_cast<bool>(replacementBlocker), "atomic-save test locks replacement of the original file");
 
 	ConfigFileCodec::WriteResult result = ConfigFileCodec::writeConfig(path, QList<QString>() << "replacement");
-	CloseHandle(replacementBlocker);
+	replacementBlocker.reset();
 
 	expectFalse(result.opened, "writeConfig reports an atomic replacement failure");
 
@@ -1316,7 +1371,7 @@ void testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails()
 void testConfigFileCodecRejectsPartialRead()
 {
 	const std::wstring pipeName = L"\\\\.\\pipe\\EditorLogicTests-ConfigRead-" + std::to_wstring(GetCurrentProcessId());
-	HANDLE pipe = CreateNamedPipeW(
+	winutil::UniqueHandle pipe(CreateNamedPipeW(
 		pipeName.c_str(),
 		PIPE_ACCESS_OUTBOUND,
 		PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
@@ -1324,20 +1379,19 @@ void testConfigFileCodecRejectsPartialRead()
 		4096,
 		4096,
 		0,
-		nullptr);
-	requireTrue(pipe != INVALID_HANDLE_VALUE, "partial-read test creates a named pipe");
+		nullptr));
+	requireTrue(static_cast<bool>(pipe), "partial-read test creates a named pipe");
 
 	bool serverSucceeded = false;
 	std::thread server([&]() {
-		BOOL connected = ConnectNamedPipe(pipe, nullptr);
+		BOOL connected = ConnectNamedPipe(pipe.get(), nullptr);
 		if (!connected && GetLastError() == ERROR_PIPE_CONNECTED)
 			connected = TRUE;
 		const char prefix[] = "Preamp: -6 dB\r\n";
 		DWORD written = 0;
-		if (connected && WriteFile(pipe, prefix, sizeof(prefix) - 1, &written, nullptr) && written == sizeof(prefix) - 1)
-			serverSucceeded = FlushFileBuffers(pipe) != FALSE;
-		DisconnectNamedPipe(pipe);
-		CloseHandle(pipe);
+		if (connected && WriteFile(pipe.get(), prefix, sizeof(prefix) - 1, &written, nullptr) && written == sizeof(prefix) - 1)
+			serverSucceeded = FlushFileBuffers(pipe.get()) != FALSE;
+		DisconnectNamedPipe(pipe.get());
 	});
 
 	ConfigFileCodec::ReadResult result = ConfigFileCodec::readConfig(QString::fromStdWString(pipeName));

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -1,5 +1,7 @@
 #include <cstdio>
 #include <cstdlib>
+#include <exception>
+#include <iostream>
 #include <malloc.h>
 #include <stdexcept>
 #include <thread>
@@ -1375,32 +1377,42 @@ void testMemoryHelperConstructReleasesStorageWhenConstructorThrows()
 
 int main(int argc, char** argv)
 {
-	QCoreApplication app(argc, argv);
+	try
+	{
+		QCoreApplication app(argc, argv);
 
-	testConvolutionPathHelper();
-	testUpdateInfoFormatter();
-	testVelopackUpdateInfo();
-	testVelopackGitHubRelease();
-	testVelopackFeeds();
-	testFilterCardDescriptors();
-	testFilterCardDepths();
-	testConfigImport();
-	testChannelSelectionModel();
-	testDeviceSelectionModel();
-	testMultiConvolutionRoutingAdapter();
-	testStageSelectionModel();
-	testStudioRoutingModel();
-	testRoutingFold();
-	testConfigFileCodec();
-	testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails();
-	testConfigFileCodecRejectsPartialRead();
-	// The constructor exception is deliberately caught inside the test; cppcheck
-	// does not propagate that catch back through MemoryHelper::construct.
-	// cppcheck-suppress throwInEntryPoint
-	testMemoryHelperConstructReleasesStorageWhenConstructorThrows();
-	testFilterListModel();
-	testFilterListUndo();
+		testConvolutionPathHelper();
+		testUpdateInfoFormatter();
+		testVelopackUpdateInfo();
+		testVelopackGitHubRelease();
+		testVelopackFeeds();
+		testFilterCardDescriptors();
+		testFilterCardDepths();
+		testConfigImport();
+		testChannelSelectionModel();
+		testDeviceSelectionModel();
+		testMultiConvolutionRoutingAdapter();
+		testStageSelectionModel();
+		testStudioRoutingModel();
+		testRoutingFold();
+		testConfigFileCodec();
+		testConfigFileCodecPreservesExistingFileWhenAtomicReplaceFails();
+		testConfigFileCodecRejectsPartialRead();
+		testMemoryHelperConstructReleasesStorageWhenConstructorThrows();
+		testFilterListModel();
+		testFilterListUndo();
 
-	harness.report();
-	return 0;
+		harness.report();
+		return EXIT_SUCCESS;
+	}
+	catch (const std::exception& error)
+	{
+		std::cerr << "Unhandled exception escaped a test: " << error.what() << '\n';
+	}
+	catch (...)
+	{
+		std::cerr << "A non-standard exception escaped a test.\n";
+	}
+
+	return EXIT_FAILURE;
 }

--- a/Tests/EngineOrchestrationTests/ConfigurationFileReaderTests.cpp
+++ b/Tests/EngineOrchestrationTests/ConfigurationFileReaderTests.cpp
@@ -18,6 +18,7 @@
 
 #include "ConfigurationFileReader.h"
 #include "Tests/TestHarness.h"
+#include "helpers/Win32Resource.h"
 
 void runConfigurationFileReaderTests(test::Harness& harness)
 {
@@ -30,7 +31,7 @@ void runConfigurationFileReaderTests(test::Harness& harness)
 	harness.expectFalse(missing.good(), "readWithRetry reports an open failure");
 
 	const std::wstring pipeName = L"\\\\.\\pipe\\EngineOrchestrationTests-ConfigRead-" + std::to_wstring(GetCurrentProcessId());
-	HANDLE pipe = CreateNamedPipeW(
+	winutil::UniqueHandle pipe(CreateNamedPipeW(
 		pipeName.c_str(),
 		PIPE_ACCESS_OUTBOUND,
 		PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
@@ -38,20 +39,19 @@ void runConfigurationFileReaderTests(test::Harness& harness)
 		4096,
 		4096,
 		0,
-		nullptr);
-	harness.require(pipe != INVALID_HANDLE_VALUE, "partial configuration read creates a named pipe");
+		nullptr));
+	harness.require(static_cast<bool>(pipe), "partial configuration read creates a named pipe");
 
 	bool serverSucceeded = false;
 	std::thread server([&]() {
-		BOOL connected = ConnectNamedPipe(pipe, nullptr);
+		BOOL connected = ConnectNamedPipe(pipe.get(), nullptr);
 		if (!connected && GetLastError() == ERROR_PIPE_CONNECTED)
 			connected = TRUE;
 		const char prefix[] = "Preamp: -6 dB\r\n";
 		DWORD written = 0;
-		if (connected && WriteFile(pipe, prefix, sizeof(prefix) - 1, &written, nullptr) && written == sizeof(prefix) - 1)
-			serverSucceeded = FlushFileBuffers(pipe) != FALSE;
-		DisconnectNamedPipe(pipe);
-		CloseHandle(pipe);
+		if (connected && WriteFile(pipe.get(), prefix, sizeof(prefix) - 1, &written, nullptr) && written == sizeof(prefix) - 1)
+			serverSucceeded = FlushFileBuffers(pipe.get()) != FALSE;
+		DisconnectNamedPipe(pipe.get());
 	});
 
 	std::stringstream input = ConfigurationFileReader::readWithRetry(pipeName);

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -13,7 +13,9 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <exception>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -22,12 +24,10 @@
 #endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
-
 #include "ConfigLoadTrace.h"
 #include "FilterEngine.h"
 #include "helpers/LogHelper.h"
+#include "helpers/SndfileRAII.h"
 #include "Tests/TestHarness.h"
 
 namespace
@@ -123,11 +123,10 @@ std::wstring writeStereoDeltaIr(test::Harness& harness, const std::wstring& file
 	info.samplerate = 48000;
 	info.channels = 2;
 	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
-	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_WRITE, &info);
-	if (file == nullptr)
+	sndfile::Handle file(sf_wchar_open(path.c_str(), SFM_WRITE, &info));
+	if (!file)
 		harness.fail("could not write stereo delta IR");
-	sf_writef_double(file, interleaved.data(), frames);
-	sf_close(file);
+	sf_writef_double(file.get(), interleaved.data(), frames);
 
 	writtenConfigFiles().push_back(path);
 	return path;
@@ -202,14 +201,13 @@ void testMultiConvolutionIgnoresChannelSelection(test::Harness& harness)
 void readStereoIr(test::Harness& harness, const std::wstring& path, std::vector<double>& ch0, std::vector<double>& ch1)
 {
 	SF_INFO info = {};
-	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_READ, &info);
-	if (file == nullptr)
+	sndfile::Handle file(sf_wchar_open(path.c_str(), SFM_READ, &info));
+	if (!file)
 		harness.fail("could not open BRIR IR file");
 	if (info.channels != 2)
 		harness.fail("BRIR IR file is not stereo");
 	std::vector<double> interleaved((size_t)info.frames * info.channels);
-	sf_readf_double(file, interleaved.data(), info.frames);
-	sf_close(file);
+	sf_readf_double(file.get(), interleaved.data(), info.frames);
 	ch0.resize((size_t)info.frames);
 	ch1.resize((size_t)info.frames);
 	for (sf_count_t i = 0; i < info.frames; i++)
@@ -233,9 +231,8 @@ void writeStereoIr(const std::wstring& path, const std::vector<double>& ch0, con
 	info.samplerate = 48000;
 	info.channels = 2;
 	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
-	SNDFILE* file = sf_wchar_open(path.c_str(), SFM_WRITE, &info);
-	sf_writef_double(file, interleaved.data(), (sf_count_t)frames);
-	sf_close(file);
+	sndfile::Handle file(sf_wchar_open(path.c_str(), SFM_WRITE, &info));
+	sf_writef_double(file.get(), interleaved.data(), (sf_count_t)frames);
 	writtenConfigFiles().push_back(path);
 }
 
@@ -291,13 +288,13 @@ void testRealBrirCrossfeed(test::Harness& harness)
 	wchar_t* dirBuf = nullptr;
 	size_t dirLen = 0;
 	_wdupenv_s(&dirBuf, &dirLen, L"EAPO_XT_BRIR_DIR");
-	if (dirBuf == nullptr)
+	std::unique_ptr<wchar_t, decltype(&std::free)> dirOwner(dirBuf, &std::free);
+	if (!dirOwner)
 	{
 		std::printf("  [skip] testRealBrirCrossfeed: set EAPO_XT_BRIR_DIR to the BRIR folder to run it\n");
 		return;
 	}
-	std::wstring dir(dirBuf);
-	free(dirBuf);
+	std::wstring dir(dirOwner.get());
 
 	std::wstring flPath = dir + L"\\Thead400FL.wav";
 	std::wstring frPath = dir + L"\\Thead400FR.wav";
@@ -568,7 +565,7 @@ void testConfigLoadTrace(test::Harness& harness)
 void runSampleIoTests(test::Harness& harness);
 void runConfigurationFileReaderTests(test::Harness& harness);
 
-int main()
+int runEngineOrchestrationTests()
 {
 	LogHelper::set(stderr, false, false, false);
 
@@ -588,4 +585,21 @@ int main()
 	removeTestDirectory();
 	harness.report();
 	return 0;
+}
+
+int main()
+{
+	try
+	{
+		return runEngineOrchestrationTests();
+	}
+	catch (const std::exception& error)
+	{
+		std::fprintf(stderr, "EngineOrchestrationTests: unhandled exception: %s\n", error.what());
+	}
+	catch (...)
+	{
+		std::fprintf(stderr, "EngineOrchestrationTests: unhandled non-standard exception\n");
+	}
+	return EXIT_FAILURE;
 }

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -18,15 +18,14 @@
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #include <windows.h>
-#include <sndfile.h>
 
 #include "filters/ConvolutionFilter.h"
 #include "filters/ConvolutionFilePath.h"
 #include "filters/IrCache.h"
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/SndfileRAII.h"
 #include "libHybridConv-0.1.1/libHybridConv_eapo.h"
 #include "Tests/TestHarness.h"
 
@@ -130,12 +129,11 @@ wstring createImpulseResponseFile(const vector<double>& impulseResponse)
 	info.channels = 1;
 	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
 
-	SNDFILE* file = sf_wchar_open(filename.c_str(), SFM_WRITE, &info);
-	if (file == nullptr)
+	sndfile::Handle file(sf_wchar_open(filename.c_str(), SFM_WRITE, &info));
+	if (!file)
 		fail("could not create temporary impulse response file");
 
-	sf_count_t written = sf_writef_double(file, impulseResponse.data(), (sf_count_t)impulseResponse.size());
-	sf_close(file);
+	sf_count_t written = sf_writef_double(file.get(), impulseResponse.data(), (sf_count_t)impulseResponse.size());
 
 	if (written != (sf_count_t)impulseResponse.size())
 		fail("could not write complete temporary impulse response file");
@@ -317,16 +315,16 @@ void assertInvalidConvolverArgumentsLeaveEmptyOutput()
 void assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix()
 {
 	constexpr unsigned slotCount = 2;
-	HConvSingle* slots = static_cast<HConvSingle*>(MemoryHelper::alloc(sizeof(HConvSingle) * slotCount));
+	auto slots = MemoryHelper::allocateArray<HConvSingle>(slotCount);
 	// cppcheck 2.21 reports a parser error on this ordinary null check after the
 	// templated/static_cast allocation expression; MSVC builds and runs the path.
 	// cppcheck-suppress syntaxError
 	if (slots == nullptr)
 		fail("could not allocate convolver slots for partial-initialization test");
-	memset(slots, 0xA5, sizeof(HConvSingle) * slotCount);
+	memset(slots.get(), 0xA5, sizeof(HConvSingle) * slotCount);
 
 	HConvSingleArray pending;
-	pending.adoptUninitialized(slots, slotCount);
+	pending.adoptUninitialized(std::move(slots), slotCount);
 	vector<double> impulseResponse(1, 1.0);
 	hcInitSingle(&pending[0], impulseResponse.data(), 1, 8, 1);
 	pending.markInitialized();
@@ -356,7 +354,7 @@ void assertConvolutionPathParsing()
 
 }
 
-int main()
+int runHybridConvTests()
 {
 	LogHelper::set(stdout, true, true, false);
 
@@ -395,4 +393,21 @@ int main()
 
 	harness.report();
 	return 0;
+}
+
+int main()
+{
+	try
+	{
+		return runHybridConvTests();
+	}
+	catch (const std::exception& error)
+	{
+		std::fprintf(stderr, "HybridConvTests: unhandled exception: %s\n", error.what());
+	}
+	catch (...)
+	{
+		std::fprintf(stderr, "HybridConvTests: unhandled non-standard exception\n");
+	}
+	return EXIT_FAILURE;
 }

--- a/Tests/HybridConvTests/MultiConvolutionTests.cpp
+++ b/Tests/HybridConvTests/MultiConvolutionTests.cpp
@@ -12,12 +12,11 @@
 #include <vector>
 
 #define WIN32_LEAN_AND_MEAN
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #include <windows.h>
-#include <sndfile.h>
 
 #include "filters/MultiConvolutionCommand.h"
 #include "filters/MultiConvolutionFilter.h"
+#include "helpers/SndfileRAII.h"
 #include "Tests/TestHarness.h"
 
 using std::vector;
@@ -60,11 +59,10 @@ wstring createMultiChannelIr(const vector<vector<double>>& channels)
 	info.channels = (int)numCh;
 	info.format = SF_FORMAT_WAV | SF_FORMAT_DOUBLE;
 
-	SNDFILE* file = sf_wchar_open(filename.c_str(), SFM_WRITE, &info);
-	if (file == nullptr)
+	sndfile::Handle file(sf_wchar_open(filename.c_str(), SFM_WRITE, &info));
+	if (!file)
 		harness.fail("could not create temporary impulse response file");
-	sf_writef_double(file, interleaved.data(), (sf_count_t)frames);
-	sf_close(file);
+	sf_writef_double(file.get(), interleaved.data(), (sf_count_t)frames);
 
 	return filename;
 }

--- a/Tests/HybridConvTests/VstHostTests.cpp
+++ b/Tests/HybridConvTests/VstHostTests.cpp
@@ -276,7 +276,7 @@ void runVstHostTests()
 
 	// Construct and initialize the instance the way the engine does (heap
 	// allocated, owned here). processLevel mirrors a realtime audio thread.
-	VSTPluginInstance* instance = new VSTPluginInstance(library, 2);
+	auto instance = std::make_unique<VSTPluginInstance>(library, 2);
 	bool initialized = instance->initialize();
 	harness.expectTrue(initialized, "VSTPluginInstance initialize succeeded");
 
@@ -373,9 +373,8 @@ void runVstHostTests()
 
 	instance->stopProcessing();
 
-	// Teardown mirrors the engine: the destructor sends effClose, which frees
-	// the plugin-side AEffect and per-instance state.
-	delete instance;
+	// The owning pointer mirrors the engine and sends effClose on every exit,
+	// including an unexpected exception from a later assertion.
 
 	harness.report();
 }

--- a/VoicemeeterAPOInfo.cpp
+++ b/VoicemeeterAPOInfo.cpp
@@ -25,8 +25,10 @@
 #include <shellapi.h>
 #include <TlHelp32.h>
 #include <Winternl.h>
+#include "helpers/ComPtr.h"
 #include "helpers/RegistryHelper.h"
 #include "helpers/StringHelper.h"
+#include "helpers/Win32Resource.h"
 #include "VoicemeeterAPOInfo.h"
 
 using std::exception;
@@ -38,6 +40,8 @@ using std::sort;
 using std::vector;
 using std::wstringstream;
 using std::wstring;
+using winutil::ComPtr;
+using winutil::CoTaskMem;
 
 #define voicemeeterKeyPath L"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\VB:Voicemeeter {17359A74-1236-5467}"
 #define voicemeeterWowKeyPath L"HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\VB:Voicemeeter {17359A74-1236-5467}"
@@ -294,11 +298,13 @@ void VoicemeeterAPOInfo::reinstall()
 
 wstring VoicemeeterAPOInfo::getStartupPath()
 {
-	PWSTR startupPath;
-	SHGetKnownFolderPath(FOLDERID_Startup, KF_FLAG_DONT_UNEXPAND, nullptr, &startupPath);
-	wstring result(startupPath);
-
-	CoTaskMemFree(startupPath);
+	CoTaskMem<wchar_t> startupPath;
+	if (FAILED(SHGetKnownFolderPath(FOLDERID_Startup, KF_FLAG_DONT_UNEXPAND,
+		nullptr, startupPath.put())))
+	{
+		return wstring();
+	}
+	wstring result(startupPath.get());
 
 	return result + L"\\" + startupFilename;
 }
@@ -316,21 +322,17 @@ wstring VoicemeeterAPOInfo::getClientPath()
 
 void VoicemeeterAPOInfo::createLink(const wstring& lnkPath, const wstring& path, const wstring& args)
 {
-	IShellLink* shellLink;
-	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink));
+	ComPtr<IShellLink> shellLink;
+	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+		IID_PPV_ARGS(shellLink.put()));
 	if (SUCCEEDED(hr))
 	{
 		shellLink->SetPath(path.c_str());
 		shellLink->SetArguments(args.c_str());
-		IPersistFile* persistFile;
-		hr = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile));
+		ComPtr<IPersistFile> persistFile;
+		hr = shellLink->QueryInterface(IID_PPV_ARGS(persistFile.put()));
 		if (SUCCEEDED(hr))
-		{
-			hr = persistFile->Save(lnkPath.c_str(), TRUE);
-			persistFile->Release();
-		}
-
-		shellLink->Release();
+			persistFile->Save(lnkPath.c_str(), TRUE);
 	}
 }
 
@@ -338,12 +340,13 @@ wstring VoicemeeterAPOInfo::getLinkArgs(const wstring& lnkPath, wstring* path)
 {
 	wstring result;
 
-	IShellLink* shellLink;
-	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink));
+	ComPtr<IShellLink> shellLink;
+	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+		IID_PPV_ARGS(shellLink.put()));
 	if (SUCCEEDED(hr))
 	{
-		IPersistFile* persistFile;
-		hr = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile));
+		ComPtr<IPersistFile> persistFile;
+		hr = shellLink->QueryInterface(IID_PPV_ARGS(persistFile.put()));
 		if (SUCCEEDED(hr))
 		{
 			hr = persistFile->Load(lnkPath.c_str(), STGM_READ);
@@ -361,10 +364,7 @@ wstring VoicemeeterAPOInfo::getLinkArgs(const wstring& lnkPath, wstring* path)
 						*path = buf;
 				}
 			}
-			persistFile->Release();
 		}
-
-		shellLink->Release();
 	}
 
 	return result;
@@ -377,10 +377,11 @@ vector<wstring> VoicemeeterAPOInfo::splitArgs(const wstring& argString)
 	if (argString.length() > 0)
 	{
 		int argc;
-		wchar_t** argv = CommandLineToArgvW(argString.c_str(), &argc);
+		winutil::UniqueLocalPtr<wchar_t*> argv(CommandLineToArgvW(argString.c_str(), &argc));
+		if (!argv)
+			return result;
 		for (int i = 0; i < argc; i++)
-			result.push_back(argv[i]);
-		LocalFree(argv);
+			result.push_back(argv.get()[i]);
 	}
 
 	return result;
@@ -410,8 +411,9 @@ void VoicemeeterAPOInfo::ensureVoicemeeterClientRunning()
 	vector<wstring> args = splitArgs(argString);
 	wstring clientPath = getClientPath();
 
-	HANDLE tokenHandle;
-	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tokenHandle))
+	winutil::UniqueHandle tokenHandle;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+		tokenHandle.put()))
 		throw RegistryException(L"Error in OpenProcessToken while taking ownership");
 
 	LUID luid;
@@ -423,52 +425,57 @@ void VoicemeeterAPOInfo::ensureVoicemeeterClientRunning()
 	tp.Privileges[0].Luid = luid;
 	tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-	if (!AdjustTokenPrivileges(tokenHandle, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
+	if (!AdjustTokenPrivileges(tokenHandle.get(), FALSE, &tp,
+		sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
 
-	HMODULE module = LoadLibraryW(L"ntdll.dll");
-	if (module == nullptr)
+	winutil::UniqueModule module(LoadLibraryW(L"ntdll.dll"));
+	if (!module)
 		throw exception("Could not load ntdll.dll");
-	SCOPE_EXIT{FreeLibrary(module); };
 
-	pfnNtQueryInformationProcess NtQueryInformationProcess = (pfnNtQueryInformationProcess)GetProcAddress(module, "NtQueryInformationProcess");
+	pfnNtQueryInformationProcess NtQueryInformationProcess =
+		reinterpret_cast<pfnNtQueryInformationProcess>(GetProcAddress(module.get(), "NtQueryInformationProcess"));
 	if (NtQueryInformationProcess == nullptr)
 		throw exception("Function NtQueryInformationProcess not found in ntdll.dll");
 
-	HANDLE snapshotHandle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-	if (snapshotHandle == INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle snapshotHandle(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
+	if (!snapshotHandle)
 		throw exception("Could not take a snapshot of all processes");
-	SCOPE_EXIT{CloseHandle(snapshotHandle); };
 
 	bool matchingProcessExists = false;
 
 	PROCESSENTRY32W entry;
 	entry.dwSize = sizeof(PROCESSENTRY32W);
-	bool loop = Process32FirstW(snapshotHandle, &entry) != 0;
+	bool loop = Process32FirstW(snapshotHandle.get(), &entry) != 0;
 	while (loop)
 	{
 		if (wcscmp(entry.szExeFile, clientFilename) == 0)
 		{
-			HANDLE processHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_TERMINATE, FALSE, entry.th32ProcessID);
-			if (processHandle == INVALID_HANDLE_VALUE)
+			winutil::UniqueHandle processHandle(OpenProcess(
+				PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_TERMINATE,
+				FALSE, entry.th32ProcessID));
+			if (!processHandle)
 				throw exception("Could not open process");
-			SCOPE_EXIT{CloseHandle(processHandle); };
 
 			PROCESS_BASIC_INFORMATION basicInformation;
-			NTSTATUS status = NtQueryInformationProcess(processHandle, ProcessBasicInformation, &basicInformation, sizeof(basicInformation), nullptr);
+			NTSTATUS status = NtQueryInformationProcess(processHandle.get(), ProcessBasicInformation,
+				&basicInformation, sizeof(basicInformation), nullptr);
 			if (status < 0)
 				throw exception("Could not query process information");
 
 			_PEB peb;
-			if (!ReadProcessMemory(processHandle, basicInformation.PebBaseAddress, &peb, sizeof(peb), nullptr))
+			if (!ReadProcessMemory(processHandle.get(), basicInformation.PebBaseAddress,
+				&peb, sizeof(peb), nullptr))
 				throw exception("Could not read peb from process memory");
 
 			RTL_USER_PROCESS_PARAMETERS processParams;
-			if (!ReadProcessMemory(processHandle, peb.ProcessParameters, &processParams, sizeof(processParams), nullptr))
+			if (!ReadProcessMemory(processHandle.get(), peb.ProcessParameters,
+				&processParams, sizeof(processParams), nullptr))
 				throw exception("Could not read process parameters from process memory");
 
 			vector<wchar_t> cmdLineBuf(processParams.CommandLine.Length / sizeof(wchar_t));
-			if (!ReadProcessMemory(processHandle, processParams.CommandLine.Buffer, cmdLineBuf.data(), processParams.CommandLine.Length, nullptr))
+			if (!ReadProcessMemory(processHandle.get(), processParams.CommandLine.Buffer,
+				cmdLineBuf.data(), processParams.CommandLine.Length, nullptr))
 				throw exception("Could not read command line from process memory");
 			wstring cmdLine(cmdLineBuf.data(), cmdLineBuf.size());
 
@@ -482,7 +489,7 @@ void VoicemeeterAPOInfo::ensureVoicemeeterClientRunning()
 				matchingProcessExists = true;
 		}
 
-		loop = Process32NextW(snapshotHandle, &entry) != 0;
+		loop = Process32NextW(snapshotHandle.get(), &entry) != 0;
 	}
 
 	if (!matchingProcessExists && !args.empty())
@@ -506,20 +513,19 @@ void VoicemeeterAPOInfo::saveVoicemeeterSampleRate(unsigned sampleRate)
 
 void VoicemeeterAPOInfo::closeProcess(unsigned long processId)
 {
-	HANDLE snapshotHandle = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
-	if (snapshotHandle == INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle snapshotHandle(CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0));
+	if (!snapshotHandle)
 		throw exception("Could not take a snapshot of all processes");
-	SCOPE_EXIT{CloseHandle(snapshotHandle); };
 
 	THREADENTRY32 entry;
 	entry.dwSize = sizeof(THREADENTRY32);
-	bool loop = Thread32First(snapshotHandle, &entry) != 0;
+	bool loop = Thread32First(snapshotHandle.get(), &entry) != 0;
 	while (loop)
 	{
 		if (entry.th32OwnerProcessID == processId)
 			// will just fail for threads not having a message queue
 			PostThreadMessageW(entry.th32ThreadID, WM_QUIT, 0, 0);
 
-		loop = Thread32Next(snapshotHandle, &entry) != 0;
+		loop = Thread32Next(snapshotHandle.get(), &entry) != 0;
 	}
 }

--- a/VoicemeeterClient/VoicemeeterClient.cpp
+++ b/VoicemeeterClient/VoicemeeterClient.cpp
@@ -53,10 +53,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	if (lpCmdLine[0] != 0)
 	{
 		int argc;
-		wchar_t** argv = CommandLineToArgvW(lpCmdLine, &argc);
+		winutil::UniqueLocalPtr<wchar_t*> argv(CommandLineToArgvW(lpCmdLine, &argc));
+		if (!argv)
+			return -1;
 		for (int i = 0; i < argc; i++)
-			outputs.push_back(argv[i]);
-		LocalFree(argv);
+			outputs.push_back(argv.get()[i]);
 	}
 
 	try
@@ -89,14 +90,13 @@ VoicemeeterClient::VoicemeeterClient(const vector<wstring>& outputs)
 	else
 		throw InitError(L"Voicemeeter is not installed");
 
-	HMODULE module = nullptr;
-	module = LoadLibraryW((voicemeeterDirectory + L"\\" voicemeeterRemoteFileName).c_str());
-	if (module == nullptr)
+	module.reset(LoadLibraryW((voicemeeterDirectory + L"\\" voicemeeterRemoteFileName).c_str()));
+	if (!module)
 		throw InitError(L"Failed to load " voicemeeterRemoteFileName);
 
 	vmr = {};
 
-#define LOAD_PROC(proc) vmr.proc = (T_ ## proc)GetProcAddress(module, # proc);if (vmr.proc == nullptr) throw InitError(L"Did not find function \"" # proc L"\" in " voicemeeterRemoteFileName)
+#define LOAD_PROC(proc) vmr.proc = (T_ ## proc)GetProcAddress(module.get(), # proc);if (vmr.proc == nullptr) throw InitError(L"Did not find function \"" # proc L"\" in " voicemeeterRemoteFileName)
 	LOAD_PROC(VBVMR_Login);
 	LOAD_PROC(VBVMR_Logout);
 	LOAD_PROC(VBVMR_GetVoicemeeterType);
@@ -106,7 +106,15 @@ VoicemeeterClient::VoicemeeterClient(const vector<wstring>& outputs)
 	LOAD_PROC(VBVMR_AudioCallbackStop);
 	LOAD_PROC(VBVMR_AudioCallbackUnregister);
 
-	initSoftware();
+	try
+	{
+		initSoftware();
+	}
+	catch (...)
+	{
+		endSoftware();
+		throw;
+	}
 }
 
 VoicemeeterClient::~VoicemeeterClient()
@@ -161,7 +169,7 @@ void VoicemeeterClient::handle(long nCommand, void* lpData, long nnn)
 		VBVMR_LPT_AUDIOINFO audioInfo = (VBVMR_LPT_AUDIOINFO)lpData;
 		sampleRate = static_cast<float>(audioInfo->samplerate);
 		maxFrameCount = audioInfo->nbSamplePerFrame;
-		for (FilterEngine* engine : engines)
+		for (const auto& engine : engines)
 			if (engine != nullptr)
 				engine->initialize(sampleRate, 8, 8, 8, 0, maxFrameCount);
 		VoicemeeterAPOInfo::saveVoicemeeterSampleRate((unsigned)audioInfo->samplerate);
@@ -183,7 +191,7 @@ void VoicemeeterClient::handle(long nCommand, void* lpData, long nnn)
 		{
 			FilterEngine* engine = nullptr;
 			if (i < engines.size())
-				engine = engines[i];
+				engine = engines[i].get();
 
 			bool idle = true;
 			bool inputSilent = true;
@@ -220,6 +228,7 @@ void VoicemeeterClient::initSoftware()
 	long rep = vmr.VBVMR_Login();
 	if (rep < 0)
 		throw InitError(L"Failed To Login");
+	loggedIn = true;
 	if (vmr.VBVMR_IsParametersDirty() == 0)
 		detectVoicemeeterType();
 	else
@@ -251,6 +260,10 @@ void VoicemeeterClient::initSoftware()
 				throw InitError(L"Failed to register audio callback");
 			}
 		}
+		else
+		{
+			callbackRegistered = true;
+		}
 	}
 }
 
@@ -273,9 +286,6 @@ void VoicemeeterClient::detectVoicemeeterType()
 		if (outputCount != engines.size())
 		{
 			idleSampleCounts.clear();
-			for (FilterEngine* engine : engines)
-				if (engine != nullptr)
-					delete engine;
 			engines.clear();
 
 			for (unsigned i = 0; i < outputCount; i++)
@@ -285,11 +295,11 @@ void VoicemeeterClient::detectVoicemeeterType()
 				wstring output = sstream.str();
 				if (find(outputs.begin(), outputs.end(), output) != outputs.end())
 				{
-					FilterEngine* engine = new FilterEngine();
+					auto engine = std::make_unique<FilterEngine>();
 					engine->setDeviceInfo(false, true, L"Voicemeeter", output, L"", L"Voicemeeter " + output);
 					if (sampleRate != 0.0f && maxFrameCount != 0)
 						engine->initialize(sampleRate, 8, 8, 8, 0, maxFrameCount);
-					engines.push_back(engine);
+					engines.push_back(std::move(engine));
 				}
 				else
 				{
@@ -304,10 +314,16 @@ void VoicemeeterClient::detectVoicemeeterType()
 
 void VoicemeeterClient::endSoftware()
 {
-	if (vmr.VBVMR_Logout != nullptr)
-		vmr.VBVMR_Logout();
-	if (vmr.VBVMR_AudioCallbackUnregister != nullptr)
+	if (callbackRegistered && vmr.VBVMR_AudioCallbackUnregister != nullptr)
+	{
 		vmr.VBVMR_AudioCallbackUnregister();
+		callbackRegistered = false;
+	}
+	if (loggedIn && vmr.VBVMR_Logout != nullptr)
+	{
+		vmr.VBVMR_Logout();
+		loggedIn = false;
+	}
 }
 
 void VoicemeeterClient::handleCommand(WPARAM wparam, LPARAM lparam)

--- a/VoicemeeterClient/VoicemeeterClient.h
+++ b/VoicemeeterClient/VoicemeeterClient.h
@@ -19,9 +19,11 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 #include "../FilterEngine.h"
+#include "../helpers/Win32Resource.h"
 #include "VoicemeeterRemote.h"
 
 class VoicemeeterClient
@@ -41,13 +43,16 @@ private:
 
 	std::vector<std::wstring> outputs;
 	unsigned long mainThreadId;
+	winutil::UniqueModule module;
 	T_VBVMR_INTERFACE vmr;
 	size_t wTimer = 0;
+	bool loggedIn = false;
+	bool callbackRegistered = false;
 	bool connected = true;
 	float sampleRate = 0.0f;
 	unsigned maxFrameCount = 0;
 
-	std::vector<FilterEngine*> engines;
+	std::vector<std::unique_ptr<FilterEngine>> engines;
 	std::vector<int> idleSampleCounts;
 };
 

--- a/devices/DeviceAPOInfo.Uninstall.cpp
+++ b/devices/DeviceAPOInfo.Uninstall.cpp
@@ -9,6 +9,7 @@
 #include "VoicemeeterAPOInfo.h"
 
 #include "helpers/StringHelper.h"
+#include "helpers/ComPtr.h"
 #include "helpers/RegistryHelper.h"
 
 using std::make_shared;
@@ -219,20 +220,25 @@ wstring DeviceAPOInfo::getPostMixChildGuid()
 
 void DeviceAPOInfo::testAPOInstallation()
 {
-	IMMDeviceEnumerator* enumerator = nullptr;
-	IMMDevice* device = nullptr;
-	IAudioClient* audioClient = nullptr;
-	WAVEFORMATEX* format = nullptr;
+	winutil::ComPtr<IMMDeviceEnumerator> enumerator;
+	winutil::ComPtr<IMMDevice> device;
+	winutil::ComPtr<IAudioClient> audioClient;
+	winutil::CoTaskMem<WAVEFORMATEX> format;
 
-	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&enumerator);
+	HRESULT hr = CoCreateInstance(
+		__uuidof(MMDeviceEnumerator),
+		nullptr,
+		CLSCTX_ALL,
+		__uuidof(IMMDeviceEnumerator),
+		reinterpret_cast<void**>(enumerator.put()));
 	if (FAILED(hr))
 		fail(L"CoCreateInstance for IMMDeviceEnumerator", hr);
-	SCOPE_EXIT{enumerator->Release(); };
 
-	hr = enumerator->GetDevice(((input ? L"{0.0.1.00000000}." : L"{0.0.0.00000000}.") + deviceGuid).c_str(), &device);
+	hr = enumerator->GetDevice(
+		((input ? L"{0.0.1.00000000}." : L"{0.0.0.00000000}.") + deviceGuid).c_str(),
+		device.put());
 	if (FAILED(hr))
 		fail(L"GetDevice", hr);
-	SCOPE_EXIT{device->Release(); };
 
 	DWORD state;
 	hr = device->GetState(&state);
@@ -241,17 +247,19 @@ void DeviceAPOInfo::testAPOInstallation()
 	if (state & DEVICE_STATE_DISABLED || state & DEVICE_STATE_UNPLUGGED)
 		return;
 
-	hr = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr, (void**)&audioClient);
+	hr = device->Activate(
+		__uuidof(IAudioClient),
+		CLSCTX_ALL,
+		nullptr,
+		reinterpret_cast<void**>(audioClient.put()));
 	if (FAILED(hr))
 		fail(L"Activate", hr);
-	SCOPE_EXIT{audioClient->Release(); };
 
-	hr = audioClient->GetMixFormat(&format);
+	hr = audioClient->GetMixFormat(format.put());
 	if (FAILED(hr))
 		fail(L"GetMixFormat", hr);
-	SCOPE_EXIT{CoTaskMemFree(format); };
 
-	hr = audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 1000000 /*100 ms*/, 0, format, nullptr);
+	hr = audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED, 0, 1000000 /*100 ms*/, 0, format.get(), nullptr);
 	if (FAILED(hr))
 	{
 		// Field machines (PC-bang demo, issue #75) showed endpoints that
@@ -262,14 +270,17 @@ void DeviceAPOInfo::testAPOInstallation()
 		// accepted format is good enough. Retry once with engine-side
 		// auto-conversion; a failed Initialize leaves the client unusable,
 		// so a fresh one must be activated for the retry.
-		IAudioClient* retryClient = nullptr;
-		HRESULT retryHr = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr, (void**)&retryClient);
+		winutil::ComPtr<IAudioClient> retryClient;
+		HRESULT retryHr = device->Activate(
+			__uuidof(IAudioClient),
+			CLSCTX_ALL,
+			nullptr,
+			reinterpret_cast<void**>(retryClient.put()));
 		if (SUCCEEDED(retryHr))
 		{
-			SCOPE_EXIT{retryClient->Release(); };
 			retryHr = retryClient->Initialize(AUDCLNT_SHAREMODE_SHARED,
 				AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
-				1000000 /*100 ms*/, 0, format, nullptr);
+				1000000 /*100 ms*/, 0, format.get(), nullptr);
 		}
 		if (FAILED(retryHr))
 			fail(L"Initialize", hr); // report the original failure

--- a/engine/FilterEngine.Runtime.cpp
+++ b/engine/FilterEngine.Runtime.cpp
@@ -186,13 +186,13 @@ void FilterEngine::finishTransitionIfReady()
 void FilterEngine::notificationThread(FilterEngine* engine)
 {
 
-	HANDLE notificationHandle = FindFirstChangeNotificationW(engine->configPath.c_str(), true, FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE);
-	if (notificationHandle == INVALID_HANDLE_VALUE)
-		notificationHandle = nullptr;
+	winutil::UniqueChangeNotification notification(
+		FindFirstChangeNotificationW(engine->configPath.c_str(), true,
+			FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE));
 
 	Win32Event registryEvent(true, false);
 
-	HANDLE handles[3] = {engine->shutdownEvent->get(), notificationHandle, registryEvent.get()};
+	HANDLE handles[3] = {engine->shutdownEvent->get(), notification.get(), registryEvent.get()};
 	while (true)
 	{
 		// watchRegistryKeys is cleared and refilled under loadMutex whenever a
@@ -205,14 +205,14 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 			watchedKeys.assign(engine->watchRegistryKeys.begin(), engine->watchRegistryKeys.end());
 		}
 
-		vector<HKEY> keyHandles;
+		vector<winutil::UniqueRegistryKey> keyHandles;
 		for (auto it = watchedKeys.begin(); it != watchedKeys.end(); it++)
 		{
 			try
 			{
-				HKEY keyHandle = RegistryHelper::openKey(*it, KEY_NOTIFY | KEY_WOW64_64KEY);
-				keyHandles.push_back(keyHandle);
-				RegNotifyChangeKeyValue(keyHandle, false, REG_NOTIFY_CHANGE_LAST_SET, registryEvent.get(), true);
+				keyHandles.push_back(RegistryHelper::openKey(*it, KEY_NOTIFY | KEY_WOW64_64KEY));
+				RegNotifyChangeKeyValue(keyHandles.back().get(), false,
+					REG_NOTIFY_CHANGE_LAST_SET, registryEvent.get(), true);
 			}
 			catch (const RegistryException& e)
 			{
@@ -221,11 +221,6 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 		}
 
 		DWORD which = Win32Event::waitAny(3, handles);
-
-		for (auto it = keyHandles.begin(); it != keyHandles.end(); it++)
-		{
-			RegCloseKey(*it);
-		}
 
 		if (which == WAIT_OBJECT_0)
 		{
@@ -236,9 +231,9 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 		{
 			if (which == WAIT_OBJECT_0 + 1)
 			{
-				FindNextChangeNotification(notificationHandle);
+				FindNextChangeNotification(notification.get());
 				// Wait for second event within 10 milliseconds to avoid loading twice
-				Win32Event::waitOne(notificationHandle, 10);
+				Win32Event::waitOne(notification.get(), 10);
 			}
 
 			if (!engine->acquireLoadPermit())
@@ -254,10 +249,9 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 			// directly; both cases must return the permit here.
 			if (!loaded || !engine->nextConfigReady.load(std::memory_order_acquire))
 				engine->releaseLoadPermit();
-			FindNextChangeNotification(notificationHandle);
+			FindNextChangeNotification(notification.get());
 			registryEvent.reset();
 		}
 	}
 
-	FindCloseChangeNotification(notificationHandle);
 }

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -145,7 +145,7 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 		filename.c_str(), ir->channels, ir->frames);
 
 	fftw_make_planner_thread_safe();
-	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	auto allocated = MemoryHelper::allocateArray<HConvSingle>(channelCount);
 	if (allocated == nullptr)
 	{
 		// alloc returns nullptr on failure; bail to the inert state (filters stays
@@ -154,7 +154,7 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 		return;
 	}
 	HConvSingleArray pendingFilters;
-	pendingFilters.adoptUninitialized(allocated, channelCount);
+	pendingFilters.adoptUninitialized(std::move(allocated), channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		// hcInitSingle reads the IR samples during planning but does not retain

--- a/filters/CopyFilter.cpp
+++ b/filters/CopyFilter.cpp
@@ -37,14 +37,8 @@ using std::wstringstream;
 using std::wstring;
 
 CopyFilter::CopyFilter(const vector<Assignment>& assignments)
+	: assignments(assignments)
 {
-	this->assignments = assignments;
-
-}
-
-CopyFilter::~CopyFilter()
-{
-	cleanup();
 }
 
 vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount, vector<wstring> channelNames)
@@ -53,39 +47,38 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 	preparedAssignments.reserve(assignments.size());
 	vector<wstring> outChannelNames;
 
-	for (Assignment& a : assignments)
+	for (const Assignment& a : assignments)
 	{
-		InternalAssignment ia;
-
 		wstring channelName = a.targetChannel;
 		int channelIndex = ChannelHelper::getChannelIndex(a.targetChannel, channelNames, true);
 		if (channelIndex != -1)
 			channelName = channelNames[channelIndex];
 		vector<wstring>::const_iterator it = find(outChannelNames.begin(), outChannelNames.end(), channelName);
-		ia.targetChannel = static_cast<int>(it - outChannelNames.begin());
+		const int targetChannel = static_cast<int>(it - outChannelNames.begin());
 		if (it == outChannelNames.end())
 			outChannelNames.push_back(channelName);
 
-		ia.sourceSum.reserve(a.sourceSum.size());
+		vector<InternalSummand> sourceSum;
+		sourceSum.reserve(a.sourceSum.size());
 
-		for (Assignment::Summand& s : a.sourceSum)
+		for (const Assignment::Summand& s : a.sourceSum)
 		{
-			InternalAssignment::InternalSummand is;
-
+			int sourceChannel;
 			if (s.channel != L"")
-				is.channel = ChannelHelper::getChannelIndex(s.channel, channelNames);
+				sourceChannel = ChannelHelper::getChannelIndex(s.channel, channelNames);
 			else
-				is.channel = -1;
+				sourceChannel = -1;
 
+			double factor;
 			if (s.isDecibel)
-				is.factor = pow(10.0, s.factor / 20.0);
+				factor = pow(10.0, s.factor / 20.0);
 			else
-				is.factor = s.factor;
+				factor = s.factor;
 
-			ia.sourceSum.push_back(is);
+			sourceSum.emplace_back(sourceChannel, factor);
 		}
 
-		preparedAssignments.push_back(std::move(ia));
+		preparedAssignments.emplace_back(targetChannel, std::move(sourceSum));
 	}
 
 	wstringstream stream;
@@ -98,7 +91,7 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 		stream << L"to channel " << outChannelNames[ia.targetChannel].c_str() << " ";
 		for (size_t j = 0; j < ia.sourceSum.size(); j++)
 		{
-			const InternalAssignment::InternalSummand& is = ia.sourceSum[j];
+			const InternalSummand& is = ia.sourceSum[j];
 			if (j > 0)
 				stream << ", ";
 			if (is.channel != -1)
@@ -117,13 +110,13 @@ vector<wstring> CopyFilter::initialize(float sampleRate, unsigned maxFrameCount,
 void CopyFilter::process(double** output, double** input, unsigned frameCount)
 {
 	PerfScope _ps("CopyFilter::process");
-	for (InternalAssignment& ia : internalAssignments)
+	for (const InternalAssignment& ia : internalAssignments)
 	{
 		if (ia.targetChannel == -1 || ia.sourceSum.empty())
 			continue;
 
 		{
-			InternalAssignment::InternalSummand& is = ia.sourceSum[0];
+			const InternalSummand& is = ia.sourceSum[0];
 
 			if (is.channel == -1)
 				for (unsigned f = 0; f < frameCount; f++)
@@ -137,7 +130,7 @@ void CopyFilter::process(double** output, double** input, unsigned frameCount)
 
 		for (size_t j = 1; j < ia.sourceSum.size(); j++)
 		{
-			const InternalAssignment::InternalSummand& is = ia.sourceSum[j];
+			const InternalSummand& is = ia.sourceSum[j];
 
 			if (is.channel == -1)
 				for (unsigned f = 0; f < frameCount; f++)
@@ -152,11 +145,6 @@ void CopyFilter::process(double** output, double** input, unsigned frameCount)
 	}
 }
 #pragma AVRT_CODE_END
-
-void CopyFilter::cleanup()
-{
-	internalAssignments.clear();
-}
 
 const std::vector<Assignment>& CopyFilter::getAssignments() const
 {

--- a/filters/CopyFilter.h
+++ b/filters/CopyFilter.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "IFilter.h"
@@ -68,7 +69,7 @@ class CopyFilter : public IFilter
 {
 public:
 	CopyFilter(const std::vector<Assignment>& assignments);
-	virtual ~CopyFilter();
+	~CopyFilter() override = default;
 	bool getAllChannels() override {return true;}
 	bool getInPlace() override {return false;}
 	bool producesTailFromSilentInput() const override {return false;}
@@ -78,21 +79,28 @@ public:
 	const std::vector<Assignment>& getAssignments() const;
 
 private:
-	void cleanup();
-
 	std::vector<Assignment> assignments;
+
+	struct InternalSummand
+	{
+		int channel;
+		double factor;
+
+		InternalSummand(int channel, double factor) noexcept
+			: channel(channel), factor(factor)
+		{
+		}
+	};
 
 	struct InternalAssignment
 	{
-		int targetChannel = 0;
-
-		struct InternalSummand
-		{
-			double factor = 0.0;
-			int channel = 0;
-		};
-
+		int targetChannel;
 		std::vector<InternalSummand> sourceSum;
+
+		InternalAssignment(int targetChannel, std::vector<InternalSummand> sourceSum)
+			: targetChannel(targetChannel), sourceSum(std::move(sourceSum))
+		{
+		}
 	};
 
 	std::vector<InternalAssignment> internalAssignments;

--- a/filters/DelayFilter.cpp
+++ b/filters/DelayFilter.cpp
@@ -31,12 +31,6 @@ using std::wstring;
 DelayFilter::DelayFilter(double delay, bool isMs)
 	: delay(delay), isMs(isMs)
 {
-	buffers = nullptr;
-}
-
-DelayFilter::~DelayFilter()
-{
-	cleanup();
 }
 
 // Upper bound on the per-channel delay ring buffer. A config Delay value is
@@ -49,7 +43,7 @@ static const double kMaxDelaySamples = 32.0 * 1024.0 * 1024.0;
 
 vector<wstring> DelayFilter::initialize(float sampleRate, unsigned maxFrameCount, vector<wstring> channelNames)
 {
-	cleanup();
+	buffers.clear();
 
 	channelCount = (unsigned)channelNames.size();
 
@@ -64,33 +58,21 @@ vector<wstring> DelayFilter::initialize(float sampleRate, unsigned maxFrameCount
 	}
 	bufferLength = static_cast<unsigned>(samples);
 
-	// MemoryHelper::alloc returns nullptr on failure. Check every result: an
-	// out-of-memory request is reachable from a config Delay value and must not
-	// crash. On failure leave buffers == nullptr; process() then passes audio
-	// through undelayed instead of touching a null ring buffer.
-	buffers = (double**)MemoryHelper::alloc(sizeof(double*) * channelCount);
-	if (buffers == nullptr)
-	{
-		LogFStatic(L"Delay pointer-array allocation failed (%u channels); passing audio through", channelCount);
-		bufferOffset = 0;
-		return channelNames;
-	}
-
+	std::vector<MemoryHelper::UniqueAllocation<double>> preparedBuffers;
+	preparedBuffers.reserve(channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
-		buffers[i] = static_cast<double*>(MemoryHelper::alloc(sizeof *buffers[i] * bufferLength));
-		if (buffers[i] == nullptr)
+		auto buffer = MemoryHelper::allocateArray<double>(bufferLength);
+		if (!buffer)
 		{
 			LogFStatic(L"Delay buffer allocation failed (%u samples); passing audio through", bufferLength);
-			for (unsigned j = 0; j < i; j++)
-				MemoryHelper::free(buffers[j]);
-			MemoryHelper::free(buffers);
-			buffers = nullptr;
 			bufferOffset = 0;
 			return channelNames;
 		}
-		std::fill_n(buffers[i], bufferLength, 0.0);
+		std::fill_n(buffer.get(), bufferLength, 0.0);
+		preparedBuffers.push_back(std::move(buffer));
 	}
+	buffers = std::move(preparedBuffers);
 
 	bufferOffset = 0;
 
@@ -101,7 +83,7 @@ vector<wstring> DelayFilter::initialize(float sampleRate, unsigned maxFrameCount
 void DelayFilter::process(double** output, double** input, unsigned frameCount)
 {
 	PerfScope _ps("DelayFilter::process");
-	if (buffers == nullptr)
+	if (buffers.empty())
 	{
 		// Allocation failed at initialize(): pass audio through undelayed rather
 		// than dereferencing a null ring buffer.
@@ -114,7 +96,7 @@ void DelayFilter::process(double** output, double** input, unsigned frameCount)
 	{
 		double* inputChannel = input[i];
 		double* outputChannel = output[i];
-		double* bufferChannel = buffers[i];
+		double* bufferChannel = buffers[i].get();
 
 		if (bufferLength <= frameCount)
 		{
@@ -146,18 +128,6 @@ void DelayFilter::process(double** output, double** input, unsigned frameCount)
 		bufferOffset = (bufferOffset + frameCount) % bufferLength;
 }
 #pragma AVRT_CODE_END
-
-void DelayFilter::cleanup()
-{
-	if (buffers != nullptr)
-	{
-		for (unsigned i = 0; i < channelCount; i++)
-			MemoryHelper::free(buffers[i]);
-
-		MemoryHelper::free(buffers);
-		buffers = nullptr;
-	}
-}
 
 bool DelayFilter::getIsMs() const
 {

--- a/filters/DelayFilter.h
+++ b/filters/DelayFilter.h
@@ -19,14 +19,17 @@
 
 #pragma once
 
+#include <vector>
+
 #include "IFilter.h"
+#include "helpers/MemoryHelper.h"
 
 #pragma AVRT_VTABLES_BEGIN
 class DelayFilter : public IFilter
 {
 public:
 	DelayFilter(double delay, bool isMs);
-	virtual ~DelayFilter();
+	~DelayFilter() override = default;
 	bool getInPlace() override {return false;}
 	std::vector<std::wstring> initialize(float sampleRate, unsigned maxFrameCount, std::vector<std::wstring> channelNames) override;
 	void process(double** output, double** input, unsigned frameCount) override;
@@ -35,13 +38,11 @@ public:
 	bool getIsMs() const;
 
 private:
-	void cleanup();
-
 	double delay;
 	bool isMs;
 	unsigned bufferLength = 0;
 	unsigned channelCount = 0;
-	double** buffers;
+	std::vector<MemoryHelper::UniqueAllocation<double>> buffers;
 	unsigned bufferOffset = 0;
 };
 #pragma AVRT_VTABLES_END

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -32,6 +32,7 @@
 #include <sndfile.h>
 
 #include "helpers/LogHelper.h"
+#include "helpers/FftwRAII.h"
 #include "helpers/MemoryHelper.h"
 #include "GraphicEQFilter.h"
 
@@ -80,26 +81,6 @@ namespace
 		}
 	};
 
-	struct FftwComplexDeleter
-	{
-		void operator()(fftw_complex* value) const noexcept
-		{
-			fftw_free(value);
-		}
-	};
-
-	struct FftwPlanDeleter
-	{
-		void operator()(fftw_plan_s* value) const noexcept
-		{
-			if (value != nullptr)
-				fftw_destroy_plan(value);
-		}
-	};
-
-	using FftwComplexPtr = std::unique_ptr<fftw_complex, FftwComplexDeleter>;
-	using FftwPlanPtr = std::unique_ptr<fftw_plan_s, FftwPlanDeleter>;
-
 	std::mutex& eqIrCacheMutex()
 	{
 		static std::mutex m;
@@ -143,14 +124,10 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 		const size_t fftLength = static_cast<size_t>(filterLength) * 2;
 
 		fftw_make_planner_thread_safe();
-		FftwComplexPtr timeData(fftw_alloc_complex(fftLength));
-		FftwComplexPtr freqData(fftw_alloc_complex(fftLength));
-		if (!timeData || !freqData)
-			throw std::bad_alloc();
-		FftwPlanPtr planForward(fftw_plan_dft_1d(static_cast<int>(fftLength), timeData.get(), freqData.get(), FFTW_FORWARD, FFTW_ESTIMATE));
-		FftwPlanPtr planReverse(fftw_plan_dft_1d(static_cast<int>(fftLength), freqData.get(), timeData.get(), FFTW_BACKWARD, FFTW_ESTIMATE));
-		if (!planForward || !planReverse)
-			throw std::runtime_error("Could not create GraphicEQ FFTW plans");
+		auto timeData = fftw::allocateComplex(fftLength);
+		auto freqData = fftw::allocateComplex(fftLength);
+		auto planForward = fftw::makeComplexPlan(static_cast<int>(fftLength), timeData.get(), freqData.get(), FFTW_FORWARD);
+		auto planReverse = fftw::makeComplexPlan(static_cast<int>(fftLength), freqData.get(), timeData.get(), FFTW_BACKWARD);
 
 		GainIterator gainIterator(nodes);
 		for (unsigned i = 0; i < filterLength; i++)
@@ -201,7 +178,7 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 	synthesizedIr = cached;
 
 	fftw_make_planner_thread_safe();
-	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * channelCount);
+	auto allocated = MemoryHelper::allocateArray<HConvSingle>(channelCount);
 	if (allocated == nullptr)
 	{
 		// alloc returns nullptr on failure; stay inert (filters is null from
@@ -210,7 +187,7 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 		return;
 	}
 	HConvSingleArray pendingFilters;
-	pendingFilters.adoptUninitialized(allocated, channelCount);
+	pendingFilters.adoptUninitialized(std::move(allocated), channelCount);
 	for (unsigned i = 0; i < channelCount; i++)
 	{
 		hcInitSingle(&pendingFilters[i], const_cast<double*>(cached->data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);

--- a/filters/IrCache.cpp
+++ b/filters/IrCache.cpp
@@ -26,11 +26,9 @@
 #include <unordered_map>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
-#include <sndfile.h>
-
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/SndfileRAII.h"
 #include "IrCache.h"
 
 using std::abs;
@@ -38,7 +36,6 @@ using std::abs;
 namespace
 {
 	constexpr unsigned kMaxIrChannels = 1024;
-	using SndFilePtr = std::unique_ptr<SNDFILE, decltype(&sf_close)>;
 
 	// Cache of decoded impulse-response PCM, keyed by path + mtime + sample rate.
 	// Lets a config reload (or a second filter using the same IR) skip the
@@ -121,7 +118,7 @@ std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, d
 		LogFStatic(L"Error while reading impulse response file: %S", sf_strerror(opened));
 		return nullptr;
 	}
-	SndFilePtr in(opened, &sf_close);
+	sndfile::Handle in(opened);
 	if (abs(sampleRate - info.samplerate) > 1.0)
 	{
 		LogFStatic(L"Impulse response sample rate (%d Hz) does not match device sample rate (%f Hz)", info.samplerate, sampleRate);
@@ -201,10 +198,9 @@ void HConvSingleArray::reset()
 	if (ptr != nullptr)
 	{
 		for (unsigned i = 0; i < initializedCount; i++)
-			hcCloseSingle(&ptr[i]);
+			hcCloseSingle(&ptr.get()[i]);
 
-		MemoryHelper::free(ptr);
-		ptr = nullptr;
+		ptr.reset();
 	}
 	capacity = 0;
 	initializedCount = 0;

--- a/filters/IrCache.h
+++ b/filters/IrCache.h
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "helpers/MemoryHelper.h"
 #include "libHybridConv-0.1.1/libHybridConv_eapo.h"
 
 // Decoded impulse-response PCM, shared between filters that reference the same
@@ -64,9 +65,8 @@ public:
 	HConvSingleArray(const HConvSingleArray&) = delete;
 	HConvSingleArray& operator=(const HConvSingleArray&) = delete;
 	HConvSingleArray(HConvSingleArray&& other) noexcept
-		: ptr(other.ptr), capacity(other.capacity), initializedCount(other.initializedCount)
+		: ptr(std::move(other.ptr)), capacity(other.capacity), initializedCount(other.initializedCount)
 	{
-		other.ptr = nullptr;
 		other.capacity = 0;
 		other.initializedCount = 0;
 	}
@@ -75,10 +75,9 @@ public:
 		if (this != &other)
 		{
 			reset();
-			ptr = other.ptr;
+			ptr = std::move(other.ptr);
 			capacity = other.capacity;
 			initializedCount = other.initializedCount;
-			other.ptr = nullptr;
 			other.capacity = 0;
 			other.initializedCount = 0;
 		}
@@ -88,24 +87,14 @@ public:
 	// Take ownership of a freshly allocated block holding `newCount` elements.
 	// Any previously held block is torn down first using the same
 	// close-then-free sequence.
-	void adopt(HConvSingle* newPtr, unsigned newCount)
-	{
-		if (newPtr != ptr)
-			reset();
-		ptr = newPtr;
-		capacity = newCount;
-		initializedCount = newCount;
-	}
-
 	// Take ownership before initialization starts, then register each element
 	// only after hcInitSingle has committed it. If a later initialization
 	// throws, reset() closes the completed prefix and never reads untouched
 	// allocation bytes.
-	void adoptUninitialized(HConvSingle* newPtr, unsigned newCapacity)
+	void adoptUninitialized(MemoryHelper::UniqueAllocation<HConvSingle> newPtr, unsigned newCapacity)
 	{
-		if (newPtr != ptr)
-			reset();
-		ptr = newPtr;
+		reset();
+		ptr = std::move(newPtr);
 		capacity = newCapacity;
 		initializedCount = 0;
 	}
@@ -122,16 +111,16 @@ public:
 		return *this;
 	}
 
-	HConvSingle& operator[](unsigned i) const { return ptr[i]; }
+	HConvSingle& operator[](unsigned i) const { return ptr.get()[i]; }
 	// Implicit decay to the raw pointer lets call sites keep raw-pointer idioms
 	// (filters[i], &filters[i], filters == nullptr, hcInitSingle(&filters[i], ...)).
-	operator HConvSingle*() const { return ptr; }
+	operator HConvSingle*() const { return ptr.get(); }
 
 	// Close the successfully initialized prefix, then free the whole block.
 	void reset();
 
 private:
-	HConvSingle* ptr = nullptr;
+	MemoryHelper::UniqueAllocation<HConvSingle> ptr;
 	unsigned capacity = 0;
 	unsigned initializedCount = 0;
 };

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -126,14 +126,14 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		return outChannelNames;
 
 	fftw_make_planner_thread_safe();
-	HConvSingle* allocated = (HConvSingle*)MemoryHelper::alloc(sizeof(HConvSingle) * totalUnits);
+	auto allocated = MemoryHelper::allocateArray<HConvSingle>(totalUnits);
 	if (allocated == nullptr)
 	{
 		LogF(L"MultiConvolutionFilter: could not allocate %u convolution units", totalUnits);
 		return outChannelNames;
 	}
 	HConvSingleArray pendingFilters;
-	pendingFilters.adoptUninitialized(allocated, totalUnits);
+	pendingFilters.adoptUninitialized(std::move(allocated), totalUnits);
 
 	tempBuffer.assign(maxFrameCount, 0.0);
 	unitFactors.assign(totalUnits, 1.0);

--- a/filters/VSTPluginFilter.cpp
+++ b/filters/VSTPluginFilter.cpp
@@ -57,25 +57,31 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	channelCount = channelNames.size();
 	if (channelCount == 0)
 		return channelNames;
+	if (channelCount > (std::numeric_limits<unsigned>::max)())
+	{
+		LogF(L"The VST plugin %s was assigned too many host channels; passing audio through.", libPath.c_str());
+		skipProcessing = true;
+		return channelNames;
+	}
 
 	skipProcessing = false;
 
-	// MemoryHelper::alloc returns nullptr on failure (and logs the size). Every
-	// result below is checked: on failure the filter degrades to skipProcessing
-	// (process() passes audio through) with the already-built state left
-	// consistent for cleanup().
-	void* mem = MemoryHelper::alloc(sizeof(VSTPluginInstance));
-	if (mem == nullptr)
+	MemoryHelper::UniqueObject<VSTPluginInstance> firstEffect;
+	try
+	{
+		firstEffect = MemoryHelper::constructUnique<VSTPluginInstance>(library, 2);
+	}
+	catch (const std::bad_alloc&)
 	{
 		LogF(L"The VST plugin %s could not allocate its host instance; passing audio through.", libPath.c_str());
 		skipProcessing = true;
 		return channelNames;
 	}
-	VSTPluginInstance* firstEffect = new(mem) VSTPluginInstance(library, 2);
 	if (!firstEffect->initialize())
 	{
 		LogF(L"The VST plugin %s crashed during initialization.", libPath.c_str());
 		skipProcessing = true;
+		return channelNames;
 	}
 
 	// Metadata is plugin-controlled. Snapshot it once, validate the signed
@@ -92,8 +98,6 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	{
 		LogF(L"The VST plugin %s reported invalid channel or latency metadata; passing audio through.", libPath.c_str());
 		skipProcessing = true;
-		firstEffect->~VSTPluginInstance();
-		MemoryHelper::free(firstEffect);
 		return channelNames;
 	}
 
@@ -103,126 +107,81 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	if (effectChannelCount == 0)
 	{
 		skipProcessing = true;
-		firstEffect->~VSTPluginInstance();
-		MemoryHelper::free(firstEffect);
 		return channelNames;
 	}
 
 	// round up
-	effectCount = channelCount / effectChannelCount + (channelCount % effectChannelCount != 0 ? 1 : 0);
-	size_t allocationBytes = 0;
-	if (!checkedMultiply(effectCount, sizeof(VSTPluginInstance*), allocationBytes))
+	const size_t requiredEffectCount = channelCount / effectChannelCount + (channelCount % effectChannelCount != 0 ? 1 : 0);
+	size_t paddedChannelCount = 0;
+	if (!checkedMultiply(requiredEffectCount, effectChannelCount, paddedChannelCount))
 	{
-		LogF(L"The VST plugin %s reported metadata that overflows its instance table; passing audio through.", libPath.c_str());
+		LogF(L"The VST plugin %s reported metadata that overflows its padded channel count; passing audio through.", libPath.c_str());
 		skipProcessing = true;
-		effectCount = 0;
-		firstEffect->~VSTPluginInstance();
-		MemoryHelper::free(firstEffect);
 		return channelNames;
 	}
-	effects = (VSTPluginInstance**)MemoryHelper::alloc(allocationBytes);
-	if (effects == nullptr)
+	effects.reserve(requiredEffectCount);
+	effects.push_back(std::move(firstEffect));
+	for (size_t i = 1; i < requiredEffectCount; i++)
 	{
-		LogF(L"The VST plugin %s could not allocate its instance table; passing audio through.", libPath.c_str());
-		skipProcessing = true;
-		effectCount = 0;
-		firstEffect->~VSTPluginInstance();
-		MemoryHelper::free(firstEffect);
-		return channelNames;
-	}
-	effects[0] = firstEffect;
-	for (unsigned i = 1; i < effectCount; i++)
-	{
-		mem = MemoryHelper::alloc(sizeof(VSTPluginInstance));
-		if (mem == nullptr)
+		try
 		{
-			LogF(L"The VST plugin %s could not allocate instance %u; passing audio through.", libPath.c_str(), i);
+			effects.push_back(MemoryHelper::constructUnique<VSTPluginInstance>(library, 2));
+		}
+		catch (const std::bad_alloc&)
+		{
+			LogF(L"The VST plugin %s could not allocate instance %Iu; passing audio through.", libPath.c_str(), i);
 			skipProcessing = true;
-			// cleanup() tears down exactly [0, effectCount); entries past i were
-			// never constructed.
-			effectCount = i;
 			return channelNames;
 		}
-		effects[i] = new(mem) VSTPluginInstance(library, 2);
-		if (!effects[i]->initialize() && !skipProcessing)
+		if (!effects[i]->initialize())
 		{
 			LogF(L"The VST plugin %s crashed during initialization.", libPath.c_str());
 			skipProcessing = true;
+			return channelNames;
+		}
+
+		const int instanceInputCount = effects[i]->numInputs();
+		const int instanceOutputCount = effects[i]->numOutputs();
+		const int instanceLatency = effects[i]->getInitialDelay();
+		if (instanceInputCount != reportedInputCount
+			|| instanceOutputCount != reportedOutputCount
+			|| instanceLatency != reportedLatency)
+		{
+			LogF(L"The VST plugin %s reported inconsistent per-instance metadata; passing audio through.", libPath.c_str());
+			skipProcessing = true;
+			return channelNames;
 		}
 	}
 
 	prepareForProcessing(sampleRate, maxFrameCount);
+	if (skipProcessing)
+		return channelNames;
 
 	// 2 times for input and output
-	size_t paddedChannelCount = 0;
-	if (!checkedMultiply(effectCount, effectChannelCount, paddedChannelCount)
-		|| paddedChannelCount < channelCount
+	if (paddedChannelCount < channelCount
 		|| paddedChannelCount - channelCount > (std::numeric_limits<size_t>::max)() / 2)
 	{
 		LogF(L"The VST plugin %s reported metadata that overflows its padding count; passing audio through.", libPath.c_str());
 		skipProcessing = true;
 		return channelNames;
 	}
-	emptyChannelCount = 2 * (paddedChannelCount - channelCount);
-	if (!checkedMultiply(emptyChannelCount, sizeof(double*), allocationBytes))
+	const size_t emptyChannelCount = 2 * (paddedChannelCount - channelCount);
+	emptyChannels.reserve(emptyChannelCount);
+	for (size_t i = 0; i < emptyChannelCount; i++)
 	{
-		LogF(L"The VST plugin %s reported metadata that overflows its padding table; passing audio through.", libPath.c_str());
-		skipProcessing = true;
-		emptyChannelCount = 0;
-		return channelNames;
-	}
-	emptyChannels = emptyChannelCount > 0
-		? (double**)MemoryHelper::alloc(allocationBytes)
-		: nullptr;
-	if (emptyChannels == nullptr && emptyChannelCount > 0)
-	{
-		LogF(L"The VST plugin %s could not allocate padding channels; passing audio through.", libPath.c_str());
-		skipProcessing = true;
-		emptyChannelCount = 0;
-		return channelNames;
-	}
-	for (unsigned i = 0; i < emptyChannelCount; i++)
-	{
-		if (!checkedMultiply(maxFrameCount, sizeof *emptyChannels[i], allocationBytes))
+		auto channel = MemoryHelper::allocateArray<double>(maxFrameCount);
+		if (!channel)
 		{
+			LogF(L"The VST plugin %s could not allocate padding channel %Iu; passing audio through.", libPath.c_str(), i);
 			skipProcessing = true;
-			emptyChannelCount = i;
 			return channelNames;
 		}
-		emptyChannels[i] = static_cast<double*>(MemoryHelper::alloc(allocationBytes));
-		if (emptyChannels[i] == nullptr)
-		{
-			LogF(L"The VST plugin %s could not allocate padding channel %u; passing audio through.", libPath.c_str(), i);
-			skipProcessing = true;
-			// Entries past i are uninitialized; shrink the count so cleanup()
-			// frees only what was built.
-			emptyChannelCount = i;
-			return channelNames;
-		}
-		std::fill_n(emptyChannels[i], maxFrameCount, 0.0);
+		std::fill_n(channel.get(), maxFrameCount, 0.0);
+		emptyChannels.push_back(std::move(channel));
 	}
 
-	if (!checkedMultiply(effectInputCount, sizeof(double*), allocationBytes))
-	{
-		LogF(L"The VST plugin %s reported an input count that overflows its bus table; passing audio through.", libPath.c_str());
-		skipProcessing = true;
-		return channelNames;
-	}
-	inputArray = effectInputCount > 0 ? (double**)MemoryHelper::alloc(allocationBytes) : nullptr;
-	if (!checkedMultiply(effectOutputCount, sizeof(double*), allocationBytes))
-	{
-		LogF(L"The VST plugin %s reported an output count that overflows its bus table; passing audio through.", libPath.c_str());
-		skipProcessing = true;
-		return channelNames;
-	}
-	outputArray = effectOutputCount > 0 ? (double**)MemoryHelper::alloc(allocationBytes) : nullptr;
-	if ((effectInputCount > 0 && inputArray == nullptr)
-		|| (effectOutputCount > 0 && outputArray == nullptr))
-	{
-		LogF(L"The VST plugin %s could not allocate its bus arrays; passing audio through.", libPath.c_str());
-		skipProcessing = true;
-		return channelNames;
-	}
+	inputArray.resize(effectInputCount);
+	outputArray.resize(effectOutputCount);
 
 	// Allocate float buffers for conversion
 	if (effectInputCount > 0) {
@@ -231,21 +190,19 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 		// cpp/integer-multiplication-cast-to-long); validate in size_t first.
 		const size_t inputCount = effectInputCount;
 		const size_t maxSize = (std::numeric_limits<size_t>::max)();
-		if (inputCount > maxSize / sizeof(float*) ||
-			(maxFrameCount != 0 &&
-				inputCount > maxSize / maxFrameCount / sizeof *_floatInputBuffer))
+		if (maxFrameCount != 0 && inputCount > maxSize / maxFrameCount)
 			throw std::bad_alloc();
 
-		floatInputs = (float**)MemoryHelper::alloc(inputCount * sizeof(float*));
-		_floatInputBuffer = static_cast<float*>(MemoryHelper::alloc(inputCount * maxFrameCount * sizeof *_floatInputBuffer));
-		if (floatInputs == nullptr || _floatInputBuffer == nullptr)
+		floatInputs.resize(inputCount);
+		floatInputBuffer = MemoryHelper::allocateArray<float>(inputCount * maxFrameCount);
+		if (!floatInputBuffer)
 		{
 			LogF(L"The VST plugin %s could not allocate float input buffers; passing audio through.", libPath.c_str());
 			skipProcessing = true;
 			return channelNames;
 		}
 		for (unsigned i = 0; i < effectInputCount; ++i) {
-			floatInputs[i] = _floatInputBuffer + i * maxFrameCount;
+			floatInputs[i] = floatInputBuffer.get() + i * maxFrameCount;
 		}
 	}
 
@@ -253,21 +210,19 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 		// Same wrap-before-widening hazard as the input buffers above.
 		const size_t outputCount = effectOutputCount;
 		const size_t maxSize = (std::numeric_limits<size_t>::max)();
-		if (outputCount > maxSize / sizeof(float*) ||
-			(maxFrameCount != 0 &&
-				outputCount > maxSize / maxFrameCount / sizeof *_floatOutputBuffer))
+		if (maxFrameCount != 0 && outputCount > maxSize / maxFrameCount)
 			throw std::bad_alloc();
 
-		floatOutputs = (float**)MemoryHelper::alloc(outputCount * sizeof(float*));
-		_floatOutputBuffer = static_cast<float*>(MemoryHelper::alloc(outputCount * maxFrameCount * sizeof *_floatOutputBuffer));
-		if (floatOutputs == nullptr || _floatOutputBuffer == nullptr)
+		floatOutputs.resize(outputCount);
+		floatOutputBuffer = MemoryHelper::allocateArray<float>(outputCount * maxFrameCount);
+		if (!floatOutputBuffer)
 		{
 			LogF(L"The VST plugin %s could not allocate float output buffers; passing audio through.", libPath.c_str());
 			skipProcessing = true;
 			return channelNames;
 		}
 		for (unsigned i = 0; i < effectOutputCount; ++i) {
-			floatOutputs[i] = _floatOutputBuffer + i * maxFrameCount;
+			floatOutputs[i] = floatOutputBuffer.get() + i * maxFrameCount;
 		}
 	}
 
@@ -275,57 +230,22 @@ std::vector<std::wstring> VSTPluginFilter::initialize(float sampleRate, unsigned
 	delayBufferLength = static_cast<unsigned>(reportedLatency);
 	if (delayBufferLength > 0)
 	{
-		if (!checkedMultiply(channelCount, sizeof(double*), allocationBytes))
+		delayBuffers.reserve(channelCount);
+		for (size_t i = 0; i < channelCount; i++)
 		{
-			LogF(L"The VST plugin %s reported a latency whose channel table overflows; passing audio through.", libPath.c_str());
-			skipProcessing = true;
-			delayBufferLength = 0;
-			return channelNames;
-		}
-		delayBuffers = (double**)MemoryHelper::alloc(allocationBytes);
-		if (delayBuffers == nullptr)
-		{
-			LogF(L"The VST plugin %s could not allocate delay buffers; passing audio through.", libPath.c_str());
-			skipProcessing = true;
-			delayBufferLength = 0;
-			return channelNames;
-		}
-		for (unsigned i = 0; i < channelCount; i++)
-		{
-			if (!checkedMultiply(delayBufferLength, sizeof *delayBuffers[i], allocationBytes))
+			auto buffer = MemoryHelper::allocateArray<double>(delayBufferLength);
+			if (!buffer)
 			{
-				for (unsigned j = 0; j < i; j++)
-					MemoryHelper::free(delayBuffers[j]);
-				MemoryHelper::free(delayBuffers);
-				delayBuffers = nullptr;
-				delayBufferLength = 0;
+				LogF(L"The VST plugin %s could not allocate delay buffer %Iu; passing audio through.", libPath.c_str(), i);
 				skipProcessing = true;
-				return channelNames;
-			}
-			delayBuffers[i] = static_cast<double*>(MemoryHelper::alloc(allocationBytes));
-			if (delayBuffers[i] == nullptr)
-			{
-				LogF(L"The VST plugin %s could not allocate delay buffer %u; passing audio through.", libPath.c_str(), i);
-				skipProcessing = true;
-				// cleanup() walks all channelCount entries; free what was built
-				// and drop the array so it never reads the uninitialized tail.
-				for (unsigned j = 0; j < i; j++)
-					MemoryHelper::free(delayBuffers[j]);
-				MemoryHelper::free(delayBuffers);
-				delayBuffers = nullptr;
 				delayBufferLength = 0;
 				return channelNames;
 			}
-			std::fill_n(delayBuffers[i], delayBufferLength, 0.0);
+			std::fill_n(buffer.get(), delayBufferLength, 0.0);
+			delayBuffers.push_back(std::move(buffer));
 		}
-		if (!checkedMultiply(maxFrameCount, sizeof *delayTempBuffer, allocationBytes))
-		{
-			skipProcessing = true;
-			delayBufferLength = 0;
-			return channelNames;
-		}
-		delayTempBuffer = static_cast<double*>(MemoryHelper::alloc(allocationBytes));
-		if (delayTempBuffer == nullptr)
+		delayTempBuffer = MemoryHelper::allocateArray<double>(maxFrameCount);
+		if (!delayTempBuffer)
 		{
 			LogF(L"The VST plugin %s could not allocate its delay scratch buffer; passing audio through.", libPath.c_str());
 			skipProcessing = true;
@@ -342,11 +262,11 @@ void VSTPluginFilter::prepareForProcessing(float sampleRate, unsigned maxFrameCo
 {
 	__try
 	{
-		for (unsigned i = 0; i < effectCount; i++)
+		for (size_t i = 0; i < effects.size(); i++)
 		{
-			VSTPluginInstance* effect = effects[i];
+			VSTPluginInstance* effect = effects[i].get();
 
-			if (i == effectCount - 1 && (channelCount % effectChannelCount) != 0)
+			if (i == effects.size() - 1 && (channelCount % effectChannelCount) != 0)
 				effect->setUsedChannelCount(channelCount % effectChannelCount);
 			else
 				effect->setUsedChannelCount(effectChannelCount);
@@ -381,16 +301,16 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 	{
 		unsigned channelOffset = 0;
 		unsigned emptyChannelIndex = 0;
-		for (unsigned i = 0; i < effectCount; i++)
+		for (size_t i = 0; i < effects.size(); i++)
 		{
-			VSTPluginInstance* effect = effects[i];
+			VSTPluginInstance* effect = effects[i].get();
 			// Setup double pointer arrays to point to the correct source/destination double buffers
 			for (unsigned j = 0; j < effectInputCount; j++)
 			{
 				if (channelOffset + j < channelCount)
 					inputArray[j] = input[channelOffset + j];
 				else
-					inputArray[j] = emptyChannels[emptyChannelIndex++];
+					inputArray[j] = emptyChannels[emptyChannelIndex++].get();
 			}
 
 			for (unsigned j = 0; j < effectOutputCount; j++)
@@ -398,11 +318,11 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 				if (channelOffset + j < channelCount)
 					outputArray[j] = output[channelOffset + j];
 				else
-					outputArray[j] = emptyChannels[emptyChannelIndex++];
+					outputArray[j] = emptyChannels[emptyChannelIndex++].get();
 			}
 
 			if (effect->canDoubleReplacing()) {
-				effect->processDoubleReplacing(inputArray, outputArray, frameCount);
+				effect->processDoubleReplacing(inputArray.data(), outputArray.data(), frameCount);
 			}
 			else {
 				// Convert input from double** to float** using pre-allocated buffers
@@ -413,14 +333,14 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 
 				if (effect->canReplacing())
 				{
-					effect->processReplacing(floatInputs, floatOutputs, frameCount);
+					effect->processReplacing(floatInputs.data(), floatOutputs.data(), frameCount);
 				}
 				else
 				{
 					// For non-replacing, VST expects to add to the output. Clear float buffer first.
 					for (unsigned j = 0; j < effectOutputCount; j++)
 						std::fill_n(floatOutputs[j], frameCount, 0.0f);
-					effect->process(floatInputs, floatOutputs, frameCount);
+					effect->process(floatInputs.data(), floatOutputs.data(), frameCount);
 				}
 
 				// Convert output from float** back to double** into the final destination
@@ -443,38 +363,38 @@ void VSTPluginFilter::process(double** output, double** input, unsigned frameCou
 		}
 
 		// Apply delay compensation if needed
-		if (delayBuffers != nullptr && delayBufferLength > 0)
+		if (!delayBuffers.empty() && delayBufferLength > 0)
 		{
 			for (unsigned i = 0; i < channelCount; i++)
 			{
 				double* outputChannel = output[i];
-				double* delayBuffer = delayBuffers[i];
+				double* delayBuffer = delayBuffers[i].get();
 
 				if (delayBufferLength <= frameCount)
 				{
-					std::copy_n(outputChannel + frameCount - delayBufferLength, delayBufferLength, delayTempBuffer);
+					std::copy_n(outputChannel + frameCount - delayBufferLength, delayBufferLength, delayTempBuffer.get());
 					std::copy_backward(outputChannel, outputChannel + frameCount - delayBufferLength, outputChannel + frameCount);
 					std::copy_n(delayBuffer + delayBufferOffset, delayBufferLength - delayBufferOffset, outputChannel);
 					std::copy_n(delayBuffer, delayBufferOffset, outputChannel + delayBufferLength - delayBufferOffset);
-					std::copy_n(delayTempBuffer, delayBufferLength, delayBuffer);
+					std::copy_n(delayTempBuffer.get(), delayBufferLength, delayBuffer);
 				}
 				else
 				{
-					std::copy_n(outputChannel, frameCount, delayTempBuffer);
+					std::copy_n(outputChannel, frameCount, delayTempBuffer.get());
 
 					if (delayBufferLength < delayBufferOffset + frameCount)
 					{
 						// Wrapping around the delay buffer
 						std::copy_n(delayBuffer + delayBufferOffset, delayBufferLength - delayBufferOffset, outputChannel);
 						std::copy_n(delayBuffer, frameCount - (delayBufferLength - delayBufferOffset), outputChannel + delayBufferLength - delayBufferOffset);
-						std::copy_n(delayTempBuffer, delayBufferLength - delayBufferOffset, delayBuffer + delayBufferOffset);
-						std::copy_n(delayTempBuffer + delayBufferLength - delayBufferOffset, frameCount - (delayBufferLength - delayBufferOffset), delayBuffer);
+						std::copy_n(delayTempBuffer.get(), delayBufferLength - delayBufferOffset, delayBuffer + delayBufferOffset);
+						std::copy_n(delayTempBuffer.get() + delayBufferLength - delayBufferOffset, frameCount - (delayBufferLength - delayBufferOffset), delayBuffer);
 					}
 					else
 					{
 						// Simple case - no wrapping
 						std::copy_n(delayBuffer + delayBufferOffset, frameCount, outputChannel);
-						std::copy_n(delayTempBuffer, frameCount, delayBuffer + delayBufferOffset);
+						std::copy_n(delayTempBuffer.get(), frameCount, delayBuffer + delayBufferOffset);
 					}
 				}
 			}
@@ -517,73 +437,22 @@ const std::unordered_map<std::wstring, float>& VSTPluginFilter::getParamMap() co
 
 void VSTPluginFilter::cleanup()
 {
-	if (effects != nullptr)
-	{
-		for (unsigned i = 0; i < effectCount; i++)
-		{
-			VSTPluginInstance* effect = effects[i];
-			effect->stopProcessing();
-			effect->~VSTPluginInstance();
-			MemoryHelper::free(effect);
-		}
-		MemoryHelper::free(effects);
-		effects = nullptr;
-	}
-	effectCount = 0;
+	for (const auto& effect : effects)
+		effect->stopProcessingSafely();
+	effects.clear();
 	effectInputCount = 0;
 	effectOutputCount = 0;
 	effectChannelCount = 0;
 
-	if (emptyChannels != nullptr)
-	{
-		for (unsigned i = 0; i < emptyChannelCount; i++)
-			MemoryHelper::free(emptyChannels[i]);
-		MemoryHelper::free(emptyChannels);
-		emptyChannels = nullptr;
-	}
-	emptyChannelCount = 0;
-
-	if (inputArray != nullptr)
-	{
-		MemoryHelper::free(inputArray);
-		inputArray = nullptr;
-	}
-
-	if (outputArray != nullptr)
-	{
-		MemoryHelper::free(outputArray);
-		outputArray = nullptr;
-	}
-    
-    if (floatInputs != nullptr) {
-		MemoryHelper::free(floatInputs);
-		floatInputs = nullptr;
-	}
-	if (_floatInputBuffer != nullptr) {
-		MemoryHelper::free(_floatInputBuffer);
-		_floatInputBuffer = nullptr;
-	}
-	if (floatOutputs != nullptr) {
-		MemoryHelper::free(floatOutputs);
-		floatOutputs = nullptr;
-	}
-	if (_floatOutputBuffer != nullptr) {
-		MemoryHelper::free(_floatOutputBuffer);
-		_floatOutputBuffer = nullptr;
-	}
-
-	if (delayBuffers != nullptr)
-	{
-		for (unsigned i = 0; i < channelCount; i++)
-			MemoryHelper::free(delayBuffers[i]);
-		MemoryHelper::free(delayBuffers);
-		delayBuffers = nullptr;
-	}
-	if (delayTempBuffer != nullptr)
-	{
-		MemoryHelper::free(delayTempBuffer);
-		delayTempBuffer = nullptr;
-	}
+	emptyChannels.clear();
+	inputArray.clear();
+	outputArray.clear();
+	floatInputs.clear();
+	floatInputBuffer.reset();
+	floatOutputs.clear();
+	floatOutputBuffer.reset();
+	delayBuffers.clear();
+	delayTempBuffer.reset();
 	delayBufferLength = 0;
 	delayBufferOffset = 0;
 }

--- a/filters/VSTPluginFilter.h
+++ b/filters/VSTPluginFilter.h
@@ -19,7 +19,10 @@
 
 #pragma once
 
+#include <vector>
+
 #include "IFilter.h"
+#include "helpers/MemoryHelper.h"
 #include "helpers/VSTPluginLibrary.h"
 
 #pragma AVRT_VTABLES_BEGIN
@@ -49,23 +52,21 @@ private:
 	unsigned effectInputCount = 0;
 	unsigned effectOutputCount = 0;
 	unsigned effectChannelCount = 0;
-	size_t effectCount = 0;
-	VSTPluginInstance** effects = nullptr;
-	size_t emptyChannelCount = 0;
-	double** emptyChannels = nullptr;
-	double** inputArray = nullptr;
-	double** outputArray = nullptr;
+	std::vector<MemoryHelper::UniqueObject<VSTPluginInstance>> effects;
+	std::vector<MemoryHelper::UniqueAllocation<double>> emptyChannels;
+	std::vector<double*> inputArray;
+	std::vector<double*> outputArray;
 
 	// Buffers for float conversion
-	float** floatInputs = nullptr;
-	float* _floatInputBuffer = nullptr;
-	float** floatOutputs = nullptr;
-	float* _floatOutputBuffer = nullptr;
+	std::vector<float*> floatInputs;
+	MemoryHelper::UniqueAllocation<float> floatInputBuffer;
+	std::vector<float*> floatOutputs;
+	MemoryHelper::UniqueAllocation<float> floatOutputBuffer;
 
 	// Delay compensation buffers
 	unsigned delayBufferLength = 0;
-	double** delayBuffers = nullptr;
-	double* delayTempBuffer = nullptr;
+	std::vector<MemoryHelper::UniqueAllocation<double>> delayBuffers;
+	MemoryHelper::UniqueAllocation<double> delayTempBuffer;
 	unsigned delayBufferOffset = 0;
 
 	bool skipProcessing = false;

--- a/filters/loudnessCorrection/VolumeController.cpp
+++ b/filters/loudnessCorrection/VolumeController.cpp
@@ -23,6 +23,9 @@
 
 VolumeController::VolumeController()
 {
+	if (!_comApartment.isUsable())
+		return;
+
 	winutil::ComPtr<IMMDeviceEnumerator> deviceEnumerator;
 	HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_INPROC_SERVER,
 		__uuidof(IMMDeviceEnumerator), reinterpret_cast<void**>(deviceEnumerator.put()));

--- a/helpers/AbstractLibrary.cpp
+++ b/helpers/AbstractLibrary.cpp
@@ -26,13 +26,12 @@ using std::wstring;
 
 AbstractLibrary::~AbstractLibrary()
 {
-	if (module != nullptr)
+	if (module)
 	{
 		wchar_t path[MAX_PATH];
-		GetModuleFileNameW(module, path, MAX_PATH);
+		GetModuleFileNameW(module.get(), path, MAX_PATH);
 
-		FreeLibrary(module);
-		module = nullptr;
+		module.reset();
 
 		TraceF(L"Unloaded library %s", path);
 	}
@@ -42,13 +41,13 @@ int AbstractLibrary::initialize()
 {
 	std::lock_guard<std::mutex> lock(initMutex);
 
-	if (module == nullptr)
+	if (!module)
 	{
 		wstring libPath = getLoadPath();
 		if (GetFileAttributesW(libPath.c_str()) == INVALID_FILE_ATTRIBUTES)
 			return FILE_NOT_FOUND;
-		module = LoadLibraryW(libPath.c_str());
-		if (module == nullptr)
+		module.reset(LoadLibraryW(libPath.c_str()));
+		if (!module)
 		{
 			unsigned short arch = getFileArchitecture(libPath);
 #if defined(_M_ARM64)
@@ -66,8 +65,8 @@ int AbstractLibrary::initialize()
 
 		if (!loadFunctions())
 		{
-			FreeLibrary(module);
-			module = nullptr;
+			customUninitialize();
+			module.reset();
 			return FUNCTIONS_MISSING;
 		}
 
@@ -75,8 +74,7 @@ int AbstractLibrary::initialize()
 		if (res < 0)
 		{
 			customUninitialize();
-			FreeLibrary(module);
-			module = nullptr;
+			module.reset();
 			return res;
 		}
 
@@ -110,23 +108,21 @@ unsigned short AbstractLibrary::getFileArchitecture(const wstring& filePath)
 {
 	unsigned short result = 0;
 
-	HANDLE hFile = CreateFileW(filePath.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-	if (hFile != INVALID_HANDLE_VALUE)
+	winutil::UniqueHandle file(CreateFileW(filePath.c_str(), GENERIC_READ, FILE_SHARE_READ,
+		nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr));
+	if (file)
 	{
-		HANDLE hMap = CreateFileMappingW(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
-		if (hMap != nullptr)
+		winutil::UniqueHandle mapping(CreateFileMappingW(file.get(), nullptr, PAGE_READONLY, 0, 0, nullptr));
+		if (mapping)
 		{
-			void* mapAddr = MapViewOfFileEx(hMap, FILE_MAP_READ, 0, 0, 0, nullptr);
-			if (mapAddr != nullptr)
+			winutil::UniqueMappedView view(MapViewOfFileEx(mapping.get(), FILE_MAP_READ, 0, 0, 0, nullptr));
+			if (view)
 			{
-				PIMAGE_NT_HEADERS ntHeaders = ImageNtHeader(mapAddr);
+				PIMAGE_NT_HEADERS ntHeaders = ImageNtHeader(view.get());
 				if (ntHeaders != nullptr)
 					result = ntHeaders->FileHeader.Machine;
-				UnmapViewOfFile(mapAddr);
 			}
-			CloseHandle(hMap);
 		}
-		CloseHandle(hFile);
 	}
 
 	return result;

--- a/helpers/AbstractLibrary.h
+++ b/helpers/AbstractLibrary.h
@@ -22,6 +22,8 @@
 #include <mutex>
 #include <string>
 
+#include "helpers/Win32Resource.h"
+
 class AbstractLibrary
 {
 public:
@@ -41,7 +43,7 @@ protected:
 	virtual int customInitialize();
 	virtual void customUninitialize() noexcept;
 
-	HMODULE module = nullptr;
+	winutil::UniqueModule module;
 
 private:
 	static unsigned short getFileArchitecture(const std::wstring& filePath);

--- a/helpers/ApoRegistration.cpp
+++ b/helpers/ApoRegistration.cpp
@@ -33,9 +33,11 @@
 #include <objidl.h>
 
 #include "AbstractAPOInfo.h"
+#include "ComPtr.h"
 #include "DeviceAPOInfo.h"
 #include "RegistryHelper.h"
 #include "ServiceHelper.h"
+#include "Win32Resource.h"
 
 namespace
 {
@@ -112,30 +114,27 @@ int ApoRegistration::waitForProcess(const std::wstring& executable, const std::w
 	startupInfo.dwFlags = STARTF_USESHOWWINDOW;
 	startupInfo.wShowWindow = SW_HIDE;
 
-	PROCESS_INFORMATION processInfo;
-	ZeroMemory(&processInfo, sizeof(processInfo));
+	winutil::UniqueProcessInformation processInfo;
 
 	if (!CreateProcessW(executable.c_str(), mutableCommand.data(), nullptr, nullptr, FALSE,
-			CREATE_NO_WINDOW, nullptr, nullptr, &startupInfo, &processInfo))
+			CREATE_NO_WINDOW, nullptr, nullptr, &startupInfo, processInfo.put()))
 	{
 		logLine(L"ERR", L"CreateProcess failed for %s (gle=%lu)", executable.c_str(), GetLastError());
 		return -1;
 	}
 
-	DWORD waitResult = WaitForSingleObject(processInfo.hProcess, timeoutMs);
+	DWORD waitResult = WaitForSingleObject(processInfo.process(), timeoutMs);
 	DWORD exitCode = static_cast<DWORD>(-1);
 	if (waitResult == WAIT_OBJECT_0)
 	{
-		GetExitCodeProcess(processInfo.hProcess, &exitCode);
+		GetExitCodeProcess(processInfo.process(), &exitCode);
 	}
 	else
 	{
 		logLine(L"ERR", L"%s timed out after %u ms", executable.c_str(), timeoutMs);
-		TerminateProcess(processInfo.hProcess, 1);
+		TerminateProcess(processInfo.process(), 1);
 	}
 
-	CloseHandle(processInfo.hProcess);
-	CloseHandle(processInfo.hThread);
 	return static_cast<int>(exitCode);
 }
 
@@ -144,8 +143,8 @@ int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregis
 	// LOAD_WITH_ALTERED_SEARCH_PATH resolves EqualizerAPO.dll's own dependencies
 	// (FFTW, libsndfile, ...) relative to the DLL directory, matching how the
 	// audio engine and regsvr32 load it.
-	HMODULE module = LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
-	if (module == nullptr)
+	winutil::UniqueModule module(LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH));
+	if (!module)
 	{
 		logLine(L"ERR", L"LoadLibrary failed for %s (gle=%lu)", dllPath.c_str(), GetLastError());
 		return -1;
@@ -153,7 +152,7 @@ int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregis
 
 	using DllServerProc = HRESULT(__stdcall*)();
 	const char* entryName = unregister ? "DllUnregisterServer" : "DllRegisterServer";
-	DllServerProc proc = reinterpret_cast<DllServerProc>(GetProcAddress(module, entryName));
+	DllServerProc proc = reinterpret_cast<DllServerProc>(GetProcAddress(module.get(), entryName));
 
 	HRESULT hr = E_FAIL;
 	if (proc != nullptr)
@@ -161,7 +160,6 @@ int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregis
 	else
 		logLine(L"ERR", L"%S not found in %s (gle=%lu)", entryName, dllPath.c_str(), GetLastError());
 
-	FreeLibrary(module);
 	return SUCCEEDED(hr) ? 0 : static_cast<int>(hr);
 }
 
@@ -347,8 +345,8 @@ ApoRegistration::Result ApoRegistration::uninstall(const std::wstring& installDi
 
 bool ApoRegistration::stopAudioService()
 {
-	SC_HANDLE manager = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
-	if (manager == nullptr)
+	winutil::UniqueServiceHandle manager(OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT));
+	if (!manager)
 	{
 		logLine(L"ERR", L"OpenSCManager failed: %lu", GetLastError());
 		return false;
@@ -356,21 +354,18 @@ bool ApoRegistration::stopAudioService()
 
 	try
 	{
-		Service service(manager, kAudioServiceName, true);
+		Service service(manager.get(), kAudioServiceName, true);
 		DWORD state = service.getState();
 		if (state == SERVICE_RUNNING)
 		{
 			service.stop();
-			CloseServiceHandle(manager);
 			logLine(L"INFO", L"Stopped AudioSrv");
 			return true;
 		}
-		CloseServiceHandle(manager);
 		return false;
 	}
 	catch (const ServiceException& e)
 	{
-		CloseServiceHandle(manager);
 		logLine(L"ERR", L"Failed to stop AudioSrv: %s", e.getMessage().c_str());
 		return false;
 	}
@@ -378,8 +373,8 @@ bool ApoRegistration::stopAudioService()
 
 bool ApoRegistration::startAudioService()
 {
-	SC_HANDLE manager = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
-	if (manager == nullptr)
+	winutil::UniqueServiceHandle manager(OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT));
+	if (!manager)
 	{
 		logLine(L"ERR", L"OpenSCManager failed: %lu", GetLastError());
 		return false;
@@ -387,21 +382,18 @@ bool ApoRegistration::startAudioService()
 
 	try
 	{
-		Service service(manager, kAudioServiceName, true);
+		Service service(manager.get(), kAudioServiceName, true);
 		DWORD state = service.getState();
 		if (state == SERVICE_STOPPED)
 		{
 			service.start();
-			CloseServiceHandle(manager);
 			logLine(L"INFO", L"Started AudioSrv");
 			return true;
 		}
-		CloseServiceHandle(manager);
 		return state == SERVICE_RUNNING;
 	}
 	catch (const ServiceException& e)
 	{
-		CloseServiceHandle(manager);
 		logLine(L"ERR", L"Failed to start AudioSrv: %s", e.getMessage().c_str());
 		return false;
 	}
@@ -434,16 +426,11 @@ constexpr wchar_t kDeviceSelectorShortcutFile[] = L"Device Selector.lnk";
 
 std::wstring publicProgramsPath()
 {
-	PWSTR raw = nullptr;
-	HRESULT hr = SHGetKnownFolderPath(FOLDERID_CommonPrograms, 0, nullptr, &raw);
-	if (FAILED(hr) || raw == nullptr)
-	{
-		if (raw != nullptr)
-			CoTaskMemFree(raw);
+	winutil::UniqueCoTaskMemPtr<wchar_t> raw;
+	HRESULT hr = SHGetKnownFolderPath(FOLDERID_CommonPrograms, 0, nullptr, raw.put());
+	if (FAILED(hr) || !raw)
 		return std::wstring();
-	}
-	std::wstring path(raw);
-	CoTaskMemFree(raw);
+	std::wstring path(raw.get());
 	return path;
 }
 
@@ -451,10 +438,10 @@ HRESULT writeShellLink(const std::wstring& target, const std::wstring& workingDi
 	const std::wstring& description, const std::wstring& iconPath, int iconIndex,
 	const std::wstring& linkPath)
 {
-	IShellLinkW* shellLink = nullptr;
+	winutil::ComPtr<IShellLinkW> shellLink;
 	HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
-		IID_IShellLinkW, reinterpret_cast<void**>(&shellLink));
-	if (FAILED(hr) || shellLink == nullptr)
+		IID_IShellLinkW, reinterpret_cast<void**>(shellLink.put()));
+	if (FAILED(hr) || !shellLink)
 		return hr;
 
 	shellLink->SetPath(target.c_str());
@@ -465,14 +452,12 @@ HRESULT writeShellLink(const std::wstring& target, const std::wstring& workingDi
 	if (!iconPath.empty())
 		shellLink->SetIconLocation(iconPath.c_str(), iconIndex);
 
-	IPersistFile* persistFile = nullptr;
-	hr = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<void**>(&persistFile));
-	if (SUCCEEDED(hr) && persistFile != nullptr)
+	winutil::ComPtr<IPersistFile> persistFile;
+	hr = shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<void**>(persistFile.put()));
+	if (SUCCEEDED(hr) && persistFile)
 	{
 		hr = persistFile->Save(linkPath.c_str(), TRUE);
-		persistFile->Release();
 	}
-	shellLink->Release();
 	return hr;
 }
 } // namespace
@@ -500,16 +485,18 @@ bool ApoRegistration::createStartMenuShortcuts(const std::wstring& installDir)
 		return false;
 	}
 
-	HRESULT comInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-	bool needsUninit = SUCCEEDED(comInit);
+	winutil::ComApartment apartment(COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+	if (!apartment.isUsable())
+	{
+		logLine(L"ERR", L"COM initialization failed (hr=0x%08lx)",
+			static_cast<unsigned long>(apartment.status()));
+		return false;
+	}
 
 	std::wstring linkPath = joinPath(shortcutFolder, kDeviceSelectorShortcutFile);
 	HRESULT hr = writeShellLink(deviceSelector, installDir,
 		L"Configure which audio devices use EqualizerAPO",
 		deviceSelector, 0, linkPath);
-
-	if (needsUninit)
-		CoUninitialize();
 
 	if (FAILED(hr))
 	{
@@ -554,8 +541,8 @@ bool ApoRegistration::migrateLegacyConfig(const std::wstring& legacyDir, const s
 	bool copiedAny = false;
 	WIN32_FIND_DATAW findData;
 	std::wstring pattern = joinPath(legacyConfig, L"*");
-	HANDLE finder = FindFirstFileW(pattern.c_str(), &findData);
-	if (finder == INVALID_HANDLE_VALUE)
+	winutil::UniqueFindHandle finder(FindFirstFileW(pattern.c_str(), &findData));
+	if (!finder)
 		return false;
 
 	do
@@ -569,8 +556,7 @@ bool ApoRegistration::migrateLegacyConfig(const std::wstring& legacyDir, const s
 		if (CopyFileW(source.c_str(), target.c_str(), TRUE))
 			copiedAny = true;
 	}
-	while (FindNextFileW(finder, &findData));
+	while (FindNextFileW(finder.get(), &findData));
 
-	FindClose(finder);
 	return copiedAny;
 }

--- a/helpers/ComPtr.h
+++ b/helpers/ComPtr.h
@@ -109,6 +109,11 @@ namespace winutil
 		{
 		}
 
+		explicit ComApartment(DWORD flags) noexcept
+			: result(CoInitializeEx(nullptr, flags))
+		{
+		}
+
 		~ComApartment()
 		{
 			if (SUCCEEDED(result))
@@ -119,6 +124,12 @@ namespace winutil
 		ComApartment& operator=(const ComApartment&) = delete;
 		ComApartment(ComApartment&&) = delete;
 		ComApartment& operator=(ComApartment&&) = delete;
+
+		HRESULT status() const noexcept { return result; }
+		bool isUsable() const noexcept
+		{
+			return SUCCEEDED(result) || result == RPC_E_CHANGED_MODE;
+		}
 
 	private:
 		HRESULT result;

--- a/helpers/FftwRAII.h
+++ b/helpers/FftwRAII.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+#include <new>
+#include <stdexcept>
+
+#include <fftw3.h>
+
+namespace fftw
+{
+	struct BufferDeleter
+	{
+		template<class T>
+		void operator()(T* ptr) const noexcept
+		{
+			fftw_free(ptr);
+		}
+	};
+
+	struct PlanDeleter
+	{
+		void operator()(fftw_plan_s* plan) const noexcept
+		{
+			if (plan != nullptr)
+				fftw_destroy_plan(plan);
+		}
+	};
+
+	using RealBuffer = std::unique_ptr<double, BufferDeleter>;
+	using ComplexBuffer = std::unique_ptr<fftw_complex, BufferDeleter>;
+	using Plan = std::unique_ptr<fftw_plan_s, PlanDeleter>;
+
+	inline RealBuffer allocateReal(size_t count)
+	{
+		RealBuffer result(fftw_alloc_real(count));
+		if (!result)
+			throw std::bad_alloc();
+		return result;
+	}
+
+	inline ComplexBuffer allocateComplex(size_t count)
+	{
+		ComplexBuffer result(fftw_alloc_complex(count));
+		if (!result)
+			throw std::bad_alloc();
+		return result;
+	}
+
+	inline Plan makeRealToComplexPlan(int length, double* input, fftw_complex* output, unsigned flags = FFTW_ESTIMATE)
+	{
+		Plan result(fftw_plan_dft_r2c_1d(length, input, output, flags));
+		if (!result)
+			throw std::runtime_error("Could not create FFTW real-to-complex plan");
+		return result;
+	}
+
+	inline Plan makeComplexToRealPlan(int length, fftw_complex* input, double* output, unsigned flags = FFTW_ESTIMATE)
+	{
+		Plan result(fftw_plan_dft_c2r_1d(length, input, output, flags));
+		if (!result)
+			throw std::runtime_error("Could not create FFTW complex-to-real plan");
+		return result;
+	}
+
+	inline Plan makeComplexPlan(int length, fftw_complex* input, fftw_complex* output,
+		int direction, unsigned flags = FFTW_ESTIMATE)
+	{
+		Plan result(fftw_plan_dft_1d(length, input, output, direction, flags));
+		if (!result)
+			throw std::runtime_error("Could not create FFTW complex plan");
+		return result;
+	}
+}

--- a/helpers/FileSharingRetry.h
+++ b/helpers/FileSharingRetry.h
@@ -22,27 +22,28 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include "Win32Resource.h"
+
 // Opens a file, retrying while another process holds it open for writing
-// (ERROR_SHARING_VIOLATION). Returns INVALID_HANDLE_VALUE on any other
+// (ERROR_SHARING_VIOLATION). Returns an empty owning handle on any other
 // error with that error code in lastError.
-inline HANDLE openFileWithSharingRetry(const wchar_t* path, DWORD desiredAccess, DWORD shareMode, DWORD creationDisposition, DWORD& lastError)
+inline winutil::UniqueHandle openFileWithSharingRetry(
+	const wchar_t* path, DWORD desiredAccess, DWORD shareMode, DWORD creationDisposition, DWORD& lastError)
 {
 	lastError = ERROR_SUCCESS;
 
-	HANDLE hFile = INVALID_HANDLE_VALUE;
-	while (hFile == INVALID_HANDLE_VALUE)
+	for (;;)
 	{
-		hFile = CreateFileW(path, desiredAccess, shareMode, nullptr, creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr);
-		if (hFile == INVALID_HANDLE_VALUE)
-		{
-			lastError = GetLastError();
-			if (lastError != ERROR_SHARING_VIOLATION)
-				return INVALID_HANDLE_VALUE;
+		winutil::UniqueHandle file(CreateFileW(
+			path, desiredAccess, shareMode, nullptr, creationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr));
+		if (file)
+			return file;
 
-			// file is being written, so wait
-			Sleep(1);
-		}
+		lastError = GetLastError();
+		if (lastError != ERROR_SHARING_VIOLATION)
+			return {};
+
+		// file is being written, so wait
+		Sleep(1);
 	}
-
-	return hFile;
 }

--- a/helpers/MemoryHelper.h
+++ b/helpers/MemoryHelper.h
@@ -19,7 +19,10 @@
 
 #pragma once
 
+#include <limits>
+#include <memory>
 #include <new>
+#include <type_traits>
 #include <utility>
 
 #ifdef USE_WINDDK
@@ -34,6 +37,30 @@
 class MemoryHelper
 {
 public:
+	template<class T>
+	struct AllocationDeleter
+	{
+		void operator()(T* ptr) const noexcept
+		{
+			MemoryHelper::free(ptr);
+		}
+	};
+
+	template<class T>
+	struct ObjectDeleter
+	{
+		void operator()(T* ptr) const noexcept
+		{
+			MemoryHelper::destroy(ptr);
+		}
+	};
+
+	template<class T>
+	using UniqueAllocation = std::unique_ptr<T, AllocationDeleter<T>>;
+
+	template<class T>
+	using UniqueObject = std::unique_ptr<T, ObjectDeleter<T>>;
+
 	static void* alloc(size_t size);
 	static void free(void* ptr);
 	// Deterministic failure injection for allocation-path tests. Passing N lets
@@ -42,6 +69,20 @@ public:
 	// is used only while filters/configurations are prepared, never in AVRT_CODE.
 	static void failAllocationAfterForTesting(size_t successfulAllocations) noexcept;
 	static void resetAllocationFailureForTesting() noexcept;
+
+	// Owns aligned storage for trivially destructible C-style arrays. A null
+	// result represents either a size overflow or allocation failure; callers
+	// can preserve their existing fallback policy without ever holding a raw
+	// allocation between the acquire and commit steps.
+	template<class T>
+	static UniqueAllocation<T> allocateArray(size_t count) noexcept
+	{
+		static_assert(std::is_trivially_destructible_v<T>,
+			"allocateArray owns storage only; use constructUnique for objects");
+		if (count > (std::numeric_limits<size_t>::max)() / sizeof(T))
+			return {};
+		return UniqueAllocation<T>(static_cast<T*>(alloc(count * sizeof(T))));
+	}
 
 	// Typed, checked construction over alloc()/free().
 	//
@@ -66,6 +107,12 @@ public:
 			free(mem);
 			throw;
 		}
+	}
+
+	template<class T, class... Args>
+	static UniqueObject<T> constructUnique(Args&&... args)
+	{
+		return UniqueObject<T>(construct<T>(std::forward<Args>(args)...));
 	}
 
 	template<class T>

--- a/helpers/RegistryHelper.cpp
+++ b/helpers/RegistryHelper.cpp
@@ -27,7 +27,7 @@
 
 #include "StringHelper.h"
 #include "RegistryHelper.h"
-#include "ScopeGuard.h"
+#include "Win32Resource.h"
 
 using std::endl;
 using std::find;
@@ -42,28 +42,24 @@ wstring RegistryHelper::readValue(const wstring& key, const wstring& valuename)
 {
 	wstring result;
 
-	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY));
 
 	LSTATUS status;
 	DWORD type;
 	DWORD bufSize;
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, &type, nullptr, &bufSize);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, &type, nullptr, &bufSize);
 	if (status != ERROR_SUCCESS)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Error while reading registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 	}
 
 	if (type != REG_SZ)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Registry value " + key + L"\\" + valuename + L" has wrong type");
 	}
 
 	vector<wchar_t> buf(bufSize / sizeof(wchar_t) + 1);
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(buf.data()), &bufSize);
-
-	RegCloseKey(keyHandle);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(buf.data()), &bufSize);
 
 	if (status != ERROR_SUCCESS)
 	{
@@ -82,27 +78,23 @@ unsigned long RegistryHelper::readDWORDValue(const wstring& key, const wstring& 
 {
 	unsigned long result;
 
-	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY));
 
 	LSTATUS status;
 	DWORD type;
 	DWORD bufSize;
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, &type, nullptr, &bufSize);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, &type, nullptr, &bufSize);
 	if (status != ERROR_SUCCESS)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Error while reading registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 	}
 
 	if (type != REG_DWORD)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Registry value " + key + L"\\" + valuename + L" has wrong type");
 	}
 
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(&result), &bufSize);
-
-	RegCloseKey(keyHandle);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(&result), &bufSize);
 
 	if (status != ERROR_SUCCESS)
 	{
@@ -116,28 +108,24 @@ vector<wstring> RegistryHelper::readMultiValue(const wstring& key, const wstring
 {
 	vector<wstring> result;
 
-	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY));
 
 	LSTATUS status;
 	DWORD type;
 	DWORD bufSize;
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, &type, nullptr, &bufSize);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, &type, nullptr, &bufSize);
 	if (status != ERROR_SUCCESS)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Error while reading registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 	}
 
 	if (type != REG_MULTI_SZ)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Registry value " + key + L"\\" + valuename + L" has wrong type");
 	}
 
 	vector<wchar_t> buf(bufSize / sizeof(wchar_t) + 1);
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(buf.data()), &bufSize);
-
-	RegCloseKey(keyHandle);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, nullptr, reinterpret_cast<LPBYTE>(buf.data()), &bufSize);
 
 	if (status != ERROR_SUCCESS)
 	{
@@ -167,28 +155,24 @@ vector<wstring> RegistryHelper::readMultiValue(const wstring& key, const wstring
 
 vector<unsigned char> RegistryHelper::readBinaryValue(const wstring& key, const wstring& valuename)
 {
-	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY));
 
 	LSTATUS status;
 	DWORD type;
 	DWORD bufSize;
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, &type, nullptr, &bufSize);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, &type, nullptr, &bufSize);
 	if (status != ERROR_SUCCESS)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Error while reading registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
 	}
 
 	if (type != REG_BINARY)
 	{
-		RegCloseKey(keyHandle);
 		throw RegistryException(L"Registry value " + key + L"\\" + valuename + L" has wrong type");
 	}
 
 	vector<unsigned char> result(bufSize, 0);
-	status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, nullptr, result.data(), &bufSize);
-
-	RegCloseKey(keyHandle);
+	status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, nullptr, result.data(), &bufSize);
 
 	if (status != ERROR_SUCCESS)
 	{
@@ -200,11 +184,9 @@ vector<unsigned char> RegistryHelper::readBinaryValue(const wstring& key, const 
 
 void RegistryHelper::writeValue(const wstring& key, const wstring& valuename, const wstring& value)
 {
-	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY));
 
-	LSTATUS status = RegSetValueExW(keyHandle, valuename.c_str(), 0, REG_SZ, reinterpret_cast<const BYTE*>(value.c_str()), static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t)));
-
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegSetValueExW(keyHandle.get(), valuename.c_str(), 0, REG_SZ, reinterpret_cast<const BYTE*>(value.c_str()), static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t)));
 
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
@@ -212,11 +194,9 @@ void RegistryHelper::writeValue(const wstring& key, const wstring& valuename, co
 
 void RegistryHelper::writeDWORDValue(const wstring& key, const wstring& valuename, unsigned long value)
 {
-	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY));
 
-	LSTATUS status = RegSetValueExW(keyHandle, valuename.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(unsigned long));
-
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegSetValueExW(keyHandle.get(), valuename.c_str(), 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(unsigned long));
 
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
@@ -224,15 +204,13 @@ void RegistryHelper::writeDWORDValue(const wstring& key, const wstring& valuenam
 
 void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuename, const wstring& value)
 {
-	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY));
 
 	wstring data = value;
 	data.push_back(L'\0');
 	data.push_back(L'\0');
 
-	LSTATUS status = RegSetValueExW(keyHandle, valuename.c_str(), 0, REG_MULTI_SZ, reinterpret_cast<const BYTE*>(data.data()), static_cast<DWORD>(data.size() * sizeof(wchar_t)));
-
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegSetValueExW(keyHandle.get(), valuename.c_str(), 0, REG_MULTI_SZ, reinterpret_cast<const BYTE*>(data.data()), static_cast<DWORD>(data.size() * sizeof(wchar_t)));
 
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
@@ -240,7 +218,7 @@ void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuenam
 
 void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuename, const vector<wstring>& values)
 {
-	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY));
 
 	size_t size = 1;
 	for (const wstring& value : values)
@@ -255,9 +233,7 @@ void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuenam
 	}
 	data.push_back(L'\0');
 
-	LSTATUS status = RegSetValueExW(keyHandle, valuename.c_str(), 0, REG_MULTI_SZ, reinterpret_cast<const BYTE*>(data.data()), static_cast<DWORD>(data.size() * sizeof(wchar_t)));
-
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegSetValueExW(keyHandle.get(), valuename.c_str(), 0, REG_MULTI_SZ, reinterpret_cast<const BYTE*>(data.data()), static_cast<DWORD>(data.size() * sizeof(wchar_t)));
 
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while writing to registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
@@ -265,11 +241,9 @@ void RegistryHelper::writeMultiValue(const wstring& key, const wstring& valuenam
 
 void RegistryHelper::deleteValue(const wstring& key, const wstring& valuename)
 {
-	HKEY keyHandle = openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_SET_VALUE | KEY_WOW64_64KEY));
 
-	LSTATUS status = RegDeleteValueW(keyHandle, valuename.c_str());
-
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegDeleteValueW(keyHandle.get(), valuename.c_str());
 
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while deleting registry value " + key + L"\\" + valuename + L": " + StringHelper::getSystemErrorString(status));
@@ -280,12 +254,12 @@ void RegistryHelper::createKey(const wstring& key)
 	HKEY rootKey;
 	wstring subKey = splitKey(key, &rootKey);
 
-	HKEY keyHandle;
-	LSTATUS status = RegCreateKeyExW(rootKey, subKey.c_str(), 0, nullptr, 0, KEY_SET_VALUE | KEY_WOW64_64KEY, nullptr, &keyHandle, nullptr);
+	winutil::UniqueRegistryKey keyHandle;
+	LSTATUS status = RegCreateKeyExW(rootKey, subKey.c_str(), 0, nullptr, 0,
+		KEY_SET_VALUE | KEY_WOW64_64KEY, nullptr, keyHandle.put(), nullptr);
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while creating registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 
-	RegCloseKey(keyHandle);
 }
 
 void RegistryHelper::deleteKey(const wstring& key)
@@ -300,29 +274,29 @@ void RegistryHelper::deleteKey(const wstring& key)
 
 void RegistryHelper::makeWritable(const wstring& key)
 {
-	HKEY keyHandle = openKey(key, READ_CONTROL | WRITE_DAC | KEY_WOW64_64KEY);
-	SCOPE_EXIT{ RegCloseKey(keyHandle); };
+	winutil::UniqueRegistryKey keyHandle(openKey(key, READ_CONTROL | WRITE_DAC | KEY_WOW64_64KEY));
 
 	DWORD descriptorSize = 0;
-	RegGetKeySecurity(keyHandle, DACL_SECURITY_INFORMATION, nullptr, &descriptorSize);
+	RegGetKeySecurity(keyHandle.get(), DACL_SECURITY_INFORMATION, nullptr, &descriptorSize);
 
-	PSECURITY_DESCRIPTOR oldSd = (PSECURITY_DESCRIPTOR)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, descriptorSize);
-	SCOPE_EXIT{ if (oldSd != nullptr) HeapFree(GetProcessHeap(), 0, oldSd); };
-	LSTATUS status = RegGetKeySecurity(keyHandle, DACL_SECURITY_INFORMATION, oldSd, &descriptorSize);
+	winutil::UniqueProcessHeapPtr<void> oldSd(
+		HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, descriptorSize));
+	if (!oldSd)
+		throw RegistryException(L"HeapAlloc failed while ensuring registry key writability");
+	LSTATUS status = RegGetKeySecurity(keyHandle.get(), DACL_SECURITY_INFORMATION, oldSd.get(), &descriptorSize);
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while getting security information for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 
 	BOOL aclPresent, aclDefaulted;
 	PACL oldAcl = nullptr;
-	if (!GetSecurityDescriptorDacl(oldSd, &aclPresent, &oldAcl, &aclDefaulted))
+	if (!GetSecurityDescriptorDacl(oldSd.get(), &aclPresent, &oldAcl, &aclDefaulted))
 		throw RegistryException(L"Error in GetSecurityDescriptorDacl while ensuring writability");
 
-	PSID sid = nullptr;
+	winutil::UniqueSid sid;
 	SID_IDENTIFIER_AUTHORITY authority = SECURITY_NT_AUTHORITY;
 	if (!AllocateAndInitializeSid(&authority, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS,
-		0, 0, 0, 0, 0, 0, &sid))
+		0, 0, 0, 0, 0, 0, sid.put()))
 		throw RegistryException(L"Error in AllocateAndInitializeSid while ensuring writability");
-	SCOPE_EXIT{ if (sid != nullptr) FreeSid(sid); };
 
 	EXPLICIT_ACCESS ea;
 	ea.grfAccessPermissions = KEY_ALL_ACCESS;
@@ -330,35 +304,32 @@ void RegistryHelper::makeWritable(const wstring& key)
 	ea.grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
 	ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
 	ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
-	ea.Trustee.ptstrName = (LPWSTR)sid;
+	ea.Trustee.ptstrName = static_cast<LPWSTR>(sid.get());
 
-	PACL acl = nullptr;
-	if (ERROR_SUCCESS != SetEntriesInAcl(1, &ea, oldAcl, &acl))
+	winutil::UniqueLocalPtr<ACL> acl;
+	if (ERROR_SUCCESS != SetEntriesInAcl(1, &ea, oldAcl, acl.put()))
 		throw RegistryException(L"Error in SetEntriesInAcl while ensuring writability");
-	SCOPE_EXIT{ if (acl != nullptr) LocalFree(acl); };
 
-	PSECURITY_DESCRIPTOR sd = (PSECURITY_DESCRIPTOR)LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH);
-	if (nullptr == sd)
+	winutil::UniqueLocalPtr<void> sd(LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH));
+	if (!sd)
 		throw RegistryException(L"Error in LocalAlloc while ensuring writability");
-	SCOPE_EXIT{ if (sd != nullptr) LocalFree(sd); };
 
-	if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION))
+	if (!InitializeSecurityDescriptor(sd.get(), SECURITY_DESCRIPTOR_REVISION))
 		throw RegistryException(L"Error in InitializeSecurityDescriptor while ensuring writability");
 
-	if (!SetSecurityDescriptorDacl(sd, TRUE, acl, FALSE))
+	if (!SetSecurityDescriptorDacl(sd.get(), TRUE, acl.get(), FALSE))
 		throw RegistryException(L"Error in SetSecurityDescriptorDacl while ensuring writability");
 
-	status = RegSetKeySecurity(keyHandle, DACL_SECURITY_INFORMATION, sd);
+	status = RegSetKeySecurity(keyHandle.get(), DACL_SECURITY_INFORMATION, sd.get());
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while setting security information for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 }
 
 void RegistryHelper::takeOwnership(const wstring& key)
 {
-	HANDLE tokenHandle;
-	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tokenHandle))
+	winutil::UniqueHandle tokenHandle;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, tokenHandle.put()))
 		throw RegistryException(L"Error in OpenProcessToken while taking ownership");
-	SCOPE_EXIT{ if (tokenHandle != nullptr) CloseHandle(tokenHandle); };
 
 	LUID luid;
 	if (!LookupPrivilegeValue(nullptr, SE_TAKE_OWNERSHIP_NAME, &luid))
@@ -369,37 +340,34 @@ void RegistryHelper::takeOwnership(const wstring& key)
 	tp.Privileges[0].Luid = luid;
 	tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-	if (!AdjustTokenPrivileges(tokenHandle, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
+	if (!AdjustTokenPrivileges(tokenHandle.get(), FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
 
-	HKEY keyHandle = openKey(key, WRITE_OWNER | KEY_WOW64_64KEY);
-	SCOPE_EXIT{ RegCloseKey(keyHandle); };
+	winutil::UniqueRegistryKey keyHandle(openKey(key, WRITE_OWNER | KEY_WOW64_64KEY));
 
-	PSECURITY_DESCRIPTOR sd = (PSECURITY_DESCRIPTOR)LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH);
-	if (nullptr == sd)
+	winutil::UniqueLocalPtr<void> sd(LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH));
+	if (!sd)
 		throw RegistryException(L"Error in SetPrivilege while taking ownership");
-	SCOPE_EXIT{ if (sd != nullptr) LocalFree(sd); };
 
-	if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION))
+	if (!InitializeSecurityDescriptor(sd.get(), SECURITY_DESCRIPTOR_REVISION))
 		throw RegistryException(L"Error in InitializeSecurityDescriptor while taking ownership");
 
-	PSID sid = nullptr;
+	winutil::UniqueSid sid;
 	SID_IDENTIFIER_AUTHORITY authority = SECURITY_NT_AUTHORITY;
 	if (!AllocateAndInitializeSid(&authority, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS,
-		0, 0, 0, 0, 0, 0, &sid))
+		0, 0, 0, 0, 0, 0, sid.put()))
 		throw RegistryException(L"Error in AllocateAndInitializeSid while taking ownership");
-	SCOPE_EXIT{ if (sid != nullptr) FreeSid(sid); };
 
-	if (!SetSecurityDescriptorOwner(sd, sid, FALSE))
+	if (!SetSecurityDescriptorOwner(sd.get(), sid.get(), FALSE))
 		throw RegistryException(L"Error in SetSecurityDescriptorOwner while taking ownership");
 
-	LSTATUS status = RegSetKeySecurity(keyHandle, OWNER_SECURITY_INFORMATION, sd);
+	LSTATUS status = RegSetKeySecurity(keyHandle.get(), OWNER_SECURITY_INFORMATION, sd.get());
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while setting security information for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 
 	tp.Privileges[0].Attributes = 0;
 
-	if (!AdjustTokenPrivileges(tokenHandle, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
+	if (!AdjustTokenPrivileges(tokenHandle.get(), FALSE, &tp, sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
 }
 
@@ -407,30 +375,24 @@ ACCESS_MASK RegistryHelper::getFileAccessForUser(const std::wstring& path, unsig
 {
 	ACCESS_MASK result;
 
-	// Cleanup runs through scope guards so the throwing paths cannot leak the
-	// security descriptor, resource manager, SID or context.
-	PSECURITY_DESCRIPTOR sd;
+	winutil::UniqueLocalPtr<void> sd;
 	if (GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION
-		| GROUP_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr, &sd) != ERROR_SUCCESS)
+		| GROUP_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr, sd.put()) != ERROR_SUCCESS)
 		throw RegistryException(L"Error in GetNamedSecurityInfoW while getting file access");
-	SCOPE_EXIT{ LocalFree(sd); };
 
-	AUTHZ_RESOURCE_MANAGER_HANDLE manager;
-	if (!AuthzInitializeResourceManager(AUTHZ_RM_FLAG_NO_AUDIT, nullptr, nullptr, nullptr, nullptr, &manager))
+	winutil::UniqueAuthzResourceManager manager;
+	if (!AuthzInitializeResourceManager(AUTHZ_RM_FLAG_NO_AUDIT, nullptr, nullptr, nullptr, nullptr, manager.put()))
 		throw RegistryException(L"Error in AuthzInitializeResourceManager while getting file access");
-	SCOPE_EXIT{ AuthzFreeResourceManager(manager); };
 
-	PSID sid = nullptr;
+	winutil::UniqueSid sid;
 	SID_IDENTIFIER_AUTHORITY authority = SECURITY_NT_AUTHORITY;
-	if (!AllocateAndInitializeSid(&authority, 1, rid, 0, 0, 0, 0, 0, 0, 0, &sid))
+	if (!AllocateAndInitializeSid(&authority, 1, rid, 0, 0, 0, 0, 0, 0, 0, sid.put()))
 		throw RegistryException(L"Error in AllocateAndInitializeSid while getting file access");
-	SCOPE_EXIT{ if (sid != nullptr) FreeSid(sid); };
 
 	LUID unusedId = {0};
-	AUTHZ_CLIENT_CONTEXT_HANDLE context;
-	if (!AuthzInitializeContextFromSid(0, sid, manager, nullptr, unusedId, nullptr, &context))
+	winutil::UniqueAuthzContext context;
+	if (!AuthzInitializeContextFromSid(0, sid.get(), manager.get(), nullptr, unusedId, nullptr, context.put()))
 		throw RegistryException(L"Error in AuthzInitializeContextFromSid while getting file access");
-	SCOPE_EXIT{ AuthzFreeContext(context); };
 
 	AUTHZ_ACCESS_REQUEST request = {0};
 
@@ -447,7 +409,7 @@ ACCESS_MASK RegistryHelper::getFileAccessForUser(const std::wstring& path, unsig
 	reply.GrantedAccessMask = reinterpret_cast<ACCESS_MASK*>(buf);
 	reply.Error = reinterpret_cast<DWORD*>(buf + sizeof(ACCESS_MASK));
 
-	if (!AuthzAccessCheck(0, context, &request, nullptr, sd, nullptr, 0, &reply, nullptr))
+	if (!AuthzAccessCheck(0, context.get(), &request, nullptr, sd.get(), nullptr, 0, &reply, nullptr))
 		throw RegistryException(L"Error in AuthzAccessCheck while getting file access");
 
 	result = *reply.GrantedAccessMask;
@@ -462,23 +424,20 @@ bool RegistryHelper::keyExists(const wstring& key)
 	HKEY rootKey;
 	wstring subKey = splitKey(key, &rootKey);
 
-	HKEY keyHandle;
-	result = (RegOpenKeyExW(rootKey, subKey.c_str(), 0, KEY_QUERY_VALUE | KEY_WOW64_64KEY, &keyHandle) == ERROR_SUCCESS);
-
-	if (result)
-		RegCloseKey(keyHandle);
+	winutil::UniqueRegistryKey keyHandle;
+	result = (RegOpenKeyExW(rootKey, subKey.c_str(), 0,
+		KEY_QUERY_VALUE | KEY_WOW64_64KEY, keyHandle.put()) == ERROR_SUCCESS);
 
 	return result;
 }
 
 bool RegistryHelper::valueExists(const wstring& key, const wstring& valuename)
 {
-	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY));
 
 	DWORD type;
 	DWORD bufSize;
-	LSTATUS status = RegQueryValueExW(keyHandle, valuename.c_str(), nullptr, &type, nullptr, &bufSize);
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegQueryValueExW(keyHandle.get(), valuename.c_str(), nullptr, &type, nullptr, &bufSize);
 	return status == ERROR_SUCCESS;
 }
 
@@ -486,21 +445,19 @@ vector<wstring> RegistryHelper::enumSubKeys(const wstring& key)
 {
 	vector<wstring> result;
 
-	HKEY keyHandle = openKey(key, KEY_ENUMERATE_SUB_KEYS | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_ENUMERATE_SUB_KEYS | KEY_WOW64_64KEY));
 
 	wchar_t keyName[256];
 	DWORD keyLength = sizeof(keyName) / sizeof(wchar_t);
 	int i = 0;
 
 	LSTATUS status;
-	while ((status = RegEnumKeyExW(keyHandle, i++, keyName, &keyLength, nullptr, nullptr, nullptr, nullptr)) == ERROR_SUCCESS)
+	while ((status = RegEnumKeyExW(keyHandle.get(), i++, keyName, &keyLength, nullptr, nullptr, nullptr, nullptr)) == ERROR_SUCCESS)
 	{
 		keyLength = sizeof(keyName) / sizeof(wchar_t);
 
 		result.push_back(keyName);
 	}
-
-	RegCloseKey(keyHandle);
 
 	if (status != ERROR_NO_MORE_ITEMS)
 		throw RegistryException(L"Error while enumerating sub keys of registry key " + key + L": " + StringHelper::getSystemErrorString(status));
@@ -510,13 +467,11 @@ vector<wstring> RegistryHelper::enumSubKeys(const wstring& key)
 
 bool RegistryHelper::keyEmpty(const wstring& key)
 {
-	HKEY keyHandle = openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY);
+	winutil::UniqueRegistryKey keyHandle(openKey(key, KEY_QUERY_VALUE | KEY_WOW64_64KEY));
 
 	DWORD keyCount;
 	DWORD valueCount;
-	LSTATUS status = RegQueryInfoKeyW(keyHandle, nullptr, nullptr, nullptr, &keyCount, nullptr, nullptr, &valueCount, nullptr, nullptr, nullptr, nullptr);
-
-	RegCloseKey(keyHandle);
+	LSTATUS status = RegQueryInfoKeyW(keyHandle.get(), nullptr, nullptr, nullptr, &keyCount, nullptr, nullptr, &valueCount, nullptr, nullptr, nullptr, nullptr);
 
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while reading info for registry key " + key + L": " + StringHelper::getSystemErrorString(status));
@@ -546,11 +501,10 @@ void RegistryHelper::saveToFile(const wstring& key, const vector<wstring>& value
 
 wstring RegistryHelper::getGuidString(GUID guid)
 {
-	wchar_t* temp;
-	if (FAILED(StringFromCLSID(guid, &temp)))
+	winutil::UniqueCoTaskMemPtr<wchar_t> temp;
+	if (FAILED(StringFromCLSID(guid, temp.put())))
 		throw RegistryException(L"Could not convert GUID to string");
-	std::wstring result(temp);
-	CoTaskMemFree(temp);
+	std::wstring result(temp.get());
 
 	return result;
 }
@@ -580,13 +534,13 @@ bool RegistryHelper::isWindowsVersionAtLeast(unsigned major, unsigned minor)
 	return windowsVersion >= compareVersion;
 }
 
-HKEY RegistryHelper::openKey(const wstring& key, REGSAM samDesired)
+winutil::UniqueRegistryKey RegistryHelper::openKey(const wstring& key, REGSAM samDesired)
 {
 	HKEY rootKey;
 	wstring subKey = splitKey(key, &rootKey);
 
-	HKEY keyHandle;
-	LSTATUS status = RegOpenKeyExW(rootKey, subKey.c_str(), 0, samDesired, &keyHandle);
+	winutil::UniqueRegistryKey keyHandle;
+	LSTATUS status = RegOpenKeyExW(rootKey, subKey.c_str(), 0, samDesired, keyHandle.put());
 	if (status != ERROR_SUCCESS)
 		throw RegistryException(L"Error while opening registry key " + key + L": " + StringHelper::getSystemErrorString(status));
 

--- a/helpers/RegistryHelper.h
+++ b/helpers/RegistryHelper.h
@@ -25,6 +25,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include "Win32Resource.h"
+
 // {EACD2258-FCAC-4FF4-B36D-419E924A6D79}
 const GUID EQUALIZERAPO_PRE_MIX_GUID = {0xeacd2258, 0xfcac, 0x4ff4, {0xb3, 0x6d, 0x41, 0x9e, 0x92, 0x4a, 0x6d, 0x79}};
 // {EC1CC9CE-FAED-4822-828A-82A81A6F018F}
@@ -61,7 +63,7 @@ public:
 	static void saveToFile(const std::wstring& key, const std::vector<std::wstring>& valuenames, const std::wstring& filepath);
 	static std::wstring getGuidString(GUID guid);
 	static bool isWindowsVersionAtLeast(unsigned major, unsigned minor);
-	static HKEY openKey(const std::wstring& key, REGSAM samDesired);
+	static winutil::UniqueRegistryKey openKey(const std::wstring& key, REGSAM samDesired);
 
 private:
 	static std::wstring splitKey(const std::wstring& key, HKEY* rootKey);

--- a/helpers/ScopeGuard.h
+++ b/helpers/ScopeGuard.h
@@ -42,13 +42,29 @@ public:
 		: fn(std::move(fn))
 	{
 	}
-	~ScopeGuard()
+
+	ScopeGuard(const ScopeGuard&) = delete;
+	ScopeGuard& operator=(const ScopeGuard&) = delete;
+
+	ScopeGuard(ScopeGuard&& other) noexcept(noexcept(Fun(std::move(other.fn))))
+		: fn(std::move(other.fn)), active(other.active)
 	{
-		fn();
+		other.dismiss();
 	}
+
+	ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+	~ScopeGuard() noexcept
+	{
+		if (active)
+			fn();
+	}
+
+	void dismiss() noexcept { active = false; }
 
 private:
 	Fun fn;
+	bool active = true;
 };
 
 class UncaughtExceptionCounter
@@ -83,13 +99,30 @@ public:
 	{
 	}
 
-	~ScopeGuardForNewException()
+	ScopeGuardForNewException(const ScopeGuardForNewException&) = delete;
+	ScopeGuardForNewException& operator=(const ScopeGuardForNewException&) = delete;
+
+	ScopeGuardForNewException(ScopeGuardForNewException&& other) noexcept(
+		noexcept(FunctionType(std::move(other.function_))))
+		: function_(std::move(other.function_)), ec_(other.ec_), active_(other.active_)
 	{
-		if (executeOnException == ec_.newUncaughtException())
+		other.dismiss();
+	}
+
+	ScopeGuardForNewException& operator=(ScopeGuardForNewException&&) = delete;
+
+	~ScopeGuardForNewException() noexcept
+	{
+		if (active_ && executeOnException == ec_.newUncaughtException())
 		{
 			function_();
 		}
 	}
+
+	void dismiss() noexcept { active_ = false; }
+
+private:
+	bool active_ = true;
 };
 
 template<typename Fun> ScopeGuard<Fun> operator+(ScopeGuardOnExit, Fun&& fn)

--- a/helpers/ServiceHelper.cpp
+++ b/helpers/ServiceHelper.cpp
@@ -24,6 +24,7 @@
 #include "PrecisionTimer.h"
 #include "StringHelper.h"
 #include "ServiceHelper.h"
+#include "Win32Resource.h"
 
 using std::make_shared;
 using std::shared_ptr;
@@ -32,13 +33,12 @@ using std::wstring;
 
 void ServiceHelper::restartService(const wstring& serviceName)
 {
-	SC_HANDLE scManager = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_ALL_ACCESS);
-	if (scManager == nullptr)
+	winutil::UniqueServiceHandle scManager(OpenSCManagerW(nullptr, nullptr, SC_MANAGER_ALL_ACCESS));
+	if (!scManager)
 		throw ServiceException(L"OpenSCManager failed (" + StringHelper::getSystemErrorString(GetLastError()) + L")");
-	SCOPE_EXIT{CloseServiceHandle(scManager); };
 
 	vector<shared_ptr<Service>> services;
-	shared_ptr<Service> mainService = make_shared<Service>(scManager, serviceName, true);
+	shared_ptr<Service> mainService = make_shared<Service>(scManager.get(), serviceName, true);
 	services.push_back(mainService);
 
 	DWORD mainState = mainService->getState();
@@ -47,7 +47,7 @@ void ServiceHelper::restartService(const wstring& serviceName)
 		vector<wstring> dependentServices = mainService->getActiveDependentServices();
 		for (const wstring& dependentServiceName : dependentServices)
 		{
-			shared_ptr<Service> dependentService = make_shared<Service>(scManager, dependentServiceName.c_str(), false);
+			shared_ptr<Service> dependentService = make_shared<Service>(scManager.get(), dependentServiceName.c_str(), false);
 			services.insert(prev(services.end()), dependentService);
 		}
 	}
@@ -105,14 +105,9 @@ Service::Service(SC_HANDLE scManager, const std::wstring& serviceName, bool allo
 	DWORD desiredAccess = SERVICE_START | SERVICE_STOP | SERVICE_QUERY_STATUS;
 	if (allowEnumerate)
 		desiredAccess |= SERVICE_ENUMERATE_DEPENDENTS;
-	serviceHandle = OpenServiceW(scManager, serviceName.c_str(), desiredAccess);
-	if (serviceHandle == nullptr)
+	serviceHandle.reset(OpenServiceW(scManager, serviceName.c_str(), desiredAccess));
+	if (!serviceHandle)
 		fail(L"OpenService", GetLastError());
-}
-
-Service::~Service()
-{
-	CloseServiceHandle(serviceHandle);
 }
 
 const std::wstring& Service::getServiceName()
@@ -124,7 +119,7 @@ DWORD Service::getState()
 {
 	SERVICE_STATUS_PROCESS ssp;
 	DWORD dwBytesNeeded;
-	if (!QueryServiceStatusEx(serviceHandle, SC_STATUS_PROCESS_INFO, (LPBYTE)&ssp, sizeof(SERVICE_STATUS_PROCESS), &dwBytesNeeded))
+	if (!QueryServiceStatusEx(serviceHandle.get(), SC_STATUS_PROCESS_INFO, (LPBYTE)&ssp, sizeof(SERVICE_STATUS_PROCESS), &dwBytesNeeded))
 		fail(L"QueryServiceStatusEx", GetLastError());
 
 	return ssp.dwCurrentState;
@@ -132,14 +127,14 @@ DWORD Service::getState()
 
 void Service::start()
 {
-	if (!StartServiceW(serviceHandle, 0, nullptr))
+	if (!StartServiceW(serviceHandle.get(), 0, nullptr))
 		fail(L"StartService", GetLastError());
 }
 
 DWORD Service::stop()
 {
 	SERVICE_STATUS ss;
-	if (!ControlService(serviceHandle, SERVICE_CONTROL_STOP, &ss))
+	if (!ControlService(serviceHandle.get(), SERVICE_CONTROL_STOP, &ss))
 		fail(L"ControlService", GetLastError());
 
 	return ss.dwCurrentState;
@@ -148,7 +143,7 @@ DWORD Service::stop()
 vector<wstring> Service::getActiveDependentServices()
 {
 	DWORD bytesNeeded, count;
-	if (EnumDependentServicesW(serviceHandle, SERVICE_ACTIVE, nullptr, 0, &bytesNeeded, &count))
+	if (EnumDependentServicesW(serviceHandle.get(), SERVICE_ACTIVE, nullptr, 0, &bytesNeeded, &count))
 		// if the call succeeds, there are no dependent services
 		return vector<wstring>();
 
@@ -156,18 +151,17 @@ vector<wstring> Service::getActiveDependentServices()
 	if (error != ERROR_MORE_DATA)
 		fail(L"EnumDependentServices", error);
 
-	LPENUM_SERVICE_STATUSW dependencies = (LPENUM_SERVICE_STATUSW)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, bytesNeeded);
+	winutil::UniqueProcessHeapPtr<ENUM_SERVICE_STATUSW> dependencies(
+		static_cast<LPENUM_SERVICE_STATUSW>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, bytesNeeded)));
 	if (!dependencies)
 		throw ServiceException(L"HeapAlloc for EnumDependentServices failed");
 
-	SCOPE_EXIT{HeapFree(GetProcessHeap(), 0, dependencies); };
-
-	if (!EnumDependentServicesW(serviceHandle, SERVICE_ACTIVE, dependencies, bytesNeeded, &bytesNeeded, &count))
+	if (!EnumDependentServicesW(serviceHandle.get(), SERVICE_ACTIVE, dependencies.get(), bytesNeeded, &bytesNeeded, &count))
 		fail(L"EnumDependentServices", GetLastError());
 
 	vector<wstring> result;
 	for (unsigned i = 0; i < count; i++)
-		result.push_back(dependencies[i].lpServiceName);
+		result.push_back(dependencies.get()[i].lpServiceName);
 
 	return result;
 }

--- a/helpers/ServiceHelper.h
+++ b/helpers/ServiceHelper.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include "Win32Resource.h"
+
 class ServiceHelper
 {
 public:
@@ -32,7 +34,7 @@ class Service
 {
 public:
 	Service(SC_HANDLE scManager, const std::wstring& serviceName, bool allowEnumerate);
-	virtual ~Service();
+	virtual ~Service() = default;
 	const std::wstring& getServiceName();
 	DWORD getState();
 	void start();
@@ -42,7 +44,7 @@ public:
 private:
 	void fail(const std::wstring& functionName, DWORD error);
 
-	SC_HANDLE serviceHandle;
+	winutil::UniqueServiceHandle serviceHandle;
 	std::wstring serviceName;
 };
 

--- a/helpers/SndfileRAII.h
+++ b/helpers/SndfileRAII.h
@@ -1,0 +1,31 @@
+/*
+	This file is part of Equalizer APO, a system-wide equalizer.
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#pragma once
+
+#ifndef ENABLE_SNDFILE_WINDOWS_PROTOTYPES
+#define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
+#endif
+#include <sndfile.h>
+
+#include <memory>
+
+namespace sndfile
+{
+	struct CloseDeleter
+	{
+		void operator()(SNDFILE* file) const noexcept
+		{
+			if (file != nullptr)
+				sf_close(file);
+		}
+	};
+
+	using Handle = std::unique_ptr<SNDFILE, CloseDeleter>;
+}

--- a/helpers/StringHelper.cpp
+++ b/helpers/StringHelper.cpp
@@ -25,6 +25,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "StringHelper.h"
+#include "Win32Resource.h"
 
 using std::find;
 using std::string;
@@ -170,18 +171,17 @@ wstring StringHelper::join(const vector<wstring>& strings, const wstring& separa
 
 wstring StringHelper::getSystemErrorString(long status)
 {
-	wchar_t* buf = nullptr;
+	winutil::UniqueLocalPtr<wchar_t> buffer;
 
-	// cppcheck-suppress knownConditionTrueFalse ; FormatMessageW allocates into buf through the casted out pointer
-	if (FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, status, 0, (LPTSTR)&buf, 0, nullptr) != 0 && buf != nullptr)
+	if (FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		nullptr, status, 0, reinterpret_cast<LPWSTR>(buffer.put()), 0, nullptr) != 0 && buffer)
 	{
-		wstring result(buf);
-		LocalFree(buf);
+		wstring result(buffer.get());
 
 		// remove trailing newline
-		if (result.back() == L'\n')
+		if (!result.empty() && result.back() == L'\n')
 			result.erase(prev(result.end()));
-		if (result.back() == L'\r')
+		if (!result.empty() && result.back() == L'\r')
 			result.erase(prev(result.end()));
 		return result;
 	}

--- a/helpers/VSTPluginInstance.Editor.cpp
+++ b/helpers/VSTPluginInstance.Editor.cpp
@@ -21,6 +21,7 @@
 #include "VSTPluginLibrary.h"
 #include "VSTPluginInstance.h"
 #include "VSTPluginInstanceInternal.h"
+#include "pluginterfaces/base/smartpointer.h"
 #include "pluginterfaces/gui/iplugviewcontentscalesupport.h"
 
 using namespace std;
@@ -79,20 +80,23 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height, dou
 		if (vst3Controller == NULL)
 			return false;
 		stopEditing();
-		vst3View = vst3Controller->createView(ViewType::kEditor);
+		vst3View = IPtr<IPlugView>::adopt(vst3Controller->createView(ViewType::kEditor));
 		if (vst3View == NULL)
 			return false;
-		vst3View->setFrame(vst3HostContext);
+		vst3View->setFrame(static_cast<IPlugFrame*>(vst3HostContext.get()));
 
 		// Hand DPI-aware plugins (FabFilter Pro-Q, etc.) the host scale before
 		// they lay out, so getSize() returns a rect that matches the real
 		// monitor. Plugins without this interface fall back to reading the DPI
 		// from their parent window, which is per-monitor aware in this process.
-		IPlugViewContentScaleSupport* scaleSupport = NULL;
-		if (vst3View->queryInterface(IPlugViewContentScaleSupport::iid, (void**)&scaleSupport) == kResultOk && scaleSupport != NULL)
+		IPlugViewContentScaleSupport* rawScaleSupport = NULL;
+		const tresult scaleResult = vst3View->queryInterface(
+			IPlugViewContentScaleSupport::iid,
+			(void**)&rawScaleSupport);
+		auto scaleSupport = IPtr<IPlugViewContentScaleSupport>::adopt(rawScaleSupport);
+		if (scaleResult == kResultOk && scaleSupport)
 		{
 			scaleSupport->setContentScaleFactor((IPlugViewContentScaleSupport::ScaleFactor)scaleFactor);
-			scaleSupport->release();
 		}
 
 		ViewRect rect;
@@ -112,15 +116,15 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height, dou
 			return false;
 		}
 		registerVST3EditorHostWindowClass();
-		vst3EditorHostWindow = CreateWindowExW(0, vst3EditorHostWindowClass, L"",
+		vst3EditorHostWindow.reset(CreateWindowExW(0, vst3EditorHostWindowClass, L"",
 			WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | WS_VISIBLE,
-			0, 0, physWidth, physHeight, hWnd, NULL, GetModuleHandleW(NULL), NULL);
-		if (vst3EditorHostWindow == NULL)
+			0, 0, physWidth, physHeight, hWnd, NULL, GetModuleHandleW(NULL), NULL));
+		if (!vst3EditorHostWindow)
 		{
 			stopEditing();
 			return false;
 		}
-		if (vst3View->attached(vst3EditorHostWindow, kPlatformTypeHWND) != kResultOk)
+		if (vst3View->attached(vst3EditorHostWindow.get(), kPlatformTypeHWND) != kResultOk)
 		{
 			stopEditing();
 			return false;
@@ -135,8 +139,8 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height, dou
 				*height = toLogical(physHeight);
 			vst3View->onSize(&rect);
 		}
-		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, physWidth, physHeight, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
-		EnumChildWindows(vst3EditorHostWindow, showChildWindow, 0);
+		SetWindowPos(vst3EditorHostWindow.get(), NULL, 0, 0, physWidth, physHeight, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+		EnumChildWindows(vst3EditorHostWindow.get(), showChildWindow, 0);
 		return true;
 	}
 
@@ -144,9 +148,9 @@ bool VSTPluginInstance::startEditing(HWND hWnd, short* width, short* height, dou
 		return false;
 
 	vst_rect_t* rect;
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_GET_RECT, 0, 0, &rect, 0.0f);
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_OPEN, 0, 0, hWnd, 0.0f);
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_GET_RECT, 0, 0, &rect, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_EDITOR_GET_RECT, 0, 0, &rect, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_EDITOR_OPEN, 0, 0, hWnd, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_EDITOR_GET_RECT, 0, 0, &rect, 0.0f);
 
 	if (width != NULL)
 		*width = rect->right - rect->left;
@@ -159,11 +163,11 @@ void VSTPluginInstance::doIdle()
 {
 	if (library->isVST3())
 	{
-		if (vst3EditorHostWindow != NULL)
+		if (vst3EditorHostWindow)
 		{
-			InvalidateRect(vst3EditorHostWindow, NULL, FALSE);
-			UpdateWindow(vst3EditorHostWindow);
-			EnumChildWindows(vst3EditorHostWindow, [](HWND hWnd, LPARAM) -> BOOL {
+			InvalidateRect(vst3EditorHostWindow.get(), NULL, FALSE);
+			UpdateWindow(vst3EditorHostWindow.get());
+			EnumChildWindows(vst3EditorHostWindow.get(), [](HWND hWnd, LPARAM) -> BOOL {
 				InvalidateRect(hWnd, NULL, FALSE);
 				UpdateWindow(hWnd);
 				return TRUE;
@@ -175,7 +179,7 @@ void VSTPluginInstance::doIdle()
 	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_EDITOR_KEEP_ALIVE, 0, 0, NULL, 0.0f);
 }
 
 void VSTPluginInstance::stopEditing()
@@ -186,19 +190,14 @@ void VSTPluginInstance::stopEditing()
 		{
 			vst3View->removed();
 			vst3View->setFrame(NULL);
-			vst3View->release();
-			vst3View = NULL;
+			vst3View.reset();
 		}
-		if (vst3EditorHostWindow != NULL)
-		{
-			DestroyWindow(vst3EditorHostWindow);
-			vst3EditorHostWindow = NULL;
-		}
+		vst3EditorHostWindow.reset();
 		return;
 	}
 
 	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_EDITOR_CLOSE, 0, 0, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_EDITOR_CLOSE, 0, 0, NULL, 0.0f);
 }

--- a/helpers/VSTPluginInstance.State.cpp
+++ b/helpers/VSTPluginInstance.State.cpp
@@ -18,15 +18,87 @@
 */
 
 #include "stdafx.h"
+#include <limits>
 #include <wincrypt.h>
 #include "StringHelper.h"
 #include "VSTPluginLibrary.h"
 #include "VSTPluginInstance.h"
 #include "VSTPluginInstanceInternal.h"
+#include "pluginterfaces/base/smartpointer.h"
 
 using namespace std;
 using namespace Steinberg;
 using namespace Steinberg::Vst;
+
+namespace
+{
+	bool decodeBase64(const wstring& encoded, vector<char>& decoded)
+	{
+		DWORD requiredSize = 0;
+		if (CryptStringToBinaryW(
+			encoded.c_str(),
+			0,
+			CRYPT_STRING_BASE64,
+			NULL,
+			&requiredSize,
+			NULL,
+			NULL) != TRUE)
+		{
+			return false;
+		}
+
+		vector<char> result(requiredSize);
+		DWORD actualSize = requiredSize;
+		if (requiredSize != 0 && CryptStringToBinaryW(
+			encoded.c_str(),
+			0,
+			CRYPT_STRING_BASE64,
+			reinterpret_cast<BYTE*>(result.data()),
+			&actualSize,
+			NULL,
+			NULL) != TRUE)
+		{
+			return false;
+		}
+
+		result.resize(actualSize);
+		decoded = move(result);
+		return true;
+	}
+
+	bool encodeBase64(const void* data, size_t size, wstring& encoded)
+	{
+		if (size > (numeric_limits<DWORD>::max)())
+			return false;
+
+		const DWORD binarySize = static_cast<DWORD>(size);
+		DWORD requiredLength = 0;
+		if (CryptBinaryToStringW(
+			static_cast<const BYTE*>(data),
+			binarySize,
+			CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
+			NULL,
+			&requiredLength) != TRUE)
+		{
+			return false;
+		}
+
+		vector<wchar_t> result(requiredLength);
+		DWORD actualLength = requiredLength;
+		if (requiredLength == 0 || CryptBinaryToStringW(
+			static_cast<const BYTE*>(data),
+			binarySize,
+			CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
+			result.data(),
+			&actualLength) != TRUE)
+		{
+			return false;
+		}
+
+		encoded.assign(result.data());
+		return true;
+	}
+}
 
 void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::unordered_map<std::wstring, float>& paramMap)
 {
@@ -34,23 +106,20 @@ void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::
 	{
 		if (chunkData != L"")
 		{
-			DWORD bufSize = 0;
-			CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, NULL, &bufSize, NULL, NULL);
-			vector<char> data(bufSize);
-			if (bufSize > 0 && CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, (BYTE*)data.data(), &bufSize, NULL, NULL) == TRUE)
+			vector<char> data;
+			if (decodeBase64(chunkData, data) && !data.empty())
 			{
-				VST3MemoryStream* stream = new VST3MemoryStream(data);
+				auto stream = IPtr<VST3MemoryStream>::adopt(new VST3MemoryStream(data));
 				if (vst3Component != NULL)
-					vst3Component->setState(stream);
+					vst3Component->setState(stream.get());
 				stream->seek(0, IBStream::kIBSeekSet);
 				if (vst3Controller != NULL)
-					vst3Controller->setState(stream);
-				stream->release();
+					vst3Controller->setState(stream.get());
 			}
 		}
 		else if (vst3Controller != NULL)
 		{
-			for (auto it : paramMap)
+			for (const auto& it : paramMap)
 			{
 				for (int32 i = 0; i < vst3Controller->getParameterCount(); i++)
 				{
@@ -74,12 +143,9 @@ void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::
 	{
 		if (chunkData != L"")
 		{
-			DWORD bufSize = 0;
-			CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, NULL, &bufSize, NULL, NULL);
-			BYTE* buf = new BYTE[bufSize];
-			if (CryptStringToBinaryW(chunkData.c_str(), 0, CRYPT_STRING_BASE64, buf, &bufSize, NULL, NULL) == TRUE)
-				effect->control(effect, VST_EFFECT_OPCODE_SET_CHUNK_DATA, 1, bufSize, buf, 0.0f);
-			delete[] buf;
+			vector<char> data;
+			if (decodeBase64(chunkData, data))
+				effect->control(effect.get(), VST_EFFECT_OPCODE_SET_CHUNK_DATA, 1, data.size(), data.data(), 0.0f);
 		}
 	}
 	else
@@ -87,12 +153,12 @@ void VSTPluginInstance::writeToEffect(const std::wstring& chunkData, const std::
 		for (int i = 0; i < effect->num_params; i++)
 		{
 			char buf[256];
-			effect->control(effect, VST_EFFECT_OPCODE_PARAM_GET_NAME, i, 0, buf, 0.0f);
+			effect->control(effect.get(), VST_EFFECT_OPCODE_PARAM_GET_NAME, i, 0, buf, 0.0f);
 			buf[255] = '\0'; // just to be sure
 			wstring name = StringHelper::toWString(buf, CP_UTF8);
 			auto it = paramMap.find(name);
 			if (it != paramMap.end())
-				effect->set_parameter(effect, i, it->second);
+				effect->set_parameter(effect.get(), i, it->second);
 		}
 	}
 }
@@ -106,17 +172,9 @@ void VSTPluginInstance::readFromEffect(std::wstring& chunkData, std::unordered_m
 
 		if (vst3Component != NULL)
 		{
-			VST3MemoryStream* stream = new VST3MemoryStream();
-			if (vst3Component->getState(stream) == kResultOk && !stream->getData().empty())
-			{
-				DWORD stringLength = 0;
-				CryptBinaryToStringW((BYTE*)stream->getData().data(), (DWORD)stream->getData().size(), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &stringLength);
-				wchar_t* string = new wchar_t[stringLength];
-				if (CryptBinaryToStringW((BYTE*)stream->getData().data(), (DWORD)stream->getData().size(), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, string, &stringLength) == TRUE)
-					chunkData = string;
-				delete[] string;
-			}
-			stream->release();
+			auto stream = IPtr<VST3MemoryStream>::adopt(new VST3MemoryStream());
+			if (vst3Component->getState(stream.get()) == kResultOk && !stream->getData().empty())
+				encodeBase64(stream->getData().data(), stream->getData().size(), chunkData);
 		}
 
 		if (chunkData == L"" && vst3Controller != NULL)
@@ -140,22 +198,18 @@ void VSTPluginInstance::readFromEffect(std::wstring& chunkData, std::unordered_m
 	if (effect->flags & VST_EFFECT_FLAG_CHUNKS)
 	{
 		BYTE* chunk = NULL;
-		int size = (int)effect->control(effect, VST_EFFECT_OPCODE_GET_CHUNK_DATA, 1, 0, &chunk, 0.0f);
-		DWORD stringLength = 0;
-		CryptBinaryToStringW(chunk, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, NULL, &stringLength);
-		wchar_t* string = new wchar_t[stringLength];
-		if (CryptBinaryToStringW(chunk, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, string, &stringLength) == TRUE)
-			chunkData = string;
-		delete[] string;
+		int size = (int)effect->control(effect.get(), VST_EFFECT_OPCODE_GET_CHUNK_DATA, 1, 0, &chunk, 0.0f);
+		if (chunk != NULL && size > 0)
+			encodeBase64(chunk, static_cast<size_t>(size), chunkData);
 	}
 	else
 	{
 		for (int i = 0; i < effect->num_params; i++)
 		{
 			char buf[256];
-			effect->control(effect, VST_EFFECT_OPCODE_PARAM_GET_NAME, i, 0, buf, 0.0f);
+			effect->control(effect.get(), VST_EFFECT_OPCODE_PARAM_GET_NAME, i, 0, buf, 0.0f);
 			buf[255] = '\0'; // just to be sure
-			float value = effect->get_parameter(effect, i);
+			float value = effect->get_parameter(effect.get(), i);
 			paramMap[StringHelper::toWString(buf, CP_UTF8)] = value;
 		}
 	}

--- a/helpers/VSTPluginInstance.VST2.cpp
+++ b/helpers/VSTPluginInstance.VST2.cpp
@@ -135,17 +135,18 @@ bool VSTPluginInstance::initializeVST2()
 
 	__try
 	{
-		effect = library->VSTPluginMain(callback);
-		effect->host_internal = this;
-		if (effect->magic_number == VST_MAGICNUMBER)
+		vst_effect_t* candidate = library->VSTPluginMain(callback);
+		if (candidate != NULL && candidate->magic_number == VST_MAGICNUMBER)
 		{
-			effect->control(effect, VST_EFFECT_OPCODE_INITIALIZE, 0, 0, NULL, 0.0f);
+			effect.reset(candidate);
+			effect->host_internal = this;
+			effect->control(effect.get(), VST_EFFECT_OPCODE_INITIALIZE, 0, 0, NULL, 0.0f);
 
 			usedChannelCount = max(numInputs(), numOutputs());
 		}
 		else
 		{
-			effect = NULL;
+			result = false;
 		}
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)

--- a/helpers/VSTPluginInstance.VST3.cpp
+++ b/helpers/VSTPluginInstance.VST3.cpp
@@ -23,6 +23,7 @@
 #include "VSTPluginInstance.h"
 #include "VSTPluginInstanceInternal.h"
 #include "pluginterfaces/base/futils.h"
+#include "pluginterfaces/base/smartpointer.h"
 
 using namespace std;
 using namespace Steinberg;
@@ -30,20 +31,26 @@ using namespace Steinberg::Vst;
 
 bool VSTPluginInstance::initializeVST3()
 {
-	vst3HostContext = new VST3HostContext(this);
+	vst3HostContext = IPtr<VST3HostContext>::adopt(new VST3HostContext(this));
 
 	const PClassInfo& classInfo = library->getVST3ClassInfo();
 	FUID componentId(classInfo.cid);
 	TUID componentIid;
 	IComponent::iid.toTUID(componentIid);
-	if (library->getFactory()->createInstance(componentId, componentIid, (void**)&vst3Component) != kResultOk || vst3Component == NULL)
+	IComponent* rawComponent = NULL;
+	const tresult componentResult = library->getFactory()->createInstance(
+		componentId,
+		componentIid,
+		(void**)&rawComponent);
+	vst3Component = IPtr<IComponent>::adopt(rawComponent);
+	if (componentResult != kResultOk || vst3Component == NULL)
 	{
 		LogF(L"Could not create IComponent instance of VST3 plugin %s.", library->getLibPath().c_str());
 		return false;
 	}
 
 	vst3Component->setIoMode(kSimple);
-	if (vst3Component->initialize(static_cast<IHostApplication*>(vst3HostContext)) != kResultOk)
+	if (vst3Component->initialize(static_cast<IHostApplication*>(vst3HostContext.get())) != kResultOk)
 	{
 		LogF(L"Could not initialize IComponent of VST3 plugin %s.", library->getLibPath().c_str());
 		return false;
@@ -51,7 +58,10 @@ bool VSTPluginInstance::initializeVST3()
 
 	TUID processorIid;
 	IAudioProcessor::iid.toTUID(processorIid);
-	if (vst3Component->queryInterface(processorIid, (void**)&vst3Processor) != kResultOk || vst3Processor == NULL)
+	IAudioProcessor* rawProcessor = NULL;
+	const tresult processorResult = vst3Component->queryInterface(processorIid, (void**)&rawProcessor);
+	vst3Processor = IPtr<IAudioProcessor>::adopt(rawProcessor);
+	if (processorResult != kResultOk || vst3Processor == NULL)
 	{
 		LogF(L"VST3 plugin %s does not provide the IAudioProcessor interface.", library->getLibPath().c_str());
 		return false;
@@ -63,31 +73,48 @@ bool VSTPluginInstance::initializeVST3()
 	{
 		TUID controllerIid;
 		IEditController::iid.toTUID(controllerIid);
-		library->getFactory()->createInstance(controllerClassId, controllerIid, (void**)&vst3Controller);
+		IEditController* rawController = NULL;
+		library->getFactory()->createInstance(controllerClassId, controllerIid, (void**)&rawController);
+		vst3Controller = IPtr<IEditController>::adopt(rawController);
 	}
 	if (vst3Controller == NULL)
 	{
 		TUID controllerIid;
 		IEditController::iid.toTUID(controllerIid);
-		vst3Component->queryInterface(controllerIid, (void**)&vst3Controller);
+		IEditController* rawController = NULL;
+		vst3Component->queryInterface(controllerIid, (void**)&rawController);
+		vst3Controller = IPtr<IEditController>::adopt(rawController);
 	}
 	if (vst3Controller != NULL)
 	{
-		vst3Controller->initialize(static_cast<IHostApplication*>(vst3HostContext));
-		vst3Controller->setComponentHandler(vst3HostContext);
+		vst3Controller->initialize(static_cast<IHostApplication*>(vst3HostContext.get()));
+		vst3Controller->setComponentHandler(static_cast<IComponentHandler*>(vst3HostContext.get()));
 
-		VST3MemoryStream* stream = new VST3MemoryStream();
-		if (vst3Component->getState(stream) == kResultOk)
+		auto stream = IPtr<VST3MemoryStream>::adopt(new VST3MemoryStream());
+		if (vst3Component->getState(stream.get()) == kResultOk)
 		{
 			stream->seek(0, IBStream::kIBSeekSet);
-			vst3Controller->setComponentState(stream);
+			vst3Controller->setComponentState(stream.get());
 		}
-		stream->release();
 
 		TUID connectionPointIid;
 		Steinberg::Vst::IConnectionPoint::iid.toTUID(connectionPointIid);
-		if (vst3Component->queryInterface(connectionPointIid, (void**)&vst3ComponentConnection) == kResultOk
-			&& vst3Controller->queryInterface(connectionPointIid, (void**)&vst3ControllerConnection) == kResultOk)
+		Steinberg::Vst::IConnectionPoint* rawComponentConnection = NULL;
+		const tresult componentConnectionResult = vst3Component->queryInterface(
+			connectionPointIid,
+			(void**)&rawComponentConnection);
+		vst3ComponentConnection = IPtr<Steinberg::Vst::IConnectionPoint>::adopt(rawComponentConnection);
+
+		Steinberg::Vst::IConnectionPoint* rawControllerConnection = NULL;
+		const tresult controllerConnectionResult = vst3Controller->queryInterface(
+			connectionPointIid,
+			(void**)&rawControllerConnection);
+		vst3ControllerConnection = IPtr<Steinberg::Vst::IConnectionPoint>::adopt(rawControllerConnection);
+
+		if (componentConnectionResult == kResultOk
+			&& controllerConnectionResult == kResultOk
+			&& vst3ComponentConnection != NULL
+			&& vst3ControllerConnection != NULL)
 		{
 			vst3ComponentConnection->connect(vst3ControllerConnection);
 			vst3ControllerConnection->connect(vst3ComponentConnection);
@@ -118,7 +145,7 @@ void VSTPluginInstance::releaseVST3()
 	automateFunc = nullptr;
 	sizeWindowFunc = nullptr;
 	stopEditing();
-	stopProcessing();
+	stopProcessingSafely();
 
 	if (vst3Controller != NULL)
 		vst3Controller->setComponentHandler(NULL);
@@ -129,37 +156,23 @@ void VSTPluginInstance::releaseVST3()
 		vst3ControllerConnection->disconnect(vst3ComponentConnection);
 	}
 	if (vst3ComponentConnection != NULL)
-	{
-		vst3ComponentConnection->release();
-		vst3ComponentConnection = NULL;
-	}
+		vst3ComponentConnection.reset();
 	if (vst3ControllerConnection != NULL)
-	{
-		vst3ControllerConnection->release();
-		vst3ControllerConnection = NULL;
-	}
+		vst3ControllerConnection.reset();
 	if (vst3Controller != NULL)
 	{
 		vst3Controller->terminate();
-		vst3Controller->release();
-		vst3Controller = NULL;
+		vst3Controller.reset();
 	}
 	if (vst3Processor != NULL)
-	{
-		vst3Processor->release();
-		vst3Processor = NULL;
-	}
+		vst3Processor.reset();
 	if (vst3Component != NULL)
 	{
 		vst3Component->terminate();
-		vst3Component->release();
-		vst3Component = NULL;
+		vst3Component.reset();
 	}
 	if (vst3HostContext != NULL)
-	{
-		vst3HostContext->release();
-		vst3HostContext = NULL;
-	}
+		vst3HostContext.reset();
 }
 
 void VSTPluginInstance::configureVST3Buses(int requestedChannelCount)

--- a/helpers/VSTPluginInstance.cpp
+++ b/helpers/VSTPluginInstance.cpp
@@ -38,6 +38,7 @@
 #include "../Version.h"
 #include "VSTPluginLibrary.h"
 #include "VSTPluginInstance.h"
+#include "VSTPluginInstanceInternal.h"
 #include "pluginterfaces/base/futils.h"
 
 using namespace std;
@@ -87,6 +88,22 @@ public:
 static EmptyVST3ParameterChanges emptyVST3ParameterChanges;
 static EmptyVST3EventList emptyVST3EventList;
 
+void VST2EffectDeleter::operator()(vst_effect_t* effect) const noexcept
+{
+	if (effect != NULL)
+	{
+		__try
+		{
+			effect->control(effect, VST_EFFECT_OPCODE_DESTROY, 0, 0, NULL, 0.0f);
+		}
+		__except (EXCEPTION_EXECUTE_HANDLER)
+		{
+			// A broken plugin must not take down the host while its RAII owner
+			// unwinds. The plugin's memory is no longer safely reclaimable here.
+		}
+	}
+}
+
 VSTPluginInstance::VSTPluginInstance(const std::shared_ptr<VSTPluginLibrary>& library, int processLevel)
 	: library(library), processLevel(processLevel)
 {
@@ -97,11 +114,7 @@ VSTPluginInstance::~VSTPluginInstance()
 	automateFunc = nullptr;
 	sizeWindowFunc = nullptr;
 	releaseVST3();
-	if (effect != NULL)
-	{
-		effect->control(effect, VST_EFFECT_OPCODE_DESTROY, 0, 0, NULL, 0.0f);
-		effect = NULL;
-	}
+	effect.reset();
 }
 
 bool VSTPluginInstance::initialize()
@@ -174,7 +187,7 @@ std::wstring VSTPluginInstance::getName() const
 
 	char buf[256];
 	memset(buf, 0, sizeof(buf));
-	effect->control(effect, VST_EFFECT_OPCODE_EFFECT_NAME, 0, 0, buf, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_EFFECT_NAME, 0, 0, buf, 0.0f);
 	buf[255] = '\0'; // just to be sure
 
 	return StringHelper::toWString(buf, CP_UTF8);
@@ -255,8 +268,8 @@ void VSTPluginInstance::prepareForProcessing(float sampleRate, int blockSize)
 		return;
 
 	this->sampleRate = sampleRate;
-	effect->control(effect, VST_EFFECT_OPCODE_SET_SAMPLE_RATE, 0, 0, NULL, sampleRate);
-	effect->control(effect, VST_EFFECT_OPCODE_SET_BLOCK_SIZE, 0, blockSize, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_SET_SAMPLE_RATE, 0, 0, NULL, sampleRate);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_SET_BLOCK_SIZE, 0, blockSize, NULL, 0.0f);
 }
 
 void VSTPluginInstance::startProcessing()
@@ -279,8 +292,8 @@ void VSTPluginInstance::startProcessing()
 	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_SUSPEND, 0, 1, NULL, 0.0f);
-	effect->control(effect, VST_EFFECT_OPCODE_PROCESS_BEGIN, 0, 0, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_SUSPEND, 0, 1, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_PROCESS_BEGIN, 0, 0, NULL, 0.0f);
 }
 
 void VSTPluginInstance::processReplacing(float** inputArray, float** outputArray, int frameCount)
@@ -318,7 +331,7 @@ void VSTPluginInstance::processReplacing(float** inputArray, float** outputArray
 	if (effect == NULL)
 		return;
 
-	effect->process_float(effect, inputArray, outputArray, frameCount);
+	effect->process_float(effect.get(), inputArray, outputArray, frameCount);
 }
 
 void VSTPluginInstance::processDoubleReplacing(double** inputArray, double** outputArray, int frameCount)
@@ -356,7 +369,7 @@ void VSTPluginInstance::processDoubleReplacing(double** inputArray, double** out
 	if (effect == NULL)
 		return;
 
-	effect->process_double(effect, inputArray, outputArray, frameCount);
+	effect->process_double(effect.get(), inputArray, outputArray, frameCount);
 }
 
 void VSTPluginInstance::process(float** inputArray, float** outputArray, int frameCount)
@@ -370,7 +383,7 @@ void VSTPluginInstance::process(float** inputArray, float** outputArray, int fra
 	if (effect == NULL)
 		return;
 
-	effect->process(effect, inputArray, outputArray, frameCount);
+	effect->process(effect.get(), inputArray, outputArray, frameCount);
 }
 
 void VSTPluginInstance::stopProcessing()
@@ -393,8 +406,20 @@ void VSTPluginInstance::stopProcessing()
 	if (effect == NULL)
 		return;
 
-	effect->control(effect, VST_EFFECT_OPCODE_PROCESS_END, 0, 0, NULL, 0.0f);
-	effect->control(effect, VST_EFFECT_OPCODE_SUSPEND, 0, 0, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_PROCESS_END, 0, 0, NULL, 0.0f);
+	effect->control(effect.get(), VST_EFFECT_OPCODE_SUSPEND, 0, 0, NULL, 0.0f);
+}
+
+void VSTPluginInstance::stopProcessingSafely() noexcept
+{
+	__try
+	{
+		stopProcessing();
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER)
+	{
+		// Cleanup is best effort across a third-party native-code boundary.
+	}
 }
 
 void VSTPluginInstance::setAutomateFunc(std::function<void()> func)
@@ -415,12 +440,12 @@ void VSTPluginInstance::setSizeWindowFunc(std::function<void(int, int)> func)
 
 void VSTPluginInstance::onSizeWindow(int w, int h)
 {
-	if (vst3EditorHostWindow != NULL)
+	if (vst3EditorHostWindow)
 	{
 		// w/h arrive in physical pixels from the plugin's resizeView request.
 		// The native host window takes physical px; the Qt frame
 		// (sizeWindowFunc) takes logical px, so divide by the editor scale.
-		SetWindowPos(vst3EditorHostWindow, NULL, 0, 0, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+		SetWindowPos(vst3EditorHostWindow.get(), NULL, 0, 0, w, h, SWP_NOZORDER | SWP_NOACTIVATE | SWP_SHOWWINDOW);
 		if (sizeWindowFunc)
 		{
 			double s = editorScaleFactor > 0.0 ? editorScaleFactor : 1.0;

--- a/helpers/VSTPluginInstance.h
+++ b/helpers/VSTPluginInstance.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include "aeffectx.h"
 #include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/base/smartpointer.h"
 #include "pluginterfaces/vst/ivstaudioprocessor.h"
 #include "pluginterfaces/vst/ivsteditcontroller.h"
 #include "pluginterfaces/vst/ivstevents.h"
@@ -32,8 +33,16 @@
 #include "pluginterfaces/vst/ivstparameterchanges.h"
 #include "pluginterfaces/vst/ivstprocesscontext.h"
 #include "pluginterfaces/gui/iplugview.h"
+#include "Win32Resource.h"
 
 class VSTPluginLibrary;
+
+struct VST2EffectDeleter
+{
+	void operator()(vst_effect_t* effect) const noexcept;
+};
+
+using VST2EffectPtr = std::unique_ptr<vst_effect_t, VST2EffectDeleter>;
 
 class VSTPluginInstance
 {
@@ -67,6 +76,7 @@ public:
 	void processReplacing(float** inputArray, float** outputArray, int frameCount);
 	void process(float** inputArray, float** outputArray, int frameCount);
 	void stopProcessing();
+	void stopProcessingSafely() noexcept;
 
 	bool startEditing(HWND hWnd, short* width, short* height, double scaleFactor = 1.0);
 	void doIdle();
@@ -93,15 +103,15 @@ private:
 	Steinberg::Vst::SpeakerArrangement speakerArrangementForChannelCount(int count) const;
 
 	std::shared_ptr<VSTPluginLibrary> library;
-	vst_effect_t* effect = NULL;
-	Steinberg::Vst::IComponent* vst3Component = NULL;
-	Steinberg::Vst::IAudioProcessor* vst3Processor = NULL;
-	Steinberg::Vst::IEditController* vst3Controller = NULL;
-	Steinberg::Vst::IConnectionPoint* vst3ComponentConnection = NULL;
-	Steinberg::Vst::IConnectionPoint* vst3ControllerConnection = NULL;
-	Steinberg::IPlugView* vst3View = NULL;
-	HWND vst3EditorHostWindow = NULL;
-	VST3HostContext* vst3HostContext = NULL;
+	VST2EffectPtr effect;
+	Steinberg::IPtr<Steinberg::Vst::IComponent> vst3Component;
+	Steinberg::IPtr<Steinberg::Vst::IAudioProcessor> vst3Processor;
+	Steinberg::IPtr<Steinberg::Vst::IEditController> vst3Controller;
+	Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> vst3ComponentConnection;
+	Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> vst3ControllerConnection;
+	Steinberg::IPtr<Steinberg::IPlugView> vst3View;
+	winutil::UniqueWindowHandle vst3EditorHostWindow;
+	Steinberg::IPtr<VST3HostContext> vst3HostContext;
 	int vst3InputBusCount = 0;
 	int vst3OutputBusCount = 0;
 	int vst3InputChannelCount = 0;

--- a/helpers/VSTPluginLibrary.cpp
+++ b/helpers/VSTPluginLibrary.cpp
@@ -22,6 +22,7 @@
 #include "RegistryHelper.h"
 #include "LogHelper.h"
 #include "VSTPluginLibrary.h"
+#include "Win32Resource.h"
 #include "pluginterfaces/vst/ivstaudioprocessor.h"
 
 using namespace std;
@@ -116,7 +117,7 @@ bool VSTPluginLibrary::isVST3() const
 
 Steinberg::IPluginFactory* VSTPluginLibrary::getFactory() const
 {
-	return factory;
+	return factory.get();
 }
 
 const Steinberg::PClassInfo& VSTPluginLibrary::getVST3ClassInfo() const
@@ -128,11 +129,11 @@ bool VSTPluginLibrary::loadFunctions()
 {
 	if (vst3)
 	{
-		GetPluginFactory = (getPluginFactoryFunc)GetProcAddress(module, "GetPluginFactory");
+		GetPluginFactory = (getPluginFactoryFunc)GetProcAddress(module.get(), "GetPluginFactory");
 		return GetPluginFactory != NULL;
 	}
 
-	VSTPluginMain = (vstPluginMain)GetProcAddress(module, "VSTPluginMain");
+	VSTPluginMain = (vstPluginMain)GetProcAddress(module.get(), "VSTPluginMain");
 	return VSTPluginMain != NULL;
 }
 
@@ -141,8 +142,8 @@ int VSTPluginLibrary::customInitialize()
 	if (!vst3)
 		return 0;
 
-	factory = GetPluginFactory();
-	if (factory == NULL)
+	factory.reset(GetPluginFactory());
+	if (!factory)
 		return FUNCTIONS_MISSING;
 
 	for (Steinberg::int32 i = 0; i < factory->countClasses(); i++)
@@ -166,11 +167,7 @@ void VSTPluginLibrary::customUninitialize() noexcept
 
 void VSTPluginLibrary::releasePluginFactory() noexcept
 {
-	if (factory != nullptr)
-	{
-		factory->release();
-		factory = nullptr;
-	}
+	factory.reset();
 	GetPluginFactory = nullptr;
 	VSTPluginMain = nullptr;
 }
@@ -214,8 +211,8 @@ wstring VSTPluginLibrary::resolveVST3ModulePath(const wstring& libPath)
 	PathAppendW(searchPath, L"*.vst3");
 
 	WIN32_FIND_DATAW findData;
-	HANDLE hFind = FindFirstFileW(searchPath, &findData);
-	if (hFind == INVALID_HANDLE_VALUE)
+	winutil::UniqueFindHandle find(FindFirstFileW(searchPath, &findData));
+	if (!find)
 		return libPath;
 
 	wchar_t modulePath[MAX_PATH];
@@ -223,7 +220,5 @@ wstring VSTPluginLibrary::resolveVST3ModulePath(const wstring& libPath)
 	PathAppendW(modulePath, L"Contents");
 	PathAppendW(modulePath, platformDir);
 	PathAppendW(modulePath, findData.cFileName);
-	FindClose(hFind);
-
 	return modulePath;
 }

--- a/helpers/VSTPluginLibrary.h
+++ b/helpers/VSTPluginLibrary.h
@@ -53,6 +53,15 @@ protected:
 	void customUninitialize() noexcept override;
 
 private:
+	struct FactoryDeleter
+	{
+		void operator()(Steinberg::IPluginFactory* value) const noexcept
+		{
+			if (value != nullptr)
+				value->release();
+		}
+	};
+
 	VSTPluginLibrary(const std::wstring& libPath);
 	void releasePluginFactory() noexcept;
 	static std::wstring resolveVST3ModulePath(const std::wstring& libPath);
@@ -61,6 +70,6 @@ private:
 	std::wstring libPath;
 	std::wstring loadPath;
 	bool vst3 = false;
-	Steinberg::IPluginFactory* factory = NULL;
+	std::unique_ptr<Steinberg::IPluginFactory, FactoryDeleter> factory;
 	Steinberg::PClassInfo vst3ClassInfo;
 };

--- a/helpers/Win32Event.h
+++ b/helpers/Win32Event.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
 #include <system_error>
-#include <utility>
+
+#include "Win32Resource.h"
 
 class Win32Event
 {
@@ -12,48 +10,31 @@ public:
 	Win32Event(bool manualReset, bool initialState)
 		: handle(CreateEventW(nullptr, manualReset, initialState, nullptr))
 	{
-		if (handle == nullptr)
+		if (!handle)
 			throw std::system_error(static_cast<int>(GetLastError()), std::system_category(), "CreateEventW");
 	}
 
-	~Win32Event()
-	{
-		if (handle != nullptr)
-			CloseHandle(handle);
-	}
+	~Win32Event() = default;
 
 	Win32Event(const Win32Event&) = delete;
 	Win32Event& operator=(const Win32Event&) = delete;
 
-	Win32Event(Win32Event&& other) noexcept
-		: handle(std::exchange(other.handle, nullptr))
-	{
-	}
-
-	Win32Event& operator=(Win32Event&& other) noexcept
-	{
-		if (this != &other)
-		{
-			if (handle != nullptr)
-				CloseHandle(handle);
-			handle = std::exchange(other.handle, nullptr);
-		}
-		return *this;
-	}
+	Win32Event(Win32Event&&) noexcept = default;
+	Win32Event& operator=(Win32Event&&) noexcept = default;
 
 	HANDLE get() const
 	{
-		return handle;
+		return handle.get();
 	}
 
 	void set() const
 	{
-		SetEvent(handle);
+		SetEvent(handle.get());
 	}
 
 	void reset() const
 	{
-		ResetEvent(handle);
+		ResetEvent(handle.get());
 	}
 
 	static DWORD waitAny(DWORD count, const HANDLE* handles, DWORD milliseconds = INFINITE)
@@ -67,5 +48,5 @@ public:
 	}
 
 private:
-	HANDLE handle;
+	winutil::UniqueHandle handle;
 };

--- a/helpers/Win32Resource.h
+++ b/helpers/Win32Resource.h
@@ -1,0 +1,292 @@
+/*
+	This file is part of EqualizerAPO, a system-wide equalizer.
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winreg.h>
+#include <winsvc.h>
+#include <authz.h>
+#include <winhttp.h>
+
+#include <utility>
+
+namespace winutil
+{
+	template<typename Traits>
+	class UniqueResource
+	{
+	public:
+		using resource_type = typename Traits::resource_type;
+
+		UniqueResource() noexcept = default;
+		explicit UniqueResource(resource_type resource) noexcept
+			: resource(resource)
+		{
+		}
+
+		~UniqueResource()
+		{
+			reset();
+		}
+
+		UniqueResource(const UniqueResource&) = delete;
+		UniqueResource& operator=(const UniqueResource&) = delete;
+
+		UniqueResource(UniqueResource&& other) noexcept
+			: resource(other.release())
+		{
+		}
+
+		UniqueResource& operator=(UniqueResource&& other) noexcept
+		{
+			if (this != &other)
+				reset(other.release());
+			return *this;
+		}
+
+		resource_type get() const noexcept { return resource; }
+		explicit operator bool() const noexcept { return Traits::isValid(resource); }
+
+		resource_type release() noexcept
+		{
+			return std::exchange(resource, Traits::invalid());
+		}
+
+		void reset(resource_type replacement = Traits::invalid()) noexcept
+		{
+			if (resource != replacement && Traits::isValid(resource))
+				Traits::close(resource);
+			resource = replacement;
+		}
+
+		// For Win32 APIs that return a resource through an out-parameter.
+		// Any currently owned resource is released before its address is exposed.
+		resource_type* put() noexcept
+		{
+			reset();
+			return &resource;
+		}
+
+	private:
+		resource_type resource = Traits::invalid();
+	};
+
+	struct HandleTraits
+	{
+		using resource_type = HANDLE;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept
+		{
+			return value != nullptr && value != INVALID_HANDLE_VALUE;
+		}
+		static void close(resource_type value) noexcept { CloseHandle(value); }
+	};
+
+	struct RegistryKeyTraits
+	{
+		using resource_type = HKEY;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { RegCloseKey(value); }
+	};
+
+	struct ServiceHandleTraits
+	{
+		using resource_type = SC_HANDLE;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { CloseServiceHandle(value); }
+	};
+
+	struct ModuleTraits
+	{
+		using resource_type = HMODULE;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { FreeLibrary(value); }
+	};
+
+	struct FindHandleTraits
+	{
+		using resource_type = HANDLE;
+		static resource_type invalid() noexcept { return INVALID_HANDLE_VALUE; }
+		static bool isValid(resource_type value) noexcept
+		{
+			return value != nullptr && value != INVALID_HANDLE_VALUE;
+		}
+		static void close(resource_type value) noexcept { FindClose(value); }
+	};
+
+	struct ChangeNotificationTraits
+	{
+		using resource_type = HANDLE;
+		static resource_type invalid() noexcept { return INVALID_HANDLE_VALUE; }
+		static bool isValid(resource_type value) noexcept
+		{
+			return value != nullptr && value != INVALID_HANDLE_VALUE;
+		}
+		static void close(resource_type value) noexcept { FindCloseChangeNotification(value); }
+	};
+
+	struct MappedViewTraits
+	{
+		using resource_type = void*;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { UnmapViewOfFile(value); }
+	};
+
+	struct WindowHandleTraits
+	{
+		using resource_type = HWND;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { DestroyWindow(value); }
+	};
+
+	struct SidTraits
+	{
+		using resource_type = PSID;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { FreeSid(value); }
+	};
+
+	struct AuthzResourceManagerTraits
+	{
+		using resource_type = AUTHZ_RESOURCE_MANAGER_HANDLE;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { AuthzFreeResourceManager(value); }
+	};
+
+	struct AuthzContextTraits
+	{
+		using resource_type = AUTHZ_CLIENT_CONTEXT_HANDLE;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { AuthzFreeContext(value); }
+	};
+
+	struct WinHttpHandleTraits
+	{
+		using resource_type = HINTERNET;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(resource_type value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { WinHttpCloseHandle(value); }
+	};
+
+	template<typename T>
+	struct LocalMemoryTraits
+	{
+		using resource_type = T*;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(const T* value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { LocalFree(value); }
+	};
+
+	template<typename T>
+	struct CoTaskMemoryTraits
+	{
+		using resource_type = T*;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(const T* value) noexcept { return value != nullptr; }
+		static void close(resource_type value) noexcept { CoTaskMemFree(value); }
+	};
+
+	template<typename T>
+	struct ProcessHeapMemoryTraits
+	{
+		using resource_type = T*;
+		static resource_type invalid() noexcept { return nullptr; }
+		static bool isValid(const T* value) noexcept { return value != nullptr; }
+		// cppcheck-suppress constParameterPointer ; HeapFree requires a mutable LPVOID even though it does not modify the block before releasing it
+		static void close(resource_type value) noexcept
+		{
+			HeapFree(GetProcessHeap(), 0, value);
+		}
+	};
+
+	using UniqueHandle = UniqueResource<HandleTraits>;
+	using UniqueRegistryKey = UniqueResource<RegistryKeyTraits>;
+	using UniqueServiceHandle = UniqueResource<ServiceHandleTraits>;
+	using UniqueModule = UniqueResource<ModuleTraits>;
+	using UniqueFindHandle = UniqueResource<FindHandleTraits>;
+	using UniqueChangeNotification = UniqueResource<ChangeNotificationTraits>;
+	using UniqueMappedView = UniqueResource<MappedViewTraits>;
+	using UniqueWindowHandle = UniqueResource<WindowHandleTraits>;
+	using UniqueSid = UniqueResource<SidTraits>;
+	using UniqueAuthzResourceManager = UniqueResource<AuthzResourceManagerTraits>;
+	using UniqueAuthzContext = UniqueResource<AuthzContextTraits>;
+	using UniqueWinHttpHandle = UniqueResource<WinHttpHandleTraits>;
+
+	template<typename T>
+	using UniqueLocalPtr = UniqueResource<LocalMemoryTraits<T>>;
+
+	template<typename T>
+	using UniqueCoTaskMemPtr = UniqueResource<CoTaskMemoryTraits<T>>;
+
+	template<typename T>
+	using UniqueProcessHeapPtr = UniqueResource<ProcessHeapMemoryTraits<T>>;
+
+	class UniqueProcessInformation
+	{
+	public:
+		UniqueProcessInformation() noexcept = default;
+		~UniqueProcessInformation() { reset(); }
+
+		UniqueProcessInformation(const UniqueProcessInformation&) = delete;
+		UniqueProcessInformation& operator=(const UniqueProcessInformation&) = delete;
+
+		UniqueProcessInformation(UniqueProcessInformation&& other) noexcept
+			: value(other.release())
+		{
+		}
+
+		UniqueProcessInformation& operator=(UniqueProcessInformation&& other) noexcept
+		{
+			if (this != &other)
+			{
+				reset();
+				value = other.release();
+			}
+			return *this;
+		}
+
+		PROCESS_INFORMATION* put() noexcept
+		{
+			reset();
+			return &value;
+		}
+
+		const PROCESS_INFORMATION& get() const noexcept { return value; }
+		HANDLE process() const noexcept { return value.hProcess; }
+		HANDLE thread() const noexcept { return value.hThread; }
+		DWORD processId() const noexcept { return value.dwProcessId; }
+
+		PROCESS_INFORMATION release() noexcept
+		{
+			return std::exchange(value, PROCESS_INFORMATION{});
+		}
+
+		void reset() noexcept
+		{
+			if (HandleTraits::isValid(value.hThread))
+				HandleTraits::close(value.hThread);
+			if (HandleTraits::isValid(value.hProcess))
+				HandleTraits::close(value.hProcess);
+			value = {};
+		}
+
+	private:
+		PROCESS_INFORMATION value{};
+	};
+}

--- a/libHybridConv-0.1.1/libHybridConv_eapo.cpp
+++ b/libHybridConv-0.1.1/libHybridConv_eapo.cpp
@@ -38,6 +38,7 @@
 #endif
 #include <math.h>
 #include <fftw3.h>
+#include "../helpers/FftwRAII.h"
 #include "../helpers/LogHelper.h"
 #include "HcAlignedStorage.h"
 #include "libHybridConv_eapo.h"
@@ -78,36 +79,6 @@ struct HConvSingleStorage
 	std::vector<double*> mixImagPtrs;
 	HcAlignedPtr<double> historyTime;
 };
-
-namespace
-{
-class HcPlanOwner
-{
-public:
-	explicit HcPlanOwner(fftw_plan plan = nullptr) noexcept : plan(plan) {}
-	~HcPlanOwner()
-	{
-		if (plan != nullptr)
-			fftw_destroy_plan(plan);
-	}
-
-	HcPlanOwner(const HcPlanOwner&) = delete;
-	HcPlanOwner& operator=(const HcPlanOwner&) = delete;
-
-	fftw_plan get() const noexcept { return plan; }
-	fftw_plan release() noexcept
-	{
-		fftw_plan result = plan;
-		plan = nullptr;
-		return result;
-	}
-
-private:
-	fftw_plan plan;
-};
-}
-
-
 
 double hcTime(void)
 {
@@ -566,6 +537,8 @@ void hcInitSingle(HConvSingle * filter, double* h, int hlen, int flen, int steps
 	// FFTW_ESTIMATE so a fresh install does not introduce a multi-second audio glitch at startup.
 	// A separate warmup tool can pre-populate %LOCALAPPDATA%\EqualizerAPO\fftw_wisdom.dat to unlock the
 	// faster MEASURE path on subsequent runs.
+	fftw::Plan fft;
+	fftw::Plan ifft;
 	{
 		static std::mutex plannerMutex;
 		std::lock_guard<std::mutex> lock(plannerMutex);
@@ -584,20 +557,9 @@ void hcInitSingle(HConvSingle * filter, double* h, int hlen, int flen, int steps
 			});
 		}
 		unsigned fftw_flags = (wisdomAvailable ? FFTW_MEASURE : FFTW_ESTIMATE) | FFTW_PRESERVE_INPUT;
-		HcPlanOwner fft(fftw_plan_dft_r2c_1d(2 * flen, temp.dft_time, temp.dft_freq, fftw_flags));
-		if (fft.get() == nullptr)
-			throw std::runtime_error("FFTW could not create the forward convolution plan");
-		HcPlanOwner ifft(fftw_plan_dft_c2r_1d(2 * flen, temp.dft_freq, temp.dft_time, fftw_flags));
-		if (ifft.get() == nullptr)
-			throw std::runtime_error("FFTW could not create the inverse convolution plan");
-
-		temp.fft = fft.release();
-		temp.ifft = ifft.release();
+		fft = fftw::makeRealToComplexPlan(2 * flen, temp.dft_time, temp.dft_freq, fftw_flags);
+		ifft = fftw::makeComplexToRealPlan(2 * flen, temp.dft_freq, temp.dft_time, fftw_flags);
 	}
-	HcPlanOwner fft(temp.fft);
-	HcPlanOwner ifft(temp.ifft);
-	temp.fft = nullptr;
-	temp.ifft = nullptr;
 
 	gain = 0.5 / flen;
 


### PR DESCRIPTION
## What changed

- decomposed the legacy Copy GUI dependency so prepared routing state is owned as backend data instead of a hidden widget
- introduced reusable RAII owners for Win32, FFTW, SNDFILE, COM, MemoryHelper, VST2/VST3, and HybridConv resources
- made Qt UI/model ownership explicit with unique_ptr, parent ownership, and transactional FilterListModel mutation
- added entry-point exception boundaries and failure-path coverage for configuration I/O, allocation, routing, and malformed VST metadata
- preserved borrowed raw pointers at C/Qt/DSP seams while moving ownership to C++ types

## Why

The prior code mixed owning raw pointers with borrowed C and Qt handles. Partial initialization, constructor exceptions, invalid plugin metadata, and row/model rebuilds could therefore leak resources or leave cleanup dependent on implicit control flow. This change makes ownership local and deterministic without changing the real-time DSP contract.

## Real-time constraints

- no new allocation, mutex, exception, or logging in AVRT_CODE paths
- no DSP operation-order changes
- C ABI boundaries remain intact

## Validation

- Common Rebuild Release x64
- Editor Release x64 and DeviceSelector Qt 6.10.1/qmake Release x64
- EqualizerAPO Release x64
- Installer Release Win32
- VoicemeeterClient Release x64
- Benchmark Release x64
- AudioRegressionTests: 20/20
- EngineOrchestrationTests: 626 checks
- EditorLogicTests: 337 checks
- HybridConv, MultiConvolution, and VST host suites green, including 6 malformed VST metadata pass-through cases
- cppcheck 2.21 with CI rules: changed TUs clean in core, Editor, and apps/tests groups
- Bump-Version.ps1 -Check
- git diff --check

A whole-tree cppcheck run was stopped after its working set reached roughly 35 GB; the same CI rules were then run over every changed translation unit in three bounded groups.