### PR TITLE
refactor(helpers): put audiodg access in one module

### DIFF
--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -362,6 +362,7 @@
     <ClInclude Include="helpers\GainIterator.h" />
     <ClInclude Include="helpers\IRegistry.h" />
     <ClInclude Include="helpers\RegistryTransaction.h" />
+    <ClInclude Include="helpers\WindowsVersion.h" />
     <ClInclude Include="helpers\LogHelper.h" />
     <ClInclude Include="helpers\FftwRAII.h" />
     <ClInclude Include="helpers\FftwPlanningPolicy.h" />
@@ -457,6 +458,7 @@
     <ClCompile Include="helpers\GainIterator.cpp" />
     <ClCompile Include="helpers\IRegistry.cpp" />
     <ClCompile Include="helpers\RegistryTransaction.cpp" />
+    <ClCompile Include="helpers\WindowsVersion.cpp" />
     <ClCompile Include="helpers\LogHelper.cpp" />
     <ClCompile Include="helpers\MemoryHelper.cpp" />
     <ClCompile Include="helpers\ParallelExecutor.cpp" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClInclude Include="helpers\RegistryTransaction.h">
       <Filter>helpers</Filter>
     </ClInclude>
+    <ClInclude Include="helpers\WindowsVersion.h">
+      <Filter>helpers</Filter>
+    </ClInclude>
     <ClInclude Include="helpers\LogHelper.h">
       <Filter>helpers</Filter>
     </ClInclude>
@@ -374,6 +377,9 @@
       <Filter>helpers</Filter>
     </ClCompile>
     <ClCompile Include="helpers\RegistryTransaction.cpp">
+      <Filter>helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="helpers\WindowsVersion.cpp">
       <Filter>helpers</Filter>
     </ClCompile>
     <ClCompile Include="helpers\LogHelper.cpp">

--- a/DeviceSelector/DeviceSelector.cpp
+++ b/DeviceSelector/DeviceSelector.cpp
@@ -20,6 +20,7 @@
 #include "stdafx.h"
 #include <DeviceAPOInfo.h>
 #include <helpers/RegistryHelper.h>
+#include <helpers/WindowsVersion.h>
 #include <helpers/ServiceHelper.h>
 #include <helpers/Win32Resource.h>
 #include <QPropertyAnimation>
@@ -54,7 +55,7 @@ DeviceSelector::DeviceSelector(QWidget* parent)
 		QMessageBox::critical(this, tr("Error while accessing the registry"), QString::fromStdWString(e.getMessage()));
 	}
 
-	if (!RegistryHelper::isWindowsVersionAtLeast(6, 3)) // Windows 8.1
+	if (!WindowsVersion::isAtLeast(6, 3)) // Windows 8.1
 	{
 		ui.installModeComboBox->removeItem(2);
 		ui.installModeComboBox->removeItem(1);
@@ -519,7 +520,7 @@ void DeviceSelector::updateButtons()
 	ui.useOriginalAPOPreMixCheckBox->setChecked(installState.useOriginalAPOPreMix && hasOriginalAPOPreMix);
 	ui.useOriginalAPOPostMixCheckBox->setChecked(installState.useOriginalAPOPostMix && hasOriginalAPOPostMix);
 
-	if (RegistryHelper::isWindowsVersionAtLeast(6, 3)) // Windows 8.1
+	if (WindowsVersion::isAtLeast(6, 3)) // Windows 8.1
 		ui.installModeComboBox->setCurrentIndex(installState.installMode);
 
 	ui.allowSilentBufferCheckBox->setChecked(installState.allowSilentBufferModification);

--- a/DeviceSelector/DeviceSelector.pro
+++ b/DeviceSelector/DeviceSelector.pro
@@ -40,6 +40,7 @@ SOURCES += \
 	skins/MatrixDeviceSkin.cpp \
 	../helpers/ServiceHelper.cpp \
 	../helpers/ApoRegistration.cpp \
+	../helpers/AudioEngineAccess.cpp \
 	stdafx.cpp
 
 HEADERS += \
@@ -57,6 +58,7 @@ HEADERS += \
 	skins/DeviceSkinPainter.h \
 	../helpers/ServiceHelper.h \
 	../helpers/ApoRegistration.h \
+	../helpers/AudioEngineAccess.h \
 	resource.h \
 	stdafx.h
 

--- a/DeviceSelector/DeviceSelector.vcxproj
+++ b/DeviceSelector/DeviceSelector.vcxproj
@@ -426,6 +426,7 @@
     <ClInclude Include="..\Editor\skins\SkinThemeData.h" />
     <ClCompile Include="..\helpers\ServiceHelper.cpp" />
     <ClCompile Include="..\helpers\ApoRegistration.cpp" />
+    <ClCompile Include="..\helpers\AudioEngineAccess.cpp" />
     <ClCompile Include="DeviceSelector.cpp" />
     <ClInclude Include="..\helpers\ServiceHelper.h" />
     <QtMoc Include="DeviceTestDialog.h" />

--- a/DeviceSelector/DeviceSelector.vcxproj.filters
+++ b/DeviceSelector/DeviceSelector.vcxproj.filters
@@ -32,6 +32,9 @@
     <ClCompile Include="..\helpers\ServiceHelper.cpp">
       <Filter>helpers</Filter>
     </ClCompile>
+    <ClCompile Include="..\helpers\AudioEngineAccess.cpp">
+      <Filter>helpers</Filter>
+    </ClCompile>
     <ClCompile Include="..\helpers\ApoRegistration.cpp">
       <Filter>helpers</Filter>
     </ClCompile>

--- a/DeviceSelector/DeviceTestThread.cpp
+++ b/DeviceSelector/DeviceTestThread.cpp
@@ -20,6 +20,7 @@
 #include "stdafx.h"
 #include <chrono>
 #include <helpers/RegistryHelper.h>
+#include <helpers/WindowsVersion.h>
 #include <helpers/ServiceHelper.h>
 #include <helpers/ComPtr.h>
 #include <ObjBase.h>
@@ -31,7 +32,7 @@ using std::thread;
 DeviceTestThread::DeviceTestThread(QObject* parent, const QVector<std::shared_ptr<DeviceAPOInfo>>& devices)
 	: QThread(parent)
 {
-	bool isNewerWindows = RegistryHelper::isWindowsVersionAtLeast(6, 3); // Windows 8.1
+	bool isNewerWindows = WindowsVersion::isAtLeast(6, 3); // Windows 8.1
 	for (const std::shared_ptr<DeviceAPOInfo>& apoInfo : devices)
 	{
 		if (apoInfo->isDisabled() || apoInfo->isUnplugged())

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -26,6 +26,8 @@ SOURCES += main.cpp\
 	../helpers/RegistryHelper.cpp \
 	../helpers/IRegistry.cpp \
 	../helpers/RegistryTransaction.cpp \
+	../helpers/WindowsVersion.cpp \
+	../helpers/AudioEngineAccess.cpp \
 	../helpers/ServiceHelper.cpp \
 	../helpers/ApoRegistration.cpp \
 	../helpers/AudioFormatProbe.cpp \
@@ -298,6 +300,8 @@ HEADERS  += \
 	../helpers/RegistryHelper.h \
 	../helpers/IRegistry.h \
 	../helpers/RegistryTransaction.h \
+	../helpers/WindowsVersion.h \
+	../helpers/AudioEngineAccess.h \
 	../helpers/ServiceHelper.h \
 	../helpers/ApoRegistration.h \
 	../helpers/AudioFormatProbe.h \

--- a/Editor/guis/ConvolutionFilterGUI.cpp
+++ b/Editor/guis/ConvolutionFilterGUI.cpp
@@ -22,7 +22,7 @@
 #include "Editor/helpers/ConvolutionPathHelper.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "filters/ConvolutionCommand.h"
-#include "helpers/RegistryHelper.h"
+#include "helpers/AudioEngineAccess.h"
 #include "helpers/SndfileRAII.h"
 #include "ConvolutionFilterGUI.h"
 #include "ui_ConvolutionFilterGUI.h"
@@ -110,17 +110,7 @@ void ConvolutionFilterGUI::updateFileInfo()
 		{
 			path = QDir::toNativeSeparators(fileInfo.absoluteFilePath());
 
-			ACCESS_MASK mask = GENERIC_READ;
-			try
-			{
-				mask = RegistryHelper::getFileAccessForUser(path.toStdWString(), SECURITY_LOCAL_SERVICE_RID);
-			}
-			catch (const RegistryException& e)
-			{
-				// ignore
-			}
-
-			if ((mask & GENERIC_READ) != GENERIC_READ && (mask & FILE_GENERIC_READ) != FILE_GENERIC_READ)
+			if (!AudioEngineAccess::isReadableByAudioEngine(path.toStdWString()))
 			{
 				error = tr("The file is not readable for the audio service.\nChange the file permissions or copy the file to the config directory.");
 				labelsVisible = false;

--- a/Editor/guis/IncludeFilterGUI.cpp
+++ b/Editor/guis/IncludeFilterGUI.cpp
@@ -19,7 +19,7 @@
 
 #include <QFileDialog>
 
-#include "helpers/RegistryHelper.h"
+#include "helpers/AudioEngineAccess.h"
 #include "Editor/SkinManager.h"
 #include "Editor/skins/ISkin.h"
 #include "IncludeFilterGUI.h"
@@ -120,17 +120,7 @@ void IncludeFilterGUI::updateFileInfo()
 		{
 			path = QDir::toNativeSeparators(fileInfo.absoluteFilePath());
 
-			ACCESS_MASK mask = GENERIC_READ;
-			try
-			{
-				mask = RegistryHelper::getFileAccessForUser(path.toStdWString(), SECURITY_LOCAL_SERVICE_RID);
-			}
-			catch (const RegistryException& e)
-			{
-				// ignore
-			}
-
-			if ((mask & GENERIC_READ) != GENERIC_READ && (mask & FILE_GENERIC_READ) != FILE_GENERIC_READ)
+			if (!AudioEngineAccess::isReadableByAudioEngine(path.toStdWString()))
 				error = tr("The file is not readable for the audio service.\nChange the file permissions or copy the file to the config directory.");
 		}
 	}

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -27,6 +27,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include "helpers/AudioEngineAccess.h"
 #include "helpers/StringHelper.h"
 #include "filters/VSTPluginCommand.h"
 #include "Editor/helpers/GUIHelper.h"
@@ -432,17 +433,7 @@ void VSTPluginFilterGUI::updatePermissionWarning()
 		return;
 	}
 
-	ACCESS_MASK mask = GENERIC_READ;
-	try
-	{
-		mask = RegistryHelper::getFileAccessForUser(library->getLibPath(), SECURITY_LOCAL_SERVICE_RID);
-	}
-	catch (const RegistryException& e)
-	{
-		// ignore
-	}
-
-	if ((mask & GENERIC_READ) != GENERIC_READ && (mask & FILE_GENERIC_READ) != FILE_GENERIC_READ)
+	if (!AudioEngineAccess::isReadableByAudioEngine(library->getLibPath()))
 	{
 		QString text = tr("The library is not readable by the audio service.\nChange the file permissions or copy the file to the VSTPlugins directory.");
 
@@ -467,17 +458,7 @@ void VSTPluginFilterGUI::updatePermissionWarning()
 			QFile file(path);
 			if (file.exists())
 			{
-				ACCESS_MASK mask = GENERIC_READ;
-				try
-				{
-					mask = RegistryHelper::getFileAccessForUser(path.toStdWString(), SECURITY_LOCAL_SERVICE_RID);
-				}
-				catch (const RegistryException& e)
-				{
-					// ignore
-				}
-
-				if ((mask & GENERIC_READ) != GENERIC_READ && (mask & FILE_GENERIC_READ) != FILE_GENERIC_READ)
+				if (!AudioEngineAccess::isReadableByAudioEngine(path.toStdWString()))
 					files.append(path);
 			}
 		}

--- a/Editor/widgets/cards/FileReferenceController.Dialogs.cpp
+++ b/Editor/widgets/cards/FileReferenceController.Dialogs.cpp
@@ -13,7 +13,7 @@
 #include "Editor/import/ConfigDependencyScanner.h"
 #include "Editor/import/ImportDialog.h"
 #include "Editor/import/ImportExecutor.h"
-#include "helpers/RegistryHelper.h"
+#include "helpers/AudioEngineAccess.h"
 
 QString FileReferenceController::chooseExistingFile(QWidget* parent,
 	const QString& title, const QString& initialPath,
@@ -41,17 +41,8 @@ bool FileReferenceController::isReadableByAudioService(const QString& absolutePa
 {
 	if (absolutePath.isEmpty() || qEnvironmentVariableIsSet("EAPO_SKIN_GALLERY"))
 		return true;
-	ACCESS_MASK mask = GENERIC_READ;
-	try
-	{
-		mask = RegistryHelper::getFileAccessForUser(
-			QDir::toNativeSeparators(absolutePath).toStdWString(), SECURITY_LOCAL_SERVICE_RID);
-	}
-	catch (const RegistryException&)
-	{
-	}
-	return (mask & GENERIC_READ) == GENERIC_READ
-		|| (mask & FILE_GENERIC_READ) == FILE_GENERIC_READ;
+	return AudioEngineAccess::isReadableByAudioEngine(
+		QDir::toNativeSeparators(absolutePath).toStdWString());
 }
 
 bool FileReferenceController::importIntoConfig(

--- a/Editor/widgets/cards/VSTCardEditor.cpp
+++ b/Editor/widgets/cards/VSTCardEditor.cpp
@@ -27,7 +27,7 @@
 #include <windows.h>
 
 #include "helpers/StringHelper.h"
-#include "helpers/RegistryHelper.h"
+#include "helpers/AudioEngineAccess.h"
 #include "filters/VSTPluginCommand.h"
 #include "Editor/helpers/GUIHelper.h"
 #include "Editor/SkinManager.h"
@@ -530,16 +530,7 @@ void VSTCardEditor::updatePermissionWarning()
 			QFile file(path);
 			if (file.exists())
 			{
-				ACCESS_MASK fileMask = GENERIC_READ;
-				try
-				{
-					fileMask = RegistryHelper::getFileAccessForUser(path.toStdWString(), SECURITY_LOCAL_SERVICE_RID);
-				}
-				catch (const RegistryException&)
-				{
-					// ignore
-				}
-				if ((fileMask & GENERIC_READ) != GENERIC_READ && (fileMask & FILE_GENERIC_READ) != FILE_GENERIC_READ)
+				if (!AudioEngineAccess::isReadableByAudioEngine(path.toStdWString()))
 					files.append(path);
 			}
 		}

--- a/Tests/EngineOrchestrationTests/DeviceApoInfoTests.cpp
+++ b/Tests/EngineOrchestrationTests/DeviceApoInfoTests.cpp
@@ -16,7 +16,7 @@
 	harder to remove.
 
 	Host dependency, deliberately not hidden: load()'s install-mode inference
-	asks RegistryHelper::isWindowsVersionAtLeast(6, 3), which reads the running
+	asks WindowsVersion::isAtLeast(6, 3), which reads the running
 	kernel32 and is not part of the port. The two inference tests therefore
 	expect whichever answer the host justifies rather than assuming Windows 8.1
 	or newer.
@@ -43,6 +43,7 @@
 #include "DeviceAPOInfo.h"
 #include "devices/DeviceAPOInfoKeys.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/WindowsVersion.h"
 #include "Tests/TestHarness.h"
 
 #include "FakeRegistry.h"
@@ -195,7 +196,7 @@ void testLoadWithForeignApoGuidsReportsNotInstalled(test::Harness& harness)
 	harness.expect(info.getOriginalAPOPostMix() == vendorPostMixGuid,
 		"the MFX slot answers the same way for the post-mix half");
 
-	const bool windows81OrNewer = RegistryHelper::isWindowsVersionAtLeast(6, 3);
+	const bool windows81OrNewer = WindowsVersion::isAtLeast(6, 3);
 	harness.expectEqual(static_cast<int>(info.getCurrentInstallState().installMode),
 		static_cast<int>(windows81OrNewer ? DeviceAPOInfo::INSTALL_SFX_EFX : DeviceAPOInfo::INSTALL_LFX_GFX),
 		"a driver that supplies SFX/MFX gets the SFX/EFX mode on Windows 8.1 and newer; before that only LFX/GFX exists");
@@ -228,7 +229,7 @@ void testLoadInfersSfxMfxForACombinedBluetoothDevice(test::Harness& harness)
 	DeviceAPOInfo info(registry);
 	harness.require(info.load(testDeviceGuid, otherDeviceGuid), "the device loads");
 
-	const bool windows81OrNewer = RegistryHelper::isWindowsVersionAtLeast(6, 3);
+	const bool windows81OrNewer = WindowsVersion::isAtLeast(6, 3);
 	harness.expectEqual(static_cast<int>(info.getCurrentInstallState().installMode),
 		static_cast<int>(windows81OrNewer ? DeviceAPOInfo::INSTALL_SFX_MFX : DeviceAPOInfo::INSTALL_LFX_GFX),
 		"a combined Bluetooth endpoint falls back to SFX/MFX because its EFX slot is never reached");

--- a/devices/DeviceAPOInfo.Load.cpp
+++ b/devices/DeviceAPOInfo.Load.cpp
@@ -11,6 +11,7 @@
 
 #include "helpers/StringHelper.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/WindowsVersion.h"
 
 using std::make_shared;
 using std::move;
@@ -216,7 +217,7 @@ bool DeviceAPOInfo::load(const wstring& deviceGuid, wstring defaultDeviceGuid)
 		}
 		else
 		{
-			if (RegistryHelper::isWindowsVersionAtLeast(6, 3)) // Windows 8.1
+			if (WindowsVersion::isAtLeast(6, 3)) // Windows 8.1
 			{
 				// only use LFX/GFX if the audio driver supplied only those APOs
 				if (registry.keyExists(keyPath + L"\\FxProperties")

--- a/devices/DeviceAPOInfo.State.cpp
+++ b/devices/DeviceAPOInfo.State.cpp
@@ -11,6 +11,7 @@
 
 #include "helpers/StringHelper.h"
 #include "helpers/RegistryHelper.h"
+#include "helpers/WindowsVersion.h"
 
 using std::make_shared;
 using std::move;
@@ -40,7 +41,7 @@ wstring DeviceAPOInfo::getOriginalAPOPreMix()
 	{
 	case INSTALL_LFX_GFX:
 		guid = originalApoGuids[LFX_INDEX];
-		if (RegistryHelper::isWindowsVersionAtLeast(6, 3)) // Windows 8.1
+		if (WindowsVersion::isAtLeast(6, 3)) // Windows 8.1
 		{
 			if (originalApoGuids[LFX_INDEX] == APOGUID_NOVALUE && originalApoGuids[GFX_INDEX] == APOGUID_NOVALUE)
 				guid = originalApoGuids[SFX_INDEX];
@@ -71,7 +72,7 @@ wstring DeviceAPOInfo::getOriginalAPOPostMix()
 	{
 	case INSTALL_LFX_GFX:
 		guid = originalApoGuids[GFX_INDEX];
-		if (RegistryHelper::isWindowsVersionAtLeast(6, 3)) // Windows 8.1
+		if (WindowsVersion::isAtLeast(6, 3)) // Windows 8.1
 		{
 			if (originalApoGuids[LFX_INDEX] == APOGUID_NOVALUE && originalApoGuids[GFX_INDEX] == APOGUID_NOVALUE)
 				guid = originalApoGuids[MFX_INDEX];

--- a/docs/ArchitectureRoadmap.md
+++ b/docs/ArchitectureRoadmap.md
@@ -23,6 +23,7 @@
 | S6 | RT 경로에서 뮤텍스·파일 입출력·힙 할당 제거 | #226 | v2.26.5 |
 | S5a | 레지스트리 포트와 인메모리 가짜 도입 | #227 | (없음) |
 | S5b | 설치·제거·재설치를 `RegistryTransaction` 안에서 수행 | #236 | |
+| S5d | audiodg 접근 검사와 부여를 `AudioEngineAccess` 한 곳으로 | (진행 중) | |
 
 S1 이 고친 사용자 체감 결함은 셋입니다. 소수점 쉼표로 적은 `Preamp: -6,5 dB` 가 카드를 건드리는
 순간 `-6.0` 으로 덮어써지던 것, REW·Dirac 이 기본으로 내보내는 `Filter 1: ON IIR ...` 에
@@ -39,6 +40,18 @@ MFX 는 드라이버 것인 엔드포인트가 남았습니다. `load()` 는 둘
 헤더에 사후 조건으로 적었습니다. 판정 수단은 가짜 레지스트리에 한 값의 쓰기 실패를 심는 것입니다.
 실제 기계에서는 드라이버가 쥔 속성 하나의 ACL 로 일어나는 실패라서, 그 외의 방법으로는 중간에서
 끊어진 설치를 재현할 수 없습니다.
+
+S5d 는 "audiodg(LOCAL SERVICE)가 이 파일을 읽을 수 있는가"를 `helpers/AudioEngineAccess.h` 한 곳으로
+모았습니다. SID 와 각 주체가 필요한 권한을 한 표에 선언하고, 검사와 부여가 같은 표를 읽습니다.
+Editor 의 6개 호출 지점이 같은 마스크 비교를 각자 적던 것은 `isReadableByAudioEngine` 하나로 줄었고,
+`ApoRegistration` 의 `icacls` 인자 문자열 두 개도 그 모듈로 들어갔습니다.
+`getFileAccessForUser`(파일 ACL 질의)와 `isWindowsVersionAtLeast`(kernel32 버전 자원)는
+레지스트리 연산이 아니므로 각각 `AudioEngineAccess` 와 `helpers/WindowsVersion.h` 로 나갔습니다.
+승격 가정은 이제 로그로 드러납니다. 승격 없이 도는 훅을 거부하지는 않습니다.
+설치기가 부르는 훅이라 거부하면 Windows 가 마칠 수 있는 설치까지 깨뜨립니다.
+
+`tools/` 의 두 PowerShell 스크립트는 아직 같은 지식을 따로 갖고 있습니다.
+그것을 프로그램 안으로 들이는 것은 S5c 의 `--diagnose` 몫입니다.
 
 ## 남은 작업
 
@@ -58,19 +71,6 @@ PowerShell 스크립트의 검사를 프로그램 안으로 들여옵니다.
 관련해서 `Editor/main.cpp` 는 Velopack 훅을 `LogHelper::useUserFile` 보다 **먼저** 실행합니다.
 그래서 훅 출력이 `%TEMP%\EqualizerAPO.log` 로 떨어지고, 승격 후에는 그 `%TEMP%` 가 다른 계정의 것일 수 있습니다.
 이것도 같이 다뤄야 합니다.
-
-### S5d. audiodg 접근 권한을 한 모듈로 (착수 전)
-
-"audiodg(LOCAL SERVICE)가 이 파일을 읽을 수 있는가"는 현장에서 가장 자주 나는 실패인데,
-검사와 수리가 세 언어 네 곳에 흩어져 있습니다. `RegistryHelper::getFileAccessForUser`(AuthZ, 읽기 전용 6곳),
-`ApoRegistration` 의 `icacls` 호출(부여), `Diagnose-EqualizerAPO.ps1`(`Get-Acl`), `Repair-EqualizerAPO.ps1`(`icacls` 재차).
-앱은 조건을 **감지**할 수 있고 권한을 **부여**할 수도 있는데, 둘을 함께 하는 경로가 없어서
-사용자에게 PowerShell 스크립트를 받으라고 안내합니다.
-
-**방향.** `isReadableByAudioEngine(path)`, `grantEngineAccess(installRoot)`, `grantConfigAccess(configDir)` 를
-가진 모듈 하나에 SID 와 권한 표를 한 번만 선언합니다. `getFileAccessForUser` 와 `isWindowsVersionAtLeast` 는
-레지스트리 연산이 아니므로 `RegistryHelper` 에서 내보냅니다.
-`ApoRegistration::install/uninstall` 이 승격을 가정만 하고 검사하지 않으므로 `requiresElevation()` 단언도 함께 둡니다.
 
 ### S7. 설정 파싱의 오류 모델 (착수 전)
 

--- a/docs/ArchitectureRoadmap.md
+++ b/docs/ArchitectureRoadmap.md
@@ -23,7 +23,7 @@
 | S6 | RT 경로에서 뮤텍스·파일 입출력·힙 할당 제거 | #226 | v2.26.5 |
 | S5a | 레지스트리 포트와 인메모리 가짜 도입 | #227 | (없음) |
 | S5b | 설치·제거·재설치를 `RegistryTransaction` 안에서 수행 | #236 | |
-| S5d | audiodg 접근 검사와 부여를 `AudioEngineAccess` 한 곳으로 | (진행 중) | |
+| S5d | audiodg 접근 검사와 부여를 `AudioEngineAccess` 한 곳으로 | #237 | (없음) |
 
 S1 이 고친 사용자 체감 결함은 셋입니다. 소수점 쉼표로 적은 `Preamp: -6,5 dB` 가 카드를 건드리는
 순간 `-6.0` 으로 덮어써지던 것, REW·Dirac 이 기본으로 내보내는 `Filter 1: ON IIR ...` 에

--- a/helpers/ApoRegistration.cpp
+++ b/helpers/ApoRegistration.cpp
@@ -33,6 +33,7 @@
 #include <objidl.h>
 
 #include "AbstractAPOInfo.h"
+#include "AudioEngineAccess.h"
 #include "ComPtr.h"
 #include "DeviceAPOInfo.h"
 #include "LogHelper.h"
@@ -46,15 +47,6 @@ constexpr wchar_t kRegPath[] = L"HKEY_LOCAL_MACHINE\\SOFTWARE\\EqualizerAPO";
 constexpr wchar_t kAudioRegPath[] = L"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Audio";
 constexpr wchar_t kAudioServiceName[] = L"AudioSrv";
 constexpr wchar_t kAudioEndpointBuilderServiceName[] = L"AudioEndpointBuilder";
-
-std::wstring systemPath()
-{
-	wchar_t buffer[MAX_PATH];
-	UINT length = GetSystemDirectoryW(buffer, MAX_PATH);
-	if (length == 0 || length > MAX_PATH)
-		return L"C:\\Windows\\System32";
-	return std::wstring(buffer, length);
-}
 
 std::wstring joinPath(const std::wstring& a, const std::wstring& b)
 {
@@ -102,42 +94,6 @@ void logLine(const wchar_t* level, const wchar_t* format, ...)
 }
 }
 
-int ApoRegistration::waitForProcess(const std::wstring& executable, const std::wstring& arguments, unsigned timeoutMs)
-{
-	std::wstring commandLine = L"\"" + executable + L"\" " + arguments;
-	std::vector<wchar_t> mutableCommand(commandLine.begin(), commandLine.end());
-	mutableCommand.push_back(L'\0');
-
-	STARTUPINFOW startupInfo;
-	ZeroMemory(&startupInfo, sizeof(startupInfo));
-	startupInfo.cb = sizeof(startupInfo);
-	startupInfo.dwFlags = STARTF_USESHOWWINDOW;
-	startupInfo.wShowWindow = SW_HIDE;
-
-	winutil::UniqueProcessInformation processInfo;
-
-	if (!CreateProcessW(executable.c_str(), mutableCommand.data(), nullptr, nullptr, FALSE,
-			CREATE_NO_WINDOW, nullptr, nullptr, &startupInfo, processInfo.put()))
-	{
-		logLine(L"ERR", L"CreateProcess failed for %s (gle=%lu)", executable.c_str(), GetLastError());
-		return -1;
-	}
-
-	DWORD waitResult = WaitForSingleObject(processInfo.process(), timeoutMs);
-	DWORD exitCode = static_cast<DWORD>(-1);
-	if (waitResult == WAIT_OBJECT_0)
-	{
-		GetExitCodeProcess(processInfo.process(), &exitCode);
-	}
-	else
-	{
-		logLine(L"ERR", L"%s timed out after %u ms", executable.c_str(), timeoutMs);
-		TerminateProcess(processInfo.process(), 1);
-	}
-
-	return static_cast<int>(exitCode);
-}
-
 int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregister)
 {
 	// LOAD_WITH_ALTERED_SEARCH_PATH resolves EqualizerAPO.dll's own dependencies
@@ -165,6 +121,15 @@ int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregis
 
 ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 {
+	// Both hooks write HKLM and rewrite ACLs on the install tree, so they only
+	// work elevated. That was an assumption nothing checked: an unelevated run
+	// failed later, one operation at a time, with a registry error that says
+	// nothing about elevation. Say it once, at the top, and keep going - the
+	// hooks are invoked by the installer and a refusal here would break an
+	// install that Windows may still be able to complete.
+	if (!AudioEngineAccess::isElevated())
+		logLine(L"WARN", L"install() is running unelevated; HKLM writes and ACL grants will fail");
+
 	std::wstring dllPath = joinPath(installDir, L"EqualizerAPO.dll");
 	if (!fileExists(dllPath))
 	{
@@ -194,38 +159,26 @@ ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 		return Result::RegistryFailed;
 	}
 
-	// audiodg.exe runs as LOCAL SERVICE (*S-1-5-19) and loads EqualizerAPO.dll
-	// via the COM InprocServer32 path written below. When Velopack installs the
-	// app under %LocalAppData% the default ACL only grants the installing user
-	// and Administrators, so the audio engine fails to map the DLL and Windows
-	// reports the device as access-denied / invalidated from outside (the
-	// symptom users see is GetMixFormat / Initialize returning E_ACCESSDENIED
-	// in DeviceSelector). Widen the ACL on the whole install root for both
-	// LOCAL SERVICE (RX recursive) and Users (RX recursive) before any APO
-	// registration takes effect.
-	// Trust boundary: installDir and the executable paths come from the local
-	// install location, and the principals are built-in well-known SIDs, not from
-	// network or untrusted user input. Spawning system icacls.exe / regsvr32 and
-	// widening these ACLs is therefore safe. Preserve this assumption — if these
-	// inputs ever become caller-supplied, they must be validated/quoted first.
-	std::wstring icacls = joinPath(systemPath(), L"icacls.exe");
-	std::wstring installAclArgs = L"\"" + installDir + L"\" "
-		L"/grant *S-1-5-19:(OI)(CI)RX "
-		L"/grant *S-1-5-32-545:(OI)(CI)RX "
-		L"/T /C /Q";
-	int rc = waitForProcess(icacls, installAclArgs, 30000);
-	if (rc != 0)
-		logLine(L"WARN", L"icacls (install root) returned %d, continuing", rc);
+	// audiodg.exe loads EqualizerAPO.dll via the COM InprocServer32 path written
+	// below, and when Velopack installs the app under %LocalAppData% the default
+	// ACL only grants the installing user and Administrators - so the audio engine
+	// cannot map the DLL and the symptom the user sees is GetMixFormat or
+	// Initialize returning E_ACCESSDENIED in DeviceSelector. Widen the tree before
+	// any APO registration takes effect. Who gets what, and the trust boundary the
+	// grant relies on, are in helpers/AudioEngineAccess.cpp.
+	AudioEngineAccess::Grant installGrant = AudioEngineAccess::grantEngineAccess(installDir);
+	if (installGrant != AudioEngineAccess::Grant::Applied)
+		logLine(L"WARN", L"Install root access grant %s, continuing", AudioEngineAccess::describe(installGrant));
 
-	rc = registerComServer(dllPath, false);
+	int rc = registerComServer(dllPath, false);
 	if (rc != 0)
 	{
 		logLine(L"ERR", L"DllRegisterServer returned 0x%08X", rc);
 		return Result::RegistrationFailed;
 	}
 
-	if (!secureConfigDir(joinPath(installDir, L"config")))
-		logLine(L"WARN", L"icacls (config dir) failed, continuing");
+	// secureConfigDir already logs which grant failed.
+	secureConfigDir(joinPath(installDir, L"config"));
 
 	// Velopack's vpk pack only emits a shortcut for --mainExe (Editor.exe).
 	// DeviceSelector is the elevated companion that performs per-device APO
@@ -240,6 +193,9 @@ ApoRegistration::Result ApoRegistration::install(const std::wstring& installDir)
 
 ApoRegistration::Result ApoRegistration::uninstall(const std::wstring& installDir)
 {
+	if (!AudioEngineAccess::isElevated())
+		logLine(L"WARN", L"uninstall() is running unelevated; device APO removal and HKLM cleanup will fail");
+
 	bool serviceWasRunning = stopAudioService();
 
 	const Result deviceResult = uninstallAllDeviceApos([](const std::wstring& message) {
@@ -384,15 +340,12 @@ bool ApoRegistration::startAudioService()
 
 bool ApoRegistration::secureConfigDir(const std::wstring& configDir)
 {
-	// Users:F so the user can edit configs, LOCAL SERVICE modify (M) so
-	// audiodg can read them and write APO trace logs. Built-in well-known
-	// SIDs and a local path — same trust boundary note as install().
-	std::wstring icacls = joinPath(systemPath(), L"icacls.exe");
-	std::wstring configAclArgs = L"\"" + configDir + L"\" "
-		L"/grant *S-1-5-32-545:(OI)(CI)F "
-		L"/grant *S-1-5-19:(OI)(CI)M "
-		L"/T /C /Q";
-	return waitForProcess(icacls, configAclArgs, 30000) == 0;
+	// Who needs what on a config directory is declared once, in
+	// helpers/AudioEngineAccess.cpp, together with the check that verifies it.
+	const AudioEngineAccess::Grant grant = AudioEngineAccess::grantConfigAccess(configDir);
+	if (grant != AudioEngineAccess::Grant::Applied)
+		logLine(L"WARN", L"Config directory access grant %s", AudioEngineAccess::describe(grant));
+	return grant == AudioEngineAccess::Grant::Applied;
 }
 
 namespace

--- a/helpers/ApoRegistration.h
+++ b/helpers/ApoRegistration.h
@@ -51,8 +51,6 @@ public:
 	// config root it creates. Returns false when icacls reports a failure.
 	static bool secureConfigDir(const std::wstring& configDir);
 
-	static int waitForProcess(const std::wstring& executable, const std::wstring& arguments, unsigned timeoutMs = 30000);
-
 	// Registers (or unregisters) the EqualizerAPO COM in-proc server by calling
 	// its DllRegisterServer / DllUnregisterServer export directly, instead of
 	// spawning regsvr32.exe. Avoids the external process and returns the real

--- a/helpers/AudioEngineAccess.cpp
+++ b/helpers/AudioEngineAccess.cpp
@@ -1,0 +1,306 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	See AudioEngineAccess.h for why this module exists.
+
+	The grants are applied by spawning the system icacls.exe rather than by
+	building an ACL here. That is what ApoRegistration did before the code moved,
+	and it is kept on purpose: icacls walks the tree, merges with the existing
+	DACL, and reports per-file failures, all of which a hand-written
+	SetNamedSecurityInfo loop would have to reproduce. This is the code path that
+	decides whether a user's audio works at all, so it is a bad place to trade
+	proven behaviour for elegance.
+
+	Trust boundary, carried over with the code: the paths come from the local
+	install location and the principals are built-in well-known SIDs, never from
+	network or user input. If either ever becomes caller-supplied it has to be
+	validated and quoted before it reaches a command line.
+*/
+
+#include "AudioEngineAccess.h"
+
+#include <vector>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <aclapi.h>
+#include <authz.h>
+#include <sddl.h>
+
+#include "LogHelper.h"
+#include "Win32Resource.h"
+
+namespace
+{
+// THE TABLE. Every principal this program cares about, the SID literal icacls
+// takes, and the RID the AuthZ check needs. Both directions read from here, so a
+// grant and the check that verifies it cannot drift apart.
+//
+// LOCAL SERVICE (S-1-5-19) is the account audiodg.exe runs under, and
+// BUILTIN\Users (S-1-5-32-545) is what covers a non-administrator running the
+// Editor or Device Selector.
+constexpr wchar_t kLocalServiceSid[] = L"*S-1-5-19";
+constexpr wchar_t kUsersSid[] = L"*S-1-5-32-545";
+
+// icacls exit codes: 0 is complete success, and anything else means at least one
+// file was refused. It prints the count of failures, which is why a non-zero code
+// is reported as a partial application rather than as a total failure - the
+// remaining files did get the grant.
+constexpr int kIcaclsSuccess = 0;
+
+std::wstring systemPath()
+{
+	wchar_t buffer[MAX_PATH];
+	UINT length = GetSystemDirectoryW(buffer, MAX_PATH);
+	if (length == 0 || length > MAX_PATH)
+		return L"C:\\Windows\\System32";
+	return std::wstring(buffer, length);
+}
+
+std::wstring joinPath(const std::wstring& directory, const std::wstring& leaf)
+{
+	if (directory.empty())
+		return leaf;
+	wchar_t last = directory.back();
+	if (last == L'\\' || last == L'/')
+		return directory + leaf;
+	return directory + L"\\" + leaf;
+}
+
+bool pathExists(const std::wstring& path)
+{
+	return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+}
+
+// Runs a system tool to completion and returns its exit code, or -1 when it
+// could not be started or timed out. Moved here with the icacls calls it exists
+// for; nothing else in the tree spawned a process through the old copy.
+int runToCompletion(const std::wstring& executable, const std::wstring& arguments, unsigned timeoutMs)
+{
+	std::wstring commandLine = L"\"" + executable + L"\" " + arguments;
+	std::vector<wchar_t> mutableCommand(commandLine.begin(), commandLine.end());
+	mutableCommand.push_back(L'\0');
+
+	STARTUPINFOW startupInfo;
+	ZeroMemory(&startupInfo, sizeof(startupInfo));
+	startupInfo.cb = sizeof(startupInfo);
+	startupInfo.dwFlags = STARTF_USESHOWWINDOW;
+	startupInfo.wShowWindow = SW_HIDE;
+
+	winutil::UniqueProcessInformation processInfo;
+
+	if (!CreateProcessW(executable.c_str(), mutableCommand.data(), nullptr, nullptr, FALSE,
+			CREATE_NO_WINDOW, nullptr, nullptr, &startupInfo, processInfo.put()))
+	{
+		LogFStatic(L"[AudioEngineAccess] CreateProcess failed for %s (gle=%lu)", executable.c_str(), GetLastError());
+		return -1;
+	}
+
+	DWORD waitResult = WaitForSingleObject(processInfo.process(), timeoutMs);
+	DWORD exitCode = static_cast<DWORD>(-1);
+	if (waitResult == WAIT_OBJECT_0)
+	{
+		GetExitCodeProcess(processInfo.process(), &exitCode);
+	}
+	else
+	{
+		LogFStatic(L"[AudioEngineAccess] %s timed out after %u ms", executable.c_str(), timeoutMs);
+		TerminateProcess(processInfo.process(), 1);
+	}
+
+	return static_cast<int>(exitCode);
+}
+
+// The AuthZ access check, moved out of RegistryHelper. It was never a registry
+// operation: it asks what a principal would be granted on a *file*, and its
+// presence in RegistryHelper.h is part of why that header has to pull in the
+// Win32 headers for every translation unit that wants to read a registry value.
+// Sub-authorities of one well-known SID. Two are needed because the accounts
+// this module asks about are not the same shape: LOCAL SERVICE is S-1-5-19, one
+// sub-authority under NT AUTHORITY, while BUILTIN\Users is S-1-5-32-545, an alias
+// inside the built-in domain. Building the second one with a single
+// sub-authority would silently produce S-1-5-545, a SID that exists nowhere and
+// would therefore be granted nothing - the check would report every path as
+// closed to normal users.
+struct WellKnownSid
+{
+	BYTE subAuthorityCount;
+	DWORD first;
+	DWORD second;
+};
+
+constexpr WellKnownSid kLocalService = {1, SECURITY_LOCAL_SERVICE_RID, 0};
+constexpr WellKnownSid kUsers = {2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_USERS};
+
+unsigned long accessForSid(const std::wstring& path, const WellKnownSid& principal)
+{
+	winutil::UniqueLocalPtr<void> securityDescriptor;
+	if (GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION
+		| GROUP_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr, securityDescriptor.put()) != ERROR_SUCCESS)
+		throw AccessQueryException(L"Error in GetNamedSecurityInfoW for " + path);
+
+	winutil::UniqueAuthzResourceManager manager;
+	if (!AuthzInitializeResourceManager(AUTHZ_RM_FLAG_NO_AUDIT, nullptr, nullptr, nullptr, nullptr, manager.put()))
+		throw AccessQueryException(L"Error in AuthzInitializeResourceManager for " + path);
+
+	winutil::UniqueSid sid;
+	SID_IDENTIFIER_AUTHORITY authority = SECURITY_NT_AUTHORITY;
+	if (!AllocateAndInitializeSid(&authority, principal.subAuthorityCount,
+			principal.first, principal.second, 0, 0, 0, 0, 0, 0, sid.put()))
+		throw AccessQueryException(L"Error in AllocateAndInitializeSid for " + path);
+
+	LUID unusedId = {0};
+	winutil::UniqueAuthzContext context;
+	if (!AuthzInitializeContextFromSid(0, sid.get(), manager.get(), nullptr, unusedId, nullptr, context.put()))
+		throw AccessQueryException(L"Error in AuthzInitializeContextFromSid for " + path);
+
+	AUTHZ_ACCESS_REQUEST request = {0};
+	request.DesiredAccess = MAXIMUM_ALLOWED;
+	request.PrincipalSelfSid = nullptr;
+	request.ObjectTypeList = nullptr;
+	request.ObjectTypeListLength = 0;
+	request.OptionalArguments = nullptr;
+
+	AUTHZ_ACCESS_REPLY reply = {0};
+	BYTE buffer[1024];
+	RtlZeroMemory(buffer, sizeof(buffer));
+	reply.ResultListLength = 1;
+	reply.GrantedAccessMask = reinterpret_cast<ACCESS_MASK*>(buffer);
+	reply.Error = reinterpret_cast<DWORD*>(buffer + sizeof(ACCESS_MASK));
+
+	if (!AuthzAccessCheck(0, context.get(), &request, nullptr, securityDescriptor.get(), nullptr, 0, &reply, nullptr))
+		throw AccessQueryException(L"Error in AuthzAccessCheck for " + path);
+
+	return *reply.GrantedAccessMask;
+}
+
+// The two spellings of "may read this" a granted mask can carry. Every one of
+// the six Editor call sites tested both, because a grant written as generic
+// rights and a grant written as file-specific rights both mean the same thing
+// here.
+bool maskAllowsRead(unsigned long mask)
+{
+	return (mask & GENERIC_READ) == GENERIC_READ
+		|| (mask & FILE_GENERIC_READ) == FILE_GENERIC_READ;
+}
+
+bool maskAllowsExecute(unsigned long mask)
+{
+	return (mask & GENERIC_EXECUTE) == GENERIC_EXECUTE
+		|| (mask & FILE_GENERIC_EXECUTE) == FILE_GENERIC_EXECUTE;
+}
+
+AudioEngineAccess::Grant applyGrant(const std::wstring& path, const std::wstring& grants)
+{
+	if (!AudioEngineAccess::isElevated())
+		return AudioEngineAccess::Grant::NotElevated;
+	if (!pathExists(path))
+		return AudioEngineAccess::Grant::Failed;
+
+	const std::wstring icacls = joinPath(systemPath(), L"icacls.exe");
+	// /T recurses, /C keeps going past a file it cannot touch, /Q keeps the log
+	// readable.
+	const std::wstring arguments = L"\"" + path + L"\" " + grants + L" /T /C /Q";
+	const int code = runToCompletion(icacls, arguments, 30000);
+	if (code == kIcaclsSuccess)
+		return AudioEngineAccess::Grant::Applied;
+	if (code < 0)
+		return AudioEngineAccess::Grant::Failed;
+	return AudioEngineAccess::Grant::PartlyApplied;
+}
+} // namespace
+
+namespace AudioEngineAccess
+{
+
+bool isElevated()
+{
+	winutil::UniqueHandle token;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, token.put()))
+		return false;
+
+	TOKEN_ELEVATION elevation = {};
+	DWORD returned = 0;
+	if (!GetTokenInformation(token.get(), TokenElevation, &elevation, sizeof(elevation), &returned))
+		return false;
+
+	return elevation.TokenIsElevated != 0;
+}
+
+unsigned long accessForAudioEngine(const std::wstring& path)
+{
+	return accessForSid(path, kLocalService);
+}
+
+unsigned long accessForUsers(const std::wstring& path)
+{
+	return accessForSid(path, kUsers);
+}
+
+bool isReadableByAudioEngine(const std::wstring& path)
+{
+	try
+	{
+		return maskAllowsRead(accessForAudioEngine(path));
+	}
+	catch (const AccessQueryException&)
+	{
+		// A path whose descriptor cannot be read is not a path we know to be
+		// unreadable, and every caller turns a false into a warning on screen.
+		return true;
+	}
+}
+
+bool isRunnableByUsers(const std::wstring& path)
+{
+	try
+	{
+		const unsigned long mask = accessForUsers(path);
+		return maskAllowsRead(mask) && maskAllowsExecute(mask);
+	}
+	catch (const AccessQueryException&)
+	{
+		return true;
+	}
+}
+
+Grant grantEngineAccess(const std::wstring& installRoot)
+{
+	// Read+execute for both: audiodg maps EqualizerAPO.dll out of this tree, and
+	// a non-administrator has to be able to start the Editor from it.
+	const std::wstring grants =
+		L"/grant " + std::wstring(kLocalServiceSid) + L":(OI)(CI)RX "
+		L"/grant " + std::wstring(kUsersSid) + L":(OI)(CI)RX";
+	return applyGrant(installRoot, grants);
+}
+
+Grant grantConfigAccess(const std::wstring& configDir)
+{
+	// Full control for Users because this is the directory they edit configs in,
+	// and modify for LOCAL SERVICE because audiodg both reads the configs and
+	// writes the APO trace log next to them.
+	const std::wstring grants =
+		L"/grant " + std::wstring(kUsersSid) + L":(OI)(CI)F "
+		L"/grant " + std::wstring(kLocalServiceSid) + L":(OI)(CI)M";
+	return applyGrant(configDir, grants);
+}
+
+const wchar_t* describe(Grant grant)
+{
+	switch (grant)
+	{
+	case Grant::Applied:
+		return L"applied";
+	case Grant::PartlyApplied:
+		return L"applied except for files that refused it";
+	case Grant::NotElevated:
+		return L"not attempted: the process is not elevated";
+	case Grant::Failed:
+		break;
+	}
+	return L"failed";
+}
+
+} // namespace AudioEngineAccess

--- a/helpers/AudioEngineAccess.h
+++ b/helpers/AudioEngineAccess.h
@@ -1,0 +1,97 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	"Can audiodg.exe read this file?" - asked and answered in one place.
+
+	That question is the most common failure in the field. audiodg.exe hosts every
+	APO and runs as LOCAL SERVICE, so a file it cannot read is a filter that never
+	loads. When Velopack installs the app under %LocalAppData%, the default ACL
+	grants the installing user and Administrators and nobody else, and the symptom
+	the user sees is not a permission error but IAudioClient::GetMixFormat or
+	Initialize returning E_ACCESSDENIED for the device.
+
+	Before this module the knowledge was spread over three languages and four
+	places: RegistryHelper::getFileAccessForUser did the AuthZ access check (read
+	only, six call sites in the Editor), ApoRegistration spawned icacls with the
+	grant spelled out inline, tools/Diagnose-EqualizerAPO.ps1 re-derived the same
+	check with Get-Acl, and tools/Repair-EqualizerAPO.ps1 re-derived the same grant
+	with icacls again. The program could detect the condition and could also fix
+	it, but no single path did both, so users were told to download a PowerShell
+	script for a repair the app was already capable of.
+
+	The SIDs and the permissions each one needs are declared here once, and both
+	directions - the check and the grant - read them from the same table.
+
+	Grants require elevation. isElevated() is exported so callers can say so
+	instead of discovering it from a failure: ApoRegistration's hooks run elevated
+	by contract, and the assertion there is what makes the contract visible.
+*/
+
+#pragma once
+
+#include <string>
+
+namespace AudioEngineAccess
+{
+
+// Result of a grant. PartlyApplied is real and worth reporting separately:
+// icacls walks a tree and reports failures per file, so a locked file somewhere
+// below the root leaves the rest correctly granted.
+enum class Grant
+{
+	Applied,
+	PartlyApplied,
+	Failed,
+	NotElevated
+};
+
+// True when this process can rewrite an ACL on a machine-wide path at all.
+bool isElevated();
+
+// The access mask LOCAL SERVICE would be granted on this path. Throws
+// AccessQueryException when the path cannot be queried, which is not the same as
+// "no access" and must not be reported as such.
+unsigned long accessForAudioEngine(const std::wstring& path);
+// The same for the BUILTIN\Users group, which is what a non-administrator
+// running the Editor or Device Selector is covered by.
+unsigned long accessForUsers(const std::wstring& path);
+
+// The question the field asks. Answers true when the path cannot be queried:
+// every caller uses this to decide whether to warn, and warning because a query
+// failed would put a permission error on screen for a file that is fine.
+bool isReadableByAudioEngine(const std::wstring& path);
+// Whether a non-administrator can run what lives here.
+bool isRunnableByUsers(const std::wstring& path);
+
+// Grants LOCAL SERVICE and Users read+execute over the install tree, so audiodg
+// can map EqualizerAPO.dll and a non-administrator can start the Editor.
+Grant grantEngineAccess(const std::wstring& installRoot);
+// Grants Users full control (they edit configs) and LOCAL SERVICE modify
+// (audiodg reads configs and writes APO trace logs) over the config tree.
+Grant grantConfigAccess(const std::wstring& configDir);
+
+// A one-line, human-readable form of a Grant, for logs and the diagnostics
+// report. Deliberately not translated: it goes into a log file a maintainer
+// reads, not onto the screen.
+const wchar_t* describe(Grant grant);
+
+} // namespace AudioEngineAccess
+
+// Thrown by the accessFor* functions when the path's security descriptor cannot
+// be read. It is a separate type from RegistryException because this module is
+// about files, and because a caller that catches it has to decide something
+// different from "no access".
+class AccessQueryException
+{
+public:
+	explicit AccessQueryException(const std::wstring& message)
+		: message(message) {}
+
+	const std::wstring& getMessage() const
+	{
+		return message;
+	}
+
+private:
+	std::wstring message;
+};

--- a/helpers/IRegistry.h
+++ b/helpers/IRegistry.h
@@ -23,12 +23,12 @@
 #include <vector>
 
 // Deliberately no <windows.h> here, and that is the whole point of this file.
-// RegistryHelper.h has to pull the Win32 headers in because getFileAccessForUser
-// returns an ACCESS_MASK and openKey takes a REGSAM; every translation unit that
-// wants to talk to the registry therefore inherits the Win32 macro soup. This
-// port names only the operations the device layer performs, all of which are
-// expressible in standard types, so a test can include it and stand up a fake
-// without a Windows toolchain in its include path.
+// RegistryHelper.h has to pull the Win32 headers in because openKey takes a
+// REGSAM and returns a handle wrapper; every translation unit that wants to talk
+// to the registry therefore inherits the Win32 macro soup. This port names only
+// the operations the device layer performs, all of which are expressible in
+// standard types, so a test can include it and stand up a fake without a Windows
+// toolchain in its include path.
 //
 // The method set is what devices/DeviceAPOInfo.{Install,Load,State,
 // Uninstall}.cpp, DeviceAPOInfo.cpp and VoicemeeterAPOInfo.cpp call, plus the
@@ -46,9 +46,10 @@
 // first. A port that could only describe the forward direction would leave the
 // rollback guessing.
 //
-// RegistryHelper keeps the rest (openKey, formatExportHeader) plus the three
-// members that are not registry operations at all and so have no business in a
-// registry port: getGuidString, isWindowsVersionAtLeast, getFileAccessForUser.
+// RegistryHelper keeps the rest (openKey, formatExportHeader) plus getGuidString,
+// which is not a registry operation at all. The other two that were not - the
+// Windows version probe and the file access check - have since moved to
+// helpers/WindowsVersion.h and helpers/AudioEngineAccess.h.
 //
 // CONTRACT - read this before writing a fake, because the real implementation's
 // failure behaviour is what the install and uninstall code is built around.

--- a/helpers/RegistryHelper.cpp
+++ b/helpers/RegistryHelper.cpp
@@ -36,7 +36,6 @@ using std::vector;
 using std::wofstream;
 using std::wstring;
 
-DWORD RegistryHelper::windowsVersion = 0;
 
 wstring RegistryHelper::readValue(const wstring& key, const wstring& valuename)
 {
@@ -371,52 +370,6 @@ void RegistryHelper::takeOwnership(const wstring& key)
 		throw RegistryException(L"Error in AdjustTokenPrivileges while taking ownership");
 }
 
-ACCESS_MASK RegistryHelper::getFileAccessForUser(const std::wstring& path, unsigned long rid)
-{
-	ACCESS_MASK result;
-
-	winutil::UniqueLocalPtr<void> sd;
-	if (GetNamedSecurityInfoW(path.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION
-		| GROUP_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr, sd.put()) != ERROR_SUCCESS)
-		throw RegistryException(L"Error in GetNamedSecurityInfoW while getting file access");
-
-	winutil::UniqueAuthzResourceManager manager;
-	if (!AuthzInitializeResourceManager(AUTHZ_RM_FLAG_NO_AUDIT, nullptr, nullptr, nullptr, nullptr, manager.put()))
-		throw RegistryException(L"Error in AuthzInitializeResourceManager while getting file access");
-
-	winutil::UniqueSid sid;
-	SID_IDENTIFIER_AUTHORITY authority = SECURITY_NT_AUTHORITY;
-	if (!AllocateAndInitializeSid(&authority, 1, rid, 0, 0, 0, 0, 0, 0, 0, sid.put()))
-		throw RegistryException(L"Error in AllocateAndInitializeSid while getting file access");
-
-	LUID unusedId = {0};
-	winutil::UniqueAuthzContext context;
-	if (!AuthzInitializeContextFromSid(0, sid.get(), manager.get(), nullptr, unusedId, nullptr, context.put()))
-		throw RegistryException(L"Error in AuthzInitializeContextFromSid while getting file access");
-
-	AUTHZ_ACCESS_REQUEST request = {0};
-
-	request.DesiredAccess = MAXIMUM_ALLOWED;
-	request.PrincipalSelfSid = nullptr;
-	request.ObjectTypeList = nullptr;
-	request.ObjectTypeListLength = 0;
-	request.OptionalArguments = nullptr;
-
-	AUTHZ_ACCESS_REPLY reply = {0};
-	BYTE buf[1024];
-	RtlZeroMemory(buf, sizeof(buf));
-	reply.ResultListLength = 1;
-	reply.GrantedAccessMask = reinterpret_cast<ACCESS_MASK*>(buf);
-	reply.Error = reinterpret_cast<DWORD*>(buf + sizeof(ACCESS_MASK));
-
-	if (!AuthzAccessCheck(0, context.get(), &request, nullptr, sd.get(), nullptr, 0, &reply, nullptr))
-		throw RegistryException(L"Error in AuthzAccessCheck while getting file access");
-
-	result = *reply.GrantedAccessMask;
-
-	return result;
-}
-
 bool RegistryHelper::keyExists(const wstring& key)
 {
 	bool result;
@@ -538,31 +491,6 @@ wstring RegistryHelper::getGuidString(GUID guid)
 	std::wstring result(temp.get());
 
 	return result;
-}
-
-bool RegistryHelper::isWindowsVersionAtLeast(unsigned major, unsigned minor)
-{
-	if (windowsVersion == 0)
-	{
-		DWORD handle;
-		DWORD size = GetFileVersionInfoSizeW(L"kernel32.dll", &handle);
-		if (size != 0)
-		{
-			vector<char> data(size);
-			if (GetFileVersionInfo(L"kernel32.dll", handle, size, data.data()))
-			{
-				VS_FIXEDFILEINFO* info;
-				UINT len;
-				if (VerQueryValueW(data.data(), L"\\", reinterpret_cast<LPVOID*>(&info), &len))
-					windowsVersion = info->dwProductVersionMS;
-			}
-		}
-	}
-
-	// this will only work for major and minor up to 99
-	DWORD compareVersion = ((major / 10) << 20) + ((major % 10) << 16) + ((minor / 10) << 4) + (minor % 10);
-
-	return windowsVersion >= compareVersion;
 }
 
 winutil::UniqueRegistryKey RegistryHelper::openKey(const wstring& key, REGSAM samDesired)

--- a/helpers/RegistryHelper.h
+++ b/helpers/RegistryHelper.h
@@ -55,7 +55,6 @@ public:
 	static void deleteKey(const std::wstring& key);
 	static void makeWritable(const std::wstring& key);
 	static void takeOwnership(const std::wstring& key);
-	static ACCESS_MASK getFileAccessForUser(const std::wstring& path, unsigned long rid);
 	static std::vector<std::wstring> enumSubKeys(const std::wstring& key);
 	static std::vector<std::wstring> enumValues(const std::wstring& key);
 	static bool keyExists(const std::wstring& key);
@@ -64,13 +63,10 @@ public:
 	static std::wstring formatExportHeader(const std::wstring& key);
 	static void saveToFile(const std::wstring& key, const std::vector<std::wstring>& valuenames, const std::wstring& filepath);
 	static std::wstring getGuidString(GUID guid);
-	static bool isWindowsVersionAtLeast(unsigned major, unsigned minor);
 	static winutil::UniqueRegistryKey openKey(const std::wstring& key, REGSAM samDesired);
 
 private:
 	static std::wstring splitKey(const std::wstring& key, HKEY* rootKey);
-
-	static unsigned long windowsVersion;
 };
 
 class RegistryException

--- a/helpers/WindowsVersion.cpp
+++ b/helpers/WindowsVersion.cpp
@@ -1,0 +1,62 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	See WindowsVersion.h. Moved out of RegistryHelper unchanged apart from the
+	cache becoming a function-local static, which also makes the first call
+	thread-safe; the old file-scope DWORD was written without synchronisation and
+	is reached from the Editor's GUI thread and the device threads alike.
+*/
+
+#include "stdafx.h"
+
+#include "WindowsVersion.h"
+
+#include <vector>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+namespace
+{
+DWORD productVersion()
+{
+	// C++11 guarantees the initialisation runs once even under concurrent first
+	// calls, which the previous plain-DWORD cache did not.
+	static const DWORD cached = []() -> DWORD {
+		DWORD handle;
+		DWORD size = GetFileVersionInfoSizeW(L"kernel32.dll", &handle);
+		if (size == 0)
+			return 0;
+
+		std::vector<char> data(size);
+		if (!GetFileVersionInfoW(L"kernel32.dll", handle, size, data.data()))
+			return 0;
+
+		VS_FIXEDFILEINFO* info;
+		UINT length;
+		if (!VerQueryValueW(data.data(), L"\\", reinterpret_cast<LPVOID*>(&info), &length))
+			return 0;
+
+		return info->dwProductVersionMS;
+	}();
+
+	return cached;
+}
+}
+
+namespace WindowsVersion
+{
+
+bool isAtLeast(unsigned major, unsigned minor)
+{
+	// The version resource packs each decimal digit into its own nibble, so 6.3
+	// is 0x00060003. This only works for major and minor up to 99.
+	const DWORD compareVersion = ((major / 10) << 20) + ((major % 10) << 16)
+		+ ((minor / 10) << 4) + (minor % 10);
+
+	return productVersion() >= compareVersion;
+}
+
+} // namespace WindowsVersion

--- a/helpers/WindowsVersion.h
+++ b/helpers/WindowsVersion.h
@@ -1,0 +1,33 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Which Windows this is running on.
+
+	The answer decides real behaviour in three places: which APO slots a device
+	can be installed into (LFX/GFX only exist as the sole option before Windows
+	8.1), whether the 24H2 subkeys below FxProperties have to be worked around,
+	and what Device Selector offers. It lived in RegistryHelper, which reads it
+	out of kernel32's version resource - not a registry operation at all, and one
+	of the two members that forced every translation unit wanting a registry read
+	to inherit the Win32 headers.
+
+	The answer is cached after the first call because it cannot change while the
+	process runs.
+*/
+
+#pragma once
+
+namespace WindowsVersion
+{
+
+// True when the running kernel is at least this major.minor. Both are limited to
+// 99, which the packed comparison below relies on and which no Windows version
+// has come close to.
+//
+// Reads kernel32.dll's product version rather than asking GetVersionEx, because
+// GetVersionEx has been subject to application-compatibility shimming since
+// Windows 8.1 and lies to a process without the right manifest - which is the
+// exact version boundary the callers care about.
+bool isAtLeast(unsigned major, unsigned minor);
+
+} // namespace WindowsVersion


### PR DESCRIPTION
`docs/ArchitectureRoadmap.md`의 S5d입니다. #236에 이어지는 두 번째 PR입니다.

## 왜

"audiodg(LOCAL SERVICE)가 이 파일을 읽을 수 있는가"는 현장에서 가장 자주 나는 실패인데, 그것을 답하는 코드가 세 언어 네 곳에 흩어져 있었습니다.

- `RegistryHelper::getFileAccessForUser`: AuthZ 검사. Editor 호출 지점 6곳이 각자 같은 마스크 비교(`GENERIC_READ` 또는 `FILE_GENERIC_READ`)와 같은 try/catch와 같은 기본값을 적었습니다.
- `ApoRegistration`: `icacls` 인자 문자열 두 개를 인라인으로.
- `tools/Diagnose-EqualizerAPO.ps1`: 같은 검사를 `Get-Acl`로 다시.
- `tools/Repair-EqualizerAPO.ps1`: 같은 부여를 `icacls`로 다시.

앱은 조건을 감지할 수도 있고 권한을 부여할 수도 있는데 둘을 함께 하는 경로가 없어서, 앱이 이미 할 수 있는 수리를 위해 사용자에게 PowerShell 스크립트를 받으라고 안내했습니다.

## 무엇을

`helpers/AudioEngineAccess.h`에 주체와 각자 필요한 권한을 한 표로 선언하고, 검사와 부여가 그 표를 함께 읽습니다. Editor 6곳은 `isReadableByAudioEngine(path)` 한 줄이 되고, `ApoRegistration`의 icacls 두 곳은 `grantEngineAccess`/`grantConfigAccess`가 됩니다. 부여 결과는 종료 코드가 아니라 `Applied`/`PartlyApplied`/`Failed`/`NotElevated`로 돌아옵니다. icacls는 트리를 걸으며 파일별로 실패를 보고하므로 '일부만 적용'은 실제로 구분할 값입니다.

**Users SID는 예전 코드가 다루지 않던 주의가 필요했습니다.** LOCAL SERVICE는 S-1-5-19로 하위 권한 하나지만, BUILTIN\Users는 S-1-5-32-545로 내장 도메인 안의 별칭입니다. 하위 권한을 하나로 만들면 아무 데도 없는 S-1-5-545가 나와 새 Users 검사가 모든 경로를 '닫혀 있음'으로 보고했을 겁니다. 표가 하위 권한 개수를 함께 들고 있는 이유입니다.

두 멤버가 `RegistryHelper`를 떠났습니다. 둘 다 레지스트리 연산이 아니기 때문입니다. `getFileAccessForUser`는 파일에 대해 묻는 것이라 새 모듈로, `isWindowsVersionAtLeast`는 kernel32의 버전 자원을 읽는 것이라 `helpers/WindowsVersion.h`로 갔습니다. 후자의 캐시는 함수 지역 static이 되어 첫 호출이 스레드 안전해졌습니다. 예전의 파일 범위 DWORD는 동기화 없이 Editor GUI 스레드와 장치 스레드에서 함께 읽고 썼습니다.

`ApoRegistration`의 두 훅은 승격을 가정만 하고 검사하지 않았습니다. 승격 없이 돌면 나중에 하나씩 실패하면서 승격을 언급하지 않는 레지스트리 오류만 남았습니다. 이제 맨 위에서 한 번 말하고 계속합니다. 거부하면 Windows가 마칠 수 있는 설치까지 깨뜨리기 때문입니다.

## 동작 변화

없습니다. icacls 인자는 문자 단위로 동일하고, 접근 검사는 보안 서술자를 읽지 못할 때 여전히 '읽을 수 있음'으로 답합니다(6개 호출 지점이 기본 마스크로 하던 것과 같습니다). `accessForUsers`/`isRunnableByUsers`는 새로 생겼지만 아직 호출자가 없습니다. S5c의 `--diagnose`가 쓸 예정입니다.

## 검증

`EngineOrchestrationTests` 1123 checks 통과, Editor와 DeviceSelector 둘 다 빌드했습니다.

실기계에서 부여가 도는 것은 확인하지 못했습니다. 승격된 설치 훅에서만 실행되고, 인자가 동일하다는 것이 근거입니다. `tools/`의 두 스크립트는 아직 같은 지식을 갖고 있습니다. 그것을 프로그램 안으로 들이는 것은 S5c의 `--diagnose` 몫입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)