### PR TITLE
docs(editor): 대화상자 캡션 최소화 버튼 기각 근거 기록

### DIFF
--- a/Editor/widgets/DialogChrome.h
+++ b/Editor/widgets/DialogChrome.h
@@ -10,6 +10,14 @@
 	main window) and a dialog-mode TitleBar (title text + the conventional
 	close X, no minimize/maximize) is inserted above the dialog's layout.
 	QDialog::close on an exec()ed dialog rejects it, matching Cancel.
+
+	Do not add a minimize button here (reviewed and rejected, 2026-07-17):
+	the platform's own file dialogs carry only the X, and these dialogs are
+	application-modal - minimizing one would leave the blocked main window
+	looking dead while the owned dialog has no taskbar entry to bring it
+	back. Moving the dialog aside (drag) and Alt-Tab already cover the
+	"look behind it" need. Revisit only if this chrome is ever mounted on a
+	modeless window.
 */
 
 #pragma once


### PR DESCRIPTION
이슈 #206 후속 검토("네이티브 캡션에 ㅡ가 필요한가")의 결론을 코드에 남깁니다. 판정: 불필요·미추가.

- 플랫폼의 네이티브 파일 대화상자도, #208 이전의 Qt 기본 캡션도 X만 두는 관례입니다.
- 파일 대화상자는 앱 모달이라 최소화되면 잠긴 메인 창만 화면에 남고, 소유 창 특성상 작업표시줄 항목이 없어 되찾는 동선도 애매합니다.
- 치워야 할 때는 드래그(HTCAPTION)와 Alt-Tab이 이미 답입니다.

주석 한 문단만 추가하는 docs 변경으로 버전은 올라가지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)