### PR TITLE
perf: parallelize convolution and card preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -863,6 +863,10 @@ jobs:
         $env:QT_QPA_PLATFORM = "offscreen"
         # GUI-subsystem exe: qWarning only reaches redirected stderr with this set
         $env:QT_FORCE_STDERR_LOGGING = "1"
+        # Keep the measured 100+ row card rebuild within a useful regression
+        # budget. The historical default (8 s) was a crash-storm guard; the
+        # prepared-row/cached-badge path is expected to stay comfortably below 4 s.
+        $env:EAPO_SWITCH_LIMIT_MS = "4000"
         $log = "${{ github.workspace }}\skin-switch-test.log"
         $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
           -ArgumentList @("--skin-switch-test") -PassThru -Wait -NoNewWindow `

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,14 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- 설정을 불러올 때 Convolution, GraphicEQ, MultiConvolution과 큰 다채널
+  IR 준비 작업이 제한된 수의 멀티코어 작업자를 사용합니다. Modern Cards는
+  각 행의 파싱된 descriptor/scope를 한 번만 준비하고 고정 정규식과 색을
+  입힌 SVG 배지를 캐시해 스킨 재구성의 반복 작업을 줄였습니다. HConv
+  소유권은 순서가 뒤섞인 초기화와 롤백도 안전하게 처리하며, AVRT 오디오
+  콜백과 DSP 순서·출력 연산은 바뀌지 않았습니다. CI는 작업자 예외 정리를
+  검사하고 138행 offscreen 스킨 전환 스트레스 테스트에 4초 상한을
+  적용합니다. ([#200](https://github.com/115dkk/EqualizerAPO-XT/pull/200))
 - 설정 저장을 원자적으로 바꾸고, 일부만 읽힌 설정은 정상 오디오 그래프로
   적용하지 않게 했습니다. 필터 팩터리, HybridConv/FFTW 플랜, IR 데이터,
   Copy/IIR 상태, VST 인스턴스, COM 아파트먼트와 VST3 DLL 팩터리에 명시적인

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- Convolution, GraphicEQ, MultiConvolution, and large multi-channel IR
+  preparation now use bounded multicore workers while a configuration is
+  loading. Modern Cards prepare each row's parsed descriptor/scope once and
+  cache fixed regexes and tinted SVG badges, reducing repeated work during
+  skin rebuilds. HConv ownership now supports out-of-order initialization and
+  rollback; the AVRT audio callback, DSP order, and output arithmetic are
+  unchanged. CI covers worker exception cleanup and enforces a 4-second
+  ceiling for the 138-row offscreen skin-switch stress test.
+  ([#200](https://github.com/115dkk/EqualizerAPO-XT/pull/200))
 - Configuration saving is now atomic and partial reads are rejected instead
   of being applied as valid audio graphs. Filter factories, HybridConv/FFTW
   plans, IR data, Copy/IIR state, VST instances, COM apartments, and VST3 DLL

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -360,6 +360,7 @@
     <ClInclude Include="helpers\LogHelper.h" />
     <ClInclude Include="helpers\FftwRAII.h" />
     <ClInclude Include="helpers\MemoryHelper.h" />
+    <ClInclude Include="helpers\ParallelExecutor.h" />
     <ClInclude Include="helpers\Win32Resource.h" />
     <ClInclude Include="helpers\PerfProfile.h" />
     <ClInclude Include="helpers\PrecisionTimer.h" />
@@ -447,6 +448,7 @@
     <ClCompile Include="helpers\GainIterator.cpp" />
     <ClCompile Include="helpers\LogHelper.cpp" />
     <ClCompile Include="helpers\MemoryHelper.cpp" />
+    <ClCompile Include="helpers\ParallelExecutor.cpp" />
     <ClCompile Include="helpers\PerfProfile.cpp" />
     <ClCompile Include="helpers\RegistryHelper.cpp" />
     <ClCompile Include="helpers\StringHelper.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClInclude Include="helpers\MemoryHelper.h">
       <Filter>helpers</Filter>
     </ClInclude>
+    <ClInclude Include="helpers\ParallelExecutor.h">
+      <Filter>helpers</Filter>
+    </ClInclude>
     <ClInclude Include="helpers\Win32Resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -351,6 +354,9 @@
       <Filter>helpers</Filter>
     </ClCompile>
     <ClCompile Include="helpers\MemoryHelper.cpp">
+      <Filter>helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="helpers\ParallelExecutor.cpp">
       <Filter>helpers</Filter>
     </ClCompile>
     <ClCompile Include="helpers\PerfProfile.cpp">

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -45,6 +45,7 @@ SOURCES += main.cpp\
 	../filters/PreampFilter.cpp \
 	../filters/PreampFilterFactory.cpp \
 	../helpers/MemoryHelper.cpp \
+	../helpers/ParallelExecutor.cpp \
 	FilterTableRow.cpp \
 	FilterTemplate.cpp \
 	guis/DeviceFilterGUI.cpp \

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -33,6 +33,8 @@
 #include <QJsonDocument>
 #include <QSettings>
 
+#include <utility>
+
 #include "MainWindow.h"
 #include "SkinManager.h"
 #include "FilterTableRow.h"
@@ -171,16 +173,23 @@ void FilterTable::updateGuis()
 	for (const auto& factory : factories)
 		factory->startOfFile(configPath);
 
-	QVector<FilterCardRowScope> rowScopes = FilterCardModel::calculateScopes(getLines());
+	const QVector<FilterCardBuildPlan> rowPlans = renderMode == ModernCards
+		? FilterCardModel::prepareRows(getLines()) : QVector<FilterCardBuildPlan>();
 	int row = 0;
 	for (Item* item : model.items())
 	{
-		IFilterGUI* gui = createRowGui(item->text);
+		FilterCardDescriptor descriptor;
+		if (renderMode == ModernCards)
+			descriptor = row < rowPlans.size()
+				? rowPlans[row].descriptor
+				: FilterCardModel::describeLine(item->text);
+		IFilterGUI* gui = createRowGui(item->text,
+			renderMode == ModernCards ? &descriptor : nullptr);
 
 		// LegacyRows is a frozen fallback that must not be extended; see the
 		// RenderMode enum and docs/FilterListUiPolicy.md.
 		QWidget* rowWidget = renderMode == ModernCards
-			? static_cast<QWidget*>(new FilterCardRow(this, row + 1, item, gui, row < rowScopes.size() ? rowScopes[row] : FilterCardRowScope()))
+			? static_cast<QWidget*>(new FilterCardRow(this, row + 1, item, gui, std::move(descriptor)))
 			: static_cast<QWidget*>(new FilterTableRow(this, row + 1, item, gui));
 		gridLayout->addWidget(rowWidget, row, 0);
 
@@ -303,12 +312,19 @@ void FilterTable::resizeEvent(QResizeEvent* event)
 		insertSeam->setGeometry(0, 0, width(), 10);
 }
 
-IFilterGUI* FilterTable::createRowGui(const QString& line)
+IFilterGUI* FilterTable::createRowGui(const QString& line, const FilterCardDescriptor* preparedDescriptor)
 {
+	FilterCardDescriptor derivedDescriptor;
+	if (renderMode == ModernCards && preparedDescriptor == nullptr)
+	{
+		derivedDescriptor = FilterCardModel::describeLine(line);
+		preparedDescriptor = &derivedDescriptor;
+	}
+
 	// A pure comment has no "command: parameters" shape (with or without an
 	// inner colon), so it never reaches the factories below. In card mode it
 	// still gets a real editor; the legacy path stays frozen (raw row).
-	if (renderMode == ModernCards && FilterCardModel::isPureCommentLine(line))
+	if (renderMode == ModernCards && preparedDescriptor->type == QStringLiteral("comment"))
 		return new CommentCardEditor(line);
 
 	// Copy's maintained card editor is the skin routing view built directly by
@@ -316,11 +332,9 @@ IFilterGUI* FilterTable::createRowGui(const QString& line)
 	// domain logic, so a normal Copy row no longer needs a hidden heritage GUI.
 	// Dynamic Copy parameters still fall through: routing editors must not
 	// parse and rewrite inline expressions.
-	QString cardParameters;
-	FilterCardModel::commandForLine(line, &cardParameters);
 	if (renderMode == ModernCards
-		&& FilterCardModel::describeLine(line, 0).type == QStringLiteral("copy")
-		&& !FilterCardModel::hasInlineExpressions(cardParameters)
+		&& preparedDescriptor->type == QStringLiteral("copy")
+		&& !preparedDescriptor->dynamicLine
 		&& SkinManager::instance()->routingRenderer() != nullptr)
 		return nullptr;
 
@@ -417,13 +431,19 @@ void FilterTable::updateSingleRowGui(Item* item)
 	// in-place edit (enabled toggle) does not change the surrounding file's
 	// structural context, so the include/depth state the factories track
 	// stays valid.
-	IFilterGUI* gui = createRowGui(item->text);
-
-	QVector<FilterCardRowScope> rowScopes = FilterCardModel::calculateScopes(getLines());
-	FilterCardRowScope scope = rowIndex < rowScopes.size() ? rowScopes[rowIndex] : FilterCardRowScope();
+	FilterCardDescriptor descriptor;
+	if (renderMode == ModernCards)
+	{
+		const QVector<FilterCardRowScope> rowScopes = FilterCardModel::calculateScopes(getLines());
+		const FilterCardRowScope scope = rowIndex < rowScopes.size() ? rowScopes[rowIndex] : FilterCardRowScope();
+		descriptor = FilterCardModel::describeLine(item->text, scope.indent);
+		descriptor.logicDepth = scope.logic;
+	}
+	IFilterGUI* gui = createRowGui(item->text,
+		renderMode == ModernCards ? &descriptor : nullptr);
 	// Same render-mode policy as updateGuis().
 	QWidget* rowWidget = renderMode == ModernCards
-		? static_cast<QWidget*>(new FilterCardRow(this, rowIndex + 1, item, gui, scope))
+		? static_cast<QWidget*>(new FilterCardRow(this, rowIndex + 1, item, gui, std::move(descriptor)))
 		: static_cast<QWidget*>(new FilterTableRow(this, rowIndex + 1, item, gui));
 	gridLayout->addWidget(rowWidget, rowIndex, 0);
 
@@ -521,11 +541,12 @@ void FilterTable::insertRowAt(int index)
 	// cache the config path there, which an edit inside the loaded file does
 	// not change.
 	Item* item = model.items().at(index);
-	IFilterGUI* gui = createRowGui(item->text);
-
 	QVector<FilterCardRowScope> rowScopes = FilterCardModel::calculateScopes(getLines());
 	FilterCardRowScope scope = index < rowScopes.size() ? rowScopes[index] : FilterCardRowScope();
-	QWidget* rowWidget = new FilterCardRow(this, index + 1, item, gui, scope);
+	FilterCardDescriptor descriptor = FilterCardModel::describeLine(item->text, scope.indent);
+	descriptor.logicDepth = scope.logic;
+	IFilterGUI* gui = createRowGui(item->text, &descriptor);
+	QWidget* rowWidget = new FilterCardRow(this, index + 1, item, gui, std::move(descriptor));
 	gridLayout->addWidget(rowWidget, index, 0);
 
 	item->gui = gui;

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -197,7 +197,7 @@ private:
 	// lookup, legacy factory chain, card override for commented lines,
 	// decorator gating). Shared by updateGuis() and updateSingleRowGui() so
 	// policy edits happen once.
-	IFilterGUI* createRowGui(const QString& line);
+	IFilterGUI* createRowGui(const QString& line, const FilterCardDescriptor* preparedDescriptor = nullptr);
 	// Inserts the mime data's lines at dropRow and makes them the selection.
 	// Shared by paste() and dropEvent(). Returns the number of inserted lines
 	// so the callers can take the incremental single-row path.

--- a/Editor/widgets/FilterCardModel.cpp
+++ b/Editor/widgets/FilterCardModel.cpp
@@ -4,6 +4,8 @@
 #include <QRegularExpression>
 #include <QSet>
 
+#include <utility>
+
 #include "filters/ExpressionCommand.h"
 #include "filters/FilterFactoryRegistry.h"
 #include "filters/BiQuadCommand.h"
@@ -80,31 +82,46 @@ QString firstCapture(const QRegularExpression& expression, const QString& text)
 // FilterFactoryRegistry and the type titles from BiQuadCommand's table (above).
 QString summarizeBiquad(const QString& parameters, const QString& code, const QString& state)
 {
+	static const QRegularExpression frequencyExpression(
+		QStringLiteral("\\bFc\\s*([-+0-9.,eE\\x{00A0}]+)\\s*H\\s*z"),
+		QRegularExpression::CaseInsensitiveOption);
+	static const QRegularExpression gainExpression(
+		QStringLiteral("\\bGain\\s*([-+0-9.,eE]+)\\s*dB"),
+		QRegularExpression::CaseInsensitiveOption);
+	static const QRegularExpression slopeExpression(
+		QStringLiteral("^\\s*(?:ON|OFF)\\s+[A-Za-z]+\\s+([-+0-9.,eE]+)\\s*dB"),
+		QRegularExpression::CaseInsensitiveOption);
+	static const QRegularExpression qExpression(
+		QStringLiteral("\\bQ\\s*([-+0-9.,eE]+)"),
+		QRegularExpression::CaseInsensitiveOption);
+	static const QRegularExpression bandwidthExpression(
+		QStringLiteral("\\bBW\\s+Oct\\s*([-+0-9.,eE]+)"),
+		QRegularExpression::CaseInsensitiveOption);
+
 	QStringList parts;
 	const bool shelf = code == QStringLiteral("LS") || code == QStringLiteral("LSC") || code == QStringLiteral("HS") || code == QStringLiteral("HSC");
 	const bool centerFrequency = code == QStringLiteral("LSC") || code == QStringLiteral("HSC");
 
-	const QString freq = firstCapture(QRegularExpression(QStringLiteral("\\bFc\\s*([-+0-9.,eE\\x{00A0}]+)\\s*H\\s*z"), QRegularExpression::CaseInsensitiveOption), parameters);
+	const QString freq = firstCapture(frequencyExpression, parameters);
 	if (!freq.isEmpty())
 		parts.append(QStringLiteral("%1 %2 Hz").arg(shelf ? (centerFrequency ? QStringLiteral("Center") : QStringLiteral("Corner")) : QStringLiteral("Fc"), freq));
 
-	const QString gain = firstCapture(QRegularExpression(QStringLiteral("\\bGain\\s*([-+0-9.,eE]+)\\s*dB"), QRegularExpression::CaseInsensitiveOption), parameters);
+	const QString gain = firstCapture(gainExpression, parameters);
 	if (!gain.isEmpty())
 		parts.append(QStringLiteral("Gain %1 dB").arg(gain));
 
 	if (shelf)
 	{
-		const QRegularExpression slopeExpression(QStringLiteral("^\\s*(?:ON|OFF)\\s+[A-Za-z]+\\s+([-+0-9.,eE]+)\\s*dB"), QRegularExpression::CaseInsensitiveOption);
 		const QString slope = firstCapture(slopeExpression, parameters);
 		if (!slope.isEmpty())
 			parts.append(QStringLiteral("Slope %1 dB/Oct").arg(slope));
 	}
 
-	const QString q = firstCapture(QRegularExpression(QStringLiteral("\\bQ\\s*([-+0-9.,eE]+)"), QRegularExpression::CaseInsensitiveOption), parameters);
+	const QString q = firstCapture(qExpression, parameters);
 	if (!q.isEmpty())
 		parts.append(QStringLiteral("Q %1").arg(q));
 
-	const QString bandwidth = firstCapture(QRegularExpression(QStringLiteral("\\bBW\\s+Oct\\s*([-+0-9.,eE]+)"), QRegularExpression::CaseInsensitiveOption), parameters);
+	const QString bandwidth = firstCapture(bandwidthExpression, parameters);
 	if (!bandwidth.isEmpty())
 		parts.append(QStringLiteral("BW %1 Oct").arg(bandwidth));
 
@@ -112,6 +129,41 @@ QString summarizeBiquad(const QString& parameters, const QString& code, const QS
 	if (state == QStringLiteral("OFF"))
 		summary = QStringLiteral("OFF \xC2\xB7 ") + summary;
 	return summary;
+}
+
+FilterCardRowScope advanceScope(bool enabled, const QString& command,
+	const QStringList& channelBadges, int& channelDepth, int& ifDepth)
+{
+	FilterCardRowScope scope;
+	if (enabled && command == QStringLiteral("channel"))
+	{
+		scope.indent = ifDepth;
+		scope.logic = ifDepth;
+		channelDepth = (channelBadges.isEmpty() || channelBadges.contains(QStringLiteral("ALL"))) ? 0 : 1;
+	}
+	else if (enabled && command == QStringLiteral("if"))
+	{
+		scope.indent = channelDepth + ifDepth;
+		scope.logic = ifDepth;
+		ifDepth++;
+	}
+	else if (enabled && (command == QStringLiteral("elseif") || command == QStringLiteral("else")))
+	{
+		scope.indent = channelDepth + qMax(0, ifDepth - 1);
+		scope.logic = ifDepth;
+	}
+	else if (enabled && command == QStringLiteral("endif"))
+	{
+		scope.indent = channelDepth + qMax(0, ifDepth - 1);
+		scope.logic = ifDepth;
+		ifDepth = qMax(0, ifDepth - 1);
+	}
+	else
+	{
+		scope.indent = channelDepth + ifDepth;
+		scope.logic = ifDepth;
+	}
+	return scope;
 }
 }
 
@@ -182,9 +234,10 @@ QString FilterCardModel::commandForLine(const QString& line, QString* parameters
 
 QStringList FilterCardModel::parseChannelList(const QString& text)
 {
+	static const QRegularExpression whitespaceExpression(QStringLiteral("\\s+"));
 	QString normalized = text;
 	normalized.replace(',', ' ');
-	QStringList result = normalized.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+	QStringList result = normalized.split(whitespaceExpression, Qt::SkipEmptyParts);
 	for (QString& channel : result)
 		channel = channel.trimmed().toUpper();
 	return result;
@@ -223,6 +276,8 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 	QString command = commandForLine(line, &parameters);
 	QString commandLower = command.toLower();
 	descriptor.command = command;
+	descriptor.parameters = parameters;
+	descriptor.dynamicLine = hasInlineExpressions(parameters);
 	descriptor.title = command.isEmpty() ? tr("Text") : command;
 	descriptor.summary = compactWhitespace(parameters);
 	descriptor.type = QStringLiteral("text");
@@ -262,18 +317,23 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 		// only the badge/title/summary say IIR. Like the biquad summary this
 		// echoes what the author wrote with light regexes - the engine
 		// (IIRFilterFactory::parseCommand) stays the single grammar owner.
-		QRegularExpression iirExpression(QStringLiteral("^\\s*(ON|OFF)\\s+IIR\\b"), QRegularExpression::CaseInsensitiveOption);
-		QRegularExpressionMatch iirMatch = iirExpression.match(parameters);
+		static const QRegularExpression iirExpression(
+			QStringLiteral("^\\s*(ON|OFF)\\s+IIR\\b"), QRegularExpression::CaseInsensitiveOption);
+		static const QRegularExpression orderExpression(
+			QStringLiteral("\\bOrder\\s+([0-9]+)"), QRegularExpression::CaseInsensitiveOption);
+		static const QRegularExpression coefficientExpression(
+			QStringLiteral("\\bCoefficients((?:\\s+[-+0-9.eE]+)+)"), QRegularExpression::CaseInsensitiveOption);
+		const QRegularExpressionMatch iirMatch = iirExpression.match(parameters);
 		if (iirMatch.hasMatch())
 		{
 			descriptor.badge = QStringLiteral("IIR");
 			descriptor.title = tr("IIR filter");
 
 			QStringList parts;
-			const QString orderText = firstCapture(QRegularExpression(QStringLiteral("\\bOrder\\s+([0-9]+)"), QRegularExpression::CaseInsensitiveOption), parameters);
+			const QString orderText = firstCapture(orderExpression, parameters);
 			if (!orderText.isEmpty())
 				parts.append(tr("Order %1").arg(orderText));
-			const QString coefficientList = firstCapture(QRegularExpression(QStringLiteral("\\bCoefficients((?:\\s+[-+0-9.eE]+)+)"), QRegularExpression::CaseInsensitiveOption), parameters).simplified();
+			const QString coefficientList = firstCapture(coefficientExpression, parameters).simplified();
 			if (!coefficientList.isEmpty())
 				parts.append(tr("%1 coefficients").arg(coefficientList.split(QLatin1Char(' ')).size()));
 			if (!parts.isEmpty())
@@ -288,8 +348,10 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 			// Recognise the full BiQuadFilterFactory vocabulary (including LSC/HSC
 			// shelf-with-slope, LPQ/HPQ Q-form, PEQ alias and Modal) so the card
 			// title and summary agree with the legacy GUI.
-			QRegularExpression typeExpression(QStringLiteral("^\\s*(ON|OFF)\\s+(PK|PEQ|MODAL|LPQ|HPQ|LSC|HSC|LP|HP|BP|LS|HS|NO|AP)\\b"), QRegularExpression::CaseInsensitiveOption);
-			QRegularExpressionMatch match = typeExpression.match(parameters);
+			static const QRegularExpression typeExpression(
+				QStringLiteral("^\\s*(ON|OFF)\\s+(PK|PEQ|MODAL|LPQ|HPQ|LSC|HSC|LP|HP|BP|LS|HS|NO|AP)\\b"),
+				QRegularExpression::CaseInsensitiveOption);
+			const QRegularExpressionMatch match = typeExpression.match(parameters);
 			if (match.hasMatch())
 			{
 				const QString state = match.captured(1).toUpper();
@@ -319,7 +381,7 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 		descriptor.color = QStringLiteral("#06b6d4");
 		descriptor.routeType = true;
 
-		QRegularExpression stepExpression(QStringLiteral("([A-Za-z0-9]+)\\s*="));
+		static const QRegularExpression stepExpression(QStringLiteral("([A-Za-z0-9]+)\\s*="));
 		QRegularExpressionMatchIterator matches = stepExpression.globalMatch(parameters);
 		QStringList destinations;
 		while (matches.hasNext())
@@ -384,7 +446,8 @@ FilterCardDescriptor FilterCardModel::describeLine(const QString& line, int dept
 		descriptor.title = tr("MultiConvolution");
 		descriptor.color = QStringLiteral("#ec4899");
 		const QString trimmedParams = parameters.trimmed();
-		const int split = trimmedParams.indexOf(QRegularExpression(QStringLiteral("\\s")));
+		static const QRegularExpression whitespaceExpression(QStringLiteral("\\s"));
+		const int split = trimmedParams.indexOf(whitespaceExpression);
 		const QString channel = split < 0 ? trimmedParams : trimmedParams.left(split);
 		const QString fileName = split < 0 ? QString() : QFileInfo(trimmedParams.mid(split + 1).trimmed()).fileName();
 		if (!channel.isEmpty() && !fileName.isEmpty())
@@ -541,45 +604,36 @@ QVector<FilterCardRowScope> FilterCardModel::calculateScopes(const QList<QString
 	int ifDepth = 0;
 	for (const QString& line : lines)
 	{
-		bool enabled = !line.trimmed().startsWith('#');
+		const bool enabled = !line.trimmed().startsWith('#');
 		QString parameters;
-		QString command = commandForLine(line, &parameters).toLower();
-		FilterCardRowScope scope;
-		if (enabled && command == QStringLiteral("channel"))
-		{
-			// The Channel row itself sits outside the group it opens but stays
-			// inside any enclosing If block.
-			scope.indent = ifDepth;
-			scope.logic = ifDepth;
-			QStringList channels = parseChannelList(parameters);
-			channelDepth = (channels.isEmpty() || channels.contains(QStringLiteral("ALL"))) ? 0 : 1;
-		}
-		else if (enabled && command == QStringLiteral("if"))
-		{
-			scope.indent = channelDepth + ifDepth;
-			scope.logic = ifDepth;
-			ifDepth++;
-		}
-		else if (enabled && (command == QStringLiteral("elseif") || command == QStringLiteral("else")))
-		{
-			scope.indent = channelDepth + qMax(0, ifDepth - 1);
-			scope.logic = ifDepth;
-		}
-		else if (enabled && command == QStringLiteral("endif"))
-		{
-			scope.indent = channelDepth + qMax(0, ifDepth - 1);
-			scope.logic = ifDepth;
-			ifDepth = qMax(0, ifDepth - 1);
-		}
-		else
-		{
-			scope.indent = channelDepth + ifDepth;
-			scope.logic = ifDepth;
-		}
-		scopes.append(scope);
+		const QString command = commandForLine(line, &parameters).toLower();
+		const QStringList channels = command == QStringLiteral("channel")
+			? parseChannelList(parameters) : QStringList();
+		scopes.append(advanceScope(enabled, command, channels, channelDepth, ifDepth));
 	}
 
 	return scopes;
+}
+
+QVector<FilterCardBuildPlan> FilterCardModel::prepareRows(const QList<QString>& lines)
+{
+	QVector<FilterCardBuildPlan> plans;
+	plans.reserve(lines.size());
+
+	int channelDepth = 0;
+	int ifDepth = 0;
+	for (const QString& line : lines)
+	{
+		FilterCardBuildPlan plan;
+		plan.descriptor = describeLine(line);
+		plan.scope = advanceScope(plan.descriptor.enabled,
+			plan.descriptor.command.toLower(), plan.descriptor.channelBadges,
+			channelDepth, ifDepth);
+		plan.descriptor.depth = plan.scope.indent;
+		plan.descriptor.logicDepth = plan.scope.logic;
+		plans.append(std::move(plan));
+	}
+	return plans;
 }
 
 QVector<int> FilterCardModel::calculateDepths(const QList<QString>& lines)

--- a/Editor/widgets/FilterCardModel.h
+++ b/Editor/widgets/FilterCardModel.h
@@ -9,6 +9,7 @@
 struct FilterCardDescriptor
 {
 	QString command;
+	QString parameters;
 	QString type;
 	QString badge;
 	QString title;
@@ -17,13 +18,14 @@ struct FilterCardDescriptor
 	QStringList channelBadges;
 	int depth = 0;
 	// Number of If scopes the row lives inside (the logic axis of depth; see
-	// FilterCardRowScope::logic). Not derivable from the line alone, so the row
-	// widget assigns it from calculateScopes() and preserves it across
-	// describeLine() re-derivations.
+	// FilterCardRowScope::logic). Not derivable from the line alone, so the
+	// build plan assigns it from neighbouring-line context and the row preserves
+	// it across describeLine() re-derivations.
 	int logicDepth = 0;
 	bool enabled = true;
 	bool canToggleEnabled = true;
 	bool routeType = false;
+	bool dynamicLine = false;
 };
 
 // Per-row scope answer of calculateScopes(): the indent that drives the left
@@ -38,6 +40,15 @@ struct FilterCardRowScope
 	int logic = 0;
 };
 
+// Immutable presentation work prepared once for a modern-card rebuild. The
+// descriptor carries the parsed line and the scope carries neighbouring-line
+// context; consumers no longer reinterpret the same command independently.
+struct FilterCardBuildPlan
+{
+	FilterCardDescriptor descriptor;
+	FilterCardRowScope scope;
+};
+
 class FilterCardModel
 {
 	// describeLine() produces the human-readable card title/summary strings. It is
@@ -47,6 +58,7 @@ class FilterCardModel
 
 public:
 	static FilterCardDescriptor describeLine(const QString& line, int depth = 0);
+	static QVector<FilterCardBuildPlan> prepareRows(const QList<QString>& lines);
 	// The modern stroke pictogram for a card's type badge, keyed by the
 	// descriptor (matching the picker tiles). Biquad rows split by their type
 	// code so every EQ shape carries its response-curve glyph; an unmapped

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -5,6 +5,7 @@
 #include <QMenu>
 #include <QPainter>
 #include <QPixmap>
+#include <QPixmapCache>
 #include <QPropertyAnimation>
 #include <QRegularExpression>
 #include <QScrollArea>
@@ -12,15 +13,17 @@
 #include <QTimer>
 #include <QVBoxLayout>
 
+#include <utility>
+
 #include "Editor/SkinManager.h"
 #include "Editor/widgets/ChBadge.h"
 #include "Editor/widgets/routing/IRoutingRenderer.h"
 #include "Editor/widgets/routing/CopyRoutingAdapter.h"
 
-FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui, FilterCardRowScope scope, QWidget* parent)
-	: QWidget(parent), table(table), item(item), gui(gui), descriptor(FilterCardModel::describeLine(item->text, scope.indent)), rowNumber(number)
+FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui,
+	FilterCardDescriptor preparedDescriptor, QWidget* parent)
+	: QWidget(parent), table(table), item(item), gui(gui), descriptor(std::move(preparedDescriptor)), rowNumber(number)
 {
-	descriptor.logicDepth = scope.logic;
 	setAttribute(Qt::WA_StyledBackground, false);
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 
@@ -89,6 +92,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	channelBadgeLayout = new QHBoxLayout(channelBadgeContainer);
 	channelBadgeLayout->setContentsMargins(0, 0, 0, 0);
 	channelBadgeLayout->setSpacing(3);
+	channelBadgeContainer->setVisible(false);
 	headerLayout->addWidget(channelBadgeContainer);
 
 	enabledButton = new QToolButton(headerWidget);
@@ -154,10 +158,8 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	// first edit would serialize the expression away. Such lines keep the
 	// raw body (dynamic-value contract), like every other dynamic line
 	// without a dynamic-capable editor.
-	QString routingParameters;
-	FilterCardModel::commandForLine(item->text, &routingParameters);
 	IRoutingRenderer* routingRenderer = (descriptor.type == QStringLiteral("copy")
-		&& !FilterCardModel::hasInlineExpressions(routingParameters))
+		&& !descriptor.dynamicLine)
 		? SkinManager::instance()->routingRenderer() : nullptr;
 
 	if (routingRenderer != nullptr)
@@ -173,9 +175,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 		QVBoxLayout* editorLayout = new QVBoxLayout(editorContainer);
 		editorLayout->setContentsMargins(12, 10, 12, 12);
 
-		QString parameters;
-		FilterCardModel::commandForLine(item->text, &parameters);
-		std::vector<Assignment> routingAssignments = CopyRoutingAdapter::parse(parameters);
+		std::vector<Assignment> routingAssignments = CopyRoutingAdapter::parse(descriptor.parameters);
 		// Seed the routing editor with the real device channel set (L, R, C, ...),
 		// the same list the legacy CopyFilterGUI receives via configureChannels.
 		// Without it the graph only shows channels already named in the line, so
@@ -293,7 +293,7 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 	// (FilterTable::updateGuis), so construction time is the right moment for
 	// the active skin to tag or extend this row.
 	SkinManager::instance()->prepareCommandRow(currentRowInfo(), cardFrame, headerWidget, bodyStack);
-	rebuildSummary();
+	applyDescriptor();
 }
 
 void FilterCardRow::configureChannels(std::vector<std::wstring>& channelNames)
@@ -301,11 +301,7 @@ void FilterCardRow::configureChannels(std::vector<std::wstring>& channelNames)
 	if (routingView != nullptr && descriptor.type == QStringLiteral("copy"))
 	{
 		if (descriptor.enabled)
-		{
-			QString parameters;
-			FilterCardModel::commandForLine(item->text, &parameters);
-			propagateCopyChannels(CopyRoutingAdapter::parse(parameters), channelNames);
-		}
+			propagateCopyChannels(CopyRoutingAdapter::parse(descriptor.parameters), channelNames);
 		return;
 	}
 
@@ -323,11 +319,7 @@ CommandRowInfo FilterCardRow::currentRowInfo() const
 	info.focused = table != nullptr && table->getFocusedItem() == item;
 	info.depth = descriptor.depth;
 	info.logicDepth = descriptor.logicDepth;
-	{
-		QString parameters;
-		FilterCardModel::commandForLine(item->text, &parameters);
-		info.dynamicLine = FilterCardModel::hasInlineExpressions(parameters);
-	}
+	info.dynamicLine = descriptor.dynamicLine;
 
 	// Fold in the analysis engine's load facts for this line (dynamic
 	// commands): branch truth for the If family, computed values for
@@ -408,7 +400,7 @@ void FilterCardRow::updateRowPosition(int rowNumber, FilterCardRowScope scope)
 		descriptor.logicDepth = scope.logic;
 		if (layout() != nullptr)
 			layout()->setContentsMargins(8 + rowIndentUnits() * SkinManager::instance()->tokens().channelGroupIndent, 4, 8, 4);
-		rebuildSummary();
+		applyDescriptor();
 	}
 	else
 	{
@@ -613,6 +605,14 @@ void FilterCardRow::paintEvent(QPaintEvent*)
 // no coverage for CompositionMode_SourceIn to paint on.
 static QPixmap badgePictogram(const QString& resource, const QColor& ink, int size, qreal devicePixelRatio)
 {
+	const QString cacheKey = QStringLiteral("FilterCardBadge:%1:%2:%3:%4")
+		.arg(resource, ink.name(QColor::HexArgb))
+		.arg(size)
+		.arg(devicePixelRatio, 0, 'f', 3);
+	QPixmap cached;
+	if (QPixmapCache::find(cacheKey, &cached))
+		return cached;
+
 	QPixmap pixmap = QIcon(resource).pixmap(QSize(size, size), devicePixelRatio);
 	if (pixmap.isNull())
 		return pixmap;
@@ -620,6 +620,7 @@ static QPixmap badgePictogram(const QString& resource, const QColor& ink, int si
 	painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
 	painter.fillRect(pixmap.rect(), ink);
 	painter.end();
+	QPixmapCache::insert(cacheKey, pixmap);
 	return pixmap;
 }
 
@@ -631,6 +632,11 @@ void FilterCardRow::rebuildSummary()
 	const int logicDepth = descriptor.logicDepth;
 	descriptor = FilterCardModel::describeLine(item->text, descriptor.depth);
 	descriptor.logicDepth = logicDepth;
+	applyDescriptor();
+}
+
+void FilterCardRow::applyDescriptor()
+{
 
 	// Blank lines render as a thin spacer: no header, no body, no raw preview.
 	// The card frame itself stays visible (so its background fills the gap and
@@ -695,6 +701,10 @@ void FilterCardRow::rebuildSummary()
 
 void FilterCardRow::buildChannelBadges(const QStringList& channels)
 {
+	if (channels == renderedChannelBadges)
+		return;
+	renderedChannelBadges = channels;
+
 	while (QLayoutItem* child = channelBadgeLayout->takeAt(0))
 	{
 		delete child->widget();

--- a/Editor/widgets/FilterCardRow.h
+++ b/Editor/widgets/FilterCardRow.h
@@ -23,7 +23,8 @@ class FilterCardRow : public QWidget
 	Q_OBJECT
 
 public:
-	FilterCardRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui, FilterCardRowScope scope, QWidget* parent = nullptr);
+	FilterCardRow(FilterTable* table, int number, FilterTable::Item* item, IFilterGUI* gui,
+		FilterCardDescriptor descriptor, QWidget* parent = nullptr);
 	void configureChannels(std::vector<std::wstring>& channelNames);
 
 	QRect getHeaderRect() const;
@@ -53,6 +54,7 @@ private slots:
 private:
 	void watchEditorScroll(QScrollArea* scroll);
 	void syncEditorScrollHeight(QScrollArea* scroll);
+	void applyDescriptor();
 	void rebuildSummary();
 	void setEditing(bool editing);
 	void buildChannelBadges(const QStringList& channels);
@@ -90,5 +92,6 @@ private:
 	QStackedWidget* bodyStack = nullptr;
 	QLineEdit* lineEdit = nullptr;
 	RoutingView* routingView = nullptr;
+	QStringList renderedChannelBadges;
 	bool editingDone = false;
 };

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -774,6 +774,37 @@ void testFilterCardDepths()
 	expectEqual(mixed[5].logic, 1, "endif closes the scope in mixed nesting");
 }
 
+void testFilterCardBuildPlans()
+{
+	const QList<QString> lines({
+		"Channel: L R",
+		"If: sampleRate == 48000",
+		"Copy: L=R*`gain`",
+		"EndIf:",
+		"Channel: ALL"
+	});
+	const QVector<FilterCardBuildPlan> plans = FilterCardModel::prepareRows(lines);
+	const QVector<FilterCardRowScope> scopes = FilterCardModel::calculateScopes(lines);
+	requireEqual(plans.size(), lines.size(), "card build-plan count");
+	requireEqual(scopes.size(), lines.size(), "card build-plan scope count");
+
+	for (int i = 0; i < plans.size(); ++i)
+	{
+		expectEqual(plans[i].descriptor.depth, scopes[i].indent,
+			QString("build plan %1 descriptor indent").arg(i));
+		expectEqual(plans[i].descriptor.logicDepth, scopes[i].logic,
+			QString("build plan %1 descriptor logic depth").arg(i));
+		expectEqual(plans[i].scope.indent, scopes[i].indent,
+			QString("build plan %1 scope indent").arg(i));
+		expectEqual(plans[i].scope.logic, scopes[i].logic,
+			QString("build plan %1 scope logic depth").arg(i));
+	}
+
+	expectEqual(plans[0].descriptor.parameters, "L R", "build plan preserves parsed parameters");
+	expectTrue(plans[2].descriptor.dynamicLine, "build plan carries inline-expression state");
+	expectEqual(plans[2].descriptor.type, "copy", "build plan carries the prepared card type");
+}
+
 void testConfigImport()
 {
 	QTemporaryDir tempDir;
@@ -1442,6 +1473,7 @@ int main(int argc, char** argv)
 		testVelopackFeeds();
 		testFilterCardDescriptors();
 		testFilterCardDepths();
+		testFilterCardBuildPlans();
 		testConfigImport();
 		testChannelSelectionModel();
 		testDeviceSelectionModel();

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -17,6 +18,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <stdexcept>
 #include <vector>
 
 #ifndef NOMINMAX
@@ -27,11 +29,41 @@
 #include "ConfigLoadTrace.h"
 #include "FilterEngine.h"
 #include "helpers/LogHelper.h"
+#include "helpers/ParallelExecutor.h"
 #include "helpers/SndfileRAII.h"
 #include "Tests/TestHarness.h"
 
 namespace
 {
+
+void testParallelExecutor(test::Harness& harness)
+{
+	constexpr size_t taskCount = 257;
+	std::vector<std::atomic<unsigned>> visits(taskCount);
+	for (std::atomic<unsigned>& visit : visits)
+		visit.store(0, std::memory_order_relaxed);
+
+	ParallelExecutor::forEach(taskCount, [&](size_t index) {
+		visits[index].fetch_add(1, std::memory_order_relaxed);
+	}, 4);
+	for (size_t index = 0; index < taskCount; ++index)
+		harness.expectEqual(visits[index].load(std::memory_order_relaxed), 1u,
+			"parallel executor visits each task exactly once");
+
+	bool propagated = false;
+	try
+	{
+		ParallelExecutor::forEach(64, [](size_t index) {
+			if (index == 7)
+				throw std::runtime_error("parallel operation failed");
+		}, 4);
+	}
+	catch (const std::runtime_error& error)
+	{
+		propagated = std::string(error.what()) == "parallel operation failed";
+	}
+	harness.expect(propagated, "parallel executor joins workers and propagates the first exception");
+}
 
 std::vector<std::wstring>& writtenConfigFiles()
 {
@@ -572,6 +604,7 @@ int runEngineOrchestrationTests()
 	test::Harness harness("EngineOrchestrationTests");
 
 	testProcessWithoutConfigurationDoesNotCrash(harness);
+	testParallelExecutor(harness);
 	runConfigurationFileReaderTests(harness);
 	runSampleIoTests(harness);
 	testChannelSelectorRouting(harness);

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -312,7 +312,7 @@ void assertInvalidConvolverArgumentsLeaveEmptyOutput()
 	harness.expect(rejected, "hcInitSingle should reject a frame length that overflows FFTW's transform size");
 }
 
-void assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix()
+void assertConvolverArraySupportsOutOfOrderInitialization()
 {
 	constexpr unsigned slotCount = 2;
 	auto slots = MemoryHelper::allocateArray<HConvSingle>(slotCount);
@@ -321,13 +321,15 @@ void assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix()
 	// cppcheck-suppress syntaxError
 	if (slots == nullptr)
 		fail("could not allocate convolver slots for partial-initialization test");
-	memset(slots.get(), 0xA5, sizeof(HConvSingle) * slotCount);
-
 	HConvSingleArray pending;
-	pending.adoptUninitialized(std::move(slots), slotCount);
+	pending.adoptStorage(std::move(slots), slotCount);
+	harness.expect(pending[0].storage == nullptr && pending[1].storage == nullptr,
+		"adopting convolver storage should establish inert slots");
 	vector<double> impulseResponse(1, 1.0);
-	hcInitSingle(&pending[0], impulseResponse.data(), 1, 8, 1);
-	pending.markInitialized();
+	// Initialize the later slot first. Parallel preparation is free to finish
+	// slots in any order, and reset must close both this live slot and the
+	// untouched zero slot safely.
+	hcInitSingle(&pending[1], impulseResponse.data(), 1, 8, 1);
 
 	HConvSingleArray owner(std::move(pending));
 	owner.reset();
@@ -364,7 +366,7 @@ int runHybridConvTests()
 	assertPartitionBuffersFormOneSlab();
 	assertEmptyConvolverCloseIsIdempotent();
 	assertInvalidConvolverArgumentsLeaveEmptyOutput();
-	assertPartiallyInitializedConvolverArrayClosesOnlyCompletedPrefix();
+	assertConvolverArraySupportsOutOfOrderInitialization();
 	assertConvolutionPathParsing();
 
 	// Pure-logic helper, command-codec and parser-extension coverage that also

--- a/docs/OptimizationNotes.md
+++ b/docs/OptimizationNotes.md
@@ -61,3 +61,28 @@
 - 세 Qt 실행 파일은 `windeployqt --release --no-opengl-sw` 배포가 통과했고, `platforms/qwindows.dll`과 SVG 플러그인이 배치됐습니다.
 - `Benchmark.exe --help` 실행이 통과해 콘솔 실행 파일의 DLL 로딩을 확인했습니다.
 - `EqualizerAPO.sln` 전체 MSBuild는 Qt VS Tools의 `QtMsBuild` 파일이 없어 `DeviceSelector.vcxproj`, `UpdateChecker.vcxproj`에서 실패합니다. CI와 로컬 검증은 이 두 프로젝트를 qmake로 빌드합니다.
+
+## 2026-07-16 멀티코어 및 Qt 재구성 패스
+
+### 적용한 최적화
+
+- `ParallelExecutor`를 설정 준비 전용 Module로 추가했습니다. 호출 스레드도 작업자로 참여하고, 동시성은 하드웨어 스레드 수와 16개 상한 중 작은 값으로 제한합니다. 첫 예외가 발생하면 새 작업을 중단하고 생성한 스레드를 모두 합류한 뒤 원래 예외를 다시 던집니다.
+- `ConvolutionFilter`, `GraphicEQFilter`, `MultiConvolutionFilter`의 서로 독립적인 `HConvSingle` 초기화를 병렬화했습니다. FFTW plan 생성은 기존 planner 잠금 아래에 있고, plan 실행과 인스턴스별 버퍼 준비는 병렬로 진행됩니다.
+- 큰 다채널 IR의 planar 변환을 채널 단위로 병렬화했습니다. 작은 IR은 스레드 생성 비용이 더 크므로 기존 순차 루프를 유지합니다.
+- `HConvSingleArray`는 완료된 prefix만 추적하던 소유권 모델을 없앴습니다. 모든 C 슬롯을 먼저 영 상태로 만들고 전체 capacity를 닫으므로 병렬 작업이 어떤 순서로 끝나거나 중간 실패해도 정리가 안전합니다.
+- Qt modern-card 재구성은 `FilterCardBuildPlan` Seam에서 descriptor와 scope를 한 번만 준비합니다. 행 GUI 선택, 카드 생성, 스킨 정보가 같은 결과를 공유하므로 한 줄당 반복되던 정규식/inline-expression 해석이 사라집니다.
+- 고정 `QRegularExpression`은 재사용하고, 타입 배지 SVG tint 결과는 resource/color/size/DPR 키로 `QPixmapCache`에 보관합니다. 동일한 채널 배지 목록도 다시 만들지 않습니다.
+
+### 의도적으로 제외한 항목
+
+- 오디오 callback 안에 영구 worker pool을 두지 않았습니다. endpoint마다 별도 callback이 실행되는 환경에서 일반 작업자 스레드를 기다리면 MMCSS 우선순위 역전과 다중 endpoint 경합이 생길 수 있습니다. 현재 AVRT 경로에는 새 할당, mutex, 예외, 로그가 없습니다.
+- 필터 체인 전체 병렬화는 적용하지 않았습니다. 필터가 앞 단계의 채널/버퍼 출력을 다음 단계 입력으로 소비하므로 일반적인 병렬 실행은 DSP 순서와 결과를 바꿉니다.
+- `MultiConvolution` 합산 루프의 SIMD 변경은 이번 패스에서 제외했습니다. 곱셈-덧셈 결합 여부가 마지막 비트를 바꿀 수 있어, 별도 수치 계약과 기준 데이터 갱신 없이 적용하지 않습니다.
+- Qt 카드 widget virtualization은 장기 후보로 남겼습니다. 현재 스킨 Interface가 각 행의 실제 QWidget과 body editor를 구성하므로, viewport 재활용은 별도 상태 모델과 포커스/접근성 설계가 필요한 독립 프로젝트입니다.
+
+### CI 회귀 경계
+
+- `EngineOrchestrationTests`가 병렬 작업의 exactly-once 실행과 예외 합류/전파를 검사합니다.
+- `HybridConvTests`가 뒤쪽 슬롯을 먼저 초기화한 배열도 반복 정리 가능한지 검사합니다.
+- `EditorLogicTests`가 build plan의 descriptor/scope/dynamic-line 결과를 기존 계산과 대조합니다.
+- offscreen skin-switch test의 138-row 재구성 상한을 8초에서 4초로 낮췄습니다. 로컬 장시간 검증을 반복하지 않고 PR의 AVX2 CI를 성능·수명 회귀 판정 기준으로 사용합니다.

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -28,6 +28,7 @@
 
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/ParallelExecutor.h"
 #include "ConvolutionFilter.h"
 #include "helpers/PerfProfile.h"
 
@@ -154,14 +155,13 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 		return;
 	}
 	HConvSingleArray pendingFilters;
-	pendingFilters.adoptUninitialized(std::move(allocated), channelCount);
-	for (unsigned i = 0; i < channelCount; i++)
-	{
+	pendingFilters.adoptStorage(std::move(allocated), channelCount);
+	ParallelExecutor::forEach(channelCount, [&](size_t index) {
+		const unsigned i = static_cast<unsigned>(index);
 		// hcInitSingle reads the IR samples during planning but does not retain
 		// the pointer, so it is safe to feed it the shared cache buffer.
 		const std::vector<double>& src = ir->buffers[i % ir->channels];
 		hcInitSingle(&pendingFilters[i], const_cast<double*>(src.data()), static_cast<int>(ir->frames), static_cast<int>(frameCount), 1);
-		pendingFilters.markInitialized();
-	}
+	});
 	filters = std::move(pendingFilters);
 }

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -34,6 +34,7 @@
 #include "helpers/LogHelper.h"
 #include "helpers/FftwRAII.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/ParallelExecutor.h"
 #include "GraphicEQFilter.h"
 
 using std::exp;
@@ -187,12 +188,11 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 		return;
 	}
 	HConvSingleArray pendingFilters;
-	pendingFilters.adoptUninitialized(std::move(allocated), channelCount);
-	for (unsigned i = 0; i < channelCount; i++)
-	{
+	pendingFilters.adoptStorage(std::move(allocated), channelCount);
+	ParallelExecutor::forEach(channelCount, [&](size_t index) {
+		const unsigned i = static_cast<unsigned>(index);
 		hcInitSingle(&pendingFilters[i], const_cast<double*>(cached->data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);
-		pendingFilters.markInitialized();
-	}
+	});
 	filters = std::move(pendingFilters);
 }
 

--- a/filters/IrCache.cpp
+++ b/filters/IrCache.cpp
@@ -28,6 +28,7 @@
 #include <windows.h>
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/ParallelExecutor.h"
 #include "helpers/SndfileRAII.h"
 #include "IrCache.h"
 
@@ -36,6 +37,7 @@ using std::abs;
 namespace
 {
 	constexpr unsigned kMaxIrChannels = 1024;
+	constexpr size_t kParallelDeinterleaveMinimumSamples = 1u << 18;
 
 	// Cache of decoded impulse-response PCM, keyed by path + mtime + sample rate.
 	// Lets a config reload (or a second filter using the same IR) skip the
@@ -166,14 +168,19 @@ std::shared_ptr<const IrCacheEntry> loadIrCached(const std::wstring& filename, d
 	entry->channels = channels;
 	entry->frames = frames;
 	entry->buffers.resize(channels);
-	for (unsigned c = 0; c < channels; ++c)
-	{
+	auto deinterleaveChannel = [&](size_t index) {
+		const unsigned c = static_cast<unsigned>(index);
 		entry->buffers[c].resize(frames);
 		double* dst = entry->buffers[c].data();
 		const double* src = interleaved.data() + c;
 		for (unsigned i = 0; i < frames; ++i)
 			dst[i] = src[i * channels];
-	}
+	};
+	if (channels > 1 && interleaved.size() >= kParallelDeinterleaveMinimumSamples)
+		ParallelExecutor::forEach(channels, deinterleaveChannel);
+	else
+		for (unsigned c = 0; c < channels; ++c)
+			deinterleaveChannel(c);
 
 	{
 		std::lock_guard<std::mutex> lock(irCacheMutex());
@@ -197,11 +204,10 @@ void HConvSingleArray::reset()
 {
 	if (ptr != nullptr)
 	{
-		for (unsigned i = 0; i < initializedCount; i++)
+		for (unsigned i = 0; i < capacity; i++)
 			hcCloseSingle(&ptr.get()[i]);
 
 		ptr.reset();
 	}
 	capacity = 0;
-	initializedCount = 0;
 }

--- a/filters/IrCache.h
+++ b/filters/IrCache.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <cassert>
 #include <cstddef>
 #include <memory>
+#include <new>
 #include <string>
 #include <utility>
 #include <vector>
@@ -65,10 +65,9 @@ public:
 	HConvSingleArray(const HConvSingleArray&) = delete;
 	HConvSingleArray& operator=(const HConvSingleArray&) = delete;
 	HConvSingleArray(HConvSingleArray&& other) noexcept
-		: ptr(std::move(other.ptr)), capacity(other.capacity), initializedCount(other.initializedCount)
+		: ptr(std::move(other.ptr)), capacity(other.capacity)
 	{
 		other.capacity = 0;
-		other.initializedCount = 0;
 	}
 	HConvSingleArray& operator=(HConvSingleArray&& other) noexcept
 	{
@@ -77,9 +76,7 @@ public:
 			reset();
 			ptr = std::move(other.ptr);
 			capacity = other.capacity;
-			initializedCount = other.initializedCount;
 			other.capacity = 0;
-			other.initializedCount = 0;
 		}
 		return *this;
 	}
@@ -87,22 +84,19 @@ public:
 	// Take ownership of a freshly allocated block holding `newCount` elements.
 	// Any previously held block is torn down first using the same
 	// close-then-free sequence.
-	// Take ownership before initialization starts, then register each element
-	// only after hcInitSingle has committed it. If a later initialization
-	// throws, reset() closes the completed prefix and never reads untouched
-	// allocation bytes.
-	void adoptUninitialized(MemoryHelper::UniqueAllocation<HConvSingle> newPtr, unsigned newCapacity)
+	// Take ownership before initialization starts and value-initialize every C
+	// slot to hcCloseSingle's inert state. Initialization may then complete in
+	// any order (including on multiple threads); rollback closes every slot,
+	// with untouched slots remaining safe no-ops.
+	void adoptStorage(MemoryHelper::UniqueAllocation<HConvSingle> newPtr, unsigned newCapacity)
 	{
+		if (newCapacity != 0 && newPtr == nullptr)
+			throw std::bad_alloc();
 		reset();
 		ptr = std::move(newPtr);
 		capacity = newCapacity;
-		initializedCount = 0;
-	}
-
-	void markInitialized() noexcept
-	{
-		assert(initializedCount < capacity);
-		initializedCount++;
+		for (unsigned i = 0; i < capacity; ++i)
+			::new (static_cast<void*>(&ptr.get()[i])) HConvSingle{};
 	}
 
 	HConvSingleArray& operator=(std::nullptr_t)
@@ -116,11 +110,10 @@ public:
 	// (filters[i], &filters[i], filters == nullptr, hcInitSingle(&filters[i], ...)).
 	operator HConvSingle*() const { return ptr.get(); }
 
-	// Close the successfully initialized prefix, then free the whole block.
+	// Close every valid zero-or-initialized slot, then free the whole block.
 	void reset();
 
 private:
 	MemoryHelper::UniqueAllocation<HConvSingle> ptr;
 	unsigned capacity = 0;
-	unsigned initializedCount = 0;
 };

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -28,6 +28,7 @@
 #include "helpers/ChannelHelper.h"
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
+#include "helpers/ParallelExecutor.h"
 #include "MultiConvolutionFilter.h"
 
 using std::find;
@@ -133,25 +134,30 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		return outChannelNames;
 	}
 	HConvSingleArray pendingFilters;
-	pendingFilters.adoptUninitialized(std::move(allocated), totalUnits);
+	pendingFilters.adoptStorage(std::move(allocated), totalUnits);
 
 	tempBuffer.assign(maxFrameCount, 0.0);
 	unitFactors.assign(totalUnits, 1.0);
+	std::vector<unsigned> unitChannels(totalUnits);
 	unsigned next = 0;
 	for (size_t i = 0; i < mappings.size(); i++)
 	{
 		plans[i].firstUnit = next;
 		for (const MultiConvolutionCommand::IrChannelRef& ref : perMapping[i])
 		{
-			// hcInitSingle reads the IR samples during planning but does not
-			// retain the pointer, so the shared cache buffer is safe to feed.
-			hcInitSingle(&pendingFilters[next], const_cast<double*>(ir->buffers[ref.channel].data()), (int)irFrames, (int)maxFrameCount, 1);
-			pendingFilters.markInitialized();
+			unitChannels[next] = ref.channel;
 			unitFactors[next] = ref.isDecibel ? pow(10.0, ref.factor / 20.0) : ref.factor;
 			next++;
 		}
 		plans[i].unitCount = next - plans[i].firstUnit;
 	}
+	ParallelExecutor::forEach(totalUnits, [&](size_t index) {
+		const unsigned unit = static_cast<unsigned>(index);
+		// hcInitSingle reads the IR samples during planning but does not
+		// retain the pointer, so the shared cache buffer is safe to feed.
+		hcInitSingle(&pendingFilters[unit], const_cast<double*>(ir->buffers[unitChannels[unit]].data()),
+			(int)irFrames, (int)maxFrameCount, 1);
+	});
 	filters = std::move(pendingFilters);
 	unitCount = next;
 	filterFrameCount = maxFrameCount;

--- a/helpers/ParallelExecutor.cpp
+++ b/helpers/ParallelExecutor.cpp
@@ -1,0 +1,107 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+	Copyright (C) 2026  EqualizerAPO-XT contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#include "stdafx.h"
+
+#include "ParallelExecutor.h"
+
+#include <algorithm>
+#include <atomic>
+#include <exception>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace
+{
+	constexpr unsigned kMaximumConcurrency = 16;
+}
+
+unsigned ParallelExecutor::concurrencyFor(size_t taskCount, unsigned maxConcurrency) noexcept
+{
+	if (taskCount == 0)
+		return 0;
+
+	unsigned hardwareConcurrency = std::thread::hardware_concurrency();
+	if (hardwareConcurrency == 0)
+		hardwareConcurrency = 1;
+
+	unsigned requestedConcurrency = maxConcurrency == 0
+		? hardwareConcurrency
+		: maxConcurrency;
+	requestedConcurrency = (std::min)(requestedConcurrency, kMaximumConcurrency);
+	const size_t boundedTaskCount = (std::min)(taskCount,
+		static_cast<size_t>((std::numeric_limits<unsigned>::max)()));
+	return (std::min)(requestedConcurrency, static_cast<unsigned>(boundedTaskCount));
+}
+
+void ParallelExecutor::forEach(size_t taskCount, const Operation& operation, unsigned maxConcurrency)
+{
+	const unsigned concurrency = concurrencyFor(taskCount, maxConcurrency);
+	if (concurrency == 0)
+		return;
+	if (concurrency == 1)
+	{
+		for (size_t index = 0; index < taskCount; ++index)
+			operation(index);
+		return;
+	}
+
+	std::atomic<size_t> nextIndex{ 0 };
+	std::atomic<bool> cancelled{ false };
+	std::mutex exceptionMutex;
+	std::exception_ptr firstException;
+
+	auto work = [&]() noexcept {
+		while (!cancelled.load(std::memory_order_acquire))
+		{
+			const size_t index = nextIndex.fetch_add(1, std::memory_order_relaxed);
+			if (index >= taskCount)
+				return;
+			try
+			{
+				operation(index);
+			}
+			catch (...)
+			{
+				{
+					std::lock_guard<std::mutex> lock(exceptionMutex);
+					if (firstException == nullptr)
+						firstException = std::current_exception();
+				}
+				cancelled.store(true, std::memory_order_release);
+				return;
+			}
+		}
+	};
+
+	std::vector<std::thread> workers;
+	workers.reserve(concurrency - 1);
+	try
+	{
+		for (unsigned i = 1; i < concurrency; ++i)
+			workers.emplace_back(work);
+	}
+	catch (...)
+	{
+		cancelled.store(true, std::memory_order_release);
+		for (std::thread& worker : workers)
+			worker.join();
+		throw;
+	}
+
+	work();
+	for (std::thread& worker : workers)
+		worker.join();
+
+	if (firstException != nullptr)
+		std::rethrow_exception(firstException);
+}

--- a/helpers/ParallelExecutor.h
+++ b/helpers/ParallelExecutor.h
@@ -1,0 +1,33 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+	Copyright (C) 2026  EqualizerAPO-XT contributors
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+
+// Bounded parallel work for configuration-time preparation. This helper is
+// deliberately not an AVRT facility: it may allocate, create threads and
+// propagate exceptions. Callers use it only while building immutable DSP/UI
+// state, then hand borrowed pointers to the real-time path.
+class ParallelExecutor
+{
+public:
+	using Operation = std::function<void(size_t)>;
+
+	// Executes every index in [0, taskCount) exactly once unless an operation
+	// throws. The caller participates as one worker; the first exception stops
+	// new work, all created workers are joined, and the exception is rethrown.
+	// maxConcurrency == 0 selects a bounded hardware-derived default.
+	static void forEach(size_t taskCount, const Operation& operation, unsigned maxConcurrency = 0);
+
+private:
+	static unsigned concurrencyFor(size_t taskCount, unsigned maxConcurrency) noexcept;
+};


### PR DESCRIPTION
## What changed

- add a bounded configuration-time `ParallelExecutor` and use it for independent Convolution, GraphicEQ, MultiConvolution, and large IR deinterleave work
- deepen `HConvSingleArray` ownership so every slot starts in a safely closable zero state and parallel/out-of-order initialization rolls back correctly
- add a `FilterCardBuildPlan` seam so Qt modern cards share one parsed descriptor/scope result across GUI selection and row construction
- reuse fixed regular expressions, cache DPR/color-specific badge pixmaps, and avoid rebuilding unchanged channel badges
- add worker exception, out-of-order HConv cleanup, and card build-plan regression coverage; tighten the 138-row offscreen skin-switch ceiling from 8 s to 4 s

## Why

Configuration loading had independent per-channel/per-IR preparation work but executed it serially. Modern-card skin rebuilds also reinterpreted the same line several times and repeatedly tinted identical SVGs. The new modules put concurrency and presentation preparation behind narrow interfaces while preserving locality at their callers.

The real-time filter chain was intentionally not parallelized: filters depend on prior outputs, and waiting on ordinary worker threads from an MMCSS callback risks priority inversion and multi-endpoint contention. No allocation, mutex, exception, or logging was added to `AVRT_CODE`; DSP order and output arithmetic are unchanged.

## Validation

- Common Release x64 build
- EngineOrchestrationTests Release x64 build/link
- HybridConvTests Release x64 build/link
- EditorLogicTests Release x64 build/link with Qt 6.10.1
- Editor Release x64 qmake/nmake build
- `git diff --check`

The GitHub Actions AVX2 job is the source of truth for test execution, the offscreen skin-switch performance gate, cppcheck, and the repository's wider build matrix.
