### PR TITLE
perf: share immutable convolution filter banks

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,13 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- GraphicEQ가 합성한 임펄스 응답을 출력 채널마다 되풀이해 변환하지 않고
+  한 번만 변환합니다. Convolution과 MultiConvolution도 실제로 참조하는
+  서로 다른 IR 채널마다 불변 주파수 영역 필터뱅크를 하나만 만들며, 채널별
+  history·mix 버퍼·FFTW 실행 plan은 계속 독립적으로 유지합니다. 공유
+  소유권으로 뱅크 수명을 보장하며 AVRT 경로, DSP 순서와 출력 연산은
+  바뀌지 않았습니다.
+  ([#201](https://github.com/115dkk/EqualizerAPO-XT/pull/201))
 - 설정을 불러올 때 Convolution, GraphicEQ, MultiConvolution과 큰 다채널
   IR 준비 작업이 제한된 수의 멀티코어 작업자를 사용합니다. Modern Cards는
   각 행의 파싱된 descriptor/scope를 한 번만 준비하고 고정 정규식과 색을

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- GraphicEQ now transforms its synthesized impulse response once instead of
+  once per output channel. Convolution and MultiConvolution likewise build one
+  immutable frequency-domain filter bank per distinct referenced IR channel,
+  while channel histories, mix buffers, and FFTW execution plans remain
+  independent. Shared ownership keeps the bank alive without changing the
+  AVRT path, DSP order, or output arithmetic.
+  ([#201](https://github.com/115dkk/EqualizerAPO-XT/pull/201))
 - Convolution, GraphicEQ, MultiConvolution, and large multi-channel IR
   preparation now use bounded multicore workers while a configuration is
   loading. Modern Cards prepare each row's parsed descriptor/scope once and

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -216,7 +216,7 @@ void assertConvolutionFilterRecoversFromInitialShortFrame()
 // offset that holds a full plane, and a constant partition stride of exactly
 // two plane offsets, so a block's partition sweep walks one contiguous
 // allocation instead of hundreds of scattered heap blocks.
-void expectSlabLayout(double* const* real, double* const* imag, int count, int planeLength, const char* what)
+void expectSlabLayout(const double* const* real, const double* const* imag, int count, int planeLength, const char* what)
 {
 	char message[128];
 
@@ -280,6 +280,48 @@ void assertEmptyConvolverCloseIsIdempotent()
 	hcCloseSingle(&filter);
 
 	harness.expect(filter.storage == nullptr, "closing an empty convolver should preserve its empty state");
+}
+
+void assertSharedFilterBankKeepsIndependentRuntimeState()
+{
+	vector<double> impulseResponse((size_t)frameLength * 2, 0.0);
+	impulseResponse[0] = 0.5;
+	impulseResponse[frameLength + 17] = -0.25;
+
+	HConvSingle prototype = {};
+	HConvSingle sibling = {};
+	hcInitSingle(&prototype, impulseResponse.data(), static_cast<int>(impulseResponse.size()), frameLength, 1);
+	hcInitSingleWithSharedFilterBank(&sibling, &prototype);
+
+	harness.expectTrue(
+		prototype.filterbuf_freq_real == sibling.filterbuf_freq_real &&
+		prototype.filterbuf_freq_imag == sibling.filterbuf_freq_imag,
+		"sibling channels should reuse one immutable transformed filter bank");
+	harness.expectTrue(
+		prototype.history_time != sibling.history_time &&
+		prototype.mixbuf_freq_real != sibling.mixbuf_freq_real &&
+		prototype.dft_time != sibling.dft_time,
+		"sibling channels must retain independent mutable convolution state");
+
+	// The sibling owns a shared reference, not a borrowed pointer. Destroying
+	// the prototype first must leave every transformed partition alive.
+	hcCloseSingle(&prototype);
+	vector<double> input(frameLength, 0.0);
+	vector<double> output(frameLength, 0.0);
+	vector<double> rendered((size_t)frameLength * 3, 0.0);
+	for (int frame = 0; frame < 3; ++frame)
+	{
+		fill(input.begin(), input.end(), 0.0);
+		if (frame == 0)
+			input[0] = 1.0;
+		hcPutSingle(&sibling, input.data());
+		hcProcessSingle(&sibling);
+		hcGetSingle(&sibling, output.data());
+		copy(output.begin(), output.end(), rendered.begin() + (size_t)frame * frameLength);
+	}
+	expectClose(rendered[0], 0.5, 0);
+	expectClose(rendered[frameLength + 17], -0.25, frameLength + 17);
+	hcCloseSingle(&sibling);
 }
 
 void assertInvalidConvolverArgumentsLeaveEmptyOutput()
@@ -364,6 +406,7 @@ int runHybridConvTests()
 	assertSparseImpulseResponseSurvivesPastOneSecond(137);
 	assertConvolutionFilterRecoversFromInitialShortFrame();
 	assertPartitionBuffersFormOneSlab();
+	assertSharedFilterBankKeepsIndependentRuntimeState();
 	assertEmptyConvolverCloseIsIdempotent();
 	assertInvalidConvolverArgumentsLeaveEmptyOutput();
 	assertConvolverArraySupportsOutOfOrderInitialization();

--- a/docs/OptimizationNotes.md
+++ b/docs/OptimizationNotes.md
@@ -86,3 +86,10 @@
 - `HybridConvTests`가 뒤쪽 슬롯을 먼저 초기화한 배열도 반복 정리 가능한지 검사합니다.
 - `EditorLogicTests`가 build plan의 descriptor/scope/dynamic-line 결과를 기존 계산과 대조합니다.
 - offscreen skin-switch test의 138-row 재구성 상한을 8초에서 4초로 낮췄습니다. 로컬 장시간 검증을 반복하지 않고 PR의 AVX2 CI를 성능·수명 회귀 판정 기준으로 사용합니다.
+
+## 2026-07-16 공유 convolution 필터뱅크
+
+- `HConvSingle`을 불변 필터뱅크와 채널별 런타임 상태로 분리했습니다. 필터뱅크는 주파수 영역 IR 파티션만 소유하며 `shared_ptr<const ...>`로 수명이 관리됩니다. history, mix slab, DFT 작업 버퍼와 FFTW plan은 계속 각 채널이 따로 소유합니다.
+- GraphicEQ는 합성 IR을 한 번만 변환합니다. Convolution은 서로 다른 IR 채널마다 한 번, MultiConvolution은 실제로 참조한 IR 채널마다 한 번만 변환하며, 같은 IR을 쓰는 나머지 출력은 완성된 뱅크를 공유합니다.
+- 공개 `HConvSingle` Interface의 필터 파티션 포인터를 `const`로 바꿔 오디오 처리 경로가 공유 뱅크를 수정할 수 없게 했습니다. AVRT 경로의 연산 순서와 채널별 상태는 바뀌지 않았습니다.
+- `HybridConvTests`는 형제 인스턴스가 동일한 필터뱅크와 서로 다른 가변 버퍼를 갖는지, 원본 인스턴스를 먼저 닫아도 공유 소유권으로 convolution 출력이 유지되는지 검사합니다.

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "stdafx.h"
+#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <memory>
@@ -156,12 +157,18 @@ void ConvolutionFilter::initializeFilters(unsigned frameCount)
 	}
 	HConvSingleArray pendingFilters;
 	pendingFilters.adoptStorage(std::move(allocated), channelCount);
-	ParallelExecutor::forEach(channelCount, [&](size_t index) {
+	// Build one immutable frequency-domain filter bank per distinct IR channel.
+	// Output channels that reuse a mono/stereo IR still receive independent
+	// histories, mix buffers and FFTW execution plans.
+	const unsigned distinctIrChannels = (std::min)(channelCount, ir->channels);
+	ParallelExecutor::forEach(distinctIrChannels, [&](size_t index) {
 		const unsigned i = static_cast<unsigned>(index);
 		// hcInitSingle reads the IR samples during planning but does not retain
 		// the pointer, so it is safe to feed it the shared cache buffer.
-		const std::vector<double>& src = ir->buffers[i % ir->channels];
+		const std::vector<double>& src = ir->buffers[i];
 		hcInitSingle(&pendingFilters[i], const_cast<double*>(src.data()), static_cast<int>(ir->frames), static_cast<int>(frameCount), 1);
 	});
+	for (unsigned i = distinctIrChannels; i < channelCount; ++i)
+		hcInitSingleWithSharedFilterBank(&pendingFilters[i], &pendingFilters[i % ir->channels]);
 	filters = std::move(pendingFilters);
 }

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -34,7 +34,6 @@
 #include "helpers/LogHelper.h"
 #include "helpers/FftwRAII.h"
 #include "helpers/MemoryHelper.h"
-#include "helpers/ParallelExecutor.h"
 #include "GraphicEQFilter.h"
 
 using std::exp;
@@ -177,6 +176,8 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 		cached = entry;
 	}
 	synthesizedIr = cached;
+	if (channelCount == 0)
+		return;
 
 	fftw_make_planner_thread_safe();
 	auto allocated = MemoryHelper::allocateArray<HConvSingle>(channelCount);
@@ -189,10 +190,12 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 	}
 	HConvSingleArray pendingFilters;
 	pendingFilters.adoptStorage(std::move(allocated), channelCount);
-	ParallelExecutor::forEach(channelCount, [&](size_t index) {
-		const unsigned i = static_cast<unsigned>(index);
-		hcInitSingle(&pendingFilters[i], const_cast<double*>(cached->data()), static_cast<int>(filterLength), static_cast<int>(frameCount), 1);
-	});
+	// Every channel uses the same synthesized IR. Transform it once, then share
+	// the immutable bank while keeping all processing state channel-local.
+	hcInitSingle(&pendingFilters[0], const_cast<double*>(cached->data()),
+		static_cast<int>(filterLength), static_cast<int>(frameCount), 1);
+	for (unsigned i = 1; i < channelCount; ++i)
+		hcInitSingleWithSharedFilterBank(&pendingFilters[i], &pendingFilters[0]);
 	filters = std::move(pendingFilters);
 }
 

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <utility>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -151,13 +152,33 @@ vector<wstring> MultiConvolutionFilter::initialize(float sampleRate, unsigned ma
 		}
 		plans[i].unitCount = next - plans[i].firstUnit;
 	}
-	ParallelExecutor::forEach(totalUnits, [&](size_t index) {
-		const unsigned unit = static_cast<unsigned>(index);
+	// A routing expression may reference the same IR channel more than once.
+	// Transform each referenced channel once and share only its immutable bank.
+	const unsigned noPrototype = (std::numeric_limits<unsigned>::max)();
+	std::vector<unsigned> prototypes(ir->channels, noPrototype);
+	std::vector<unsigned> prototypeUnits;
+	for (unsigned unit = 0; unit < totalUnits; ++unit)
+	{
+		const unsigned irChannel = unitChannels[unit];
+		if (prototypes[irChannel] == noPrototype)
+		{
+			prototypes[irChannel] = unit;
+			prototypeUnits.push_back(unit);
+		}
+	}
+	ParallelExecutor::forEach(prototypeUnits.size(), [&](size_t index) {
+		const unsigned unit = prototypeUnits[index];
 		// hcInitSingle reads the IR samples during planning but does not
 		// retain the pointer, so the shared cache buffer is safe to feed.
 		hcInitSingle(&pendingFilters[unit], const_cast<double*>(ir->buffers[unitChannels[unit]].data()),
 			(int)irFrames, (int)maxFrameCount, 1);
 	});
+	for (unsigned unit = 0; unit < totalUnits; ++unit)
+	{
+		const unsigned prototype = prototypes[unitChannels[unit]];
+		if (unit != prototype)
+			hcInitSingleWithSharedFilterBank(&pendingFilters[unit], &pendingFilters[prototype]);
+	}
 	filters = std::move(pendingFilters);
 	unitCount = next;
 	filterFrameCount = maxFrameCount;

--- a/libHybridConv-0.1.1/libHybridConv_eapo.cpp
+++ b/libHybridConv-0.1.1/libHybridConv_eapo.cpp
@@ -56,25 +56,30 @@
 
 namespace hn = hwy::HWY_NAMESPACE;
 
-// Definitions of the instance-owned storage declared in libHybridConv_eapo.h.
-// hcInit* allocates one per instance and the matching hcClose* deletes it, so
-// no state is shared between instances; the FFTW planner lock in hcInitSingle
-// stays the only cross-instance synchronization in this file.
+// The transformed impulse response is immutable after initialization and can
+// be shared by several channel instances. Runtime state and FFTW plans remain
+// instance-owned because hcProcessSingle mutates them on the audio thread.
+struct HConvFilterBankStorage
+{
+	HcSlabPtr<double> slab;
+	std::vector<double*> realPtrs;
+	std::vector<double*> imagPtrs;
+	int frameLength = 0;
+	int segmentCount = 0;
+	std::size_t planeStride = 0;
+};
+
 struct HConvSingleStorage
 {
+	std::shared_ptr<const HConvFilterBankStorage> filterBank;
 	HcAlignedPtr<double> dftTime;
 	HcAlignedPtr<fftw_complex> dftFreq;
 	HcAlignedPtr<double> inFreqReal;
 	HcAlignedPtr<double> inFreqImag;
 	std::vector<int> stepTask;
-	// The per-partition real/imag planes live in two contiguous slabs (filter
-	// read-only, mix read-modify-write) so the per-block partition sweep walks
-	// two allocations instead of hundreds of scattered heap blocks. The plane
-	// layout inside the slabs is pinned by HybridConvTests.
-	HcSlabPtr<double> filterSlab;
+	// Mix planes are mutable per-channel state. The immutable filter planes live
+	// in filterBank; both layouts are pinned by HybridConvTests.
 	HcSlabPtr<double> mixSlab;
-	std::vector<double*> filterRealPtrs;
-	std::vector<double*> filterImagPtrs;
 	std::vector<double*> mixRealPtrs;
 	std::vector<double*> mixImagPtrs;
 	HcAlignedPtr<double> historyTime;
@@ -439,171 +444,234 @@ static inline void copy_split_complex_vec(const fftw_complex* __restrict src,
 		im[j] = s[2 * (size_t)j + 1];
 	}
 }
-void hcInitSingle(HConvSingle * filter, double* h, int hlen, int flen, int steps)
+namespace
+{
+	struct PendingSingle
+	{
+		HConvSingle value = {};
+		std::unique_ptr<HConvSingleStorage> storage = std::make_unique<HConvSingleStorage>();
+		fftw::Plan fft;
+		fftw::Plan ifft;
+
+		void publish(HConvSingle* output) noexcept
+		{
+			value.fft = fft.release();
+			value.ifft = ifft.release();
+			value.storage = storage.release();
+			*output = value;
+		}
+	};
+
+	void validateSingleShape(int frameLength, int steps)
+	{
+		if (frameLength <= 0 || steps <= 0)
+			throw std::invalid_argument("hcInitSingle frame length and step count must be positive");
+		if (frameLength > (std::numeric_limits<int>::max)() / 2)
+			throw std::length_error("hcInitSingle frame length is too large");
+		if (steps == (std::numeric_limits<int>::max)())
+			throw std::length_error("hcInitSingle step count is too large");
+	}
+
+	std::shared_ptr<HConvFilterBankStorage> makeFilterBank(int impulseLength, int frameLength)
+	{
+		const size_t frameSize = static_cast<size_t>(frameLength);
+		const size_t complexLength = frameSize + 1;
+		const size_t segmentCount =
+			(static_cast<size_t>(impulseLength) + frameSize - 1) / frameSize;
+		if (segmentCount >= static_cast<size_t>((std::numeric_limits<int>::max)()))
+			throw std::length_error("hcInitSingle requires too many partitions");
+
+		auto bank = std::make_shared<HConvFilterBankStorage>();
+		bank->frameLength = frameLength;
+		bank->segmentCount = static_cast<int>(segmentCount);
+		bank->planeStride = (complexLength + 7) & ~static_cast<size_t>(7);
+		const size_t partitionStride = checkedHcMultiply(bank->planeStride, 2);
+		const size_t slabElements = checkedHcMultiply(segmentCount, partitionStride);
+		bank->slab = makeHcSlab<double>(slabElements);
+		bank->realPtrs.resize(segmentCount);
+		bank->imagPtrs.resize(segmentCount);
+		for (size_t i = 0; i < segmentCount; ++i)
+		{
+			bank->realPtrs[i] = bank->slab.get() + i * partitionStride;
+			bank->imagPtrs[i] = bank->realPtrs[i] + bank->planeStride;
+		}
+		memset(bank->slab.get(), 0, checkedHcMultiply(slabElements, sizeof(double)));
+		return bank;
+	}
+
+	PendingSingle prepareSingleRuntime(
+		std::shared_ptr<const HConvFilterBankStorage> filterBank,
+		int steps)
+	{
+		PendingSingle pending;
+		HConvSingle& temp = pending.value;
+		HConvSingleStorage& storage = *pending.storage;
+		storage.filterBank = std::move(filterBank);
+		const HConvFilterBankStorage& bank = *storage.filterBank;
+		const size_t frameLength = static_cast<size_t>(bank.frameLength);
+		const size_t dftLength = checkedHcMultiply(frameLength, 2);
+		const size_t complexLength = frameLength + 1;
+		const size_t mixSegmentCount = static_cast<size_t>(bank.segmentCount) + 1;
+		const size_t partitionStride = checkedHcMultiply(bank.planeStride, 2);
+		const size_t mixSlabElements = checkedHcMultiply(mixSegmentCount, partitionStride);
+
+		temp.maxstep = steps;
+		temp.framelength = bank.frameLength;
+		temp.num_filterbuf = bank.segmentCount;
+		temp.filterbuf_freq_real = bank.realPtrs.data();
+		temp.filterbuf_freq_imag = bank.imagPtrs.data();
+
+		storage.dftTime = makeHcAlignedArray<double>(dftLength);
+		temp.dft_time = storage.dftTime.get();
+		storage.dftFreq = makeHcAlignedArray<fftw_complex>(complexLength);
+		temp.dft_freq = storage.dftFreq.get();
+		storage.inFreqReal = makeHcAlignedArray<double>(complexLength);
+		storage.inFreqImag = makeHcAlignedArray<double>(complexLength);
+		temp.in_freq_real = storage.inFreqReal.get();
+		temp.in_freq_imag = storage.inFreqImag.get();
+
+		storage.stepTask.resize(static_cast<size_t>(steps) + 1);
+		temp.steptask = storage.stepTask.data();
+		int num = temp.num_filterbuf / steps;
+		for (int i = 0; i <= steps; ++i)
+			temp.steptask[i] = i * num;
+		const int pos = temp.steptask[1] == 0 ? 1 : 2;
+		num = temp.num_filterbuf % steps;
+		for (int j = pos; j < pos + num; ++j)
+		{
+			for (int i = j; i <= steps; ++i)
+				++temp.steptask[i];
+		}
+
+		temp.num_mixbuf = static_cast<int>(mixSegmentCount);
+		storage.mixSlab = makeHcSlab<double>(mixSlabElements);
+		storage.mixRealPtrs.resize(mixSegmentCount);
+		storage.mixImagPtrs.resize(mixSegmentCount);
+		temp.mixbuf_freq_real = storage.mixRealPtrs.data();
+		temp.mixbuf_freq_imag = storage.mixImagPtrs.data();
+		for (int i = 0; i < temp.num_mixbuf; ++i)
+		{
+			temp.mixbuf_freq_real[i] = storage.mixSlab.get() + static_cast<size_t>(i) * partitionStride;
+			temp.mixbuf_freq_imag[i] = temp.mixbuf_freq_real[i] + bank.planeStride;
+		}
+		memset(storage.mixSlab.get(), 0, checkedHcMultiply(mixSlabElements, sizeof(double)));
+
+		storage.historyTime = makeHcAlignedArray<double>(frameLength);
+		temp.history_time = storage.historyTime.get();
+		memset(temp.history_time, 0, checkedHcMultiply(frameLength, sizeof(double)));
+
+		// FFTW's planner mutates process-global state. The lock is only held while
+		// creating each channel's private execution plans; filter-bank transforms
+		// happen after it is released.
+		{
+			static std::mutex plannerMutex;
+			std::lock_guard<std::mutex> lock(plannerMutex);
+			char appData[MAX_PATH];
+			static std::string wisdomPath;
+			static bool wisdomAvailable = false;
+			if (wisdomPath.empty() && GetEnvironmentVariableA("LOCALAPPDATA", appData, MAX_PATH) > 0)
+			{
+				std::string dir = std::string(appData) + "\\EqualizerAPO";
+				CreateDirectoryA(dir.c_str(), nullptr);
+				wisdomPath = dir + "\\fftw_wisdom.dat";
+				static std::once_flag importedFlag;
+				std::call_once(importedFlag, []() {
+					if (!wisdomPath.empty() && GetFileAttributesA(wisdomPath.c_str()) != INVALID_FILE_ATTRIBUTES)
+						wisdomAvailable = fftw_import_wisdom_from_filename(wisdomPath.c_str()) != 0;
+				});
+			}
+			const unsigned flags =
+				(wisdomAvailable ? FFTW_MEASURE : FFTW_ESTIMATE) | FFTW_PRESERVE_INPUT;
+			pending.fft = fftw::makeRealToComplexPlan(
+				2 * bank.frameLength, temp.dft_time, temp.dft_freq, flags);
+			pending.ifft = fftw::makeComplexToRealPlan(
+				2 * bank.frameLength, temp.dft_freq, temp.dft_time, flags);
+		}
+
+		return pending;
+	}
+
+	void transformFilterBank(
+		PendingSingle& pending,
+		HConvFilterBankStorage& bank,
+		const double* impulse,
+		int impulseLength)
+	{
+		HConvSingle& temp = pending.value;
+		const int frameLength = bank.frameLength;
+		const size_t dftLength = checkedHcMultiply(static_cast<size_t>(frameLength), 2);
+		const double gain = 0.5 / frameLength;
+		memset(temp.dft_time, 0, checkedHcMultiply(dftLength, sizeof(double)));
+
+		int partition = 0;
+		for (; partition < bank.segmentCount - 1; ++partition)
+		{
+			mul_store_gain_double(
+				temp.dft_time,
+				impulse + static_cast<size_t>(partition) * frameLength,
+				frameLength,
+				gain);
+			fftw_execute(pending.fft.get());
+			copy_split_complex_vec(
+				temp.dft_freq,
+				bank.realPtrs[partition],
+				bank.imagPtrs[partition],
+				frameLength + 1);
+		}
+
+		const int tailLength = impulseLength - partition * frameLength;
+		if (tailLength > 0)
+		{
+			mul_store_gain_double(temp.dft_time, impulse + static_cast<size_t>(partition) * frameLength,
+				tailLength, gain);
+			memset(temp.dft_time + tailLength, 0,
+				checkedHcMultiply(dftLength - static_cast<size_t>(tailLength), sizeof(double)));
+		}
+		else
+		{
+			memset(temp.dft_time, 0, checkedHcMultiply(dftLength, sizeof(double)));
+		}
+		fftw_execute(pending.fft.get());
+		copy_split_complex_vec(temp.dft_freq, bank.realPtrs[partition], bank.imagPtrs[partition],
+			frameLength + 1);
+	}
+}
+
+void hcInitSingle(HConvSingle* filter, double* h, int hlen, int flen, int steps)
 {
 	if (filter == nullptr)
 		throw std::invalid_argument("hcInitSingle requires an output filter");
-
 	if (h == nullptr)
 		throw std::invalid_argument("hcInitSingle requires impulse-response samples");
-	if (hlen <= 0 || flen <= 0 || steps <= 0)
-		throw std::invalid_argument("hcInitSingle lengths and step count must be positive");
-	if (flen > (std::numeric_limits<int>::max)() / 2)
-		throw std::length_error("hcInitSingle frame length is too large");
-	if (steps == (std::numeric_limits<int>::max)())
-		throw std::length_error("hcInitSingle step count is too large");
+	if (hlen <= 0)
+		throw std::invalid_argument("hcInitSingle impulse length must be positive");
+	validateSingleShape(flen, steps);
 
-	int i, j, num, pos;
-	double gain;
-	const size_t frameLength = static_cast<size_t>(flen);
-	const size_t dftLength = checkedHcMultiply(frameLength, 2);
-	const size_t complexLength = frameLength + 1;
-	const size_t filterSegmentCount =
-		(static_cast<size_t>(hlen) + frameLength - 1) / frameLength;
-	if (filterSegmentCount >= static_cast<size_t>((std::numeric_limits<int>::max)()))
-		throw std::length_error("hcInitSingle requires too many partitions");
-
-	const size_t planeStride = (complexLength + 7) & ~static_cast<size_t>(7);
-	const size_t partitionStride = checkedHcMultiply(planeStride, 2);
-	const size_t filterSlabElements = checkedHcMultiply(filterSegmentCount, partitionStride);
-	const size_t mixSegmentCount = filterSegmentCount + 1;
-	const size_t mixSlabElements = checkedHcMultiply(mixSegmentCount, partitionStride);
-
-	HConvSingle temp = {};
-	auto storageOwner = std::make_unique<HConvSingleStorage>();
-	auto& storage = *storageOwner;
-
-	temp.step = 0;
-	temp.maxstep = steps;
-	temp.mixpos = 0;
-	temp.framelength = flen;
-
-	storage.dftTime = makeHcAlignedArray<double>(dftLength);
-	temp.dft_time = storage.dftTime.get();
-	storage.dftFreq = makeHcAlignedArray<fftw_complex>(complexLength);
-	temp.dft_freq = storage.dftFreq.get();
-	storage.inFreqReal = makeHcAlignedArray<double>(complexLength);
-	storage.inFreqImag = makeHcAlignedArray<double>(complexLength);
-	temp.in_freq_real = storage.inFreqReal.get();
-	temp.in_freq_imag = storage.inFreqImag.get();
-
-	temp.num_filterbuf = static_cast<int>(filterSegmentCount);
-	storage.stepTask.resize(static_cast<size_t>(steps) + 1);
-	temp.steptask = storage.stepTask.data();
-	num = temp.num_filterbuf / steps;
-	for (i = 0; i <= steps; i++)
-		temp.steptask[i] = i * num;
-	pos = (temp.steptask[1] == 0) ? 1 : 2;
-	num = temp.num_filterbuf % steps;
-	for (j = pos; j < pos + num; j++) {
-		for (i = j; i <= steps; i++)
-			temp.steptask[i]++;
-	}
-
-	// Each plane is padded to a whole number of cache lines so every real and
-	// imag plane starts 64-byte aligned; a partition is [real|imag]. The
-	// memset doubles as a pre-touch so first use on the audio thread does not
-	// take the soft page faults.
-	storage.filterSlab = makeHcSlab<double>(filterSlabElements);
-	storage.filterRealPtrs.resize(filterSegmentCount);
-	storage.filterImagPtrs.resize(filterSegmentCount);
-	temp.filterbuf_freq_real = storage.filterRealPtrs.data();
-	temp.filterbuf_freq_imag = storage.filterImagPtrs.data();
-	for (i = 0; i < temp.num_filterbuf; i++) {
-		temp.filterbuf_freq_real[i] = storage.filterSlab.get() + (size_t)i * partitionStride;
-		temp.filterbuf_freq_imag[i] = temp.filterbuf_freq_real[i] + planeStride;
-	}
-	memset(storage.filterSlab.get(), 0, checkedHcMultiply(filterSlabElements, sizeof(double)));
-
-	temp.num_mixbuf = static_cast<int>(mixSegmentCount);
-
-	storage.mixSlab = makeHcSlab<double>(mixSlabElements);
-	storage.mixRealPtrs.resize(mixSegmentCount);
-	storage.mixImagPtrs.resize(mixSegmentCount);
-	temp.mixbuf_freq_real = storage.mixRealPtrs.data();
-	temp.mixbuf_freq_imag = storage.mixImagPtrs.data();
-	for (i = 0; i < temp.num_mixbuf; i++) {
-		temp.mixbuf_freq_real[i] = storage.mixSlab.get() + (size_t)i * partitionStride;
-		temp.mixbuf_freq_imag[i] = temp.mixbuf_freq_real[i] + planeStride;
-	}
-	memset(storage.mixSlab.get(), 0, checkedHcMultiply(mixSlabElements, sizeof(double)));
-
-	storage.historyTime = makeHcAlignedArray<double>(frameLength);
-	temp.history_time = storage.historyTime.get();
-	memset(temp.history_time, 0, checkedHcMultiply(frameLength, sizeof(double)));
-
-	// When a cached wisdom file exists we use FFTW_MEASURE — planner returns immediately from the cache,
-	// giving the optimized plan without the multi-second learning cost. Without wisdom we fall back to
-	// FFTW_ESTIMATE so a fresh install does not introduce a multi-second audio glitch at startup.
-	// A separate warmup tool can pre-populate %LOCALAPPDATA%\EqualizerAPO\fftw_wisdom.dat to unlock the
-	// faster MEASURE path on subsequent runs.
-	fftw::Plan fft;
-	fftw::Plan ifft;
-	{
-		static std::mutex plannerMutex;
-		std::lock_guard<std::mutex> lock(plannerMutex);
-		char appData[MAX_PATH];
-		static std::string wisdomPath;
-		static bool wisdomAvailable = false;
-		if (wisdomPath.empty() && GetEnvironmentVariableA("LOCALAPPDATA", appData, MAX_PATH) > 0)
-		{
-			std::string dir = std::string(appData) + "\\EqualizerAPO";
-			CreateDirectoryA(dir.c_str(), nullptr);
-			wisdomPath = dir + "\\fftw_wisdom.dat";
-			static std::once_flag importedFlag;
-			std::call_once(importedFlag, []() {
-				if (!wisdomPath.empty() && GetFileAttributesA(wisdomPath.c_str()) != INVALID_FILE_ATTRIBUTES)
-					wisdomAvailable = (fftw_import_wisdom_from_filename(wisdomPath.c_str()) != 0);
-			});
-		}
-		unsigned fftw_flags = (wisdomAvailable ? FFTW_MEASURE : FFTW_ESTIMATE) | FFTW_PRESERVE_INPUT;
-		fft = fftw::makeRealToComplexPlan(2 * flen, temp.dft_time, temp.dft_freq, fftw_flags);
-		ifft = fftw::makeComplexToRealPlan(2 * flen, temp.dft_freq, temp.dft_time, fftw_flags);
-	}
-
-	gain = 0.5 / flen;
-
-	memset(temp.dft_time, 0, checkedHcMultiply(dftLength, sizeof(double)));
-
-	// Full-length segments
-	for (i = 0; i < temp.num_filterbuf - 1; i++) {
-		// dft_time[0:flen] = gain * h[i * flen + 0 : + flen]
-		mul_store_gain_double(temp.dft_time, h + (size_t)i * flen, flen, gain);
-
-		fftw_execute(fft.get());
-
-		// Split complex to separate real/imag buffers
-		copy_split_complex_vec((const fftw_complex*)temp.dft_freq,
-			temp.filterbuf_freq_real[i],
-			temp.filterbuf_freq_imag[i],
-			flen + 1);
-	}
-
-	// Tail (possibly partial) segment
-	int last_segment_len = hlen - i * flen;
-	if (last_segment_len > 0) {
-		mul_store_gain_double(temp.dft_time, h + (size_t)i * flen, last_segment_len, gain);
-		// zero the remainder up to 2*flen
-		memset(&temp.dft_time[last_segment_len], 0,
-			checkedHcMultiply(dftLength - (size_t)last_segment_len, sizeof(double)));
-	}
-	else {
-		// No tail data: ensure the time buffer is zeroed
-		memset(temp.dft_time, 0, checkedHcMultiply(dftLength, sizeof(double)));
-	}
-
-	fftw_execute(fft.get());
-	copy_split_complex_vec((const fftw_complex*)temp.dft_freq,
-		temp.filterbuf_freq_real[i],
-		temp.filterbuf_freq_imag[i],
-		flen + 1);
-
-	temp.fft = fft.release();
-	temp.ifft = ifft.release();
-	temp.storage = storageOwner.release();
+	auto filterBank = makeFilterBank(hlen, flen);
+	PendingSingle pending = prepareSingleRuntime(filterBank, steps);
+	transformFilterBank(pending, *filterBank, h, hlen);
 	// Publish only after every allocation, plan, and initial transform has
 	// succeeded. A throwing path never exposes partial ownership to the caller.
-	*filter = temp;
+	pending.publish(filter);
+}
+
+void hcInitSingleWithSharedFilterBank(HConvSingle* filter, const HConvSingle* prototype)
+{
+	if (filter == nullptr)
+		throw std::invalid_argument("shared hcInitSingle requires an output filter");
+	if (prototype == nullptr || prototype->storage == nullptr ||
+		prototype->storage->filterBank == nullptr)
+	{
+		throw std::invalid_argument("shared hcInitSingle requires an initialized prototype");
+	}
+	if (filter == prototype)
+		throw std::invalid_argument("shared hcInitSingle output must differ from its prototype");
+	validateSingleShape(prototype->framelength, prototype->maxstep);
+
+	PendingSingle pending = prepareSingleRuntime(
+		prototype->storage->filterBank,
+		prototype->maxstep);
+	pending.publish(filter);
 }
 
 void hcCloseSingle(HConvSingle* filter)

--- a/libHybridConv-0.1.1/libHybridConv_eapo.h
+++ b/libHybridConv-0.1.1/libHybridConv_eapo.h
@@ -26,11 +26,9 @@
 #include <fftw3.h>
 
 
-/* Instance-owned buffer storage, defined in libHybridConv_eapo.cpp. Each
- * hcInit* call allocates one and the matching hcClose* frees it, so buffer
- * lifetime follows the struct instance. Instance-owned rather than
- * process-global: APO instances load configs concurrently, so process-wide
- * shared state here would be unguarded. */
+/* Instance-owned runtime storage, defined in libHybridConv_eapo.cpp. A storage
+ * object may retain an immutable filter bank shared with sibling channels;
+ * mutable histories, mix buffers and FFTW plans always remain per instance. */
 struct HConvSingleStorage;
 
 
@@ -46,8 +44,8 @@ typedef struct str_HConvSingle
 	double *in_freq_real;		// input buffer (frequency domain)
 	double *in_freq_imag;		// input buffer (frequency domain)
 	int num_filterbuf;		// number of filter segments
-	double **filterbuf_freq_real;	// filter segments (frequency domain)
-	double **filterbuf_freq_imag;	// filter segments (frequency domain)
+	const double *const *filterbuf_freq_real;	// shared immutable filter segments (frequency domain)
+	const double *const *filterbuf_freq_imag;	// shared immutable filter segments (frequency domain)
 	int num_mixbuf;			// number of mixing segments		
 	double **mixbuf_freq_real;	// mixing segments (frequency domain)
 	double **mixbuf_freq_imag;	// mixing segments (frequency domain)
@@ -67,6 +65,7 @@ void hcProcessSingle(HConvSingle *filter);
 void hcGetSingle(HConvSingle *filter, double*y);
 void hcGetAddSingle(HConvSingle *filter, double*y);
 void hcInitSingle(HConvSingle *filter, double*h, int hlen, int flen, int steps);
+void hcInitSingleWithSharedFilterBank(HConvSingle *filter, const HConvSingle *prototype);
 void hcCloseSingle(HConvSingle *filter);
 
 /* The dual/tripple (low-latency) API is parked in


### PR DESCRIPTION
## What changed

- split HybridConv ownership into an immutable transformed filter bank and per-channel runtime state
- reuse one bank for every GraphicEQ channel, one per distinct Convolution IR channel, and one per referenced MultiConvolution IR channel
- make the public filter-bank view const while retaining independent history, mix buffers, working buffers, and FFTW plans
- add a lifetime regression test that closes the prototype before processing through a sharing sibling

## Why

The previous multicore setup ran identical IR partition transforms once per output channel. Parallel workers hid the wall-clock cost but still performed N copies of the same FFT work and retained N identical filter slabs. This change removes that duplicated work and memory while preserving channel-local mutable state.

## Validation

- `Common.vcxproj` x64 Release build (VS 2026/v145)
- `HybridConvTests.vcxproj` x64 Release build
- `HybridConvTests.exe`: 1,632 HybridConv checks and all companion suites passed, including 5,355 MultiConvolution checks
- `git diff --check`

The PR CI remains the authority for cppcheck, the full AVX2 project matrix, audio regression references, Qt builds, and skin-switch tests.
