### PR TITLE
Drive the golden audio regression across block boundaries

### DIFF
--- a/Tests/AudioRegressionTests/AudioRegressionTests.cpp
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.cpp
@@ -73,25 +73,39 @@ struct TestCase
 	unsigned sampleRate;
 	unsigned channels;
 	unsigned frames;
+	// The engine is driven this many frames at a time, the way Windows calls the
+	// APO with a fixed period. Every stateful filter here - BiQuad, Delay,
+	// Convolution's partitioned overlap-add, GraphicEQ - carries state between
+	// calls, and that carry-over is only observable across successive process()
+	// calls. A single whole-buffer call cannot see it at all.
+	//
+	// Must divide frames exactly. ConvolutionFilter freezes its block length at
+	// initialize() and mutes any block of a different size (ConvolutionFilter.cpp
+	// frameCount mismatch guard), so a short final block would silence the tail
+	// rather than test it.
+	unsigned blockFrames;
 };
 
 void ensureDirectory(const std::wstring& path);
 
 const TestCase kCases[] = {
-	{ "preamp_minus6",       "preamp_minus6.txt",       SignalType::DCStereo,      48000, 2, 4800  },
-	{ "biquad_peaking_1khz", "biquad_peaking_1khz.txt", SignalType::ImpulseStereo, 48000, 2, 8192  },
-	{ "copy_crossfeed",      "copy_crossfeed.txt",      SignalType::ImpulseStereo, 48000, 2, 256   },
-	{ "delay_512",           "delay_512.txt",           SignalType::ImpulseStereo, 48000, 2, 2048  },
-	{ "graphiceq_15band",    "graphiceq_15band.txt",    SignalType::ImpulseStereo, 48000, 2, 8192  },
-	{ "convolution_short",   "convolution_short.txt",   SignalType::ImpulseStereo, 48000, 2, 4096  },
-	{ "iir_order2_lowpass",  "iir_order2_lowpass.txt",  SignalType::ImpulseStereo, 48000, 2, 256   },
-	{ "channel_left_only",   "channel_left_only.txt",   SignalType::DCStereo,      48000, 2, 256   },
+	{ "preamp_minus6",       "preamp_minus6.txt",       SignalType::DCStereo,      48000, 2, 4800, 480 },
+	{ "biquad_peaking_1khz", "biquad_peaking_1khz.txt", SignalType::ImpulseStereo, 48000, 2, 8192, 512 },
+	{ "copy_crossfeed",      "copy_crossfeed.txt",      SignalType::ImpulseStereo, 48000, 2, 256,  64  },
+	// 2048 frames in 256-frame blocks puts the 512-sample delay line's read and
+	// write heads in different blocks, which is where a delay's ring-buffer
+	// wrap-around goes wrong if it goes wrong at all.
+	{ "delay_512",           "delay_512.txt",           SignalType::ImpulseStereo, 48000, 2, 2048, 256 },
+	{ "graphiceq_15band",    "graphiceq_15band.txt",    SignalType::ImpulseStereo, 48000, 2, 8192, 512 },
+	{ "convolution_short",   "convolution_short.txt",   SignalType::ImpulseStereo, 48000, 2, 4096, 512 },
+	{ "iir_order2_lowpass",  "iir_order2_lowpass.txt",  SignalType::ImpulseStereo, 48000, 2, 256,  64  },
+	{ "channel_left_only",   "channel_left_only.txt",   SignalType::DCStereo,      48000, 2, 256,  64  },
 	// LoudnessCorrection with State 0 is a deterministic pass-through. With
 	// State 1 the filter reads the live system master volume (VolumeController)
 	// and runs a background parameter thread, so its output is not stable
 	// enough for a stored reference; State 0 keeps the factory + parameter
 	// parsing covered without that non-determinism.
-	{ "loudnesscorrection_bypassed", "loudnesscorrection_bypassed.txt", SignalType::ImpulseStereo, 48000, 2, 256 },
+	{ "loudnesscorrection_bypassed", "loudnesscorrection_bypassed.txt", SignalType::ImpulseStereo, 48000, 2, 256, 64 },
 };
 
 bool writeCaseManifest(const std::wstring& directory)
@@ -688,7 +702,16 @@ bool runCase(const TestCase& tc, const Options& opts, bool& outFailed)
 	ensureDirectory(outVariantDir);
 	std::wstring outPath = outVariantDir + L"\\" + toWide(tc.name) + L".raw";
 
-	printf("\n[%s] config=%S frames=%u channels=%u\n", tc.name, configPath.c_str(), tc.frames, tc.channels);
+	printf("\n[%s] config=%S frames=%u channels=%u block=%u\n", tc.name, configPath.c_str(), tc.frames, tc.channels, tc.blockFrames);
+
+	// A short final block would be muted by the convolution filters rather than
+	// processed, which would quietly weaken the case instead of failing it.
+	if (tc.blockFrames == 0 || tc.frames % tc.blockFrames != 0)
+	{
+		fprintf(stderr, "  ERROR: blockFrames %u does not divide frames %u\n", tc.blockFrames, tc.frames);
+		outFailed = true;
+		return false;
+	}
 
 	std::vector<float> input = generateSignal(tc.inputType, tc.sampleRate, tc.channels, tc.frames);
 	std::vector<float> output((size_t)tc.frames * tc.channels, 0.0f);
@@ -701,8 +724,14 @@ bool runCase(const TestCase& tc, const Options& opts, bool& outFailed)
 		std::wstring deviceGuid = L"";
 		std::wstring deviceString = deviceName + L" " + connectionName + L" " + deviceGuid;
 		engine.setDeviceInfo(false, true, deviceName, connectionName, deviceGuid, deviceString);
-		engine.initialize((float)tc.sampleRate, tc.channels, tc.channels, tc.channels, 0, tc.frames, configPath);
-		engine.process(output.data(), input.data(), tc.frames);
+		// maxFrameCount is the block size, not the signal length: that is what the
+		// APO passes and what the convolution filters partition against.
+		engine.initialize((float)tc.sampleRate, tc.channels, tc.channels, tc.channels, 0, tc.blockFrames, configPath);
+		for (unsigned offset = 0; offset < tc.frames; offset += tc.blockFrames)
+		{
+			const size_t sampleOffset = (size_t)offset * tc.channels;
+			engine.process(output.data() + sampleOffset, input.data() + sampleOffset, tc.blockFrames);
+		}
 	}
 	catch (const std::exception& e)
 	{

--- a/Tests/AudioRegressionTests/references/README.md
+++ b/Tests/AudioRegressionTests/references/README.md
@@ -1,5 +1,33 @@
 # Audio regression references
 
+## These baselines are deliberately not regenerated
+
+The harness used to hand each case's whole signal to `process()` in one call,
+which meant a stored baseline could not observe anything that a stateful filter
+carries between calls. Every case now drives the engine in fixed-size blocks the
+way Windows drives the APO, with `blockFrames` chosen per case to divide the
+signal length exactly.
+
+The baselines below were **not** regenerated for that change, and that is the
+point: they were produced by whole-buffer runs, the blocked runs reproduce them
+to within floating-point noise (worst case `3.1e-17` on `convolution_short`,
+`1.0e-38` on `biquad_peaking_1khz`, exact elsewhere), and the tolerance is
+-120 dB. So the files now assert something stronger than they used to. They pin
+the output *and* the fact that chunking the signal differently does not change
+it.
+
+Keep it that way. If a future change genuinely requires new baselines, prefer
+regenerating from a whole-buffer run and letting the blocked comparison prove
+invariance again, rather than regenerating in block mode - the latter would
+silently discard the evidence.
+
+Note that `blockFrames` must divide `frames`. `ConvolutionFilter` freezes its
+block length at `initialize()` and mutes any block of a different size, so a
+short final block would silence the tail instead of testing it. The harness
+fails the case rather than letting that happen quietly.
+
+## Provenance
+
 These raw float baselines were generated from commit `329db3a`
 (`fix(engine): link all filter factories from Common.lib and cache FFTW wisdom`).
 


### PR DESCRIPTION
Third batch from the architecture review. This one strengthens the net *before*
the next PR touches real-time code.

### The gap

All nine golden cases handed the whole signal to `process()` in a single call,
with `maxFrameCount` set to the signal length. But Windows calls the APO with a
fixed period, and every stateful filter here — `BiQuadFilter`, `DelayFilter`,
`ConvolutionFilter`'s partitioned overlap-add, `GraphicEQFilter` — carries state
between calls. **A single call cannot observe any of that.** The stored
baselines were pinning output the real audio path never produces.

For a PR touching a filter, the entire audio gate was those nine whole-buffer
comparisons: PR builds are avx2 only, and cross-variant compare is disabled on
pull requests.

### The change

Each case names a `blockFrames`; the harness loops `process()` at that size and
initializes `maxFrameCount` to the block, which is what the convolution filters
partition against.

`blockFrames` must divide `frames`. `ConvolutionFilter` freezes its block length
at `initialize()` and mutes a block of any other size, so a short final block
would silence the tail rather than test it. The harness fails the case instead
of letting that pass quietly.

### The baselines are deliberately not regenerated

This is the part worth reading. The review suggested regenerating; empirically
it is unnecessary and regenerating would have been worse.

The blocked runs reproduce the existing whole-buffer files to within
floating-point noise:

| case | max abs error |
|---|---|
| `convolution_short` | 3.139e-17 |
| `biquad_peaking_1khz` | 1.032e-38 |
| other seven | exact |

Tolerance is -120 dB. So the same files now assert strictly more than they did:
the output, **and** that chunking the signal differently does not change it.
Regenerating in block mode would have discarded that evidence — the new files
would simply encode whatever block mode produced. `references/README.md` records
this so a future maintainer does not regenerate it away.

It is also a real result about the code: the filters are block-size invariant,
which is what you want to know before rearranging their synchronization.

### Verification

- `AudioRegressionTests.exe` local x64/avx2: **20/20 passed**, exit 0, against
  unmodified references
- Includes the MultiConvolution SHA-256 equivalence battery, unchanged

### Next

PR after this removes the `std::mutex` from `LoudnessCorrectionFilter::process()`
and the `LogF` calls from `AVRT_CODE` regions. That is a synchronization change
that must not alter a single sample, and these nine cases are now able to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)