### PR TITLE
fix(ui): give the analysis bar's drop-downs room and its option a voice

### DIFF
--- a/Editor/MainWindow.ui
+++ b/Editor/MainWindow.ui
@@ -172,7 +172,7 @@
          <number>6</number>
         </property>
         <property name="rightMargin">
-         <number>10</number>
+         <number>18</number>
         </property>
         <property name="bottomMargin">
          <number>6</number>

--- a/Editor/MainWindowParts/MainWindow.Analysis.cpp
+++ b/Editor/MainWindowParts/MainWindow.Analysis.cpp
@@ -148,6 +148,7 @@ void MainWindow::setupAnalysisMetricControls()
 	// 250px wide and this control gets no label column, so the cells have to
 	// carry the whole width themselves.
 	ui->analysisMetricSegment->setLabels({tr("Mag"), tr("Phase"), tr("GD")});
+	ui->includeBaseDelayCheckBox->setObjectName(QStringLiteral("AnalysisFormCheck"));
 	ui->analysisMetricSegment->setToolTip(tr("What the graph shows: magnitude in dB, phase in degrees, or group delay in ms."));
 	ui->includeBaseDelayCheckBox->setToolTip(
 		tr("The analyzer removes the configuration's bulk delay before measuring, so a filter's own phase is readable. "

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -509,7 +509,7 @@ QWidget* buildAnalysisPanelReplica(QWidget* parent)
 	// joined this bar: the two extra rows are paid for by tightening the
 	// rhythm and by pairing the four readouts two to a row, so the row count
 	// stays at nine and the 250px cap is untouched.
-	grid->setContentsMargins(10, 6, 10, 6);
+	grid->setContentsMargins(10, 6, 18, 6);
 	grid->setHorizontalSpacing(8);
 	grid->setVerticalSpacing(4);
 
@@ -547,7 +547,7 @@ QWidget* buildAnalysisPanelReplica(QWidget* parent)
 	grid->addWidget(metricSegment, 4, 0, 1, 2);
 
 	QCheckBox* includeBaseDelay = new QCheckBox(QStringLiteral("Include base delay"));
-	includeBaseDelay->setObjectName(QStringLiteral("includeBaseDelayCheckBox"));
+	includeBaseDelay->setObjectName(QStringLiteral("AnalysisFormCheck"));
 	grid->addWidget(includeBaseDelay, 5, 0, 1, 2);
 
 	const QStringList statLabels = { QStringLiteral("Peak"), QStringLiteral("Lat"),

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -198,7 +198,7 @@ QToolBar#MainToolBar QToolButton:disabled {
     border-style: dashed;
 }
 /* Instant mode engage cell. */
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck {
     background: transparent;
     color: @TEXT@;
     border: 1px solid @BORDER@;
@@ -212,16 +212,16 @@ QToolBar#MainToolBar QCheckBox#InstantModeCheckBox {
     text-transform: uppercase;
     letter-spacing: 1px;
 }
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator, QCheckBox#AnalysisFormCheck::indicator {
     width: 10px;
     height: 10px;
     background: @GRAPH@;
     border: 1px solid @BORDER@;
 }
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:hover {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:hover, QCheckBox#AnalysisFormCheck::indicator:hover {
     border-color: @ACCENT@;
 }
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:checked {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:checked, QCheckBox#AnalysisFormCheck::indicator:checked {
     background: @ACCENT@;
     border-color: @ACCENT@;
 }
@@ -901,6 +901,18 @@ QLabel#AnalysisFormLabel {
     padding: 0 4px;
     font-size: 9pt;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo {
     min-width: 110px;
 }

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -198,7 +198,7 @@ QToolBar#MainToolBar QToolButton:disabled {
     border-style: dashed;
 }
 /* Instant mode engage cell. */
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck {
     background: transparent;
     color: @TEXT@;
     border: 1px solid @BORDER@;
@@ -212,16 +212,16 @@ QToolBar#MainToolBar QCheckBox#InstantModeCheckBox {
     text-transform: uppercase;
     letter-spacing: 1px;
 }
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator, QCheckBox#AnalysisFormCheck::indicator {
     width: 10px;
     height: 10px;
     background: @GRAPH@;
     border: 1px solid @BORDER@;
 }
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:hover {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:hover, QCheckBox#AnalysisFormCheck::indicator:hover {
     border-color: @ACCENT@;
 }
-QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:checked {
+QToolBar#MainToolBar QCheckBox#InstantModeCheckBox::indicator:checked, QCheckBox#AnalysisFormCheck::indicator:checked {
     background: @ACCENT@;
     border-color: @ACCENT@;
 }
@@ -897,6 +897,18 @@ QLabel#AnalysisFormLabel {
     padding: 0 4px;
     font-size: 9pt;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9pt;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo {
     min-width: 110px;
 }

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -359,6 +359,17 @@ QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip {
     background: @CARD@; border: 1px solid @BORDER@; border-radius: 0;

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -326,6 +326,17 @@ QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: @BG@; border: 1px solid @BORDER@; border-radius: 0; }
 QLabel#AnalysisStatLabel {

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -160,13 +160,25 @@ QToolButton[rackTransport="true"]:disabled {
 }
 /* Instant mode is a panel switch read by its lamp: the stock indicator
    collapses and RackChrome paints a real LED in the padding-reserved well. */
-QCheckBox#InstantModeCheckBox {
+QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck {
     color: @TEXT@; background: transparent;
     font-weight: 700; font-size: 8pt;
     text-transform: uppercase; letter-spacing: 1px;
     padding: 2px 4px 2px 22px; spacing: 0;
 }
 QCheckBox#InstantModeCheckBox::indicator { width: 0; height: 0; background: transparent; border: 0; image: none; }
+/* The analysis bar's base-delay option is not painted by RackChrome the way
+   the toolbar switch is, so it keeps a real indicator: the same dark LCD well
+   the save-state readout uses, lit in phosphor when engaged. */
+QCheckBox#AnalysisFormCheck { padding: 2px 4px; spacing: 8px; }
+QCheckBox#AnalysisFormCheck::indicator {
+    width: 11px; height: 11px; border-radius: 2px;
+    background: #0B0F0C;
+    border: 1px solid #050807; border-bottom-color: #39424A;
+    image: none;
+}
+QCheckBox#AnalysisFormCheck::indicator:checked { background: #86F2BA; }
+QCheckBox#AnalysisFormCheck::indicator:hover { border-color: @ACCENT@; }
 /* The save-state readout is a dark LCD well in both modes - displays do not
    follow the panel finish. Modified state burns amber segments. */
 QLabel#DirtyStatusBadge {
@@ -452,6 +464,17 @@ QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: #0A0D0F; border: 1px solid #060809; border-radius: 2px; }
 QLabel#AnalysisStatLabel {

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -160,13 +160,25 @@ QToolButton[rackTransport="true"]:disabled {
 }
 /* Instant mode is a panel switch read by its lamp: the stock indicator
    collapses and RackChrome paints a real LED in the padding-reserved well. */
-QCheckBox#InstantModeCheckBox {
+QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck {
     color: @TEXT@; background: transparent;
     font-weight: 700; font-size: 8pt;
     text-transform: uppercase; letter-spacing: 1px;
     padding: 2px 4px 2px 22px; spacing: 0;
 }
 QCheckBox#InstantModeCheckBox::indicator { width: 0; height: 0; background: transparent; border: 0; image: none; }
+/* The analysis bar's base-delay option is not painted by RackChrome the way
+   the toolbar switch is, so it keeps a real indicator: the same dark LCD well
+   the save-state readout uses, lit in phosphor when engaged. */
+QCheckBox#AnalysisFormCheck { padding: 2px 4px; spacing: 8px; }
+QCheckBox#AnalysisFormCheck::indicator {
+    width: 11px; height: 11px; border-radius: 2px;
+    background: #11150F;
+    border: 1px solid #4A4438; border-bottom-color: #6B6354;
+    image: none;
+}
+QCheckBox#AnalysisFormCheck::indicator:checked { background: #3ED68E; }
+QCheckBox#AnalysisFormCheck::indicator:hover { border-color: @ACCENT@; }
 /* The save-state readout is a dark LCD well in both modes - displays do not
    follow the panel finish (a cream panel still carries a dark glass
    window). Modified state burns amber segments. */
@@ -453,6 +465,17 @@ QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 700; text-transform: uppercase; letter-spacing: 2px; padding: 0 4px;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: #11150F; border: 1px solid #4A4438; border-radius: 2px; }
 QLabel#AnalysisStatLabel {

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -219,6 +219,15 @@ QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0
 
 QFrame#analysisControlBar { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 14px; }
 QLabel#AnalysisFormLabel { color: @MUTED@; background: transparent; font-weight: 600; padding: 0 6px; }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 600;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: @CARD@; border: 1px solid @BORDER@; border-radius: 14px; }
 QLabel#AnalysisStatLabel { color: @MUTED@; background: transparent; font-weight: 600; font-size: 9pt; letter-spacing: 1px; }
@@ -416,18 +425,18 @@ QToolBar#MainToolBar QLabel#ToolBarLabel { color: @MUTED@; padding: 0 6px 0 14px
 /* Instant mode as a friendly toggle: stadium track, knob baked into the
    state SVGs, calm accent when on. The off track is the muted token at low
    alpha so the near-white knob reads in both modes. */
-QCheckBox#InstantModeCheckBox { color: @TEXT@; font-weight: 600; spacing: 10px; padding: 4px 6px; }
-QCheckBox#InstantModeCheckBox::indicator {
+QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck { color: @TEXT@; font-weight: 600; spacing: 10px; padding: 4px 6px; }
+QCheckBox#InstantModeCheckBox::indicator, QCheckBox#AnalysisFormCheck::indicator {
     width: 36px; height: 20px; border-radius: 10px; border: 0;
     background: rgba(179, 171, 157, 0.38);
     image: url(:/icons/modern/soft-toggle-knob-off.svg);
 }
-QCheckBox#InstantModeCheckBox::indicator:hover { background: rgba(179, 171, 157, 0.50); }
-QCheckBox#InstantModeCheckBox::indicator:checked {
+QCheckBox#InstantModeCheckBox::indicator:hover, QCheckBox#AnalysisFormCheck::indicator:hover { background: rgba(179, 171, 157, 0.50); }
+QCheckBox#InstantModeCheckBox::indicator:checked, QCheckBox#AnalysisFormCheck::indicator:checked {
     background: @ACCENT@;
     image: url(:/icons/modern/soft-toggle-knob-on.svg);
 }
-QCheckBox#InstantModeCheckBox::indicator:checked:hover { background: #7FA3D5; }
+QCheckBox#InstantModeCheckBox::indicator:checked:hover, QCheckBox#AnalysisFormCheck::indicator:checked:hover { background: #7FA3D5; }
 
 /* The save state is a status pill: a solid pastel chip carrying the
    deep warm ink (the type chip's grammar promoted to chrome). Unsaved

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -220,6 +220,15 @@ QFrame[frameShape="4"], QFrame[frameShape="5"] { background: @BORDER@; border: 0
 
 QFrame#analysisControlBar { background: @CARD@; border: 1px solid @BORDER@; border-radius: 14px; }
 QLabel#AnalysisFormLabel { color: @MUTED@; background: transparent; font-weight: 600; padding: 0 6px; }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 600;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 14px; }
 QLabel#AnalysisStatLabel { color: @MUTED@; background: transparent; font-weight: 600; font-size: 9pt; letter-spacing: 1px; }
@@ -417,18 +426,18 @@ QToolBar#MainToolBar QLabel#ToolBarLabel { color: @MUTED@; padding: 0 6px 0 14px
 /* Instant mode as a friendly toggle: stadium track, knob baked into the
    state SVGs, calm accent when on. The off track is the muted token at low
    alpha so the near-white knob reads in both modes. */
-QCheckBox#InstantModeCheckBox { color: @TEXT@; font-weight: 600; spacing: 10px; padding: 4px 6px; }
-QCheckBox#InstantModeCheckBox::indicator {
+QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck { color: @TEXT@; font-weight: 600; spacing: 10px; padding: 4px 6px; }
+QCheckBox#InstantModeCheckBox::indicator, QCheckBox#AnalysisFormCheck::indicator {
     width: 36px; height: 20px; border-radius: 10px; border: 0;
     background: rgba(120, 111, 103, 0.35);
     image: url(:/icons/modern/soft-toggle-knob-off.svg);
 }
-QCheckBox#InstantModeCheckBox::indicator:hover { background: rgba(120, 111, 103, 0.45); }
-QCheckBox#InstantModeCheckBox::indicator:checked {
+QCheckBox#InstantModeCheckBox::indicator:hover, QCheckBox#AnalysisFormCheck::indicator:hover { background: rgba(120, 111, 103, 0.45); }
+QCheckBox#InstantModeCheckBox::indicator:checked, QCheckBox#AnalysisFormCheck::indicator:checked {
     background: @ACCENT@;
     image: url(:/icons/modern/soft-toggle-knob-on.svg);
 }
-QCheckBox#InstantModeCheckBox::indicator:checked:hover { background: #79A1D8; }
+QCheckBox#InstantModeCheckBox::indicator:checked:hover, QCheckBox#AnalysisFormCheck::indicator:checked:hover { background: #79A1D8; }
 
 /* The save state is a status pill: a solid pastel chip carrying the
    deep warm ink (the type chip's grammar promoted to chrome). Unsaved

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -191,34 +191,34 @@ QToolBar#MainToolBar QToolButton:pressed {
 
 /* Instant mode: a round signal lamp recast as a switch; the label is lit
    with the lamp. */
-QCheckBox#InstantModeCheckBox {
+QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck {
     color: @MUTED@;
     background: transparent;
     spacing: 8px;
     padding: 2px 4px;
 }
-QCheckBox#InstantModeCheckBox:checked {
+QCheckBox#InstantModeCheckBox:checked, QCheckBox#AnalysisFormCheck:checked {
     color: @TEXT@;
 }
-QCheckBox#InstantModeCheckBox:disabled {
+QCheckBox#InstantModeCheckBox:disabled, QCheckBox#AnalysisFormCheck:disabled {
     color: #5a5a72;
 }
-QCheckBox#InstantModeCheckBox::indicator {
+QCheckBox#InstantModeCheckBox::indicator, QCheckBox#AnalysisFormCheck::indicator {
     width: 14px;
     height: 14px;
     border-radius: 7px;
     background: #08080f;
     border: 1px solid @BORDER@;
 }
-QCheckBox#InstantModeCheckBox::indicator:hover {
+QCheckBox#InstantModeCheckBox::indicator:hover, QCheckBox#AnalysisFormCheck::indicator:hover {
     border-color: rgba(91, 140, 255, 0.65);
 }
-QCheckBox#InstantModeCheckBox::indicator:checked {
+QCheckBox#InstantModeCheckBox::indicator:checked, QCheckBox#AnalysisFormCheck::indicator:checked {
     background: qradialgradient(cx: 0.5, cy: 0.42, radius: 0.75, fx: 0.5, fy: 0.36,
         stop: 0 #E2EBFF, stop: 0.35 @ACCENT@, stop: 1 rgba(91, 140, 255, 0.16));
     border: 1px solid rgba(91, 140, 255, 0.8);
 }
-QCheckBox#InstantModeCheckBox::indicator:checked:disabled {
+QCheckBox#InstantModeCheckBox::indicator:checked:disabled, QCheckBox#AnalysisFormCheck::indicator:checked:disabled {
     background: @BORDER@;
     border-color: @BORDER@;
 }
@@ -840,6 +840,17 @@ QLabel#AnalysisFormLabel {
     letter-spacing: 1px;
     padding: 0 4px;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo {
     min-width: 110px;
 }

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -174,34 +174,34 @@ QToolBar#MainToolBar QToolButton:pressed {
         stop: 0 rgba(47, 107, 255, 0.46), stop: 0.4 rgba(47, 107, 255, 0.20), stop: 1 rgba(47, 107, 255, 0.02));
 }
 
-QCheckBox#InstantModeCheckBox {
+QCheckBox#InstantModeCheckBox, QCheckBox#AnalysisFormCheck {
     color: @MUTED@;
     background: transparent;
     spacing: 8px;
     padding: 2px 4px;
 }
-QCheckBox#InstantModeCheckBox:checked {
+QCheckBox#InstantModeCheckBox:checked, QCheckBox#AnalysisFormCheck:checked {
     color: @TEXT@;
 }
-QCheckBox#InstantModeCheckBox:disabled {
+QCheckBox#InstantModeCheckBox:disabled, QCheckBox#AnalysisFormCheck:disabled {
     color: #a0a0b4;
 }
-QCheckBox#InstantModeCheckBox::indicator {
+QCheckBox#InstantModeCheckBox::indicator, QCheckBox#AnalysisFormCheck::indicator {
     width: 14px;
     height: 14px;
     border-radius: 7px;
     background: @CARD_HOVER@;
     border: 1px solid @BORDER@;
 }
-QCheckBox#InstantModeCheckBox::indicator:hover {
+QCheckBox#InstantModeCheckBox::indicator:hover, QCheckBox#AnalysisFormCheck::indicator:hover {
     border-color: rgba(47, 107, 255, 0.65);
 }
-QCheckBox#InstantModeCheckBox::indicator:checked {
+QCheckBox#InstantModeCheckBox::indicator:checked, QCheckBox#AnalysisFormCheck::indicator:checked {
     background: qradialgradient(cx: 0.5, cy: 0.42, radius: 0.75, fx: 0.5, fy: 0.36,
         stop: 0 #FFFFFF, stop: 0.35 @ACCENT@, stop: 1 rgba(47, 107, 255, 0.18));
     border: 1px solid rgba(47, 107, 255, 0.8);
 }
-QCheckBox#InstantModeCheckBox::indicator:checked:disabled {
+QCheckBox#InstantModeCheckBox::indicator:checked:disabled, QCheckBox#AnalysisFormCheck::indicator:checked:disabled {
     background: @BORDER@;
     border-color: @BORDER@;
 }
@@ -540,6 +540,17 @@ QLabel#AnalysisFormLabel {
     color: @MUTED@; background: transparent;
     font-weight: 600; text-transform: uppercase; letter-spacing: 1px; padding: 0 4px;
 }
+/* The base-delay option speaks in the same register as the field labels
+   beside it, derived from this skin's own AnalysisFormLabel rule. Its
+   indicator is the toolbar checkbox's, added to those selectors above. */
+QCheckBox#AnalysisFormCheck {
+    color: @MUTED@;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    background: transparent;
+}
+
 QComboBox#AnalysisFormCombo { min-width: 110px; }
 QFrame#AnalysisStatChip {
     background: rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
Design review round 3 on #228.

## The drop-downs looked clipped

They stretch to fill their column, so their right edge landed hard against the
graph pane with nothing between them — which reads as the pane eating into the
bar. The bar's right margin goes from 10 to 18, shortening every control in
that column at once rather than capping each one to a number that would drift
apart later. The 250px cap and the nine rows are untouched.

## "Include base delay" spoke in the system font

It was the last widget in this campaign with no name a skin sheet knows. It now
joins the toolbar checkbox's selectors for its indicator, and takes its type
from that skin's own field-label rule — so it reads in the same register as
FROM / CHANNEL / RES / POS beside it.

**Rack needed an exception.** Its rule sets the toolbar checkbox's indicator to
zero size, because `RackChrome` paints that switch itself. Nothing paints this
one, so inheriting the rule left an invisible toggle. Rack's option keeps a real
indicator instead, built from the dark LCD well its save-state readout already
uses and lit in phosphor when engaged.

That is worth stating as a rule: reusing an existing selector is right only when
the reason the rule exists still holds. The previous round's lesson was to
register new names beside existing selectors; this round is the limit of it.

## Evidence

Gallery branch `gallery-phase-time-r2`. Only the 10 analysis panel shots differ
against the previous build — the toolbar's own checkbox is unchanged in every
skin. EditorLogicTests 2463 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
