### PR TITLE
Fix silent empty-config channel expansion

### DIFF
--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -519,6 +519,52 @@ void testProcessWithoutConfigurationDoesNotCrash(test::Harness& harness)
 		"process() without a configuration wrote output despite zero channel counts");
 }
 
+// Windows may give a render APO fewer input channels than the endpoint output
+// layout (for example, a stereo application stream feeding an 8-channel
+// endpoint). An empty configuration is still responsible for adapting that
+// connection: preserve the real input channels and silence the extra outputs.
+void testEmptyConfigurationExpandsRenderChannels(test::Harness& harness)
+{
+	const std::wstring configPath = writeConfig(harness, L"empty-channel-expansion.txt",
+		"# All filters are disabled\n");
+
+	FilterEngine engine;
+	const std::wstring deviceName = L"EngineOrchestrationTests";
+	engine.setDeviceInfo(false, true, deviceName, L"File", L"", deviceName + L" File");
+	engine.initialize(48000.0f, 2, 2, 8, 0, 16, configPath);
+
+	constexpr unsigned frames = 4;
+	float input[frames * 2] = {
+		0.25f, -0.5f,
+		0.5f, -0.25f,
+		0.75f, 0.125f,
+		1.0f, 0.0f
+	};
+	auto expectExpanded = [&](const float* output, const std::string& layout) {
+		for (unsigned frame = 0; frame < frames; ++frame)
+		{
+			harness.expectEqual(output[frame * 8], input[frame * 2],
+				layout + " preserves the left input channel while expanding");
+			harness.expectEqual(output[frame * 8 + 1], input[frame * 2 + 1],
+				layout + " preserves the right input channel while expanding");
+			for (unsigned channel = 2; channel < 8; ++channel)
+				harness.expectEqual(output[frame * 8 + channel], 0.0f,
+					layout + " silences an added output channel");
+		}
+	};
+
+	float output[frames * 8];
+	std::fill_n(output, frames * 8, -1.0f);
+	engine.process(output, input, frames);
+	expectExpanded(output, "distinct-buffer empty config");
+
+	float inPlace[frames * 8];
+	std::fill_n(inPlace, frames * 8, -1.0f);
+	std::copy_n(input, frames * 2, inPlace);
+	engine.process(inPlace, inPlace, frames);
+	expectExpanded(inPlace, "in-place empty config");
+}
+
 // The engine reports per-line facts while loading
 // (branch decisions, Eval values, swallowed lines) through an attached
 // ConfigLoadTraceSink so the Editor can echo them next to the config rows.
@@ -604,6 +650,7 @@ int runEngineOrchestrationTests()
 	test::Harness harness("EngineOrchestrationTests");
 
 	testProcessWithoutConfigurationDoesNotCrash(harness);
+	testEmptyConfigurationExpandsRenderChannels(harness);
 	testParallelExecutor(harness);
 	runConfigurationFileReaderTests(harness);
 	runSampleIoTests(harness);

--- a/engine/FilterEngine.Process.cpp
+++ b/engine/FilterEngine.Process.cpp
@@ -92,7 +92,9 @@ namespace
 		}
 
 		const unsigned copiedChannelCount = (std::min)(inputChannelCount, outputChannelCount);
-		const bool copyMonoToStereo = inputChannelCount == 1 && outputChannelCount >= 2;
+		// Equal layouts and zero outputs returned above, so a remaining mono input
+		// necessarily expands to at least stereo.
+		const bool copyMonoToStereo = inputChannelCount == 1;
 		auto adaptFrame = [&](unsigned frame) {
 			Sample* outputFrame = output + static_cast<size_t>(frame) * outputChannelCount;
 			Sample* inputFrame = input + static_cast<size_t>(frame) * inputChannelCount;

--- a/engine/FilterEngine.Process.cpp
+++ b/engine/FilterEngine.Process.cpp
@@ -19,6 +19,7 @@
 
 #include "stdafx.h"
 #include <algorithm>
+#include <cstring>
 
 #include "helpers/PerfProfile.h"
 #include "helpers/MxcsrGuard.h"
@@ -73,6 +74,78 @@ void convertDoubleToFloat(float* dest, const double* src, size_t count) {
 
 namespace
 {
+	template <typename Sample>
+	void bypassInterleaved(Sample* output, Sample* input, unsigned inputChannelCount,
+		unsigned outputChannelCount, unsigned frameCount)
+	{
+		if (frameCount == 0 || outputChannelCount == 0)
+			return;
+
+		if (inputChannelCount == outputChannelCount)
+		{
+			if (input != output)
+			{
+				const size_t sampleCount = static_cast<size_t>(frameCount) * outputChannelCount;
+				std::memmove(output, input, sampleCount * sizeof(Sample));
+			}
+			return;
+		}
+
+		const unsigned copiedChannelCount = (std::min)(inputChannelCount, outputChannelCount);
+		const bool copyMonoToStereo = inputChannelCount == 1 && outputChannelCount >= 2;
+		auto adaptFrame = [&](unsigned frame) {
+			Sample* outputFrame = output + static_cast<size_t>(frame) * outputChannelCount;
+			Sample* inputFrame = input + static_cast<size_t>(frame) * inputChannelCount;
+			if (copiedChannelCount != 0)
+			{
+				std::memmove(outputFrame, inputFrame,
+					static_cast<size_t>(copiedChannelCount) * sizeof(Sample));
+			}
+			unsigned initializedChannelCount = copiedChannelCount;
+			if (copyMonoToStereo)
+			{
+				outputFrame[1] = outputFrame[0];
+				initializedChannelCount = 2;
+			}
+			std::fill(outputFrame + initializedChannelCount,
+				outputFrame + outputChannelCount, static_cast<Sample>(0));
+		};
+
+		if (input == output && outputChannelCount > inputChannelCount)
+		{
+			for (unsigned frame = frameCount; frame-- > 0;)
+				adaptFrame(frame);
+		}
+		else
+		{
+			for (unsigned frame = 0; frame < frameCount; ++frame)
+				adaptFrame(frame);
+		}
+	}
+
+	template <typename Sample>
+	void bypassPlanar(Sample** output, Sample** input, unsigned inputChannelCount,
+		unsigned outputChannelCount, unsigned frameCount)
+	{
+		const unsigned copiedChannelCount = (std::min)(inputChannelCount, outputChannelCount);
+		const size_t channelBytes = static_cast<size_t>(frameCount) * sizeof(Sample);
+		for (unsigned channel = 0; channel < copiedChannelCount; ++channel)
+		{
+			if (output[channel] != input[channel])
+				std::memmove(output[channel], input[channel], channelBytes);
+		}
+
+		unsigned initializedChannelCount = copiedChannelCount;
+		if (inputChannelCount == 1 && outputChannelCount >= 2)
+		{
+			if (output[1] != output[0])
+				std::memmove(output[1], output[0], channelBytes);
+			initializedChannelCount = 2;
+		}
+		for (unsigned channel = initializedChannelCount; channel < outputChannelCount; ++channel)
+			std::fill_n(output[channel], frameCount, static_cast<Sample>(0));
+	}
+
 	// Per-layout I/O policy for FilterEngine::processImpl below. Only the bypass
 	// copy and the configuration read/write entry points differ per layout;
 	// the hot-swap/transition choreography lives once in processImpl. The
@@ -86,9 +159,10 @@ namespace
 		static constexpr const char* readNextLabel = "FilterConfiguration::readFloatInterleaved(next)";
 		static constexpr const char* writeLabel = "FilterConfiguration::writeFloatInterleaved";
 
-		static void bypassCopy(float* output, float* input, unsigned outputChannelCount, unsigned, unsigned frameCount)
+		static void bypass(float* output, float* input, unsigned inputChannelCount,
+			unsigned outputChannelCount, unsigned frameCount)
 		{
-			std::copy_n(input, outputChannelCount * frameCount, output);
+			bypassInterleaved(output, input, inputChannelCount, outputChannelCount, frameCount);
 		}
 		static void read(FilterConfiguration& config, float* input, unsigned frameCount)
 		{
@@ -109,10 +183,10 @@ namespace
 		static constexpr const char* readNextLabel = "FilterConfiguration::readFloatPlanar(next)";
 		static constexpr const char* writeLabel = "FilterConfiguration::writeFloatPlanar";
 
-		static void bypassCopy(float** output, float** input, unsigned, unsigned realChannelCount, unsigned frameCount)
+		static void bypass(float** output, float** input, unsigned inputChannelCount,
+			unsigned outputChannelCount, unsigned frameCount)
 		{
-			for (unsigned c = 0; c < realChannelCount; c++)
-				std::copy_n(input[c], frameCount, output[c]);
+			bypassPlanar(output, input, inputChannelCount, outputChannelCount, frameCount);
 		}
 		static void read(FilterConfiguration& config, float** input, unsigned frameCount)
 		{
@@ -131,9 +205,10 @@ namespace
 		static constexpr const char* readNextLabel = "FilterConfiguration::read(interleaved)";
 		static constexpr const char* writeLabel = "FilterConfiguration::write(interleaved)";
 
-		static void bypassCopy(double* output, double* input, unsigned outputChannelCount, unsigned, unsigned frameCount)
+		static void bypass(double* output, double* input, unsigned inputChannelCount,
+			unsigned outputChannelCount, unsigned frameCount)
 		{
-			std::copy_n(input, outputChannelCount * frameCount, output);
+			bypassInterleaved(output, input, inputChannelCount, outputChannelCount, frameCount);
 		}
 		static void read(FilterConfiguration& config, double* input, unsigned frameCount)
 		{
@@ -152,10 +227,10 @@ namespace
 		static constexpr const char* readNextLabel = "FilterConfiguration::read(planar)";
 		static constexpr const char* writeLabel = "FilterConfiguration::write(planar)";
 
-		static void bypassCopy(double** output, double** input, unsigned, unsigned realChannelCount, unsigned frameCount)
+		static void bypass(double** output, double** input, unsigned inputChannelCount,
+			unsigned outputChannelCount, unsigned frameCount)
 		{
-			for (unsigned c = 0; c < realChannelCount; c++)
-				std::copy_n(input[c], frameCount, output[c]);
+			bypassPlanar(output, input, inputChannelCount, outputChannelCount, frameCount);
 		}
 		static void read(FilterConfiguration& config, double** input, unsigned frameCount)
 		{
@@ -185,16 +260,16 @@ void FilterEngine::processImpl(SampleType output, SampleType input, unsigned fra
 		// ConfigPath with no custom path, or an empty path value), and the APO
 		// can call process() before initialize(). Treat both like the
 		// empty-config bypass below instead of dereferencing null.
-		if (realChannelCount == outputChannelCount && input != output)
-			IoTraits::bypassCopy(output, input, outputChannelCount, realChannelCount, frameCount);
+		IoTraits::bypass(output, input, realChannelCount, outputChannelCount, frameCount);
 		return;
 	}
 
 	if (currentConfig->isEmpty() && !nextConfigReady.load(std::memory_order_acquire))
 	{
-		// Bypass mode: if no filters are active, just copy input to output if necessary.
-		if (realChannelCount == outputChannelCount && input != output)
-			IoTraits::bypassCopy(output, input, outputChannelCount, realChannelCount, frameCount);
+		// A render APO can legitimately receive fewer channels than the endpoint
+		// exposes. Preserve the real input channels and initialize every output even
+		// when no filter is active; the adapter also handles exact in-place buffers.
+		IoTraits::bypass(output, input, realChannelCount, outputChannelCount, frameCount);
 		return;
 	}
 


### PR DESCRIPTION
## What changed

- replace the empty-filter direct copy with a no-allocation channel-layout adapter
- preserve common channels, zero newly exposed channels, and retain the existing mono-to-stereo rule
- handle distinct and exact in-place interleaved/planar buffers without overwriting unread samples
- add an EngineOrchestration regression for the observed stereo-to-8-channel render path, including distinct and in-place buffers

## Root cause

Windows negotiated a valid IEEE-float render connection with 2 input channels and 8 output channels. With every filter disabled, `FilterEngine::processImpl` entered its empty-configuration bypass, copied only when both channel counts matched, and then returned. For 2-to-8 connections it therefore left the host's distinct output buffer untouched, which reached VB-CABLE as silence.

## Impact

Applications using this connection shape, including REW shared mode and a normal ffplay PCM stream in the reproduced setup, now reach the endpoint even when the EqualizerAPO configuration contains no active filters. The AVRT path remains allocation-free, lock-free, exception-free, and log-free.

## Validation

- `EngineOrchestrationTests` Release x64: 948 checks passed
- real CABLE Input/CABLE Output A/B with all filters disabled:
  - REW before: peak 0.0, RMS 0.0
  - REW after: peak 0.125885, RMS 0.026752
  - ffplay before: mean -91.0 dB, max -90.3 dB
  - ffplay after: mean -23.2 dB, max -18.1 dB
- non-invasive WinDbg snapshot confirmed `EqualizerAPO.dll` and `audioeng.dll` loaded with no suspended audiodg threads