### PR TITLE
feat(config): 레거시 Equalizer APO 설정 자동 이관과 전용 설정 루트

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,22 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- EqualizerAPO-XT가 전용 설정 루트(`%LOCALAPPDATA%\EqualizerAPO-XT\config`)를
+  갖습니다. 지금까지는 기존 Equalizer APO 설치가 잡아 둔 레지스트리 설정
+  경로를 그대로 읽어서, XT 설치 폴더의 `config\config.txt`를 아무리 고쳐도
+  적용되지 않고 옛 `Program Files` 폴더가 계속 오디오를 움직였습니다.
+  기존 APO를 제거한 뒤에도 마찬가지였습니다. 이제 설치와 업데이트 때마다
+  훅이 신뢰 경로를 판정합니다. 기존 Equalizer APO 폴더라면 `config.txt`가
+  참조하는 모든 파일(몇 단계든 Include 체인, Convolution·MultiConvolution
+  임펄스 응답, VST 참조, 폴더 구조 보존)을 가져온 뒤 신뢰를 새 루트로
+  돌리며, 이후 옛 폴더는 더 이상 읽히지 않습니다. Velopack `current\` 안의
+  설정 폴더라면 통째로 구출합니다(업데이트가 `current\`를 재생성하며
+  지워버리기 때문입니다). 사용자가 직접 고른 폴더는 건드리지 않습니다.
+  이관이 일어나면 에디터가 한 번 안내를 띄우고, `Editor.exe
+  --migration-dry-run`으로 아무것도 바꾸지 않고 어떤 판정이 나는지 확인할
+  수 있습니다. 가져오기 스캐너는 `MultiConvolution:` 줄과 따옴표로 감싼
+  컨볼루션 경로도 인식합니다.
+  ([#204](https://github.com/115dkk/EqualizerAPO-XT/pull/204))
 - 카드 보기에서 큰 설정 파일을 열면 오래된 CPU 기준 10초 넘게 걸리던
   문제를 고쳤습니다(i7-7700K 보고). 에디터가 스킨 스타일시트를 모든 카드
   위젯에 대해 여러 번 다시 해석하고 있었습니다. 카드를 부모 없이 만든 뒤

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- EqualizerAPO-XT now has its own configuration root:
+  `%LOCALAPPDATA%\EqualizerAPO-XT\config`. The fork used to keep reading the
+  registry config path a legacy Equalizer APO install had claimed, so edits
+  to the XT install's own `config\config.txt` did nothing while the old
+  `Program Files` folder kept driving the audio — even after the legacy APO
+  was uninstalled. On install and on every update, the hook now classifies
+  the trusted path: a legacy Equalizer APO folder has its `config.txt`
+  imported with everything it references (Include chains at any depth,
+  Convolution and MultiConvolution impulse responses, VST references,
+  folder structure preserved) and the trust is repointed, after which the
+  old folder is no longer read; a config folder inside a Velopack
+  `current\` dir is rescued wholesale, since updates recreate `current\`
+  and would have deleted it; a folder the user chose on purpose is left
+  alone. The Editor shows a one-time notice after a migration, and
+  `Editor.exe --migration-dry-run` prints what would happen on a machine
+  without changing anything. The import scanner also learned
+  `MultiConvolution:` lines and quoted convolution paths.
+  ([#204](https://github.com/115dkk/EqualizerAPO-XT/pull/204))
 - Opening a large configuration in the card view took over ten seconds on
   older CPUs (reported on an i7-7700K). The Editor was resolving its skin
   stylesheet against every card widget several times over: cards were built

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -265,6 +265,8 @@ SOURCES += main.cpp\
 	import/ConfigDependencyScanner.cpp \
 	import/ImportDialog.cpp \
 	import/ImportExecutor.cpp \
+	import/LegacyMigration.cpp \
+	import/LegacyMigrationPolicy.cpp \
 	widgets/MiddleClickTabBar.cpp
 
 HEADERS  += \
@@ -487,6 +489,8 @@ HEADERS  += \
 	import/ImportDialog.h \
 	import/ImportExecutor.h \
 	import/ImportManifest.h \
+	import/LegacyMigration.h \
+	import/LegacyMigrationPolicy.h \
 	widgets/MiddleClickTabBar.h
 
 FORMS    += \

--- a/Editor/import/ConfigDependencyScanner.cpp
+++ b/Editor/import/ConfigDependencyScanner.cpp
@@ -4,6 +4,7 @@
 
 #include "ConfigDependencyScanner.h"
 #include "../widgets/FilterCardModel.h"
+#include "filters/MultiConvolutionCommand.h"
 
 #include <QDir>
 #include <QFile>
@@ -24,6 +25,7 @@ bool isReferenceCommand(const QString& commandLower)
 {
     return commandLower == QStringLiteral("include")
         || commandLower == QStringLiteral("convolution")
+        || commandLower == QStringLiteral("multiconvolution")
         || commandLower == QStringLiteral("vstplugin");
 }
 
@@ -31,8 +33,36 @@ QString kindForCommand(const QString& commandLower)
 {
     if (commandLower == QStringLiteral("include")) return QStringLiteral("Include");
     if (commandLower == QStringLiteral("convolution")) return QStringLiteral("Convolution");
+    if (commandLower == QStringLiteral("multiconvolution")) return QStringLiteral("MultiConvolution");
     if (commandLower == QStringLiteral("vstplugin")) return QStringLiteral("VSTPlugin");
     return commandLower;
+}
+
+// The engine unquotes convolution paths in ConvolutionFilePath::resolve, so a
+// quoted reference is a valid line; the scanner must look at the same file.
+QString stripSurroundingQuotes(const QString& text)
+{
+    QString trimmed = text.trimmed();
+    if (trimmed.length() >= 2 && trimmed.startsWith(QLatin1Char('"')) && trimmed.endsWith(QLatin1Char('"')))
+        return trimmed.mid(1, trimmed.length() - 2);
+    return trimmed;
+}
+
+// The path portion of the line for the given reference command. Include and
+// VSTPlugin use the raw parameters; the convolution family shares the
+// engine's own grammar so factors/mappings never leak into the path.
+QString referencePath(const QString& commandLower, const QString& parameters)
+{
+    if (commandLower == QStringLiteral("multiconvolution"))
+    {
+        MultiConvolutionCommand command;
+        if (!MultiConvolutionCommand::parse(L"MultiConvolution", parameters.toStdWString(), command))
+            return QString();
+        return stripSurroundingQuotes(QString::fromStdWString(command.path));
+    }
+    if (commandLower == QStringLiteral("convolution"))
+        return stripSurroundingQuotes(parameters);
+    return parameters;
 }
 
 QString resolveAbsolute(const QString& reference, const QString& baseDir)
@@ -58,6 +88,15 @@ QString relativeToRoot(const QString& targetAbs, const QString& rootDir)
     if (rel.isEmpty() || rel.startsWith(QStringLiteral("..")))
         return QString();
     return QDir::fromNativeSeparators(rel);
+}
+
+// Destination path for a source-relative path under the chosen layout.
+QString destForRelative(const QString& rel, const QString& rootSourceDir, DestLayout layout)
+{
+    if (layout == DestLayout::SourceFolderIsRoot)
+        return rel;
+    QString rootName = QFileInfo(rootSourceDir).fileName();
+    return rootName.isEmpty() ? rel : rootName + QStringLiteral("/") + rel;
 }
 
 void appendItem(ImportManifest& manifest,
@@ -96,6 +135,7 @@ void appendItem(ImportManifest& manifest,
 void scanConfigFile(ImportManifest& manifest,
                     const QString& sourceTxtAbs,
                     const QString& rootSourceDir,
+                    DestLayout layout,
                     int depth,
                     QSet<QString>& visited)
 {
@@ -136,7 +176,8 @@ void scanConfigFile(ImportManifest& manifest,
         if (!isReferenceCommand(commandLower))
             continue;
 
-        QString refAbs = resolveAbsolute(parameters, baseDir);
+        QString reference = referencePath(commandLower, parameters);
+        QString refAbs = resolveAbsolute(reference, baseDir);
         if (refAbs.isEmpty())
             continue;
 
@@ -149,19 +190,16 @@ void scanConfigFile(ImportManifest& manifest,
             continue;
         }
 
-        QString rootName = QFileInfo(rootSourceDir).fileName();
-        QString destRel = rootName.isEmpty() ? rel : rootName + QStringLiteral("/") + rel;
-
-        appendItem(manifest, refAbs, destRel, kindForCommand(commandLower));
+        appendItem(manifest, refAbs, destForRelative(rel, rootSourceDir, layout), kindForCommand(commandLower));
 
         if (commandLower == QStringLiteral("include"))
-            scanConfigFile(manifest, refAbs, rootSourceDir, depth + 1, visited);
+            scanConfigFile(manifest, refAbs, rootSourceDir, layout, depth + 1, visited);
     }
 }
 
 }
 
-ImportManifest ConfigDependencyScanner::scan(const QString& rootSource, const QString& configDir)
+ImportManifest ConfigDependencyScanner::scan(const QString& rootSource, const QString& configDir, DestLayout layout)
 {
     Q_UNUSED(configDir);
 
@@ -177,11 +215,7 @@ ImportManifest ConfigDependencyScanner::scan(const QString& rootSource, const QS
     }
 
     manifest.rootSourceDir = rootInfo.absoluteDir().absolutePath();
-    QString rootName = QFileInfo(manifest.rootSourceDir).fileName();
-    QString rootRel = rootName.isEmpty()
-        ? rootInfo.fileName()
-        : rootName + QStringLiteral("/") + rootInfo.fileName();
-    manifest.rootDest = rootRel;
+    manifest.rootDest = destForRelative(rootInfo.fileName(), manifest.rootSourceDir, layout);
 
     appendItem(manifest, manifest.rootSource, manifest.rootDest, QStringLiteral("Root"));
 
@@ -189,7 +223,7 @@ ImportManifest ConfigDependencyScanner::scan(const QString& rootSource, const QS
     if (suffix == QStringLiteral("txt"))
     {
         QSet<QString> visited;
-        scanConfigFile(manifest, manifest.rootSource, manifest.rootSourceDir, 0, visited);
+        scanConfigFile(manifest, manifest.rootSource, manifest.rootSourceDir, layout, 0, visited);
     }
 
     return manifest;

--- a/Editor/import/ConfigDependencyScanner.h
+++ b/Editor/import/ConfigDependencyScanner.h
@@ -3,9 +3,9 @@
 
     Walks an external EqualizerAPO config file (the one the user is
     about to import) and collects every file it references through
-    Include, Convolution, and VSTPlugin commands. Recursion follows the
-    same pattern as filters/IncludeFilterFactory.cpp so nested config
-    trees are picked up.
+    Include, Convolution, MultiConvolution, and VSTPlugin commands.
+    Recursion follows the same pattern as filters/IncludeFilterFactory.cpp
+    so nested config trees are picked up.
 
     The scanner is read-only and side-effect free. ImportExecutor is the
     component that actually copies files.
@@ -20,6 +20,19 @@
 namespace EqAPO::Import
 {
 
+// Where the collected files land relative to the target config directory.
+// NestUnderSourceFolder reproduces the card editors' behavior: everything
+// goes under a subfolder named after the source's own folder, so an import
+// never mixes into the config root. SourceFolderIsRoot maps the source
+// folder 1:1 onto the target root (config.txt stays config.txt) - the
+// layout the legacy-install migration needs, where the source folder IS
+// the old config root.
+enum class DestLayout
+{
+    NestUnderSourceFolder,
+    SourceFolderIsRoot
+};
+
 class ConfigDependencyScanner
 {
 public:
@@ -32,7 +45,8 @@ public:
     // walked recursively — or a single binary (.wav, .dll, etc.) in
     // which case the manifest contains exactly one item. configDir is
     // only used to compute dest paths; the scanner never writes there.
-    static ImportManifest scan(const QString& rootSource, const QString& configDir);
+    static ImportManifest scan(const QString& rootSource, const QString& configDir,
+        DestLayout layout = DestLayout::NestUnderSourceFolder);
 };
 
 }

--- a/Editor/import/LegacyMigration.cpp
+++ b/Editor/import/LegacyMigration.cpp
@@ -1,0 +1,293 @@
+/*
+    This file is part of EqualizerAPO-XT.
+*/
+
+#include "LegacyMigration.h"
+#include "LegacyMigrationPolicy.h"
+#include "ConfigDependencyScanner.h"
+#include "ImportExecutor.h"
+
+#include "helpers/ApoRegistration.h"
+#include "helpers/LogHelper.h"
+#include "helpers/RegistryHelper.h"
+
+#include <cstdio>
+
+#include <QDateTime>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QMessageBox>
+#include <QSettings>
+#include <QString>
+
+namespace EqAPO::Import
+{
+
+namespace
+{
+
+QString readRegistryString(const wchar_t* name)
+{
+    try
+    {
+        if (RegistryHelper::valueExists(APP_REGPATH, name))
+            return QString::fromStdWString(RegistryHelper::readValue(APP_REGPATH, name));
+    }
+    catch (const RegistryException&)
+    {
+    }
+    return QString();
+}
+
+// Copy every file below sourceDir into targetDir, keeping the relative
+// layout and overwriting what is already there. Used to rescue a config
+// tree out of a Velopack current\ dir, where the source is authoritative.
+int copyTreeOverwriting(const QString& sourceDir, const QString& targetDir)
+{
+    int copied = 0;
+    QDir source(sourceDir);
+    QDirIterator it(sourceDir, QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        const QString sourceFile = it.next();
+        const QString rel = source.relativeFilePath(sourceFile);
+        const QString targetFile = QDir(targetDir).absoluteFilePath(rel);
+        QDir().mkpath(QFileInfo(targetFile).absolutePath());
+        if (QFile::exists(targetFile))
+            QFile::remove(targetFile);
+        if (QFile::copy(sourceFile, targetFile))
+            copied++;
+        else
+            LogFStatic(L"Migration: failed to copy %s", reinterpret_cast<const wchar_t*>(sourceFile.utf16()));
+    }
+    return copied;
+}
+
+// Ship the sample configs into the root without ever touching a file the
+// user (or the migration) already put there.
+void seedMissingSamples(const QString& shippedConfigDir, const QString& targetDir)
+{
+    QDirIterator it(shippedConfigDir, QDir::Files, QDirIterator::Subdirectories);
+    QDir shipped(shippedConfigDir);
+    while (it.hasNext())
+    {
+        const QString sourceFile = it.next();
+        const QString rel = shipped.relativeFilePath(sourceFile);
+        const QString targetFile = QDir(targetDir).absoluteFilePath(rel);
+        if (QFile::exists(targetFile))
+            continue;
+        QDir().mkpath(QFileInfo(targetFile).absolutePath());
+        QFile::copy(sourceFile, targetFile);
+    }
+}
+
+void writeMigrationBreadcrumbs(const QString& from, int filesCopied)
+{
+    RegistryHelper::writeValue(APP_REGPATH, L"MigratedFrom", from.toStdWString());
+    RegistryHelper::writeValue(APP_REGPATH, L"MigrationStamp",
+        QDateTime::currentDateTime().toString(Qt::ISODate).toStdWString());
+    RegistryHelper::writeDWORDValue(APP_REGPATH, L"MigratedFiles", static_cast<unsigned long>(filesCopied));
+}
+
+}
+
+QString LegacyMigration::stableConfigRoot()
+{
+    return LegacyMigrationPolicy::stableConfigRoot(
+        QString::fromLocal8Bit(qgetenv("LOCALAPPDATA")));
+}
+
+bool LegacyMigration::looksLikeLegacyApoConfigDir(const QString& configDir)
+{
+    const QString clean = QDir::cleanPath(configDir);
+    if (clean.isEmpty() || !QDir(clean).exists())
+        return false;
+    // The installer's folder name is enough: uninstalling the legacy APO
+    // deletes its binaries but leaves the config folder and the stale
+    // ConfigPath value behind, so binary markers cannot be required.
+    if (LegacyMigrationPolicy::hasLegacyApoFolderName(clean))
+        return true;
+    QDir parent(clean);
+    if (!parent.cdUp())
+        return false;
+    return QFile::exists(parent.absoluteFilePath(QStringLiteral("EqualizerAPO.dll")))
+        || QFile::exists(parent.absoluteFilePath(QStringLiteral("Uninstall.exe")));
+}
+
+void LegacyMigration::runElevatedHookStep(const std::wstring& exeDir)
+{
+    const QString stableRoot = stableConfigRoot();
+    if (stableRoot.isEmpty())
+    {
+        LogFStatic(L"Migration: LOCALAPPDATA missing, keeping existing ConfigPath");
+        return;
+    }
+
+    const QString existing = readRegistryString(L"ConfigPath");
+    const LegacyMigrationPolicy::Action action = LegacyMigrationPolicy::classify(
+        existing, stableRoot,
+        looksLikeLegacyApoConfigDir(existing),
+        LegacyMigrationPolicy::isVolatileXtConfigDir(existing));
+
+    if (action == LegacyMigrationPolicy::Action::RespectCustom)
+    {
+        LogFStatic(L"Migration: ConfigPath %s is user-chosen, leaving it alone",
+            reinterpret_cast<const wchar_t*>(existing.utf16()));
+        return;
+    }
+
+    QDir().mkpath(stableRoot);
+    // audiodg (LOCAL SERVICE) must read configs here and the user must be
+    // able to edit them; same grants the install() hook applies to the
+    // packaged config dir.
+    ApoRegistration::secureConfigDir(QDir::toNativeSeparators(stableRoot).toStdWString());
+
+    try
+    {
+        switch (action)
+        {
+        case LegacyMigrationPolicy::Action::AlreadyOurs:
+            break;
+        case LegacyMigrationPolicy::Action::AdoptStableRoot:
+            RegistryHelper::writeValue(APP_REGPATH, L"ConfigPath",
+                QDir::toNativeSeparators(stableRoot).toStdWString());
+            LogFStatic(L"Migration: ConfigPath adopted %s",
+                reinterpret_cast<const wchar_t*>(stableRoot.utf16()));
+            break;
+        case LegacyMigrationPolicy::Action::MigrateLegacy:
+        {
+            // Bring over exactly what the legacy config.txt reaches: Include
+            // chains at any depth, convolution IRs, VST references, with the
+            // legacy folder mapped 1:1 onto the stable root. Unreferenced
+            // files stay behind; absolute references outside the legacy root
+            // keep working unmoved.
+            const QString legacyConfigTxt = QDir(existing).absoluteFilePath(QStringLiteral("config.txt"));
+            int copied = 0;
+            if (QFile::exists(legacyConfigTxt))
+            {
+                const ImportManifest manifest = ConfigDependencyScanner::scan(
+                    legacyConfigTxt, stableRoot, DestLayout::SourceFolderIsRoot);
+                for (const QString& warning : manifest.warnings)
+                    LogFStatic(L"Migration: %s", reinterpret_cast<const wchar_t*>(warning.utf16()));
+                const ExecutionResult result = ImportExecutor::execute(manifest, stableRoot);
+                for (const QString& error : result.errors)
+                    LogFStatic(L"Migration: %s", reinterpret_cast<const wchar_t*>(error.utf16()));
+                copied = result.filesCopied;
+            }
+            else
+            {
+                LogFStatic(L"Migration: legacy dir %s has no config.txt, repointing without import",
+                    reinterpret_cast<const wchar_t*>(existing.utf16()));
+            }
+            RegistryHelper::writeValue(APP_REGPATH, L"ConfigPath",
+                QDir::toNativeSeparators(stableRoot).toStdWString());
+            writeMigrationBreadcrumbs(existing, copied);
+            LogFStatic(L"Migration: imported %d file(s) from legacy %s",
+                copied, reinterpret_cast<const wchar_t*>(existing.utf16()));
+            break;
+        }
+        case LegacyMigrationPolicy::Action::MigrateVolatileXt:
+        {
+            // Everything in a current\config dir is one update away from
+            // deletion (Velopack recreates current\ wholesale), so the whole
+            // folder is rescued, not just what config.txt references.
+            const int copied = QDir(existing).exists()
+                ? copyTreeOverwriting(existing, stableRoot) : 0;
+            RegistryHelper::writeValue(APP_REGPATH, L"ConfigPath",
+                QDir::toNativeSeparators(stableRoot).toStdWString());
+            writeMigrationBreadcrumbs(existing, copied);
+            LogFStatic(L"Migration: rescued %d file(s) from volatile %s",
+                copied, reinterpret_cast<const wchar_t*>(existing.utf16()));
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    catch (const RegistryException& e)
+    {
+        LogFStatic(L"Migration: registry write failed: %s", e.getMessage().c_str());
+        return;
+    }
+
+    seedMissingSamples(
+        QDir(QString::fromStdWString(exeDir)).absoluteFilePath(QStringLiteral("config")),
+        stableRoot);
+}
+
+int LegacyMigration::dryRun()
+{
+	const QString stableRoot = stableConfigRoot();
+	const QString existing = readRegistryString(L"ConfigPath");
+	const bool legacyMarkers = looksLikeLegacyApoConfigDir(existing);
+	const bool volatileXt = LegacyMigrationPolicy::isVolatileXtConfigDir(existing);
+	const LegacyMigrationPolicy::Action action = LegacyMigrationPolicy::classify(
+		existing, stableRoot, legacyMarkers, volatileXt);
+
+	const char* actionName = "?";
+	switch (action)
+	{
+	case LegacyMigrationPolicy::Action::AdoptStableRoot: actionName = "AdoptStableRoot"; break;
+	case LegacyMigrationPolicy::Action::AlreadyOurs: actionName = "AlreadyOurs"; break;
+	case LegacyMigrationPolicy::Action::MigrateLegacy: actionName = "MigrateLegacy"; break;
+	case LegacyMigrationPolicy::Action::MigrateVolatileXt: actionName = "MigrateVolatileXt"; break;
+	case LegacyMigrationPolicy::Action::RespectCustom: actionName = "RespectCustom"; break;
+	}
+
+	fwprintf(stderr, L"[migration dry-run] ConfigPath: %s\n",
+		existing.isEmpty() ? L"(absent)" : reinterpret_cast<const wchar_t*>(existing.utf16()));
+	fwprintf(stderr, L"[migration dry-run] stable root: %s\n",
+		reinterpret_cast<const wchar_t*>(stableRoot.utf16()));
+	fwprintf(stderr, L"[migration dry-run] legacy markers: %d, volatile XT dir: %d\n",
+		legacyMarkers ? 1 : 0, volatileXt ? 1 : 0);
+	fwprintf(stderr, L"[migration dry-run] action: %S\n", actionName);
+
+	if (action == LegacyMigrationPolicy::Action::MigrateLegacy)
+	{
+		const QString legacyConfigTxt = QDir(existing).absoluteFilePath(QStringLiteral("config.txt"));
+		if (!QFile::exists(legacyConfigTxt))
+		{
+			fwprintf(stderr, L"[migration dry-run] no config.txt in the legacy dir; would repoint without import\n");
+			return 0;
+		}
+		const ImportManifest manifest = ConfigDependencyScanner::scan(
+			legacyConfigTxt, stableRoot, DestLayout::SourceFolderIsRoot);
+		for (const ImportItem& item : manifest.items)
+			fwprintf(stderr, L"[migration dry-run] %s%s -> %s (%lld bytes)\n",
+				item.exists ? L"" : L"MISSING ",
+				reinterpret_cast<const wchar_t*>(item.sourceAbsolute.utf16()),
+				reinterpret_cast<const wchar_t*>(item.destRelative.utf16()),
+				static_cast<long long>(item.sizeBytes));
+		for (const QString& warning : manifest.warnings)
+			fwprintf(stderr, L"[migration dry-run] warning: %s\n",
+				reinterpret_cast<const wchar_t*>(warning.utf16()));
+		fwprintf(stderr, L"[migration dry-run] %d file(s), %lld bytes total\n",
+			int(manifest.items.size()), static_cast<long long>(manifest.totalBytes));
+	}
+	return 0;
+}
+
+void LegacyMigration::maybeShowStartupNotice(QWidget* parent)
+{
+    const QString stamp = readRegistryString(L"MigrationStamp");
+    if (stamp.isEmpty())
+        return;
+
+    QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+    if (settings.value(QStringLiteral("interface/migrationNoticeShown")).toString() == stamp)
+        return;
+
+    const QString from = readRegistryString(L"MigratedFrom");
+    const QString root = stableConfigRoot();
+    QMessageBox::information(parent, QObject::tr("Configuration folder moved"),
+        QObject::tr("Your Equalizer APO configuration was imported into the EqualizerAPO-XT "
+                    "configuration folder:\n\n%1\n\nThis folder is now the one the audio "
+                    "pipeline reads. The previous folder is no longer used:\n\n%2")
+        .arg(QDir::toNativeSeparators(root), QDir::toNativeSeparators(from)));
+
+    settings.setValue(QStringLiteral("interface/migrationNoticeShown"), stamp);
+}
+
+}

--- a/Editor/import/LegacyMigration.h
+++ b/Editor/import/LegacyMigration.h
@@ -1,0 +1,50 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    Side-effecting orchestrator of the legacy-install config migration. The
+    elevated Velopack install/update hook calls runElevatedHookStep() after
+    APO registration: it decides via LegacyMigrationPolicy what the trusted
+    ConfigPath should become, imports the legacy config tree (Include chains,
+    convolution IRs) through the existing import module when one is found,
+    repoints HKLM ConfigPath at the stable XT config root, and leaves
+    breadcrumbs the Editor turns into a one-time startup notice.
+*/
+
+#pragma once
+
+#include <QString>
+
+#include <string>
+
+class QWidget;
+
+namespace EqAPO::Import
+{
+
+class LegacyMigration
+{
+public:
+    // %LOCALAPPDATA%\EqualizerAPO-XT\config for the current user; empty when
+    // the environment variable is missing.
+    static QString stableConfigRoot();
+
+    // On-disk verdict for a candidate legacy config dir: its parent holds an
+    // Equalizer APO install (EqualizerAPO.dll or the NSIS Uninstall.exe).
+    static bool looksLikeLegacyApoConfigDir(const QString& configDir);
+
+    // The whole hook-side step. Runs elevated (registry writes go to HKLM);
+    // must not show UI. exeDir is the install's current\ dir, whose config\
+    // subfolder carries the shipped sample configs.
+    static void runElevatedHookStep(const std::wstring& exeDir);
+
+    // "--migration-dry-run": print the classification and the manifest the
+    // hook would act on, write nothing. Field diagnostics for "why did my
+    // config not move" reports. Returns the process exit code.
+    static int dryRun();
+
+    // Editor startup: if the hook migrated a config tree this user has not
+    // been told about yet, show a one-time notice with the old and new roots.
+    static void maybeShowStartupNotice(QWidget* parent);
+};
+
+}

--- a/Editor/import/LegacyMigrationPolicy.cpp
+++ b/Editor/import/LegacyMigrationPolicy.cpp
@@ -1,0 +1,59 @@
+/*
+    This file is part of EqualizerAPO-XT.
+*/
+
+#include "LegacyMigrationPolicy.h"
+
+#include <QDir>
+#include <QRegularExpression>
+
+namespace EqAPO::Import
+{
+
+QString LegacyMigrationPolicy::stableConfigRoot(const QString& localAppData)
+{
+    if (localAppData.trimmed().isEmpty())
+        return QString();
+    return QDir::cleanPath(localAppData + QStringLiteral("/EqualizerAPO-XT/config"));
+}
+
+bool LegacyMigrationPolicy::isVolatileXtConfigDir(const QString& dir)
+{
+    const QString clean = QDir::cleanPath(QDir::fromNativeSeparators(dir));
+    // ...\EqualizerAPO-XT-<variant>\current\config, any drive or profile.
+    static const QRegularExpression volatilePattern(
+        QStringLiteral("/EqualizerAPO-XT-[^/]+/current/config$"),
+        QRegularExpression::CaseInsensitiveOption);
+    return volatilePattern.match(clean).hasMatch();
+}
+
+bool LegacyMigrationPolicy::hasLegacyApoFolderName(const QString& dir)
+{
+    const QString clean = QDir::cleanPath(QDir::fromNativeSeparators(dir));
+    static const QRegularExpression legacyPattern(
+        QStringLiteral("/(EqualizerAPO|Equalizer APO)/config$"),
+        QRegularExpression::CaseInsensitiveOption);
+    return legacyPattern.match(clean).hasMatch();
+}
+
+LegacyMigrationPolicy::Action LegacyMigrationPolicy::classify(const QString& existingConfigPath,
+    const QString& stableRoot, bool legacyMarkersPresent, bool volatileXt)
+{
+    const QString existing = QDir::cleanPath(QDir::fromNativeSeparators(existingConfigPath.trimmed()));
+    if (existing.isEmpty())
+        return Action::AdoptStableRoot;
+
+    const QString stable = QDir::cleanPath(QDir::fromNativeSeparators(stableRoot));
+    if (QString::compare(existing, stable, Qt::CaseInsensitive) == 0)
+        return Action::AlreadyOurs;
+
+    if (volatileXt)
+        return Action::MigrateVolatileXt;
+
+    if (legacyMarkersPresent)
+        return Action::MigrateLegacy;
+
+    return Action::RespectCustom;
+}
+
+}

--- a/Editor/import/LegacyMigrationPolicy.h
+++ b/Editor/import/LegacyMigrationPolicy.h
@@ -1,0 +1,66 @@
+/*
+    This file is part of EqualizerAPO-XT.
+
+    Pure decision logic for the legacy-install config migration: given the
+    ConfigPath value the audio pipeline currently trusts, decide whether the
+    installer hook should adopt it, migrate it, or leave it alone. No
+    registry or filesystem access lives here (EditorLogicTests covers the
+    decisions); LegacyMigration is the side-effecting orchestrator.
+*/
+
+#pragma once
+
+#include <QString>
+
+namespace EqAPO::Import
+{
+
+class LegacyMigrationPolicy
+{
+public:
+    enum class Action
+    {
+        // No ConfigPath (or an empty one): claim the stable root outright.
+        AdoptStableRoot,
+        // ConfigPath already points at the stable root; nothing to change.
+        AlreadyOurs,
+        // ConfigPath points into a legacy Equalizer APO install: import the
+        // referenced config tree, then repoint.
+        MigrateLegacy,
+        // ConfigPath points into an EqualizerAPO-XT ...\current\config dir,
+        // which Velopack recreates on every update: rescue the whole folder,
+        // then repoint.
+        MigrateVolatileXt,
+        // ConfigPath points somewhere the user chose on purpose: respect it.
+        RespectCustom
+    };
+
+    // The canonical XT config root: %LOCALAPPDATA%\EqualizerAPO-XT\config.
+    // Lives outside every Velopack-managed folder (variant install roots and
+    // their current\ dirs), so it survives updates, SIMD-variant switches,
+    // and reinstalls. localAppData is passed in so the derivation is testable.
+    static QString stableConfigRoot(const QString& localAppData);
+
+    // True for paths of the shape ...\EqualizerAPO-XT-<variant>\current\config:
+    // the packaged config dir inside a Velopack current folder. Velopack
+    // recreates current\ wholesale on every update (observed: all file
+    // creation times equal the update time), so user configs here are one
+    // update away from deletion.
+    static bool isVolatileXtConfigDir(const QString& dir);
+
+    // True when the config dir sits under a folder carrying the original
+    // Equalizer APO installer's name ("EqualizerAPO" or "Equalizer APO").
+    // Complements the on-disk binary markers: uninstalling the legacy APO
+    // removes EqualizerAPO.dll and Uninstall.exe but leaves the config
+    // folder (and the stale ConfigPath) behind — the exact shape of the
+    // field reports this migration exists for.
+    static bool hasLegacyApoFolderName(const QString& dir);
+
+    // The classification. legacyMarkersPresent is the caller's on-disk
+    // verdict for existingConfigPath's parent (EqualizerAPO.dll or the NSIS
+    // Uninstall.exe next to the config dir).
+    static Action classify(const QString& existingConfigPath, const QString& stableRoot,
+        bool legacyMarkersPresent, bool volatileXt);
+};
+
+}

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -46,6 +46,7 @@
 #include "MainWindow.h"
 #include "SkinGallery.h"
 #include "SkinManager.h"
+#include "import/LegacyMigration.h"
 #include "filters/VSTPluginFilter.h"
 #include "filters/VSTPluginFilterFactory.h"
 #include "guis/VSTPluginFilterGUI.h"
@@ -285,12 +286,18 @@ int handleVelopackHook(int argc, char* argv[])
 		if (matchesHook(arg, "--veloapp-install"))
 		{
 			auto rc = ApoRegistration::install(exeDir);
+			// The trusted config root: adopt the stable folder, or migrate a
+			// legacy Equalizer APO / volatile current\config tree into it.
+			if (rc == ApoRegistration::Result::Success)
+				EqAPO::Import::LegacyMigration::runElevatedHookStep(exeDir);
 			return rc == ApoRegistration::Result::Success ? 0 : static_cast<int>(rc);
 		}
 		if (matchesHook(arg, "--veloapp-updated"))
 		{
 			ApoRegistration::stopAudioService();
 			auto rc = ApoRegistration::install(exeDir);
+			if (rc == ApoRegistration::Result::Success)
+				EqAPO::Import::LegacyMigration::runElevatedHookStep(exeDir);
 			ApoRegistration::startAudioService();
 			return rc == ApoRegistration::Result::Success ? 0 : static_cast<int>(rc);
 		}
@@ -458,6 +465,11 @@ int main(int argc, char* argv[])
 		if (application.arguments().contains(QStringLiteral("--skin-switch-test")))
 			return SkinGallery::runSwitchTest(application.arguments());
 
+		// Read-only report of what the install hook's config migration would
+		// do on this machine (classification + manifest); writes nothing.
+		if (application.arguments().contains(QStringLiteral("--migration-dry-run")))
+			return EqAPO::Import::LegacyMigration::dryRun();
+
 		// Diagnostic self-test: crash deliberately so a field machine can verify
 		// that the crash handler leaves a dump + report under
 		// %LOCALAPPDATA%\EqualizerAPO-XT\crashdumps.
@@ -488,7 +500,12 @@ int main(int argc, char* argv[])
 		QTranslator editorTranslator;
 		QtAppBootstrap::installTranslators(application, QStringLiteral("Editor"), qtTranslator, editorTranslator);
 
-		QString configPath = QDir::currentPath();
+		// Without a registry value the old fallback was the process CWD, which
+		// silently edits whatever folder the Editor was launched from; prefer
+		// the stable XT config root when it exists.
+		QString stableRoot = EqAPO::Import::LegacyMigration::stableConfigRoot();
+		QString configPath = !stableRoot.isEmpty() && QDir(stableRoot).exists()
+			? stableRoot : QDir::currentPath();
 		if (RegistryHelper::keyExists(APP_REGPATH) && RegistryHelper::valueExists(APP_REGPATH, L"ConfigPath"))
 			configPath = QString::fromStdWString(RegistryHelper::readValue(APP_REGPATH, L"ConfigPath"));
 		QDir configDir(configPath);
@@ -504,6 +521,10 @@ int main(int argc, char* argv[])
 
 		MainWindow w(configDir);
 		w.show();
+
+		// One-time notice after the install hook migrated a config tree; a
+		// no-op for everyone else.
+		EqAPO::Import::LegacyMigration::maybeShowStartupNotice(&w);
 
 		QCommandLineParser parser;
 		parser.process(application);

--- a/Editor/translations/Editor_ko.ts
+++ b/Editor/translations/Editor_ko.ts
@@ -2565,6 +2565,28 @@ Do you want to run the Device Selector application to fix the problem?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../import/LegacyMigration.cpp" line="279"/>
+        <source>Configuration folder moved</source>
+        <translation>설정 폴더 이동 안내</translation>
+    </message>
+    <message>
+        <location filename="../import/LegacyMigration.cpp" line="280"/>
+        <source>Your Equalizer APO configuration was imported into the EqualizerAPO-XT configuration folder:
+
+%1
+
+This folder is now the one the audio pipeline reads. The previous folder is no longer used:
+
+%2</source>
+        <translation>기존 Equalizer APO 설정을 EqualizerAPO-XT 설정 폴더로 가져왔습니다.
+
+%1
+
+이제 오디오 처리는 이 폴더를 읽습니다. 이전 폴더는 더 이상 사용되지 않습니다.
+
+%2</translation>
+    </message>
+    <message>
         <location filename="../import/ConfigDependencyScanner.cpp" line="90"/>
         <source>Missing file: %1</source>
         <translation>누락된 파일: %1</translation>

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -30,6 +30,7 @@
 #include "Editor/import/ConfigDependencyScanner.h"
 #include "Editor/import/ImportExecutor.h"
 #include "Editor/import/ImportManifest.h"
+#include "Editor/import/LegacyMigrationPolicy.h"
 #include "Editor/widgets/FilterCardModel.h"
 #include "Editor/widgets/FilterListModel.h"
 #include "Editor/widgets/FilterListUndo.h"
@@ -924,6 +925,99 @@ void testConfigImport()
 	expectTrue(QFile::exists(convConfigDest + "/Surround/ir.wav"), "ir.wav missing after single-file import");
 }
 
+void testLegacyMigrationScanAndPolicy()
+{
+	QTemporaryDir tempDir;
+	requireTrue(tempDir.isValid(), "QTemporaryDir must be valid");
+
+	// A legacy config root: config.txt reaching files through a nested
+	// Include, a quoted Convolution path in a subfolder, and both
+	// MultiConvolution forms (simple and factor mappings).
+	QString legacyDir = tempDir.path() + "/config";
+	expectTrue(QDir().mkpath(legacyDir + "/irs"), "failed to create legacy tree");
+
+	auto writeText = [](const QString& path, const QString& body) {
+		QFile f(path);
+		expectTrue(f.open(QIODevice::WriteOnly | QIODevice::Text), QString("could not open %1 for write").arg(path));
+		QTextStream ts(&f);
+		ts << body;
+	};
+	auto writeBlob = [](const QString& path, int bytes) {
+		QFile f(path);
+		expectTrue(f.open(QIODevice::WriteOnly), QString("could not open %1 for write").arg(path));
+		f.write(QByteArray(bytes, '\0'));
+	};
+
+	writeText(legacyDir + "/config.txt",
+		"Preamp: -3 dB\n"
+		"Include: upmix.txt\n"
+		"MultiConvolution: L=0.5*0+1 R=1 irs/hrir.wav\n");
+	writeText(legacyDir + "/upmix.txt",
+		"Convolution: \"irs/room ir.wav\"\n"
+		"MultiConvolution: C brir.wav\n");
+	writeBlob(legacyDir + "/irs/hrir.wav", 96);
+	writeBlob(legacyDir + "/irs/room ir.wav", 48);
+	writeBlob(legacyDir + "/brir.wav", 32);
+
+	// SourceFolderIsRoot maps the legacy folder 1:1 onto the target root:
+	// no "config/" prefix on any destination.
+	EqAPO::Import::ImportManifest manifest = EqAPO::Import::ConfigDependencyScanner::scan(
+		legacyDir + "/config.txt", tempDir.path() + "/root",
+		EqAPO::Import::DestLayout::SourceFolderIsRoot);
+	expectFalse(manifest.hasErrors, "legacy scan should not flag errors");
+	requireEqual(int(manifest.items.size()), 5, "expected config + include + three IRs");
+	expectEqual(manifest.rootDest, "config.txt", "migration layout keeps the root name bare");
+
+	QStringList destRels;
+	for (const auto& item : manifest.items)
+		destRels.append(item.destRelative);
+	expectTrue(destRels.contains("config.txt"), "root config present without folder prefix");
+	expectTrue(destRels.contains("upmix.txt"), "included file present");
+	expectTrue(destRels.contains("irs/hrir.wav"), "factor-form MultiConvolution IR collected");
+	expectTrue(destRels.contains("irs/room ir.wav"), "quoted Convolution path collected");
+	expectTrue(destRels.contains("brir.wav"), "simple-form MultiConvolution IR collected");
+
+	// The card editors' nested layout still prefixes the source folder name.
+	EqAPO::Import::ImportManifest nested = EqAPO::Import::ConfigDependencyScanner::scan(
+		legacyDir + "/config.txt", tempDir.path() + "/root");
+	expectEqual(nested.rootDest, "config/config.txt", "default layout keeps the folder prefix");
+
+	// Policy: the pure classification the elevated hook acts on.
+	using Policy = EqAPO::Import::LegacyMigrationPolicy;
+	const QString stableRoot = Policy::stableConfigRoot("C:/Users/me/AppData/Local");
+	expectEqual(stableRoot, "C:/Users/me/AppData/Local/EqualizerAPO-XT/config",
+		"stable root derives from LOCALAPPDATA");
+	expectTrue(Policy::stableConfigRoot(" ").isEmpty(), "missing LOCALAPPDATA yields no root");
+
+	expectTrue(Policy::isVolatileXtConfigDir("C:\\Users\\me\\AppData\\Local\\EqualizerAPO-XT-x64-avx2\\current\\config"),
+		"variant current\\config is volatile");
+	expectTrue(Policy::isVolatileXtConfigDir("D:/apps/EqualizerAPO-XT-arm64-neon/current/config"),
+		"volatile match is drive- and variant-independent");
+	expectFalse(Policy::isVolatileXtConfigDir("C:\\Program Files\\EqualizerAPO\\config"),
+		"legacy Program Files root is not volatile");
+	expectFalse(Policy::isVolatileXtConfigDir(stableRoot), "the stable root itself is not volatile");
+
+	expectTrue(Policy::hasLegacyApoFolderName("C:\\Program Files\\EqualizerAPO\\config"),
+		"upstream default install dir is recognized by name");
+	expectTrue(Policy::hasLegacyApoFolderName("D:/tools/Equalizer APO/config"),
+		"spaced installer folder name is recognized on any drive");
+	expectFalse(Policy::hasLegacyApoFolderName("C:\\Users\\me\\AppData\\Local\\EqualizerAPO-XT\\config"),
+		"the XT stable root is not mistaken for the legacy install");
+	expectFalse(Policy::hasLegacyApoFolderName("D:\\my configs"),
+		"unrelated folders carry no legacy name");
+
+	expectTrue(Policy::classify(QString(), stableRoot, false, false) == Policy::Action::AdoptStableRoot,
+		"no ConfigPath adopts the stable root");
+	expectTrue(Policy::classify("c:\\users\\me\\appdata\\local\\equalizerapo-xt\\CONFIG", stableRoot, false, false)
+		== Policy::Action::AlreadyOurs, "case-insensitive match on the stable root");
+	expectTrue(Policy::classify("C:\\Program Files\\EqualizerAPO\\config", stableRoot, true, false)
+		== Policy::Action::MigrateLegacy, "legacy markers trigger the import");
+	expectTrue(Policy::classify("C:\\Users\\me\\AppData\\Local\\EqualizerAPO-XT-x64-avx2\\current\\config",
+		stableRoot, false, true) == Policy::Action::MigrateVolatileXt, "volatile XT dir is rescued");
+	expectTrue(Policy::classify("D:\\my configs", stableRoot, false, false) == Policy::Action::RespectCustom,
+		"a user-chosen folder is left alone");
+}
+
 void testChannelSelectionModel()
 {
 	// ChannelSelectionModel serialization identity: for equivalent
@@ -1506,6 +1600,7 @@ int main(int argc, char** argv)
 		testFilterCardDepths();
 		testFilterCardBuildPlans();
 		testConfigImport();
+		testLegacyMigrationScanAndPolicy();
 		testChannelSelectionModel();
 		testDeviceSelectionModel();
 		testMultiConvolutionRoutingAdapter();

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -119,6 +119,7 @@
     <ClCompile Include="..\..\Editor\helpers\ConvolutionPathHelper.cpp" />
     <ClCompile Include="..\..\Editor\import\ConfigDependencyScanner.cpp" />
     <ClCompile Include="..\..\Editor\import\ImportExecutor.cpp" />
+    <ClCompile Include="..\..\Editor\import\LegacyMigrationPolicy.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterListModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterListUndo.cpp" />
@@ -143,6 +144,7 @@
     <ClInclude Include="..\..\Editor\helpers\ConvolutionPathHelper.h" />
     <ClInclude Include="..\..\Editor\import\ConfigDependencyScanner.h" />
     <ClInclude Include="..\..\Editor\import\ImportExecutor.h" />
+    <ClInclude Include="..\..\Editor\import\LegacyMigrationPolicy.h" />
     <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterListModel.h" />

--- a/helpers/ApoRegistration.cpp
+++ b/helpers/ApoRegistration.cpp
@@ -224,16 +224,8 @@ ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 		return Result::RegistrationFailed;
 	}
 
-	// Config dir gets Users:F so the user can edit configs, and LOCAL SERVICE
-	// modify (M) so audiodg can read/write trace logs from the APO.
-	std::wstring configDir = joinPath(installDir, L"config");
-	std::wstring configAclArgs = L"\"" + configDir + L"\" "
-		L"/grant *S-1-5-32-545:(OI)(CI)F "
-		L"/grant *S-1-5-19:(OI)(CI)M "
-		L"/T /C /Q";
-	rc = waitForProcess(icacls, configAclArgs, 30000);
-	if (rc != 0)
-		logLine(L"WARN", L"icacls (config dir) returned %d, continuing", rc);
+	if (!secureConfigDir(joinPath(installDir, L"config")))
+		logLine(L"WARN", L"icacls (config dir) failed, continuing");
 
 	// Velopack's vpk pack only emits a shortcut for --mainExe (Editor.exe).
 	// DeviceSelector is the elevated companion that performs per-device APO
@@ -399,24 +391,17 @@ bool ApoRegistration::startAudioService()
 	}
 }
 
-std::wstring ApoRegistration::detectLegacyInstall()
+bool ApoRegistration::secureConfigDir(const std::wstring& configDir)
 {
-	try
-	{
-		if (!RegistryHelper::valueExists(kRegPath, L"InstallPath"))
-			return std::wstring();
-		std::wstring legacy = RegistryHelper::readValue(kRegPath, L"InstallPath");
-		if (legacy.empty())
-			return std::wstring();
-		std::wstring marker = joinPath(legacy, L"Uninstall.exe");
-		if (!fileExists(marker))
-			return std::wstring();
-		return legacy;
-	}
-	catch (const RegistryException&)
-	{
-		return std::wstring();
-	}
+	// Users:F so the user can edit configs, LOCAL SERVICE modify (M) so
+	// audiodg can read them and write APO trace logs. Built-in well-known
+	// SIDs and a local path — same trust boundary note as install().
+	std::wstring icacls = joinPath(systemPath(), L"icacls.exe");
+	std::wstring configAclArgs = L"\"" + configDir + L"\" "
+		L"/grant *S-1-5-32-545:(OI)(CI)F "
+		L"/grant *S-1-5-19:(OI)(CI)M "
+		L"/T /C /Q";
+	return waitForProcess(icacls, configAclArgs, 30000) == 0;
 }
 
 namespace
@@ -526,37 +511,4 @@ bool ApoRegistration::removeStartMenuShortcuts()
 	// Best-effort cleanup of empty folder; ignore failure (other lnks may live there).
 	RemoveDirectoryW(shortcutFolder.c_str());
 	return ok;
-}
-
-bool ApoRegistration::migrateLegacyConfig(const std::wstring& legacyDir, const std::wstring& newDir)
-{
-	std::wstring legacyConfig = joinPath(legacyDir, L"config");
-	std::wstring newConfig = joinPath(newDir, L"config");
-
-	if (!directoryExists(legacyConfig))
-		return false;
-	if (!createDirectoryRecursive(newConfig))
-		return false;
-
-	bool copiedAny = false;
-	WIN32_FIND_DATAW findData;
-	std::wstring pattern = joinPath(legacyConfig, L"*");
-	winutil::UniqueFindHandle finder(FindFirstFileW(pattern.c_str(), &findData));
-	if (!finder)
-		return false;
-
-	do
-	{
-		if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-			continue;
-		std::wstring source = joinPath(legacyConfig, findData.cFileName);
-		std::wstring target = joinPath(newConfig, findData.cFileName);
-		if (fileExists(target))
-			continue;
-		if (CopyFileW(source.c_str(), target.c_str(), TRUE))
-			copiedAny = true;
-	}
-	while (FindNextFileW(finder.get(), &findData));
-
-	return copiedAny;
 }

--- a/helpers/ApoRegistration.h
+++ b/helpers/ApoRegistration.h
@@ -41,8 +41,12 @@ public:
 	static bool stopAudioService();
 	static bool startAudioService();
 
-	static std::wstring detectLegacyInstall();
-	static bool migrateLegacyConfig(const std::wstring& legacyDir, const std::wstring& newDir);
+	// Grants Users full control and LOCAL SERVICE modify on a config
+	// directory (recursive), so the user can edit configs and audiodg can
+	// read them (and write APO trace logs). install() applies it to the
+	// packaged config dir; the legacy migration applies it to the stable
+	// config root it creates. Returns false when icacls reports a failure.
+	static bool secureConfigDir(const std::wstring& configDir);
 
 	static int waitForProcess(const std::wstring& executable, const std::wstring& arguments, unsigned timeoutMs = 30000);
 


### PR DESCRIPTION
## 배경

디스코드 보고: 설치 경로(`AppData\Local\EqualizerAPO-XT-x64-avx2\current\config\config.txt`)를 수정해도 적용되지 않고 `Program Files\EqualizerAPO\config`만 오디오에 반영됨.

원인은 둘입니다.

1. XT가 업스트림과 같은 `HKLM\SOFTWARE\EqualizerAPO\ConfigPath`를 쓰는데, `ApoRegistration::install()`이 이 값을 **없을 때만** 써서 레거시 설치가 잡아 둔 값이 영구히 살아남음 (제 기기 실측: InstallPath=XT인데 ConfigPath=Program Files, 레거시 APO를 **제거한 뒤에도** 그대로)
2. 애초에 `current\config`는 사용자 설정을 둘 곳이 못 됨 — Velopack 업데이트가 `current\`를 통째로 재생성함을 실측(전 파일 CreationTime=업데이트 시각). ConfigPath가 거기를 가리키던 사용자는 업데이트마다 설정을 잃는 구조였음

## What changed

**전용 설정 루트** `%LOCALAPPDATA%\EqualizerAPO-XT\config` — Velopack 관리 폴더 밖이라 업데이트·SIMD 변형 전환·재설치에서 생존. 설치/업데이트 훅이 icacls(Users:F, LOCAL SERVICE:M)로 audiodg 읽기를 보장합니다.

**신뢰 경로 판정** (순수 로직 `LegacyMigrationPolicy`, 훅에서 실행):

| 기존 ConfigPath | 처리 |
|---|---|
| 없음 | 새 루트 채택 |
| 이미 새 루트 | 유지 |
| 레거시 APO 폴더 | config.txt 참조 세트 이관 후 신뢰 전환 |
| XT `current\config` | 통째 구출 후 신뢰 전환 |
| 사용자 지정 폴더 | 존중(무변경) |

**레거시 이관**은 기존 `Editor/import` 모듈을 재사용해 config.txt가 참조하는 것만 가져옵니다 — Include 체인(깊이 무관), Convolution/MultiConvolution IR, VST 참조, 폴더 구조 보존. 미참조 파일(.peace, 실험 txt)은 남고 원본은 복사라 그대로입니다. 전환 후 옛 폴더는 더 이상 읽히지 않습니다.

레거시 판정은 바이너리 마커(EqualizerAPO.dll/Uninstall.exe)에 더해 **설치 폴더명**(EqualizerAPO/Equalizer APO)도 인정합니다. 제 기기에서 레거시 APO 제거 후 config 폴더만 남아 바이너리 마커가 실패하는 것을 실제로 확인하고 넣은 규칙입니다.

부속 변경: 스캐너의 MultiConvolution:/따옴표 경로 인식, 이관 후 1회 에디터 안내(ko 번역 포함), `--migration-dry-run` 진단 플래그, ConfigPath 부재 시 CWD 폴백을 안정 루트 우선으로, 죽은 스캐폴딩(detectLegacyInstall/migrateLegacyConfig) 제거.

## Validation

- EditorLogicTests 403건 통과 (신규: MultiConvolution 양식 2종·따옴표 경로·이관 배치·판정 5분기·폴더명 규칙)
- 실기기(위 보고와 동일 상태) dry-run: `MigrateLegacy` 판정, config.txt + Include 하위폴더 설정 + 참조 WAV 5개 = 7파일을 폴더 구조 보존으로 수집
- Editor/EditorLogicTests 빌드 클린, `git diff --check` 통과
- 실제 전환은 이 릴리스로 업데이트되는 순간 각 기기의 훅(--veloapp-updated)이 수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)