### PR TITLE
fix(ui): stop the analysis bar's drop-downs overflowing their column

### DIFF
--- a/Editor/MainWindow.cpp
+++ b/Editor/MainWindow.cpp
@@ -160,9 +160,26 @@ MainWindow::MainWindow(QDir configDir, QWidget* parent)
 	ui->analysisControlBar->setAttribute(Qt::WA_StyledBackground, true);
 	for (QLabel* label : { ui->startFromLabel, ui->analysisChannelLabel, ui->resolutionLabel })
 		label->setObjectName(QStringLiteral("AnalysisFormLabel"));
-	for (QComboBox* combo : { ui->startFromComboBox, ui->analysisChannelComboBox })
+	// Ignored rather than Preferred: these sit in a bar capped at 250px, and a
+	// combo's own size hint is its widest item plus the drop-down and whatever
+	// padding the active skin gives it. That hint has always been larger than
+	// the column can offer, so the layout laid them out at their minimum and
+	// the bar clipped their right edge - which reads as the graph pane eating
+	// into the bar. With the hint ignored they take the column's width instead
+	// and elide, which is what a fixed-width bar needs them to do.
+	for (QComboBox* combo : { ui->startFromComboBox, ui->analysisChannelComboBox, ui->graphPositionComboBox })
+	{
 		combo->setObjectName(QStringLiteral("AnalysisFormCombo"));
+		combo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+		combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+		combo->setMinimumContentsLength(6);
+	}
 	ui->resolutionSpinBox->setObjectName(QStringLiteral("AnalysisFormSpin"));
+	ui->resolutionSpinBox->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+	// With the hints ignored the control column has nothing left asking for
+	// width, so it has to be told to take what is spare. The label column keeps
+	// its own width, which is what aligns the four captions.
+	ui->analysisControlLayout->setColumnStretch(1, 1);
 	for (QFrame* chip : { ui->peakChip, ui->latencyChip, ui->initChip, ui->cpuChip })
 	{
 		chip->setObjectName(QStringLiteral("AnalysisStatChip"));

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -512,6 +512,7 @@ QWidget* buildAnalysisPanelReplica(QWidget* parent)
 	grid->setContentsMargins(10, 6, 18, 6);
 	grid->setHorizontalSpacing(8);
 	grid->setVerticalSpacing(4);
+	grid->setColumnStretch(1, 1);
 
 	const QStringList formLabels = { QStringLiteral("From"), QStringLiteral("Channel"),
 		QStringLiteral("Res"), QStringLiteral("Pos") };
@@ -529,6 +530,7 @@ QWidget* buildAnalysisPanelReplica(QWidget* parent)
 			// the lighter widget under the same object name.
 			QSpinBox* spin = new QSpinBox;
 			spin->setObjectName(QStringLiteral("AnalysisFormSpin"));
+			spin->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
 			spin->setRange(128, 8388608);
 			spin->setValue(65536);
 			grid->addWidget(spin, row, 1);
@@ -537,6 +539,9 @@ QWidget* buildAnalysisPanelReplica(QWidget* parent)
 		{
 			QComboBox* combo = new QComboBox;
 			combo->setObjectName(QStringLiteral("AnalysisFormCombo"));
+			combo->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+			combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+			combo->setMinimumContentsLength(6);
 			combo->addItem(formValues[row]);
 			grid->addWidget(combo, row, 1);
 		}

--- a/Editor/skins/matrix_dark.qss
+++ b/Editor/skins/matrix_dark.qss
@@ -914,7 +914,7 @@ QCheckBox#AnalysisFormCheck {
 }
 
 QComboBox#AnalysisFormCombo {
-    min-width: 110px;
+    min-width: 80px;
 }
 QFrame#AnalysisStatChip {
     background: @GRAPH@;

--- a/Editor/skins/matrix_light.qss
+++ b/Editor/skins/matrix_light.qss
@@ -910,7 +910,7 @@ QCheckBox#AnalysisFormCheck {
 }
 
 QComboBox#AnalysisFormCombo {
-    min-width: 110px;
+    min-width: 80px;
 }
 QFrame#AnalysisStatChip {
     background: #FFFFFF;

--- a/Editor/skins/precision_dark.qss
+++ b/Editor/skins/precision_dark.qss
@@ -370,7 +370,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip {
     background: @CARD@; border: 1px solid @BORDER@; border-radius: 0;
 }

--- a/Editor/skins/precision_light.qss
+++ b/Editor/skins/precision_light.qss
@@ -337,7 +337,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip { background: @BG@; border: 1px solid @BORDER@; border-radius: 0; }
 QLabel#AnalysisStatLabel {
     color: @MUTED@; background: transparent;

--- a/Editor/skins/rack_dark.qss
+++ b/Editor/skins/rack_dark.qss
@@ -475,7 +475,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip { background: #0A0D0F; border: 1px solid #060809; border-radius: 2px; }
 QLabel#AnalysisStatLabel {
     color: @MUTED@; background: transparent;

--- a/Editor/skins/rack_light.qss
+++ b/Editor/skins/rack_light.qss
@@ -476,7 +476,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip { background: #11150F; border: 1px solid #4A4438; border-radius: 2px; }
 QLabel#AnalysisStatLabel {
     color: #9AA08E; background: transparent;

--- a/Editor/skins/soft_dark.qss
+++ b/Editor/skins/soft_dark.qss
@@ -228,7 +228,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip { background: @CARD@; border: 1px solid @BORDER@; border-radius: 14px; }
 QLabel#AnalysisStatLabel { color: @MUTED@; background: transparent; font-weight: 600; font-size: 9pt; letter-spacing: 1px; }
 QLabel#AnalysisStatValue { color: @TEXT@; background: transparent; font-weight: 700; font-family: "@MONO@", "Consolas", "JetBrains Mono", "Malgun Gothic", monospace; }

--- a/Editor/skins/soft_light.qss
+++ b/Editor/skins/soft_light.qss
@@ -229,7 +229,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip { background: @SURFACE@; border: 1px solid @BORDER@; border-radius: 14px; }
 QLabel#AnalysisStatLabel { color: @MUTED@; background: transparent; font-weight: 600; font-size: 9pt; letter-spacing: 1px; }
 QLabel#AnalysisStatValue { color: @TEXT@; background: transparent; font-weight: 700; font-family: "@MONO@", "Consolas", "JetBrains Mono", "Malgun Gothic", monospace; }

--- a/Editor/skins/studio_dark.qss
+++ b/Editor/skins/studio_dark.qss
@@ -852,7 +852,7 @@ QCheckBox#AnalysisFormCheck {
 }
 
 QComboBox#AnalysisFormCombo {
-    min-width: 110px;
+    min-width: 80px;
 }
 QFrame#AnalysisStatChip {
     background: rgba(255, 255, 255, 0.04);

--- a/Editor/skins/studio_light.qss
+++ b/Editor/skins/studio_light.qss
@@ -551,7 +551,7 @@ QCheckBox#AnalysisFormCheck {
     background: transparent;
 }
 
-QComboBox#AnalysisFormCombo { min-width: 110px; }
+QComboBox#AnalysisFormCombo { min-width: 80px; }
 QFrame#AnalysisStatChip {
     background: rgba(0, 0, 0, 0.04);
     border: 1px solid rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
The right edge is still eaten — reported after #231 merged, and correctly.

## What was actually wrong

Widening the bar's right margin could not have fixed it. The controls were not
sitting inside the margin; they were **overflowing past it** and being clipped
by the bar's boundary.

A combo's size hint is its widest item plus the drop-down plus whatever padding
the active skin gives it, with a QSS floor of `min-width: 110px` on top. That
total has always exceeded what a 250px-capped bar can give the control column,
so the layout laid the row out at its minimum and the bar clipped the rest.

Measured, not guessed: on the `From` row the combo's interior runs to x=259 and
the panel background resumes at x=260 — the combo covers the bar's own 1px
border. **The same measurement on renders from before this campaign started
gives the same x=259**, so the defect predates all of this work; the campaign
only drew attention to the bar.

## The fix

- The controls let the layout size them (hint ignored, eliding instead).
- The control column is given the spare width — with the hints ignored, nothing
  in that column asks for any, so without this the column collapses to nothing.
  Both halves are needed; that is why this took two passes.
- The QSS floor drops from 110px to 80px so it cannot re-impose the old minimum.

Result: the drop-down keeps its right edge and rounded corner, with 23px of bar
between it and the frame.

## Evidence

Gallery branch `gallery-phase-time-r2`. Only the 10 analysis panel shots differ.
EditorLogicTests 2463 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
