### PR TITLE
refactor(editor): use Qt guards for scoped state

### DIFF
--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -10,6 +10,7 @@
 #include <QAction>
 #include <QFileDialog>
 #include <QPainter>
+#include <QPainterStateGuard>
 #include <QToolBar>
 #include <QToolButton>
 #include <QtMath>
@@ -387,7 +388,7 @@ void ISkin::paintSegmentedControl(QPainter& painter, const SegmentedControlState
 	if (state.labels.isEmpty())
 		return;
 
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 	painter.setRenderHint(QPainter::Antialiasing, true);
 	painter.setRenderHint(QPainter::TextAntialiasing, true);
 
@@ -426,8 +427,6 @@ void ISkin::paintSegmentedControl(QPainter& painter, const SegmentedControlState
 		painter.setPen(ink);
 		painter.drawText(cell, Qt::AlignCenter, state.labels.at(i));
 	}
-
-	painter.restore();
 }
 
 void ISkin::paintInsertSeam(QPainter& painter, const QRect& rect, const ListChromeState& state, const SkinTokens& tokens) const

--- a/Editor/skins/MatrixSkin.cpp
+++ b/Editor/skins/MatrixSkin.cpp
@@ -14,6 +14,7 @@
 #include <QLabel>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPainterStateGuard>
 #include <QRegion>
 #include <QToolBar>
 #include <QVBoxLayout>
@@ -1261,7 +1262,7 @@ public:
 			const QRect zone(plot.left(), plot.top(), plot.width(), zeroYpx - plot.top());
 			QColor hatch(hazardInk);
 			hatch.setAlpha(darkBoard ? 60 : 70);
-			painter.save();
+			QPainterStateGuard hazardState(&painter);
 			painter.setClipRect(zone);
 			painter.setPen(QPen(hatch, 1));
 			// Diagonals on the board's 12px half-pitch (gridPitch 24 = two
@@ -1295,7 +1296,6 @@ public:
 				for (int x = zone.left() - zone.height(); x <= zone.right(); x += 5)
 					painter.drawLine(x, zone.bottom(), x + zone.height(), zone.top());
 			}
-			painter.restore();
 		}
 
 		// The zero bus: the board's reference rule, one rank of authority
@@ -1654,7 +1654,7 @@ public:
 		const QColor accent(tokens.accent);
 		const QRect frame = state.rect;
 
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		// Invariant rule 7: no antialiasing under a 1px rule. Nothing here is
 		// a curve, so only the type is smoothed.
 		painter.setRenderHint(QPainter::Antialiasing, false);
@@ -1667,7 +1667,6 @@ public:
 			painter.setPen(QPen(borderInk, 1));
 			painter.setBrush(Qt::NoBrush);
 			painter.drawRect(frame.adjusted(0, 0, -1, -1));
-			painter.restore();
 			return;
 		}
 
@@ -1811,19 +1810,19 @@ public:
 						qMax(0, column.width() - 8)));
 			}
 		};
-		painter.save();
-		QRegion unlit(frame);
-		if (state.enabled)
-			unlit -= QRegion(mark);
-		painter.setClipRegion(unlit);
-		drawLabels(false);
-		painter.restore();
+		{
+			QPainterStateGuard unlitLabelState(&painter);
+			QRegion unlit(frame);
+			if (state.enabled)
+				unlit -= QRegion(mark);
+			painter.setClipRegion(unlit);
+			drawLabels(false);
+		}
 		if (state.enabled)
 		{
-			painter.save();
+			QPainterStateGuard litLabelState(&painter);
 			painter.setClipRect(mark);
 			drawLabels(true);
-			painter.restore();
 		}
 
 		// Keyboard focus brackets the engaged port at the port's own edges -
@@ -1856,7 +1855,6 @@ public:
 		painter.setPen(QPen(borderInk, 1, state.enabled ? Qt::SolidLine : Qt::DashLine));
 		painter.setBrush(Qt::NoBrush);
 		painter.drawRect(frame.adjusted(0, 0, -1, -1));
-		painter.restore();
 	}
 
 	// The board's masthead: the faint 24px column grid behind the title

--- a/Editor/skins/MinimalSkin.cpp
+++ b/Editor/skins/MinimalSkin.cpp
@@ -15,6 +15,7 @@
 #include <QLabel>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPainterStateGuard>
 #include <QStringList>
 #include <QToolBar>
 #include <QWidget>
@@ -527,10 +528,9 @@ void paintMinimalAnalysisGraph(QPainter& painter, const AnalysisGraphState& stat
 			dangerBase.hsvSaturationF() * (darkSheet ? 0.70 : 0.84),
 			dangerBase.valueF() * (darkSheet ? 0.56 : 0.55));
 
-		painter.save();
+		QPainterStateGuard overshootState(&painter);
 		painter.setClipRect(QRectF(plotLeft, plotTop, plotRight - plotLeft, state.zeroY - plotTop));
 		painter.fillPath(overshoot, errorBlock);
-		painter.restore();
 	}
 
 	// The zero rule: the one full-strength straight line, body ink 1px. It
@@ -562,12 +562,11 @@ void paintMinimalAnalysisGraph(QPainter& painter, const AnalysisGraphState& stat
 		painter.drawPolyline(segment);
 		if (overshootValid)
 		{
-			painter.save();
+			QPainterStateGuard overshootSegmentState(&painter);
 			painter.setClipRect(QRectF(plotLeft, plotTop, plotRight - plotLeft, state.zeroY - plotTop));
 			painter.setClipPath(overshoot, Qt::IntersectClip);
 			painter.setPen(QPen(ground, 1));
 			painter.drawPolyline(segment);
-			painter.restore();
 		}
 	}
 

--- a/Editor/skins/RackChrome.cpp
+++ b/Editor/skins/RackChrome.cpp
@@ -18,6 +18,7 @@
 #include <QHash>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPainterStateGuard>
 #include <QToolBar>
 #include <QtMath>
 
@@ -392,7 +393,7 @@ void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo&
 		return;
 
 	const bool dark = skinIsDark(tokens);
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 	painter.setRenderHint(QPainter::Antialiasing);
 
 	// Stay inside the 1px QSS border (the machined plate edge) and clip all
@@ -547,13 +548,12 @@ void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo&
 		earFont.setPixelSize(8);
 		earFont.setBold(true);
 		earFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.5);
-		painter.save();
+		QPainterStateGuard labelState(&painter);
 		painter.translate(r.left() + 14.5, r.bottom() - 16);
 		painter.rotate(-90);
 		painter.setFont(earFont);
 		const QRectF textRect(0, -10, r.height() - 64, 20);
 		engraveText(painter, textRect, Qt::AlignLeft | Qt::AlignVCenter, label, withAlpha(QColor(tokens.mutedText), 200), dark);
-		painter.restore();
 	}
 
 	// Commented-out line: the whole unit is powered down behind a dim film.
@@ -568,8 +568,6 @@ void paintCardChrome(QPainter& painter, const QRect& rect, const CommandRowInfo&
 		painter.setBrush(Qt::NoBrush);
 		painter.drawRoundedRect(r.adjusted(1.5, 1.5, -1.5, -1.5), radius - 1, radius - 1);
 	}
-
-	painter.restore();
 }
 
 void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, const SkinTokens& tokens)
@@ -719,7 +717,7 @@ void paintKnob(QPainter& painter, const QRect& rect, const KnobState& state, con
 void paintAddRow(QPainter& painter, const QRect& rect, const ListChromeState& state, const SkinTokens& tokens)
 {
 	const bool dark = skinIsDark(tokens);
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 	painter.setRenderHint(QPainter::Antialiasing);
 
 	const QRectF r = QRectF(rect).adjusted(0.5, 0.5, -0.5, -0.5);
@@ -819,8 +817,6 @@ void paintAddRow(QPainter& painter, const QRect& rect, const ListChromeState& st
 		painter.setBrush(Qt::NoBrush);
 		painter.drawRoundedRect(r.adjusted(1.5, 1.5, -1.5, -1.5), radius - 1, radius - 1);
 	}
-
-	painter.restore();
 }
 
 void paintInsertSeam(QPainter& painter, const QRect& rect, const ListChromeState& state, const SkinTokens& tokens)
@@ -831,7 +827,7 @@ void paintInsertSeam(QPainter& painter, const QRect& rect, const ListChromeState
 		return;
 
 	const bool dark = skinIsDark(tokens);
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 	painter.setRenderHint(QPainter::Antialiasing);
 
 	// A service slot heating up between the rail and the first unit:
@@ -856,15 +852,13 @@ void paintInsertSeam(QPainter& painter, const QRect& rect, const ListChromeState
 	painter.setPen(QPen(withAlpha(amber, state.pressed ? 255 : 210), 1.4, Qt::SolidLine, Qt::FlatCap));
 	painter.drawLine(QPointF(left + kEarWidth, y - 3), QPointF(left + kEarWidth, y + 3));
 	painter.drawLine(QPointF(right - kEarWidth, y - 3), QPointF(right - kEarWidth, y + 3));
-
-	painter.restore();
 }
 
 void paintGraphicEqPlot(QPainter& painter, const GraphicEQPlotState& state, const SkinTokens& tokens)
 {
 	const bool dark = skinIsDark(tokens);
 	const bool powered = state.enabled;
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 
 	// The scope well is dark in BOTH finishes (the display law). The
 	// graticule sits in the scope-grid family: the cream table's grid token
@@ -965,7 +959,7 @@ void paintGraphicEqPlot(QPainter& painter, const GraphicEQPlotState& state, cons
 	}
 
 	// The beam stays inside the graticule area, like a tube masks its trace.
-	painter.save();
+	QPainterStateGuard beamState(&painter);
 	painter.setClipRect(state.plotRect.adjusted(-1, -1, 1, 1), Qt::IntersectClip);
 
 	if (state.curve.size() >= 2)
@@ -1063,7 +1057,7 @@ void paintGraphicEqPlot(QPainter& painter, const GraphicEQPlotState& state, cons
 			painter.drawEllipse(center, 7.0, 7.0);
 		}
 	}
-	painter.restore();
+	beamState.restore();
 
 	// Cursor readout: top-right inside the glass, bright segments.
 	if (powered && state.cursorValid && !state.cursorText.isEmpty())
@@ -1101,8 +1095,6 @@ void paintGraphicEqPlot(QPainter& painter, const GraphicEQPlotState& state, cons
 		painter.setPen(QPen(bezelLip, 1));
 		painter.drawLine(QPointF(r.left() + radius, r.bottom()), QPointF(r.right() - radius, r.bottom()));
 	}
-
-	painter.restore();
 }
 
 void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens)

--- a/Editor/skins/RackSkin.cpp
+++ b/Editor/skins/RackSkin.cpp
@@ -14,6 +14,7 @@
 #include <QLinearGradient>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPainterStateGuard>
 #include <QStyle>
 #include <QToolBar>
 #include <QToolButton>
@@ -278,7 +279,7 @@ void paintSelectorBank(QPainter& painter, const SegmentedControlState& state, co
 	const QColor lightInk(255, 255, 255);
 	const QColor grainInk = dark ? lightInk : mixColor(bodyInk, panel, 0.30);
 
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 	painter.setRenderHint(QPainter::Antialiasing, true);
 	painter.setRenderHint(QPainter::TextAntialiasing, true);
 
@@ -295,7 +296,7 @@ void paintSelectorBank(QPainter& painter, const SegmentedControlState& state, co
 	painter.setPen(Qt::NoPen);
 	painter.fillPath(well, panel.darker(dark ? 178 : 122));
 
-	painter.save();
+	QPainterStateGuard wellState(&painter);
 	painter.setClipPath(well);
 
 	QLinearGradient overhang(frame.topLeft(), QPointF(frame.left(), frame.top() + 4.0));
@@ -351,10 +352,11 @@ void paintSelectorBank(QPainter& painter, const SegmentedControlState& state, co
 		painter.setPen(Qt::NoPen);
 		painter.fillPath(capPath, face);
 
-		painter.save();
-		painter.setClipPath(capPath);
-		monitorGrain(painter, cap, grainInk, seed);
-		painter.restore();
+		{
+			QPainterStateGuard capState(&painter);
+			painter.setClipPath(capPath);
+			monitorGrain(painter, cap, grainInk, seed);
+		}
 
 		const QColor topEdge = raised ? withAlpha(lightInk, dark ? 46 : 155) : withAlpha(shadowInk, dark ? 175 : 125);
 		const QColor bottomEdge = raised ? withAlpha(shadowInk, dark ? 165 : 95) : withAlpha(lightInk, dark ? 70 : 175);
@@ -505,14 +507,12 @@ void paintSelectorBank(QPainter& painter, const SegmentedControlState& state, co
 		painter.fillPath(well, withAlpha(shadowInk, dark ? 140 : 96));
 	}
 
-	painter.restore();
+	wellState.restore();
 
 	// The machined bezel around the opening.
 	painter.setBrush(Qt::NoBrush);
 	painter.setPen(QPen(withAlpha(shadowInk, dark ? 215 : 135), 1));
 	painter.drawPath(well);
-
-	painter.restore();
 }
 
 // The instrument itself: a dark phosphor-glass window in BOTH finishes (the
@@ -529,7 +529,7 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 	// is fenced behind this flag. Nothing outside those fences changes with the
 	// function, so the magnitude face is the one it always had.
 	const bool magnitude = state.metric == AnalysisMetric::MagnitudeDb;
-	painter.save();
+	QPainterStateGuard painterState(&painter);
 	painter.setRenderHint(QPainter::TextAntialiasing, true);
 
 	// Display-glass idiom shared with the GEQ scope and the LCD wells: the
@@ -642,7 +642,7 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 	// ── The glass window ──
 	QPainterPath glassPath;
 	glassPath.addRoundedRect(glassFrame, 2.0, 2.0);
-	painter.save();
+	QPainterStateGuard glassState(&painter);
 	painter.setClipPath(glassPath);
 
 	QLinearGradient ground(glassFrame.topLeft(), glassFrame.bottomLeft());
@@ -774,7 +774,7 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 	}
 
 	// ── The beam ── (masked to the graticule area, like a tube's trace)
-	painter.save();
+	QPainterStateGuard beamState(&painter);
 	painter.setClipRect(state.plotRect.adjusted(-1, -1, 1, 1), Qt::IntersectClip);
 	painter.setRenderHint(QPainter::Antialiasing, true);
 	// One sweep per segment. The metric goes dark where it has no value, and the
@@ -827,7 +827,7 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 		// a white-hot core - an overdriven beam, not an annotation.
 		if (overZone)
 		{
-			painter.save();
+			QPainterStateGuard overZoneState(&painter);
 			painter.setClipRect(QRectF(state.plotRect.left() - 1.0, state.plotRect.top() - 1.0,
 				state.plotRect.width() + 2.0, zeroY - state.plotRect.top() + 1.0), Qt::IntersectClip);
 			painter.setPen(Qt::NoPen);
@@ -842,10 +842,9 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 			painter.drawPolyline(segment);
 			painter.setPen(QPen(withAlpha(mixColor(overInk, QColor(255, 255, 255), 0.55), 215), 0.9, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 			painter.drawPolyline(segment);
-			painter.restore();
 		}
 	}
-	painter.restore();
+	beamState.restore();
 
 	// ── The measurement cursor ── a scope cursor line with grab ticks, a
 	// brightened measured point on the beam and a segment readout in the
@@ -908,7 +907,7 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 	overhang.setColorAt(1.0, QColor(0, 0, 0, 0));
 	painter.fillRect(QRectF(glassFrame.left(), glassFrame.top(), glassFrame.width(), 9.0), overhang);
 
-	painter.restore();
+	glassState.restore();
 
 	// Bezel frame and the lit lower lip between glass and plate.
 	painter.setBrush(Qt::NoBrush);
@@ -918,8 +917,6 @@ void paintAnalysisMonitor(QPainter& painter, const AnalysisGraphState& state, co
 	painter.setRenderHint(QPainter::Antialiasing, false);
 	painter.setPen(QPen(bezelLip, 1));
 	painter.drawLine(int(glassFrame.left()) + 2, int(glassFrame.bottom()), int(glassFrame.right()) - 2, int(glassFrame.bottom()));
-
-	painter.restore();
 }
 
 class RackSkin : public ISkin

--- a/Editor/skins/SoftSkin.cpp
+++ b/Editor/skins/SoftSkin.cpp
@@ -18,6 +18,7 @@
 #include <QLinearGradient>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPainterStateGuard>
 #include <QPixmap>
 #include <QRegularExpression>
 #include <QToolBar>
@@ -371,7 +372,7 @@ public:
 		painter.setBrush(well);
 		painter.drawPath(wellPath);
 
-		painter.save();
+		QPainterStateGuard wellState(&painter);
 		painter.setClipPath(wellPath);
 
 		// Axis captions ride the body face in faded ink - the constitution
@@ -470,7 +471,7 @@ public:
 				for (int pass = 0; pass < 2; pass++)
 				{
 					const bool boostPass = pass == 0;
-					painter.save();
+					QPainterStateGuard curvePassState(&painter);
 					painter.setClipRect(boostPass ? aboveZero : belowZero, Qt::IntersectClip);
 					painter.setPen(Qt::NoPen);
 					painter.setBrush(withAlpha(boostPass ? accent : accent2, 40));
@@ -478,7 +479,6 @@ public:
 					painter.setPen(QPen(boostPass ? boost : cut, 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 					painter.setBrush(Qt::NoBrush);
 					painter.drawPolyline(state.curve);
-					painter.restore();
 				}
 			}
 		}
@@ -561,7 +561,7 @@ public:
 			painter.drawText(pill, Qt::AlignCenter, state.cursorText);
 		}
 
-		painter.restore();
+		wellState.restore();
 
 		// The well edge: a very light 1px line awake; asleep it becomes the
 		// dashed outline of the sleeping-slot triple.
@@ -607,7 +607,7 @@ public:
 		painter.setBrush(well);
 		painter.drawPath(wellPath);
 
-		painter.save();
+		QPainterStateGuard wellState(&painter);
 		painter.setClipPath(wellPath);
 
 		// Axis captions ride the body face in faded ink, exactly like the
@@ -711,7 +711,7 @@ public:
 			{
 				const bool overshootPass = pass == 0;
 				const QColor side = overshootPass ? overFill : accent;
-				painter.save();
+				QPainterStateGuard curvePassState(&painter);
 				painter.setClipRect(overshootPass ? aboveZero : belowZero, Qt::IntersectClip);
 				painter.setPen(Qt::NoPen);
 				painter.setBrush(side);
@@ -719,7 +719,6 @@ public:
 				painter.setPen(QPen(mixColor(side, warmInk, 0.40), 3, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 				painter.setBrush(Qt::NoBrush);
 				painter.drawPolyline(segment);
-				painter.restore();
 			}
 		}
 
@@ -891,7 +890,7 @@ public:
 		const double entry = qBound(0.0, state.hover, 1.0);
 		if (state.cursorValid && entry > 0.01)
 		{
-			painter.save();
+			QPainterStateGuard cursorState(&painter);
 			painter.setOpacity(entry);
 
 			painter.setPen(QPen(withAlpha(QColor(tokens.text), 70), 2, Qt::SolidLine, Qt::RoundCap));
@@ -934,10 +933,9 @@ public:
 				painter.drawText(pill, Qt::AlignCenter,
 					pillMetrics.elidedText(state.cursorText, Qt::ElideRight, int(pillW - 12.0)));
 			}
-			painter.restore();
 		}
 
-		painter.restore();
+		wellState.restore();
 
 		// The well edge: the very light 1px line of the two-step elevation.
 		painter.setPen(QPen(border, 1));
@@ -967,7 +965,7 @@ public:
 		if (state.labels.isEmpty())
 			return;
 
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		painter.setRenderHint(QPainter::Antialiasing, true);
 		painter.setRenderHint(QPainter::TextAntialiasing, true);
 
@@ -1071,8 +1069,6 @@ public:
 		painter.setPen(edge);
 		painter.setBrush(Qt::NoBrush);
 		painter.drawRoundedRect(frame, trackRadius, trackRadius);
-
-		painter.restore();
 	}
 
 	// The plain-text rows (bare note lines and programmatic commands such

--- a/Editor/skins/StudioSkin.cpp
+++ b/Editor/skins/StudioSkin.cpp
@@ -16,6 +16,7 @@
 #include <QLabel>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPainterStateGuard>
 #include <QToolBar>
 #include <QWidget>
 #include <QtMath>
@@ -218,7 +219,7 @@ public:
 	void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens) const override
 	{
 		const bool dark = skinIsDark(tokens);
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 
 		// The 1px lighter top edge, quieter than a panel's reflection.
 		painter.fillRect(QRectF(rect.left(), rect.top(), rect.width(), 1.0),
@@ -246,8 +247,6 @@ public:
 		corePen.setCapStyle(Qt::RoundCap);
 		painter.setPen(corePen);
 		painter.drawLine(QPointF(x0, y), QPointF(x0 + span, y));
-
-		painter.restore();
 	}
 
 	// The QSS sheets own the toolbar strip itself; code only re-inks the
@@ -499,7 +498,7 @@ public:
 			return;
 
 		const bool dark = skinIsDark(tokens);
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		painter.setRenderHint(QPainter::Antialiasing);
 
 		// The pane: the glass surface treatment stays inside the border.
@@ -578,7 +577,6 @@ public:
 					}
 				}
 			}
-			painter.restore();
 			return;
 		}
 
@@ -618,8 +616,6 @@ public:
 			painter.fillRect(QRectF(rect.left(), y0 - 3.0, 4.0, segment + 6.0), bloom);
 			painter.fillRect(QRectF(rect.left(), y0, 2.0, segment), lamp);
 		}
-
-		painter.restore();
 	}
 
 	// The If-block scope is a gate beam: the knob arc's stroke ladder turned
@@ -648,7 +644,7 @@ public:
 		const QColor beam(tokens.accent);
 		const bool live = info.enabled && !info.lineSkipped;
 
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		painter.setRenderHint(QPainter::Antialiasing, true);
 		painter.setPen(Qt::NoPen);
 
@@ -759,8 +755,6 @@ public:
 				beamRun(level, 0.0, h, true, false);
 			beamRun(channelLevels + logic - 1, 0.0, h, live, false);
 		}
-
-		painter.restore();
 		return true;
 	}
 
@@ -921,7 +915,7 @@ public:
 		const bool lit = state.enabled;
 		const QRectF plot = state.plotRect;
 
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		if (!lit)
 			painter.setOpacity(0.45);
 
@@ -1110,8 +1104,6 @@ public:
 		painter.setRenderHint(QPainter::Antialiasing, false);
 		painter.fillRect(QRectF(frame.left() + 7.0, frame.top() + 1.0, frame.width() - 14.0, 1.0),
 			dark ? QColor(0, 0, 0, lit ? 140 : 80) : QColor(0, 0, 0, lit ? 30 : 16));
-
-		painter.restore();
 	}
 
 	// The analysis dock's response graph: the GraphicEQ gauge widened into
@@ -1130,7 +1122,7 @@ public:
 		const double hover = qBound(0.0, state.hover, 1.0);
 		const bool magnitude = state.metric == AnalysisMetric::MagnitudeDb;
 
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		painter.setRenderHint(QPainter::Antialiasing, true);
 		painter.setRenderHint(QPainter::TextAntialiasing, true);
 
@@ -1383,7 +1375,7 @@ public:
 			// in danger, clipped to the glass above the anchor.
 			if (state.clipping && zeroClamped > plot.top())
 			{
-				painter.save();
+				QPainterStateGuard overshootState(&painter);
 				painter.setClipRect(QRectF(plot.left(), plot.top(), plot.width(), zeroClamped - plot.top()),
 					Qt::IntersectClip);
 				const struct { double width; int alpha; } flames[] = {
@@ -1399,7 +1391,6 @@ public:
 					painter.setPen(firePen);
 					painter.drawPolyline(segment);
 				}
-				painter.restore();
 			}
 		}
 
@@ -1431,7 +1422,7 @@ public:
 		// group rides state.hover for its entry motion.
 		if (state.cursorValid && hover > 0.01)
 		{
-			painter.save();
+			QPainterStateGuard cursorState(&painter);
 			painter.setOpacity(painter.opacity() * hover);
 
 			const double cx = state.cursor.x();
@@ -1510,7 +1501,6 @@ public:
 				painter.setPen(QColor(tokens.text));
 				painter.drawText(chip, Qt::AlignCenter, readout);
 			}
-			painter.restore();
 		}
 
 		// The pane's edge: a hairline border over a darker inner top edge.
@@ -1521,8 +1511,6 @@ public:
 		painter.setRenderHint(QPainter::Antialiasing, false);
 		painter.fillRect(QRectF(frame.left() + 7.0, frame.top() + 1.0, frame.width() - 14.0, 1.0),
 			dark ? QColor(0, 0, 0, 140) : QColor(0, 0, 0, 30));
-
-		painter.restore();
 	}
 
 	// A row of exclusive choices: the knob's track laid flat, with the arc's
@@ -1547,7 +1535,7 @@ public:
 		const QColor light = studioBandPaintColor(painter, tokens);
 		const int pointed = state.pressedIndex >= 0 ? state.pressedIndex : state.hoveredIndex;
 
-		painter.save();
+		QPainterStateGuard painterState(&painter);
 		painter.setRenderHint(QPainter::Antialiasing, true);
 		painter.setRenderHint(QPainter::TextAntialiasing, true);
 
@@ -1563,7 +1551,7 @@ public:
 		painter.setPen(Qt::NoPen);
 		painter.fillPath(channel, dark ? QColor(0, 0, 0, lit ? 92 : 62) : withAlpha(tokens.text, lit ? 20 : 12));
 
-		painter.save();
+		QPainterStateGuard channelState(&painter);
 		painter.setClipPath(channel);
 
 		// The sunken tell: a dark line settling just inside the top edge, the
@@ -1660,7 +1648,7 @@ public:
 			painter.drawRoundedRect(cap, capRadius, capRadius);
 		}
 
-		painter.restore();
+		channelState.restore();
 
 		// The channel's edge: a hairline that lights to the focus ring when
 		// the keyboard holds the control.
@@ -1700,8 +1688,6 @@ public:
 			painter.drawText(cell, Qt::AlignCenter,
 				cellMetrics.elidedText(state.labels.at(i), Qt::ElideRight, qMax(8.0, cell.width() - 6.0)));
 		}
-
-		painter.restore();
 	}
 
 	// The type badge is a lit glass chip: translucent fill with the ink and

--- a/Editor/widgets/cards/AllPassCardEditor.cpp
+++ b/Editor/widgets/cards/AllPassCardEditor.cpp
@@ -6,6 +6,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLocale>
+#include <QScopedValueRollback>
 #include <QSignalBlocker>
 #include <QVBoxLayout>
 
@@ -335,17 +336,18 @@ void AllPassCardEditor::setFrequency(double value, bool notify)
 	if (synchronizing)
 		return;
 
-	synchronizing = true;
 	{
-		const QSignalBlocker blocker(frequencyKnob);
-		frequencyKnob->setValue(logKnobValue(currentFrequency, FrequencyMin, FrequencyMax));
+		const QScopedValueRollback<bool> sync(synchronizing, true);
+		{
+			const QSignalBlocker blocker(frequencyKnob);
+			frequencyKnob->setValue(logKnobValue(currentFrequency, FrequencyMin, FrequencyMax));
+		}
+		frequencyKnob->setValueText(QLocale::c().toString(currentFrequency, 'f', 0));
+		{
+			const QSignalBlocker valueBlocker(frequencyValue);
+			frequencyValue->setValue(currentFrequency);
+		}
 	}
-	frequencyKnob->setValueText(QLocale::c().toString(currentFrequency, 'f', 0));
-	{
-		const QSignalBlocker blocker(frequencyValue);
-		frequencyValue->setValue(currentFrequency);
-	}
-	synchronizing = false;
 
 	if (notify)
 		emit updateModel();
@@ -358,18 +360,19 @@ void AllPassCardEditor::setWidth(double value, bool notify)
 		return;
 
 	const double asQ = bandwidthMode() ? BiQuadWidth::qFromBandwidth(currentWidth) : currentWidth;
-	synchronizing = true;
 	{
-		const QSignalBlocker blocker(widthKnob);
-		widthKnob->setValue(logKnobValue(asQ, QMin, QMax));
+		const QScopedValueRollback<bool> sync(synchronizing, true);
+		{
+			const QSignalBlocker blocker(widthKnob);
+			widthKnob->setValue(logKnobValue(asQ, QMin, QMax));
+		}
+		widthKnob->setValueText(QLocale::c().toString(currentWidth, 'f', 3));
+		{
+			const QSignalBlocker blocker(widthValue);
+			widthValue->setUnit(bandwidthMode() ? tr("Oct") : QString());
+			widthValue->setValue(currentWidth);
+		}
 	}
-	widthKnob->setValueText(QLocale::c().toString(currentWidth, 'f', 3));
-	{
-		const QSignalBlocker blocker(widthValue);
-		widthValue->setUnit(bandwidthMode() ? tr("Oct") : QString());
-		widthValue->setValue(currentWidth);
-	}
-	synchronizing = false;
 
 	if (notify)
 		emit updateModel();

--- a/Editor/widgets/cards/ScalarKnobCardEditor.cpp
+++ b/Editor/widgets/cards/ScalarKnobCardEditor.cpp
@@ -2,6 +2,7 @@
 
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QScopedValueRollback>
 #include <QSignalBlocker>
 #include <QVBoxLayout>
 
@@ -79,17 +80,18 @@ void ScalarKnobCardEditor::synchronizeScalar(double value, int knobValue,
 	if (synchronizing || editableValue == nullptr)
 		return;
 
-	synchronizing = true;
 	{
-		const QSignalBlocker knobBlocker(knob);
-		knob->setValue(knobValue);
+		const QScopedValueRollback<bool> sync(synchronizing, true);
+		{
+			const QSignalBlocker knobBlocker(knob);
+			knob->setValue(knobValue);
+		}
+		knob->setValueText(knobText);
+		{
+			const QSignalBlocker valueBlocker(editableValue);
+			editableValue->setValue(value);
+		}
 	}
-	knob->setValueText(knobText);
-	{
-		const QSignalBlocker valueBlocker(editableValue);
-		editableValue->setValue(value);
-	}
-	synchronizing = false;
 
 	if (notify)
 		emit updateModel();


### PR DESCRIPTION
## Summary

- replace all 35 manual `QPainter::save()` / `restore()` sites in the seven current skin sources with Qt 6.9+'s `QPainterStateGuard`
- use `QScopedValueRollback<bool>` for the AllPass and scalar-knob re-entrancy flags, restoring them before `updateModel()` is emitted
- preserve intentional mid-function painter restore points with `QPainterStateGuard::restore()` and keep nested clip scopes lexical

## Why

Manual painter-state balancing and flag resets are easy to leave unbalanced on an early return or exception. The project is fixed on Qt 6.10.1, so Qt's own RAII types cover both cases without local helper classes.

## Validation

- Qt 6.10.1 Release/AVX2 Editor build (`qmake` + `nmake`)
- offscreen skin gallery: 1,020 images generated successfully
- same-path baseline comparison: 1,019/1,020 PNGs SHA-256-identical; the only remaining difference was 34 pixels in the platform file dialog's back-button hover, outside the repository painter code
- offscreen skin-switch regression: 30 switches over 150 rows, 0 failures, 881 ms worst case (5,000 ms limit)
- `git diff --check`

Closes #233