### PR TITLE
ci: put the release pipeline's last inline code behind scripts and tests (audit #250 F067+F068+F056)

### DIFF
--- a/.github/scripts/Build-Solution.ps1
+++ b/.github/scripts/Build-Solution.ps1
@@ -32,11 +32,18 @@ $toolArchitecture = if ($Platform -eq "ARM64") { "ARM64" } else { "x64" }
 # fault at static init, so it belongs behind the same gate as the others.
 $runtimeTests = @()
 if ($CanExecute) { $runtimeTests += @("EditorLogicTests", "HybridConvTests", "EngineOrchestrationTests") }
+# The auto-detect installer is a Win32-only, CPU-baseline binary: it must run
+# on machines with no AVX at all, so it takes no arch flag, and one build
+# covers every variant. The avx2 leg builds it so a PR that breaks it fails
+# in CI instead of on release day (audit #250 F056); the other legs skip the
+# duplicate work, and create-release still builds its own copy to publish.
+$installerProject = if ($Platform -eq "x64" -and $SimdVariant -eq "avx2") { "Installer\Installer.vcxproj" } else { $null }
 $plan = [pscustomobject]@{
     Projects = $projects
     PlatformToolset = $platformToolset
     ToolArchitecture = $toolArchitecture
     RuntimeTests = $runtimeTests
+    InstallerProject = $installerProject
 }
 if ($PlanOnly) { return $plan }
 
@@ -81,6 +88,16 @@ if ($Platform -eq "x64") { $buildParams += "/p:EnableEnhancedInstructionSet=$Arc
 foreach ($project in $projects) {
     msbuild $project @buildParams
     if ($LASTEXITCODE -ne 0) { throw "Build failed for $project" }
+}
+
+if ($installerProject) {
+    $installerParams = @(
+        "/m", "/p:Configuration=$Configuration", "/p:Platform=Win32", "/t:rebuild",
+        "/p:PlatformToolset=$platformToolset",
+        "/p:PreferredToolArchitecture=$toolArchitecture"
+    )
+    msbuild $installerProject @installerParams
+    if ($LASTEXITCODE -ne 0) { throw "Build failed for $installerProject" }
 }
 
 $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$qtRoot\bin;$env:PATH"

--- a/.github/scripts/Initialize-DepsEnvironment.ps1
+++ b/.github/scripts/Initialize-DepsEnvironment.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+    Resolves the dependency include/lib paths under deps\ and exports them as
+    the *_INCLUDE / *_LIB / *_ROOT environment the vcxproj defaults consume.
+
+.DESCRIPTION
+    Extracted from the inline "Setup dependency structures" step in build.yml
+    (audit #250 F068): the step re-stated deps layout knowledge that
+    Directory.Build.props and setup-build.ps1 also carry, with no way to test
+    the probe-or-fail decisions outside a live runner.
+
+    The plan phase probes the layout (fftw3.h and libfftw3.lib are searched
+    for because the extracted FFTW archive nests them differently per
+    variant; the rest are fixed spellings off the deps root) and returns the
+    ordered name -> path map, throwing on the four fatal absences. Execution
+    appends the map to $env:GITHUB_ENV and prints the structure listings the
+    CI log always carried.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $DepsPath,
+    [switch] $PlanOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+$fftwHeader = Get-ChildItem -Path "$DepsPath\fftw\Include" -Recurse -Filter "fftw3.h" -ErrorAction SilentlyContinue | Select-Object -First 1
+$fftwLib = Get-ChildItem -Path "$DepsPath\fftw\Release" -Recurse -Filter "libfftw3.lib" -ErrorAction SilentlyContinue | Select-Object -First 1
+$mpxLib = Get-ChildItem -Path "$DepsPath\muparserx\build\Release" -Recurse -Filter "muparserx.lib" -ErrorAction SilentlyContinue | Select-Object -First 1
+
+if (-not $fftwHeader) { throw "fftw3.h not found under $DepsPath\fftw\Include" }
+if (-not $fftwLib) { throw "libfftw3.lib not found under $DepsPath\fftw\Release" }
+if (-not (Test-Path "$DepsPath\muparserx")) { throw "muparserx folder not found under $DepsPath" }
+if (-not $mpxLib) { throw "muparserx.lib not found under $DepsPath\muparserx\build\Release" }
+
+$environment = [ordered]@{
+    FFTW_INCLUDE       = $fftwHeader.Directory.FullName
+    FFTW_LIB           = $fftwLib.Directory.FullName
+    MUPARSERX_INCLUDE  = "$DepsPath\muparserx\parser"
+    MUPARSERX_LIB      = $mpxLib.Directory.FullName
+    LIBSNDFILE_INCLUDE = "$DepsPath\libsndfile\include"
+    LIBSNDFILE_LIB     = "$DepsPath\libsndfile\build\Release"
+    TCLAP_ROOT         = "$DepsPath\tclap"
+    # VST3 SDK root (contains pluginterfaces/) for VST3 hosting headers.
+    VST3_SDK           = "$DepsPath\vst3sdk"
+    # Highway header root (contains hwy/) for the portable SIMD kernels.
+    HIGHWAY_INCLUDE    = "$DepsPath\highway"
+    # Velopack runtime paths for the Editor's auto-update link.
+    VELOPACK_INCLUDE   = "$DepsPath\velopack_libc\include"
+    VELOPACK_LIB       = "$DepsPath\velopack_libc\lib"
+}
+
+if ($PlanOnly) {
+    return [pscustomobject]$environment
+}
+
+Write-Host "=== Dependency structures ==="
+foreach ($dependency in @(
+        @{ Name = "FFTW"; Path = "$DepsPath\fftw"; Depth = $null },
+        @{ Name = "muParserX"; Path = "$DepsPath\muparserx"; Depth = $null },
+        @{ Name = "libsndfile"; Path = "$DepsPath\libsndfile"; Depth = $null },
+        @{ Name = "TCLAP"; Path = "$DepsPath\tclap"; Depth = 1 }))
+{
+    Write-Host "`n$($dependency.Name) structure:"
+    if (Test-Path $dependency.Path) {
+        if ($null -ne $dependency.Depth) {
+            Get-ChildItem $dependency.Path -Recurse -Depth $dependency.Depth | Select-Object FullName
+        } else {
+            Get-ChildItem $dependency.Path -Recurse | Select-Object FullName
+        }
+    } else {
+        Write-Warning "$($dependency.Name) directory not found"
+    }
+}
+
+foreach ($pair in $environment.GetEnumerator()) {
+    "$($pair.Key)=$($pair.Value)" >> $env:GITHUB_ENV
+    Write-Host "$($pair.Key)=$($pair.Value)"
+}
+Write-Host "`nAll dependency paths configured successfully"

--- a/.github/scripts/Install-ReleaseBuild.ps1
+++ b/.github/scripts/Install-ReleaseBuild.ps1
@@ -13,7 +13,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$asset = "EqualizerAPO-XT-$Channel-$Channel-Setup.exe"
+Import-Module (Join-Path $PSScriptRoot "ReleaseAssets.psm1") -Force
+$asset = Get-SetupAssetName -Channel $Channel
 New-Item -ItemType Directory -Force -Path $DownloadDirectory | Out-Null
 
 if (-not $SkipDownload) {
@@ -26,7 +27,7 @@ if (-not $SkipDownload) {
 
     $sumArgs = @("release", "download")
     if (-not [string]::IsNullOrWhiteSpace($Tag)) { $sumArgs += $Tag }
-    $sumArgs += @("--repo", $Repository, "--pattern", "SHA256SUMS.txt",
+    $sumArgs += @("--repo", $Repository, "--pattern", (Get-ChecksumsAssetName),
         "--dir", $DownloadDirectory, "--clobber")
     gh @sumArgs
     if ($LASTEXITCODE -ne 0) {
@@ -44,7 +45,7 @@ if (-not (Test-Path -LiteralPath $setup)) {
     throw "Could not find $asset"
 }
 
-$sums = Join-Path $DownloadDirectory "SHA256SUMS.txt"
+$sums = Join-Path $DownloadDirectory (Get-ChecksumsAssetName)
 if (Test-Path -LiteralPath $sums) {
     $line = Get-Content -LiteralPath $sums |
         Where-Object { $_ -match ("  " + [regex]::Escape($asset) + '$') } |
@@ -73,7 +74,7 @@ if (-not $SkipInstall) {
 $root = $null
 $current = $null
 if (-not $SkipInstallRootResolution) {
-    $packId = "EqualizerAPO-XT-$Channel"
+    $packId = Get-VelopackPackId -Channel $Channel
     $candidates = @(
         (Join-Path $env:LOCALAPPDATA $packId),
         (Join-Path $env:ProgramData $packId)

--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -19,6 +19,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+Import-Module (Join-Path $PSScriptRoot "ReleaseAssets.psm1") -Force
 
 # Release-channel table for the SIMD/architecture builds. The channel KEYS are the
 # single source of truth in .github/simd-variants.psd1 (Variants[].Channel); the
@@ -55,7 +56,7 @@ $UnknownChannelGuidance = "Special-purpose asset. Use one of the setup executabl
 # The architecture-agnostic front-door installer (docs/AutoDetectInstaller.md).
 # It is not a channel: it detects the CPU at install time and pulls the matching
 # per-channel build. Featured first in the download table.
-$UniversalInstallerName = "EqualizerAPO-XT-Setup.exe"
+$UniversalInstallerName = Get-UniversalSetupAssetName
 $UniversalInstallerSortOrder = -1
 $UniversalInstallerGuidance = "Recommended. Detects your CPU (architecture and AVX level) and installs the matching build automatically. Use this unless you have a reason to pick a specific build below."
 

--- a/.github/scripts/New-VelopackRelease.ps1
+++ b/.github/scripts/New-VelopackRelease.ps1
@@ -1,0 +1,195 @@
+<#
+.SYNOPSIS
+    Packages and uploads the per-channel Velopack releases (and the source
+    zip) for a tag, resuming any channels a previous attempt left missing.
+
+.DESCRIPTION
+    Extracted from the inline "Create Velopack release" step in build.yml
+    (audit #250 F068): the 159 lines that actually create a release were the
+    last release-critical code outside the script + Pester pattern, so their
+    errors could only be discovered on release day.
+
+    The plan phase is pure: it enumerates the downloaded build artifacts,
+    resolves each to its manifest variant (audit F066 - the artifact name is
+    "<platform>-<simd>"; nothing re-derives channels by string convention),
+    filters against the missing-channel resume list from Publish-Release.ps1,
+    and answers what would be packed under which identity. -PlanOnly returns
+    that plan for Pester. Execution stages each channel's payload (Qt plugin
+    folders under qt\ because Editor.exe calls addLibraryPath("qt"), bundled
+    configs, doc shortcuts), downloads the previous release for delta
+    generation (a miss downgrades to a full package), then vpk pack/upload
+    and, when asked, uploads the source zip.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $Repository,
+    [Parameter(Mandatory)] [string] $Tag,
+    [Parameter(Mandatory)] [string] $PackVersion,
+    [Parameter(Mandatory)] [string] $TargetCommit,
+    [Parameter(Mandatory)] [string] $WorkspaceRoot,
+    [string] $InputRoot,
+    [string[]] $MissingChannels = @(),
+    [switch] $NeedsSource,
+    [string] $ManifestPath,
+    [switch] $PlanOnly
+)
+
+$ErrorActionPreference = "Stop"
+Import-Module (Join-Path $PSScriptRoot "ReleaseAssets.psm1") -Force
+
+if (-not $InputRoot) { $InputRoot = Join-Path $WorkspaceRoot "release-input" }
+if (-not $ManifestPath) { $ManifestPath = Join-Path $PSScriptRoot "..\simd-variants.psd1" }
+$manifest = Import-PowerShellDataFile $ManifestPath
+
+$buildArtifacts = @(Get-ChildItem -Path $InputRoot -Directory -Filter "EqualizerAPO-*" -ErrorAction SilentlyContinue)
+if ($buildArtifacts.Count -eq 0) {
+    throw "No build artifacts were found in $InputRoot"
+}
+
+$channelWork = @()
+foreach ($artifact in $buildArtifacts) {
+    $variant = $artifact.Name.Substring("EqualizerAPO-".Length)
+    $sep = $variant.IndexOf('-')
+    $variantPlatform = $variant.Substring(0, $sep)
+    $variantSimd = $variant.Substring($sep + 1)
+    $variantEntry = $manifest.Variants |
+        Where-Object { $_.Platform -eq $variantPlatform -and $_.Simd -eq $variantSimd } |
+        Select-Object -First 1
+    if (-not $variantEntry) {
+        throw "Artifact $($artifact.Name) has no matching variant in simd-variants.psd1"
+    }
+    $channel = $variantEntry.Channel
+    $channelWork += [pscustomobject]@{
+        ArtifactPath = $artifact.FullName
+        Variant      = $variant
+        Channel      = $channel
+        Skipped      = $MissingChannels -notcontains $channel
+        PackId       = Get-VelopackPackId -Channel $channel
+        PackTitle    = "EqualizerAPO-XT $variant"
+        Framework    = if ($variant -like "ARM64*" -or $variant -like "arm64*") { "vcredist143-arm64" } else { "vcredist143-x64" }
+        PackDir      = Join-Path $WorkspaceRoot "velopack-input\$channel"
+        OutputDir    = Join-Path $WorkspaceRoot "velopack-output\$channel"
+    }
+}
+
+$plan = [pscustomobject]@{
+    VpkVersion    = $manifest.Shared.VelopackVpkVersion
+    ReleaseName   = "EqualizerAPO-XT $PackVersion"
+    RepoUrl       = "https://github.com/$Repository"
+    Channels      = @($channelWork)
+    NeedsSource   = [bool]$NeedsSource
+    SourceZipPath = Join-Path $WorkspaceRoot (Get-SourceZipAssetName -PackVersion $PackVersion)
+}
+if ($PlanOnly) {
+    return $plan
+}
+
+dotnet tool install -g vpk --version $plan.VpkVersion
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
+
+$iconPath = Join-Path $WorkspaceRoot "Editor\icons\app-icon.ico"
+$configSource = Join-Path $WorkspaceRoot "Setup\config"
+$extrasSource = @(
+    (Join-Path $WorkspaceRoot "Setup\Configuration tutorial (online).url"),
+    (Join-Path $WorkspaceRoot "Setup\Configuration reference (online).url")
+)
+$qtPluginFolders = @('iconengines', 'imageformats', 'platforms', 'styles', 'tls')
+$mainExe = "Editor.exe"
+
+foreach ($work in $plan.Channels) {
+    if ($work.Skipped) {
+        Write-Host "Channel $($work.Channel) is already complete on $Tag; skipping."
+        continue
+    }
+
+    New-Item -ItemType Directory -Force -Path $work.OutputDir | Out-Null
+    if (Test-Path $work.PackDir) {
+        Remove-Item -Path $work.PackDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Force -Path $work.PackDir | Out-Null
+
+    Write-Host "`n=== Preparing Velopack pack dir for $($work.Variant) ==="
+    # Copy everything from the build artifact (binaries + Qt deps at top level)
+    Copy-Item -Path (Join-Path $work.ArtifactPath "*") -Destination $work.PackDir -Recurse -Force
+
+    # Editor.exe calls addLibraryPath("qt"), so Qt plugin folders must live under qt\
+    $qtTarget = Join-Path $work.PackDir "qt"
+    New-Item -ItemType Directory -Force -Path $qtTarget | Out-Null
+    foreach ($folder in $qtPluginFolders) {
+        $source = Join-Path $work.PackDir $folder
+        if (Test-Path $source) {
+            $dest = Join-Path $qtTarget $folder
+            if (Test-Path $dest) {
+                Remove-Item -Path $dest -Recurse -Force
+            }
+            Move-Item -Path $source -Destination $dest -Force
+            Write-Host "Relocated $folder -> qt\$folder"
+        }
+    }
+
+    # Bundle the sample configs and shortcuts
+    if (Test-Path $configSource) {
+        $configTarget = Join-Path $work.PackDir "config"
+        New-Item -ItemType Directory -Force -Path $configTarget | Out-Null
+        Copy-Item -Path (Join-Path $configSource "*") -Destination $configTarget -Recurse -Force
+    }
+    foreach ($extra in $extrasSource) {
+        if (Test-Path $extra) {
+            Copy-Item -Path $extra -Destination $work.PackDir -Force
+        }
+    }
+
+    if (-not (Test-Path (Join-Path $work.PackDir $mainExe))) {
+        throw "$mainExe not found in $($work.PackDir)"
+    }
+
+    vpk download github `
+        --repoUrl $plan.RepoUrl `
+        --token $env:GITHUB_TOKEN `
+        --outputDir $work.OutputDir `
+        --channel $work.Channel
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "No previous Velopack release was downloaded for channel $($work.Channel). Continuing with a full package."
+        $global:LASTEXITCODE = 0
+    }
+
+    $packArgs = @(
+        'pack',
+        '--packId', $work.PackId,
+        '--packVersion', $PackVersion,
+        '--packDir', $work.PackDir,
+        '--mainExe', $mainExe,
+        '--packTitle', $work.PackTitle,
+        '--packAuthors', 'EqualizerAPO-XT contributors',
+        '--outputDir', $work.OutputDir,
+        '--channel', $work.Channel,
+        '--framework', $work.Framework,
+        '--noPortable',
+        '--skipVeloAppCheck'
+    )
+    if (Test-Path $iconPath) {
+        $packArgs += @('--icon', $iconPath)
+    }
+
+    Write-Host "vpk $($packArgs -join ' ')"
+    vpk @packArgs
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    vpk upload github `
+        --repoUrl $plan.RepoUrl `
+        --token $env:GITHUB_TOKEN `
+        --outputDir $work.OutputDir `
+        --channel $work.Channel `
+        --publish `
+        --merge `
+        --releaseName $plan.ReleaseName `
+        --tag $Tag `
+        --targetCommitish $TargetCommit
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+if ($plan.NeedsSource) {
+    gh release upload $Tag $plan.SourceZipPath --clobber --repo $Repository
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}

--- a/.github/scripts/Publish-Release.ps1
+++ b/.github/scripts/Publish-Release.ps1
@@ -10,6 +10,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+Import-Module (Join-Path $PSScriptRoot "ReleaseAssets.psm1") -Force
 
 if (-not $PSBoundParameters.ContainsKey("AssetNames")) {
     $releaseJson = gh release view $Tag --repo $Repository --json assets,body 2>$null
@@ -33,18 +34,18 @@ else {
 $manifest = Import-PowerShellDataFile $ManifestPath
 $missingChannels = @()
 foreach ($channel in @($manifest.Variants.Channel)) {
-    $setup = "EqualizerAPO-XT-$channel-$channel-Setup.exe"
-    $feed = "releases.$channel.json"
+    $setup = Get-SetupAssetName -Channel $channel
+    $feed = Get-FeedAssetName -Channel $channel
     if ($AssetNames -notcontains $setup -or $AssetNames -notcontains $feed) {
         $missingChannels += $channel
     }
 }
 
-$sourceName = "EqualizerAPO-XT-source-$PackVersion.zip"
+$sourceName = Get-SourceZipAssetName -PackVersion $PackVersion
 $needsSource = $AssetNames -notcontains $sourceName
-$needsInstaller = $AssetNames -notcontains "EqualizerAPO-XT-Setup.exe"
+$needsInstaller = $AssetNames -notcontains (Get-UniversalSetupAssetName)
 $releaseShapeChanged = $missingChannels.Count -gt 0 -or $needsSource -or $needsInstaller
-$needsChecksums = $releaseShapeChanged -or $AssetNames -notcontains "SHA256SUMS.txt"
+$needsChecksums = $releaseShapeChanged -or $AssetNames -notcontains (Get-ChecksumsAssetName)
 $needsNotes = $releaseShapeChanged -or [string]::IsNullOrWhiteSpace($ReleaseNotes)
 $complete = -not $needsChecksums -and -not $needsNotes
 

--- a/.github/scripts/ReleaseAssets.psm1
+++ b/.github/scripts/ReleaseAssets.psm1
@@ -1,0 +1,43 @@
+# The release asset-name grammar, spelled once. Audit #250 F067: the
+# EqualizerAPO-XT-<channel>-<channel>-Setup.exe shape (the channel appears
+# twice because the Velopack pack id already embeds it and vpk appends the
+# channel again), the universal installer, the feed, the source zip, the
+# checksums file and the pack id used to live as parallel literals in two
+# languages and six files. PowerShell consumers import this module; the C++
+# consumers (Installer/AutoInstaller, UpdateChecker) include
+# helpers/ReleaseAssetNames.h, and ReleaseAssets.Tests.ps1 keeps the two
+# spellings in step.
+
+$script:ProductPrefix = "EqualizerAPO-XT"
+
+function Get-VelopackPackId {
+    param([Parameter(Mandatory)] [string] $Channel)
+    "$script:ProductPrefix-$Channel"
+}
+
+function Get-SetupAssetName {
+    param([Parameter(Mandatory)] [string] $Channel)
+    "$(Get-VelopackPackId -Channel $Channel)-$Channel-Setup.exe"
+}
+
+function Get-UniversalSetupAssetName {
+    "$script:ProductPrefix-Setup.exe"
+}
+
+function Get-FeedAssetName {
+    param([Parameter(Mandatory)] [string] $Channel)
+    "releases.$Channel.json"
+}
+
+function Get-SourceZipAssetName {
+    param([Parameter(Mandatory)] [string] $PackVersion)
+    "$script:ProductPrefix-source-$PackVersion.zip"
+}
+
+function Get-ChecksumsAssetName {
+    "SHA256SUMS.txt"
+}
+
+Export-ModuleMember -Function Get-VelopackPackId, Get-SetupAssetName,
+Get-UniversalSetupAssetName, Get-FeedAssetName, Get-SourceZipAssetName,
+Get-ChecksumsAssetName

--- a/.github/scripts/Test-VariantSync.ps1
+++ b/.github/scripts/Test-VariantSync.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-    Fails when the channel strings compiled into Installer/AutoInstaller.cpp drift
+    Fails when the channel strings compiled into Installer/AutoInstallerLogic.cpp drift
     from .github/simd-variants.psd1.
 
 .DESCRIPTION
-    AutoInstaller.cpp cannot read the manifest (it is a dependency-free compiled
+    AutoInstallerLogic.cpp cannot read the manifest (it is a dependency-free compiled
     C++ binary), so detectChannel() returns hardcoded channel literals. This lint
     extracts every channel-shaped wide-string literal (L"x64-..." / L"arm64-...")
     from the installer source and requires set equality with the manifest's
@@ -21,7 +21,7 @@ $manifestPath = Join-Path $RepoRoot ".github" "simd-variants.psd1"
 $manifest = Import-PowerShellDataFile -Path $manifestPath
 $manifestChannels = @($manifest.Variants | ForEach-Object { $_.Channel } | Sort-Object -Unique)
 
-$installerPath = Join-Path $RepoRoot "Installer" "AutoInstaller.cpp"
+$installerPath = Join-Path $RepoRoot "Installer" "AutoInstallerLogic.cpp"
 $source = Get-Content -Path $installerPath -Raw
 $pattern = 'L"((?:x64|arm64)-[a-z0-9][a-z0-9-]*)"'
 $installerChannels = @(
@@ -33,12 +33,12 @@ $unknownInInstaller = @($installerChannels | Where-Object { $manifestChannels -n
 
 if ($missingInInstaller.Count -gt 0 -or $unknownInInstaller.Count -gt 0) {
   if ($missingInInstaller.Count -gt 0) {
-    Write-Host "::error file=Installer/AutoInstaller.cpp::Missing manifest channels: $($missingInInstaller -join ', ')"
+    Write-Host "::error file=Installer/AutoInstallerLogic.cpp::Missing manifest channels: $($missingInInstaller -join ', ')"
   }
   if ($unknownInInstaller.Count -gt 0) {
-    Write-Host "::error file=Installer/AutoInstaller.cpp::Channels not in simd-variants.psd1: $($unknownInInstaller -join ', ')"
+    Write-Host "::error file=Installer/AutoInstallerLogic.cpp::Channels not in simd-variants.psd1: $($unknownInInstaller -join ', ')"
   }
-  throw "Installer/AutoInstaller.cpp and .github/simd-variants.psd1 are out of sync."
+  throw "Installer/AutoInstallerLogic.cpp and .github/simd-variants.psd1 are out of sync."
 }
 
-Write-Host "AutoInstaller.cpp channels match simd-variants.psd1: $($manifestChannels -join ', ')"
+Write-Host "AutoInstallerLogic.cpp channels match simd-variants.psd1: $($manifestChannels -join ', ')"

--- a/.github/scripts/Tests/BuildScripts.Tests.ps1
+++ b/.github/scripts/Tests/BuildScripts.Tests.ps1
@@ -12,6 +12,17 @@ Describe "extracted build script decisions" {
         # links Common.lib whole-archive and so now carries the variant's /arch
         # into a static initializer.
         $plan.RuntimeTests | Should -BeNullOrEmpty
+        # No x86 cross-build on the ARM64 leg; the avx2 leg owns the installer.
+        $plan.InstallerProject | Should -BeNullOrEmpty
+    }
+
+    It "builds the auto-detect installer on the avx2 leg only" {
+        $avx2 = & (Join-Path $PSScriptRoot "..\Build-Solution.ps1") `
+            -WorkspaceRoot $root -Platform x64 -SimdVariant avx2 -ArchFlag AdvancedVectorExtensions2 -PlanOnly
+        $avx2.InstallerProject | Should -Be "Installer\Installer.vcxproj"
+        $sse2 = & (Join-Path $PSScriptRoot "..\Build-Solution.ps1") `
+            -WorkspaceRoot $root -Platform x64 -SimdVariant sse2 -ArchFlag NotSet -PlanOnly
+        $sse2.InstallerProject | Should -BeNullOrEmpty
     }
 
     It "derives the AVX10 and ARM64 update channels" {

--- a/.github/scripts/Tests/Initialize-DepsEnvironment.Tests.ps1
+++ b/.github/scripts/Tests/Initialize-DepsEnvironment.Tests.ps1
@@ -1,0 +1,57 @@
+Describe "Initialize-DepsEnvironment.ps1 planning" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot "..\Initialize-DepsEnvironment.ps1"
+
+        function NewDepsTree {
+            $deps = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+            # FFTW nests per archive layout, so the script probes for the files.
+            New-Item -ItemType Directory -Force -Path "$deps\fftw\Include\nested" | Out-Null
+            Set-Content "$deps\fftw\Include\nested\fftw3.h" "// header"
+            New-Item -ItemType Directory -Force -Path "$deps\fftw\Release\x64" | Out-Null
+            Set-Content "$deps\fftw\Release\x64\libfftw3.lib" "lib"
+            New-Item -ItemType Directory -Force -Path "$deps\muparserx\parser" | Out-Null
+            New-Item -ItemType Directory -Force -Path "$deps\muparserx\build\Release" | Out-Null
+            Set-Content "$deps\muparserx\build\Release\muparserx.lib" "lib"
+            $deps
+        }
+    }
+
+    It "resolves the probed paths to the directories holding the files" {
+        $deps = NewDepsTree
+        $plan = & $scriptPath -DepsPath $deps -PlanOnly
+        $plan.FFTW_INCLUDE | Should -Be (Join-Path $deps "fftw\Include\nested")
+        $plan.FFTW_LIB | Should -Be (Join-Path $deps "fftw\Release\x64")
+        $plan.MUPARSERX_LIB | Should -Be (Join-Path $deps "muparserx\build\Release")
+    }
+
+    It "spells the fixed roots off the deps path" {
+        $deps = NewDepsTree
+        $plan = & $scriptPath -DepsPath $deps -PlanOnly
+        $plan.MUPARSERX_INCLUDE | Should -Be "$deps\muparserx\parser"
+        $plan.LIBSNDFILE_INCLUDE | Should -Be "$deps\libsndfile\include"
+        $plan.LIBSNDFILE_LIB | Should -Be "$deps\libsndfile\build\Release"
+        $plan.TCLAP_ROOT | Should -Be "$deps\tclap"
+        $plan.VST3_SDK | Should -Be "$deps\vst3sdk"
+        $plan.HIGHWAY_INCLUDE | Should -Be "$deps\highway"
+        $plan.VELOPACK_INCLUDE | Should -Be "$deps\velopack_libc\include"
+        $plan.VELOPACK_LIB | Should -Be "$deps\velopack_libc\lib"
+    }
+
+    It "fails loudly on each of the four fatal absences" {
+        $deps = NewDepsTree
+        Remove-Item "$deps\fftw\Include" -Recurse -Force
+        { & $scriptPath -DepsPath $deps -PlanOnly } | Should -Throw "*fftw3.h not found*"
+
+        $deps = NewDepsTree
+        Remove-Item "$deps\fftw\Release" -Recurse -Force
+        { & $scriptPath -DepsPath $deps -PlanOnly } | Should -Throw "*libfftw3.lib not found*"
+
+        $deps = NewDepsTree
+        Remove-Item "$deps\muparserx\build" -Recurse -Force
+        { & $scriptPath -DepsPath $deps -PlanOnly } | Should -Throw "*muparserx.lib not found*"
+
+        $deps = NewDepsTree
+        Remove-Item "$deps\muparserx" -Recurse -Force
+        { & $scriptPath -DepsPath $deps -PlanOnly } | Should -Throw "*muparserx folder not found*"
+    }
+}

--- a/.github/scripts/Tests/New-VelopackRelease.Tests.ps1
+++ b/.github/scripts/Tests/New-VelopackRelease.Tests.ps1
@@ -1,0 +1,66 @@
+Describe "New-VelopackRelease.ps1 planning" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot "..\New-VelopackRelease.ps1"
+        $manifestPath = Join-Path $PSScriptRoot "..\..\simd-variants.psd1"
+
+        function NewInputRoot([string[]] $artifactNames) {
+            $root = Join-Path $TestDrive ([guid]::NewGuid().ToString("N"))
+            $inputRoot = Join-Path $root "release-input"
+            New-Item -ItemType Directory -Force -Path $inputRoot | Out-Null
+            foreach ($name in $artifactNames) {
+                New-Item -ItemType Directory -Force -Path (Join-Path $inputRoot $name) | Out-Null
+            }
+            @{ Workspace = $root; InputRoot = $inputRoot }
+        }
+
+        function PlanFor([hashtable] $tree, [string[]] $missing, [switch] $needsSource) {
+            & $scriptPath -Repository owner/repo -Tag v9.9.9 -PackVersion 9.9.9 `
+                -TargetCommit abc123 -WorkspaceRoot $tree.Workspace `
+                -InputRoot $tree.InputRoot -MissingChannels $missing `
+                -NeedsSource:$needsSource -ManifestPath $manifestPath -PlanOnly
+        }
+    }
+
+    It "resolves channels from the manifest, not a naming convention" {
+        $tree = NewInputRoot @("EqualizerAPO-x64-avx10_1", "EqualizerAPO-ARM64-neon")
+        $plan = PlanFor $tree @("x64-avx10-1", "arm64-neon")
+        $plan.Channels | Should -HaveCount 2
+        # avx10_1 folds to the avx10-1 channel and arm64 keeps its own; both
+        # are exactly what a "x64- + simd" string convention would get wrong.
+        ($plan.Channels | Where-Object Variant -eq "x64-avx10_1").Channel | Should -Be "x64-avx10-1"
+        ($plan.Channels | Where-Object Variant -eq "ARM64-neon").Channel | Should -Be "arm64-neon"
+        ($plan.Channels | Where-Object Variant -eq "ARM64-neon").Framework | Should -Be "vcredist143-arm64"
+        ($plan.Channels | Where-Object Variant -eq "x64-avx10_1").Framework | Should -Be "vcredist143-x64"
+    }
+
+    It "packs under the grammar module's pack id" {
+        $tree = NewInputRoot @("EqualizerAPO-x64-avx2")
+        $plan = PlanFor $tree @("x64-avx2")
+        $plan.Channels[0].PackId | Should -Be "EqualizerAPO-XT-x64-avx2"
+        $plan.ReleaseName | Should -Be "EqualizerAPO-XT 9.9.9"
+    }
+
+    It "skips channels the release already carries (resume)" {
+        $tree = NewInputRoot @("EqualizerAPO-x64-avx2", "EqualizerAPO-x64-sse2")
+        $plan = PlanFor $tree @("x64-sse2")
+        ($plan.Channels | Where-Object Channel -eq "x64-avx2").Skipped | Should -BeTrue
+        ($plan.Channels | Where-Object Channel -eq "x64-sse2").Skipped | Should -BeFalse
+    }
+
+    It "carries the source zip decision and its grammar name" {
+        $tree = NewInputRoot @("EqualizerAPO-x64-avx2")
+        $plan = PlanFor $tree @("x64-avx2") -needsSource
+        $plan.NeedsSource | Should -BeTrue
+        Split-Path $plan.SourceZipPath -Leaf | Should -Be "EqualizerAPO-XT-source-9.9.9.zip"
+    }
+
+    It "fails the plan on an artifact no manifest variant claims" {
+        $tree = NewInputRoot @("EqualizerAPO-x64-quantum")
+        { PlanFor $tree @() } | Should -Throw "*no matching variant*"
+    }
+
+    It "fails the plan when no artifacts arrived" {
+        $tree = NewInputRoot @()
+        { PlanFor $tree @() } | Should -Throw "*No build artifacts*"
+    }
+}

--- a/.github/scripts/Tests/ReleaseAssets.Tests.ps1
+++ b/.github/scripts/Tests/ReleaseAssets.Tests.ps1
@@ -1,0 +1,41 @@
+Describe "ReleaseAssets grammar module" {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot "..\ReleaseAssets.psm1") -Force
+        $headerPath = Join-Path $PSScriptRoot "..\..\..\helpers\ReleaseAssetNames.h"
+    }
+
+    It "spells the per-channel setup asset with the doubled channel" {
+        Get-SetupAssetName -Channel "x64-avx2" |
+            Should -Be "EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe"
+        Get-SetupAssetName -Channel "arm64-neon" |
+            Should -Be "EqualizerAPO-XT-arm64-neon-arm64-neon-Setup.exe"
+    }
+
+    It "spells the companion assets" {
+        Get-UniversalSetupAssetName | Should -Be "EqualizerAPO-XT-Setup.exe"
+        Get-FeedAssetName -Channel "arm64-neon" | Should -Be "releases.arm64-neon.json"
+        Get-SourceZipAssetName -PackVersion "2.35.0" | Should -Be "EqualizerAPO-XT-source-2.35.0.zip"
+        Get-ChecksumsAssetName | Should -Be "SHA256SUMS.txt"
+        Get-VelopackPackId -Channel "x64-sse2" | Should -Be "EqualizerAPO-XT-x64-sse2"
+    }
+
+    It "stays in step with the C++ grammar header" {
+        # The two languages cannot share code, so this asserts the header's
+        # literals and shape against the module's output. A grammar change
+        # that lands in only one language fails here.
+        $header = Get-Content $headerPath -Raw
+        $header | Should -Match 'productPrefix\[\] = L"EqualizerAPO-XT";'
+        $header | Should -Match 'checksumsAssetName\[\] = L"SHA256SUMS\.txt";'
+        $header | Should -Match ([regex]::Escape('velopackPackId(channel) + L"-" + channel + L"-Setup.exe"'))
+        $header | Should -Match ([regex]::Escape('std::wstring(productPrefix) + L"-" + channel'))
+        $header | Should -Match ([regex]::Escape('std::wstring(productPrefix) + L"-Setup.exe"'))
+    }
+
+    It "yields well-formed names for every manifest channel" {
+        $manifest = Import-PowerShellDataFile (Join-Path $PSScriptRoot "..\..\simd-variants.psd1")
+        foreach ($channel in @($manifest.Variants.Channel)) {
+            Get-SetupAssetName -Channel $channel |
+                Should -Match "^EqualizerAPO-XT-$([regex]::Escape($channel))-$([regex]::Escape($channel))-Setup\.exe$"
+        }
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,100 +289,7 @@ jobs:
     - name: Setup dependency structures
       shell: pwsh
       run: |
-        $depsPath = "${{ github.workspace }}\deps"
-        Write-Host "=== Creating Dependency Structures ==="
-
-        # Check FFTW structure
-        Write-Host "`nFFTW structure:"
-        if (Test-Path "$depsPath\fftw") {
-          Get-ChildItem "$depsPath\fftw" -Recurse | Select-Object FullName
-        } else {
-          Write-Warning "FFTW directory not found"
-        }
-
-        # Check muParserX structure
-        Write-Host "`nmuParserX structure:"
-        if (Test-Path "$depsPath\muparserx") {
-          Get-ChildItem "$depsPath\muparserx" -Recurse | Select-Object FullName
-        } else {
-          Write-Warning "muParserX directory not found"
-        }
-
-        # Check libsndfile structure
-        Write-Host "`nlibsndfile structure:"
-        if (Test-Path "$depsPath\libsndfile") {
-          Get-ChildItem "$depsPath\libsndfile" -Recurse | Select-Object FullName
-        } else {
-          Write-Warning "libsndfile directory not found"
-        }
-
-        # Check TCLAP structure
-        Write-Host "`nTCLAP structure:"
-        if (Test-Path "$depsPath\tclap") {
-          Get-ChildItem "$depsPath\tclap" -Recurse -Depth 1 | Select-Object FullName
-        } else {
-          Write-Warning "TCLAP directory not found"
-        }
-
-        Write-Host "=== Locating dependency files ==="
-
-        # Find actual locations of critical files
-        $fftwHeader = Get-ChildItem -Path "$depsPath\fftw\Include" -Recurse -Filter "fftw3.h" -ErrorAction SilentlyContinue | Select-Object -First 1
-        $fftwLib = Get-ChildItem -Path "$depsPath\fftw\Release" -Recurse -Filter "libfftw3.lib" -ErrorAction SilentlyContinue | Select-Object -First 1
-        $mpxLib = Get-ChildItem -Path "$depsPath\muparserx\build\Release" -Recurse -Filter "muparserx.lib" -ErrorAction SilentlyContinue | Select-Object -First 1
-
-        # Set environment variables pointing to actual locations
-        if ($fftwHeader) {
-          $fftwInclude = $fftwHeader.Directory.FullName
-          echo "FFTW_INCLUDE=$fftwInclude" >> $env:GITHUB_ENV
-          Write-Host "FFTW_INCLUDE=$fftwInclude"
-        } else {
-          Write-Error "fftw3.h not found"
-          exit 1
-        }
-
-        if ($fftwLib) {
-          $fftwLibPath = $fftwLib.Directory.FullName
-          echo "FFTW_LIB=$fftwLibPath" >> $env:GITHUB_ENV
-          Write-Host "FFTW_LIB=$fftwLibPath"
-        } else {
-          Write-Error "libfftw3.lib not found"
-          exit 1
-        }
-
-        if (Test-Path  "$depsPath\muparserx") {
-          echo "MUPARSERX_INCLUDE=$depsPath\muparserx\parser" >> $env:GITHUB_ENV
-          Write-Host "MUPARSERX_INCLUDE=$depsPath\muparserx\parser"
-        } else {
-          Write-Error "muparserx folder not found"
-          exit 1
-        }
-
-        if ($mpxLib) {
-          $mpxLibPath = $mpxLib.Directory.FullName
-          echo "MUPARSERX_LIB=$mpxLibPath" >> $env:GITHUB_ENV
-          Write-Host "MUPARSERX_LIB=$mpxLibPath"
-        } else {
-          Write-Error "muparserx.lib not found"
-          exit 1
-        }
-
-        # Set root paths for libsndfile and tclap (still used by projects)
-        echo "LIBSNDFILE_INCLUDE=$depsPath\libsndfile\include" >> $env:GITHUB_ENV
-        echo "LIBSNDFILE_LIB=$depsPath\libsndfile\build\Release" >> $env:GITHUB_ENV
-        echo "TCLAP_ROOT=$depsPath\tclap" >> $env:GITHUB_ENV
-
-        # VST3 SDK root (contains pluginterfaces/) for VST3 hosting headers.
-        echo "VST3_SDK=$depsPath\vst3sdk" >> $env:GITHUB_ENV
-
-        # Highway header root (contains hwy/) for the portable SIMD kernels.
-        echo "HIGHWAY_INCLUDE=$depsPath\highway" >> $env:GITHUB_ENV
-
-        # Velopack runtime paths for the Editor's auto-update link.
-        echo "VELOPACK_INCLUDE=$depsPath\velopack_libc\include" >> $env:GITHUB_ENV
-        echo "VELOPACK_LIB=$depsPath\velopack_libc\lib" >> $env:GITHUB_ENV
-
-        Write-Host "`nAll dependency paths configured successfully"
+        .\.github\scripts\Initialize-DepsEnvironment.ps1 -DepsPath "${{ github.workspace }}\deps"
 
     - name: Setup Python
       uses: actions/setup-python@v6
@@ -912,7 +819,8 @@ jobs:
       if: steps.version.outputs.needs_source == 'true'
       shell: pwsh
       run: |
-        $sourceZip = "${{ github.workspace }}\EqualizerAPO-XT-source-${{ steps.version.outputs.pack_version }}.zip"
+        Import-Module .\.github\scripts\ReleaseAssets.psm1
+        $sourceZip = Join-Path "${{ github.workspace }}" (Get-SourceZipAssetName -PackVersion "${{ steps.version.outputs.pack_version }}")
         git archive --format=zip --output="$sourceZip" HEAD
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
@@ -930,158 +838,16 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $manifest = Import-PowerShellDataFile "${{ github.workspace }}\.github\simd-variants.psd1"
-        dotnet tool install -g vpk --version $manifest.Shared.VelopackVpkVersion
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
-        $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
-
-        $repoUrl = "https://github.com/${{ github.repository }}"
-        $releaseName = "EqualizerAPO-XT ${{ steps.version.outputs.pack_version }}"
-        $tag = "${{ steps.version.outputs.tag }}"
-        $targetCommit = "${{ github.sha }}"
-        $inputRoot = "${{ github.workspace }}\release-input"
-        $licensePath = "${{ github.workspace }}\License.txt"
-        $iconPath = "${{ github.workspace }}\Editor\icons\app-icon.ico"
-        $configSource = "${{ github.workspace }}\Setup\config"
-        $extrasSource = @(
-          "${{ github.workspace }}\Setup\Configuration tutorial (online).url",
-          "${{ github.workspace }}\Setup\Configuration reference (online).url"
-        )
-        $qtPluginFolders = @('iconengines', 'imageformats', 'platforms', 'styles', 'tls')
-        $buildArtifacts = @(Get-ChildItem -Path $inputRoot -Directory -Filter "EqualizerAPO-*")
         $missingChannels = @("${{ steps.version.outputs.missing_channels }}".Split(
           ',', [System.StringSplitOptions]::RemoveEmptyEntries))
-
-        if ($buildArtifacts.Count -eq 0) {
-          Write-Error "No build artifacts were found in $inputRoot"
-          exit 1
-        }
-
-        foreach ($artifact in $buildArtifacts) {
-          $variant = $artifact.Name.Substring("EqualizerAPO-".Length)
-          # Audit #250 F066: resolve the channel from the manifest (the
-          # artifact name is "<platform>-<simd>") instead of re-deriving it
-          # by string convention, which nothing asserted.
-          $sep = $variant.IndexOf('-')
-          $variantPlatform = $variant.Substring(0, $sep)
-          $variantSimd = $variant.Substring($sep + 1)
-          $variantEntry = $manifest.Variants | Where-Object { $_.Platform -eq $variantPlatform -and $_.Simd -eq $variantSimd } | Select-Object -First 1
-          if (-not $variantEntry) {
-            Write-Error "Artifact $($artifact.Name) has no matching variant in simd-variants.psd1"
-            exit 1
-          }
-          $channel = $variantEntry.Channel
-          if ($missingChannels -notcontains $channel) {
-            Write-Host "Channel $channel is already complete on $tag; skipping."
-            continue
-          }
-          $packId = "EqualizerAPO-XT-$channel"
-          $packTitle = "EqualizerAPO-XT $variant"
-          $outputDir = "${{ github.workspace }}\velopack-output\$channel"
-          $packDir = "${{ github.workspace }}\velopack-input\$channel"
-          $mainExe = "Editor.exe"
-          $framework = if ($variant -like "ARM64*" -or $variant -like "arm64*") { "vcredist143-arm64" } else { "vcredist143-x64" }
-
-          New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
-          if (Test-Path $packDir) {
-            Remove-Item -Path $packDir -Recurse -Force
-          }
-          New-Item -ItemType Directory -Force -Path $packDir | Out-Null
-
-          Write-Host "`n=== Preparing Velopack pack dir for $variant ==="
-          # Copy everything from the build artifact (binaries + Qt deps at top level)
-          Copy-Item -Path (Join-Path $artifact.FullName "*") -Destination $packDir -Recurse -Force
-
-          # Editor.exe calls addLibraryPath("qt"), so Qt plugin folders must live under qt\
-          $qtTarget = Join-Path $packDir "qt"
-          New-Item -ItemType Directory -Force -Path $qtTarget | Out-Null
-          foreach ($folder in $qtPluginFolders) {
-            $source = Join-Path $packDir $folder
-            if (Test-Path $source) {
-              $dest = Join-Path $qtTarget $folder
-              if (Test-Path $dest) {
-                Remove-Item -Path $dest -Recurse -Force
-              }
-              Move-Item -Path $source -Destination $dest -Force
-              Write-Host "Relocated $folder -> qt\$folder"
-            }
-          }
-
-          # Bundle the sample configs and shortcuts
-          if (Test-Path $configSource) {
-            $configTarget = Join-Path $packDir "config"
-            New-Item -ItemType Directory -Force -Path $configTarget | Out-Null
-            Copy-Item -Path (Join-Path $configSource "*") -Destination $configTarget -Recurse -Force
-          }
-          foreach ($extra in $extrasSource) {
-            if (Test-Path $extra) {
-              Copy-Item -Path $extra -Destination $packDir -Force
-            }
-          }
-
-          if (-not (Test-Path (Join-Path $packDir $mainExe))) {
-            Write-Error "$mainExe not found in $packDir"
-            exit 1
-          }
-
-          vpk download github `
-            --repoUrl $repoUrl `
-            --token $env:GITHUB_TOKEN `
-            --outputDir $outputDir `
-            --channel $channel
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "No previous Velopack release was downloaded for channel $channel. Continuing with a full package."
-            $global:LASTEXITCODE = 0
-          }
-
-          $packArgs = @(
-            'pack',
-            '--packId', $packId,
-            '--packVersion', '${{ steps.version.outputs.pack_version }}',
-            '--packDir', $packDir,
-            '--mainExe', $mainExe,
-            '--packTitle', $packTitle,
-            '--packAuthors', 'EqualizerAPO-XT contributors',
-            '--outputDir', $outputDir,
-            '--channel', $channel,
-            '--framework', $framework,
-            '--noPortable',
-            '--skipVeloAppCheck'
-          )
-          if (Test-Path $iconPath) {
-            $packArgs += @('--icon', $iconPath)
-          }
-
-          Write-Host "vpk $($packArgs -join ' ')"
-          vpk @packArgs
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
-
-          vpk upload github `
-            --repoUrl $repoUrl `
-            --token $env:GITHUB_TOKEN `
-            --outputDir $outputDir `
-            --channel $channel `
-            --publish `
-            --merge `
-            --releaseName $releaseName `
-            --tag $tag `
-            --targetCommitish $targetCommit
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
-        }
-
-        if ("${{ steps.version.outputs.needs_source }}" -eq "true") {
-          $sourceZip = "${{ github.workspace }}\EqualizerAPO-XT-source-${{ steps.version.outputs.pack_version }}.zip"
-          gh release upload $tag $sourceZip --clobber --repo "${{ github.repository }}"
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
-        }
+        .\.github\scripts\New-VelopackRelease.ps1 `
+          -Repository "${{ github.repository }}" `
+          -Tag "${{ steps.version.outputs.tag }}" `
+          -PackVersion "${{ steps.version.outputs.pack_version }}" `
+          -TargetCommit "${{ github.sha }}" `
+          -WorkspaceRoot "${{ github.workspace }}" `
+          -MissingChannels $missingChannels `
+          -NeedsSource:("${{ steps.version.outputs.needs_source }}" -eq "true")
 
     - name: Build and publish auto-detect installer
       if: steps.version.outputs.needs_installer == 'true'

--- a/Installer/AutoInstaller.cpp
+++ b/Installer/AutoInstaller.cpp
@@ -38,6 +38,7 @@
 #include <string>
 
 #include "../helpers/ComPtr.h"
+#include "../helpers/ReleaseAssetNames.h"
 #include "../helpers/Win32Resource.h"
 #include "../version.h"
 
@@ -73,9 +74,9 @@ const wchar_t* kReleasesPage = EAPO_REPO_URL_W L"/releases/latest";
 const wchar_t* kUserAgent = L"EqualizerAPO-XT-Setup";
 
 // Checksums asset that CI publishes to every release, one sha256sum-style
-// "<lowercase-hex-sha256>  <name>" line per asset. The name must match the
-// upload in .github/workflows/build.yml.
-const wchar_t* kChecksumsAssetName = L"SHA256SUMS.txt";
+// "<lowercase-hex-sha256>  <name>" line per asset. The grammar header keeps
+// this in step with the upload in .github/workflows/build.yml.
+const wchar_t* kChecksumsAssetName = ReleaseAssetNames::checksumsAssetName;
 
 // Channel index used as the process exit code for --detect-only, so a script can
 // read the detected variant without parsing stdout.
@@ -194,12 +195,11 @@ std::wstring detectChannel(int* outIndex)
     return L"x64-sse2";
 }
 
-// Per-variant installer asset name. The channel appears twice because each
-// variant's packId already embeds the channel (EqualizerAPO-XT-<channel>), and
-// Velopack appends "-<channel>-Setup.exe".
+// Per-variant installer asset name; the shared grammar header explains the
+// doubled channel.
 std::wstring assetName(const std::wstring& channel)
 {
-    return L"EqualizerAPO-XT-" + channel + L"-" + channel + L"-Setup.exe";
+    return ReleaseAssetNames::setupAssetName(channel);
 }
 
 // Always-latest download path. GitHub redirects /releases/latest/download/<asset>

--- a/Installer/AutoInstaller.cpp
+++ b/Installer/AutoInstaller.cpp
@@ -41,6 +41,12 @@
 #include "../helpers/ReleaseAssetNames.h"
 #include "../helpers/Win32Resource.h"
 #include "../version.h"
+#include "AutoInstallerLogic.h"
+
+// The decision logic (channel mapping, asset grammar, checksum parsing, flag
+// scan) lives in AutoInstallerLogic so EditorLogicTests can compile it; this
+// TU keeps the Win32 machinery and the entry point.
+using namespace AutoInstallerLogic;
 
 #pragma comment(lib, "winhttp.lib")
 #pragma comment(lib, "bcrypt.lib")
@@ -78,18 +84,6 @@ const wchar_t* kUserAgent = L"EqualizerAPO-XT-Setup";
 // this in step with the upload in .github/workflows/build.yml.
 const wchar_t* kChecksumsAssetName = ReleaseAssetNames::checksumsAssetName;
 
-// Channel index used as the process exit code for --detect-only, so a script can
-// read the detected variant without parsing stdout.
-enum ChannelIndex
-{
-    kSse2 = 0,
-    kAvx = 1,
-    kAvx2 = 2,
-    kAvx512 = 3,
-    kAvx10_1 = 4,
-    kArm64 = 5
-};
-
 // IsWow64Process2 reports the native machine even when this x86 process runs
 // under x64/ARM64 emulation. Fall back to GetNativeSystemInfo on the (very old)
 // systems that lack it.
@@ -115,16 +109,16 @@ bool isArm64Native()
     return si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64;
 }
 
-// Resolve the best build channel for this machine. The CPUID feature bits are
-// gated on the OS having actually enabled the wider register state (XGETBV/XCR0),
-// so we never pick a build the OS cannot context-switch.
-std::wstring detectChannel(int* outIndex)
+// Gather the CPU/OS facts the channel choice needs. The feature bits are
+// gated on the OS having actually enabled the wider register state
+// (XGETBV/XCR0), so we never pick a build the OS cannot context-switch.
+CpuFeatures detectCpuFeatures()
 {
+    CpuFeatures features;
     if (isArm64Native())
     {
-        if (outIndex != nullptr)
-            *outIndex = kArm64;
-        return L"arm64-neon";
+        features.arm64Native = true;
+        return features;
     }
 
     int info[4] = { 0, 0, 0, 0 };
@@ -143,81 +137,31 @@ std::wstring detectChannel(int* outIndex)
         osYmm = (xcr0 & 0x6) == 0x6;                 // bits 1,2
         osZmm = osYmm && ((xcr0 & 0xE0) == 0xE0);    // bits 5,6,7
     }
-    const bool haveAvx = cpuAvx && osYmm;
+    features.avx = cpuAvx && osYmm;
 
-    bool haveAvx2 = false;
-    bool haveAvx512f = false;
-    bool haveAvx10_1 = false;
     if (maxLeaf >= 7)
     {
         __cpuidex(info, 7, 0);
-        haveAvx2 = ((info[1] & (1 << 5)) != 0) && haveAvx;       // EBX[5], needs YMM
-        haveAvx512f = ((info[1] & (1 << 16)) != 0) && osZmm;     // EBX[16], needs ZMM
+        features.avx2 = ((info[1] & (1 << 5)) != 0) && features.avx; // EBX[5], needs YMM
+        features.avx512f = ((info[1] & (1 << 16)) != 0) && osZmm;    // EBX[16], needs ZMM
 
         __cpuidex(info, 7, 1);
-        const bool avx10Enumerated = (info[3] & (1 << 19)) != 0; // EDX[19]
+        const bool avx10Enumerated = (info[3] & (1 << 19)) != 0;     // EDX[19]
         if (avx10Enumerated && maxLeaf >= 0x24)
         {
             __cpuidex(info, 0x24, 0);
-            const int avx10Version = info[1] & 0xFF;             // EBX[7:0]
-            const bool avx10Has512 = (info[1] & (1 << 18)) != 0; // EBX[18] AVX10/512
-            haveAvx10_1 = (avx10Version >= 1) && avx10Has512 && osZmm;
+            const int avx10Version = info[1] & 0xFF;                 // EBX[7:0]
+            const bool avx10Has512 = (info[1] & (1 << 18)) != 0;     // EBX[18] AVX10/512
+            features.avx10_1 = (avx10Version >= 1) && avx10Has512 && osZmm;
         }
     }
-
-    // Most specific / newest first.
-    if (haveAvx10_1)
-    {
-        if (outIndex != nullptr)
-            *outIndex = kAvx10_1;
-        return L"x64-avx10-1";
-    }
-    if (haveAvx512f)
-    {
-        if (outIndex != nullptr)
-            *outIndex = kAvx512;
-        return L"x64-avx512";
-    }
-    if (haveAvx2)
-    {
-        if (outIndex != nullptr)
-            *outIndex = kAvx2;
-        return L"x64-avx2";
-    }
-    if (haveAvx)
-    {
-        if (outIndex != nullptr)
-            *outIndex = kAvx;
-        return L"x64-avx";
-    }
-    if (outIndex != nullptr)
-        *outIndex = kSse2;
-    return L"x64-sse2";
+    return features;
 }
 
-// Per-variant installer asset name; the shared grammar header explains the
-// doubled channel.
-std::wstring assetName(const std::wstring& channel)
+// Resolve the best build channel for this machine.
+std::wstring detectChannel(int* outIndex)
 {
-    return ReleaseAssetNames::setupAssetName(channel);
-}
-
-// Always-latest download path. GitHub redirects /releases/latest/download/<asset>
-// to the newest release's asset, so this binary never needs rebuilding per release.
-std::wstring latestAssetPath(const std::wstring& asset)
-{
-    return std::wstring(L"/") + EAPO_REPO_SLUG_W +
-        L"/releases/latest/download/" + asset;
-}
-
-std::wstring assetPath(const std::wstring& channel)
-{
-    return latestAssetPath(assetName(channel));
-}
-
-std::wstring downloadUrl(const std::wstring& channel)
-{
-    return std::wstring(L"https://github.com") + assetPath(channel);
+    return channelForCpu(detectCpuFeatures(), outIndex);
 }
 
 std::wstring tempFilePath(const std::wstring& fileName)
@@ -409,100 +353,6 @@ cleanup:
     return ok;
 }
 
-bool isHexDigit(char c)
-{
-    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-}
-
-char toLowerAscii(char c)
-{
-    return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
-}
-
-// Find fileName in sha256sum-style checksum text and return its digest as
-// lowercase hex. Each line is "<64 hex chars>  <name>"; the binary-mode form
-// "<hash> *<name>" is accepted too, and the name comparison ignores ASCII
-// case. Returns an empty string when no line matches.
-std::wstring expectedHashFromChecksums(const std::string& text, const std::wstring& fileName)
-{
-    std::string narrowName;
-    int needed = WideCharToMultiByte(CP_UTF8, 0, fileName.c_str(), -1, nullptr, 0,
-        nullptr, nullptr);
-    if (needed > 1)
-    {
-        narrowName.resize(needed - 1);
-        WideCharToMultiByte(CP_UTF8, 0, fileName.c_str(), -1, &narrowName[0], needed - 1,
-            nullptr, nullptr);
-    }
-    if (narrowName.empty())
-        return std::wstring();
-
-    // Skip a UTF-8 byte order mark, in case the generator wrote one.
-    size_t lineStart = 0;
-    if (text.size() >= 3 && text.compare(0, 3, "\xEF\xBB\xBF") == 0)
-        lineStart = 3;
-
-    while (lineStart < text.size())
-    {
-        size_t lineEnd = text.find('\n', lineStart);
-        if (lineEnd == std::string::npos)
-            lineEnd = text.size();
-        std::string line = text.substr(lineStart, lineEnd - lineStart);
-        lineStart = lineEnd + 1;
-        while (!line.empty() &&
-            (line.back() == '\r' || line.back() == ' ' || line.back() == '\t'))
-        {
-            line.pop_back();
-        }
-
-        // 64 hex digits, separating whitespace, an optional '*' binary-mode
-        // marker, then the asset name.
-        if (line.size() < 64 + 2)
-            continue;
-        bool hexOk = true;
-        for (size_t i = 0; i < 64; ++i)
-        {
-            if (!isHexDigit(line[i]))
-            {
-                hexOk = false;
-                break;
-            }
-        }
-        if (!hexOk || (line[64] != ' ' && line[64] != '\t'))
-            continue;
-
-        size_t nameStart = 64;
-        while (nameStart < line.size() && (line[nameStart] == ' ' || line[nameStart] == '\t'))
-            ++nameStart;
-        if (nameStart < line.size() && line[nameStart] == '*')
-            ++nameStart;
-        if (nameStart >= line.size())
-            continue;
-
-        const std::string name = line.substr(nameStart);
-        if (name.size() != narrowName.size())
-            continue;
-        bool nameMatches = true;
-        for (size_t i = 0; i < name.size(); ++i)
-        {
-            if (toLowerAscii(name[i]) != toLowerAscii(narrowName[i]))
-            {
-                nameMatches = false;
-                break;
-            }
-        }
-        if (!nameMatches)
-            continue;
-
-        std::wstring hex;
-        hex.reserve(64);
-        for (size_t i = 0; i < 64; ++i)
-            hex += static_cast<wchar_t>(toLowerAscii(line[i]));
-        return hex;
-    }
-    return std::wstring();
-}
-
 // Read a small file fully into memory. The checksums list is at most a few
 // kilobytes; refuse anything over 1 MiB so an unexpected response cannot
 // balloon.
@@ -610,25 +460,7 @@ bool launchSetup(const std::wstring& setupPath, bool silent, DWORD& exitCode)
     return true;
 }
 
-bool hasFlag(int argc, wchar_t** argv, const wchar_t* flag)
-{
-    for (int i = 1; i < argc; ++i)
-    {
-        if (_wcsicmp(argv[i], flag) == 0)
-            return true;
-    }
-    return false;
-}
-
-const wchar_t* flagValue(int argc, wchar_t** argv, const wchar_t* flag)
-{
-    for (int i = 1; i + 1 < argc; ++i)
-    {
-        if (_wcsicmp(argv[i], flag) == 0)
-            return argv[i + 1];
-    }
-    return nullptr;
-}
+// hasFlag / flagValue moved to AutoInstallerLogic.
 
 void writeTextFile(const wchar_t* path, const std::wstring& text)
 {

--- a/Installer/AutoInstallerLogic.cpp
+++ b/Installer/AutoInstallerLogic.cpp
@@ -1,0 +1,190 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	Kept intentionally free of project libraries: the installer is a
+	standalone 32-bit binary (see AutoInstaller.cpp) and EditorLogicTests
+	compiles this file directly.
+*/
+
+#include "AutoInstallerLogic.h"
+
+#include <windows.h>
+#include <wchar.h>
+
+#include "../helpers/ReleaseAssetNames.h"
+#include "../version.h"
+
+namespace AutoInstallerLogic
+{
+namespace
+{
+bool isHexDigit(char c)
+{
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+char toLowerAscii(char c)
+{
+	return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+}
+}
+
+std::wstring channelForCpu(const CpuFeatures& features, int* outIndex)
+{
+	if (features.arm64Native)
+	{
+		if (outIndex != nullptr)
+			*outIndex = kArm64;
+		return L"arm64-neon";
+	}
+	// Most specific / newest first.
+	if (features.avx10_1)
+	{
+		if (outIndex != nullptr)
+			*outIndex = kAvx10_1;
+		return L"x64-avx10-1";
+	}
+	if (features.avx512f)
+	{
+		if (outIndex != nullptr)
+			*outIndex = kAvx512;
+		return L"x64-avx512";
+	}
+	if (features.avx2)
+	{
+		if (outIndex != nullptr)
+			*outIndex = kAvx2;
+		return L"x64-avx2";
+	}
+	if (features.avx)
+	{
+		if (outIndex != nullptr)
+			*outIndex = kAvx;
+		return L"x64-avx";
+	}
+	if (outIndex != nullptr)
+		*outIndex = kSse2;
+	return L"x64-sse2";
+}
+
+std::wstring assetName(const std::wstring& channel)
+{
+	return ReleaseAssetNames::setupAssetName(channel);
+}
+
+std::wstring latestAssetPath(const std::wstring& asset)
+{
+	return std::wstring(L"/") + EAPO_REPO_SLUG_W +
+		L"/releases/latest/download/" + asset;
+}
+
+std::wstring assetPath(const std::wstring& channel)
+{
+	return latestAssetPath(assetName(channel));
+}
+
+std::wstring downloadUrl(const std::wstring& channel)
+{
+	return std::wstring(L"https://github.com") + assetPath(channel);
+}
+
+std::wstring expectedHashFromChecksums(const std::string& text, const std::wstring& fileName)
+{
+	std::string narrowName;
+	int needed = WideCharToMultiByte(CP_UTF8, 0, fileName.c_str(), -1, nullptr, 0,
+		nullptr, nullptr);
+	if (needed > 1)
+	{
+		narrowName.resize(needed - 1);
+		WideCharToMultiByte(CP_UTF8, 0, fileName.c_str(), -1, &narrowName[0], needed - 1,
+			nullptr, nullptr);
+	}
+	if (narrowName.empty())
+		return std::wstring();
+
+	// Skip a UTF-8 byte order mark, in case the generator wrote one.
+	size_t lineStart = 0;
+	if (text.size() >= 3 && text.compare(0, 3, "\xEF\xBB\xBF") == 0)
+		lineStart = 3;
+
+	while (lineStart < text.size())
+	{
+		size_t lineEnd = text.find('\n', lineStart);
+		if (lineEnd == std::string::npos)
+			lineEnd = text.size();
+		std::string line = text.substr(lineStart, lineEnd - lineStart);
+		lineStart = lineEnd + 1;
+		while (!line.empty() &&
+			(line.back() == '\r' || line.back() == ' ' || line.back() == '\t'))
+		{
+			line.pop_back();
+		}
+
+		// 64 hex digits, separating whitespace, an optional '*' binary-mode
+		// marker, then the asset name.
+		if (line.size() < 64 + 2)
+			continue;
+		bool hexOk = true;
+		for (size_t i = 0; i < 64; ++i)
+		{
+			if (!isHexDigit(line[i]))
+			{
+				hexOk = false;
+				break;
+			}
+		}
+		if (!hexOk || (line[64] != ' ' && line[64] != '\t'))
+			continue;
+
+		size_t nameStart = 64;
+		while (nameStart < line.size() && (line[nameStart] == ' ' || line[nameStart] == '\t'))
+			++nameStart;
+		if (nameStart < line.size() && line[nameStart] == '*')
+			++nameStart;
+		if (nameStart >= line.size())
+			continue;
+
+		const std::string name = line.substr(nameStart);
+		if (name.size() != narrowName.size())
+			continue;
+		bool nameMatches = true;
+		for (size_t i = 0; i < name.size(); ++i)
+		{
+			if (toLowerAscii(name[i]) != toLowerAscii(narrowName[i]))
+			{
+				nameMatches = false;
+				break;
+			}
+		}
+		if (!nameMatches)
+			continue;
+
+		std::wstring hex;
+		hex.reserve(64);
+		for (size_t i = 0; i < 64; ++i)
+			hex += static_cast<wchar_t>(toLowerAscii(line[i]));
+		return hex;
+	}
+	return std::wstring();
+}
+
+bool hasFlag(int argc, wchar_t** argv, const wchar_t* flag)
+{
+	for (int i = 1; i < argc; ++i)
+	{
+		if (_wcsicmp(argv[i], flag) == 0)
+			return true;
+	}
+	return false;
+}
+
+const wchar_t* flagValue(int argc, wchar_t** argv, const wchar_t* flag)
+{
+	for (int i = 1; i + 1 < argc; ++i)
+	{
+		if (_wcsicmp(argv[i], flag) == 0)
+			return argv[i + 1];
+	}
+	return nullptr;
+}
+}

--- a/Installer/AutoInstallerLogic.h
+++ b/Installer/AutoInstallerLogic.h
@@ -1,0 +1,69 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	The auto-detect installer's decision logic, split out of the wWinMain
+	translation unit (audit #250 F056) so a test suite can compile it: which
+	channel a CPU maps to, which asset that names, and how the sha256sum
+	checksums text is read. The Win32 work (CPUID/XGETBV gathering, WinHTTP,
+	BCrypt, process launch) stays in AutoInstaller.cpp; this unit only
+	decides. EditorLogicTests compiles AutoInstallerLogic.cpp directly, the
+	same pattern it uses for UpdateChecker's decision core, so PRs verify
+	logic the release-only installer build used to leave until release day.
+
+	Like the installer itself this must stay free of project libraries: it
+	is std C++ plus the grammar header and version.h.
+*/
+
+#pragma once
+
+#include <string>
+
+namespace AutoInstallerLogic
+{
+// Channel index used as the process exit code for --detect-only, so a script
+// can read the detected variant without parsing stdout.
+enum ChannelIndex
+{
+	kSse2 = 0,
+	kAvx = 1,
+	kAvx2 = 2,
+	kAvx512 = 3,
+	kAvx10_1 = 4,
+	kArm64 = 5
+};
+
+// The CPU/OS facts the channel choice depends on. The installer gathers them
+// with CPUID/XGETBV (each flag already includes the OS-enabled-state gate, so
+// a build the OS cannot context-switch is never picked); tests supply
+// fixtures.
+struct CpuFeatures
+{
+	bool arm64Native = false;
+	bool avx = false;     // CPU AVX and the OS enabled YMM state
+	bool avx2 = false;    // CPUID leaf 7 AVX2, gated on avx
+	bool avx512f = false; // AVX-512F, gated on OS ZMM state
+	bool avx10_1 = false; // AVX10 version >= 1 with 512-bit vectors, gated on OS ZMM state
+};
+
+// Most specific / newest first: arm64, avx10-1, avx512, avx2, avx, sse2.
+std::wstring channelForCpu(const CpuFeatures& features, int* outIndex = nullptr);
+
+// Per-variant installer asset name; the shared grammar header explains the
+// doubled channel.
+std::wstring assetName(const std::wstring& channel);
+
+// Always-latest download path. GitHub redirects /releases/latest/download/<asset>
+// to the newest release's asset, so this binary never needs rebuilding per release.
+std::wstring latestAssetPath(const std::wstring& asset);
+std::wstring assetPath(const std::wstring& channel);
+std::wstring downloadUrl(const std::wstring& channel);
+
+// Find fileName in sha256sum-style checksum text and return its digest as
+// lowercase hex. Each line is "<64 hex chars>  <name>"; the binary-mode form
+// "<hash> *<name>" is accepted too, and the name comparison ignores ASCII
+// case. Returns an empty string when no line matches.
+std::wstring expectedHashFromChecksums(const std::string& text, const std::wstring& fileName);
+
+bool hasFlag(int argc, wchar_t** argv, const wchar_t* flag);
+const wchar_t* flagValue(int argc, wchar_t** argv, const wchar_t* flag);
+}

--- a/Installer/Installer.vcxproj
+++ b/Installer/Installer.vcxproj
@@ -93,6 +93,10 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AutoInstaller.cpp" />
+    <ClCompile Include="AutoInstallerLogic.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="AutoInstallerLogic.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="AutoInstaller.rc" />

--- a/Tests/EditorLogicTests/AutoInstallerLogicTests.cpp
+++ b/Tests/EditorLogicTests/AutoInstallerLogicTests.cpp
@@ -1,0 +1,115 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	The auto-detect installer's decision logic (audit #250 F056). The
+	installer binary itself is built release-only, so until this split its
+	channel mapping, asset grammar and checksum parsing were verified for
+	the first time on release day. These tests compile the logic unit
+	directly, the same pattern the suite uses for UpdateChecker's decision
+	core.
+*/
+
+#include <string>
+
+#include "Installer/AutoInstallerLogic.h"
+
+#include "EditorLogicTestSupport.h"
+
+using namespace AutoInstallerLogic;
+
+namespace
+{
+QString wide(const std::wstring& text)
+{
+	return QString::fromStdWString(text);
+}
+}
+
+void testAutoInstallerChannelMapping()
+{
+	// Most specific / newest first; ARM64 outranks everything; the exit-code
+	// channel index rides along for --detect-only consumers.
+	int index = -1;
+	CpuFeatures features;
+	expectEqual(wide(channelForCpu(features, &index)), QStringLiteral("x64-sse2"), "no features means sse2");
+	expectEqual(index, int(kSse2), "sse2 index");
+
+	features.avx = true;
+	expectEqual(wide(channelForCpu(features, &index)), QStringLiteral("x64-avx"), "avx alone picks avx");
+	expectEqual(index, int(kAvx), "avx index");
+
+	features.avx2 = true;
+	expectEqual(wide(channelForCpu(features, &index)), QStringLiteral("x64-avx2"), "avx2 outranks avx");
+	expectEqual(index, int(kAvx2), "avx2 index");
+
+	features.avx512f = true;
+	expectEqual(wide(channelForCpu(features, &index)), QStringLiteral("x64-avx512"), "avx512 outranks avx2");
+	expectEqual(index, int(kAvx512), "avx512 index");
+
+	features.avx10_1 = true;
+	expectEqual(wide(channelForCpu(features, &index)), QStringLiteral("x64-avx10-1"), "avx10.1 outranks avx512");
+	expectEqual(index, int(kAvx10_1), "avx10.1 index");
+
+	features.arm64Native = true;
+	expectEqual(wide(channelForCpu(features, &index)), QStringLiteral("arm64-neon"), "arm64 outranks all x64 features");
+	expectEqual(index, int(kArm64), "arm64 index");
+}
+
+void testAutoInstallerAssetGrammar()
+{
+	expectEqual(wide(assetName(L"x64-avx2")),
+		QStringLiteral("EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe"),
+		"asset name follows the shared grammar header");
+	const QString url = wide(downloadUrl(L"arm64-neon"));
+	expectTrue(url.startsWith(QStringLiteral("https://github.com/")),
+		"download URL is absolute https");
+	expectTrue(url.endsWith(QStringLiteral(
+		"/releases/latest/download/EqualizerAPO-XT-arm64-neon-arm64-neon-Setup.exe")),
+		"download URL uses the always-latest redirect path");
+}
+
+void testAutoInstallerChecksumParsing()
+{
+	const std::string hash(64, 'A');
+	const std::string other(64, '2');
+	const std::wstring name = L"EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe";
+
+	// Plain line: digest comes back lowercased.
+	std::string text = hash + "  EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe\n"
+		+ other + "  SHA256SUMS.txt\n";
+	expectEqual(wide(expectedHashFromChecksums(text, name)),
+		QString(64, QLatin1Char('a')), "matching line yields the lowercased digest");
+
+	// Binary-mode marker, CRLF endings, BOM, and case-insensitive names.
+	text = "\xEF\xBB\xBF" + hash + " *equalizerapo-xt-x64-avx2-x64-avx2-setup.exe\r\n";
+	expectEqual(wide(expectedHashFromChecksums(text, name)),
+		QString(64, QLatin1Char('a')),
+		"BOM, binary marker, CRLF and ASCII case are all tolerated");
+
+	// Rejections: short hash, non-hex hash, absent name.
+	text = std::string(63, 'a') + "  EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe\n";
+	expectTrue(expectedHashFromChecksums(text, name).empty(), "63 hex digits do not parse");
+	text = std::string(64, 'g') + "  EqualizerAPO-XT-x64-avx2-x64-avx2-Setup.exe\n";
+	expectTrue(expectedHashFromChecksums(text, name).empty(), "non-hex digest does not parse");
+	text = hash + "  some-other-asset.zip\n";
+	expectTrue(expectedHashFromChecksums(text, name).empty(), "absent asset yields empty");
+	expectTrue(expectedHashFromChecksums(std::string(), name).empty(), "empty text yields empty");
+}
+
+void testAutoInstallerFlagScan()
+{
+	wchar_t exe[] = L"setup.exe";
+	wchar_t silent[] = L"/silent";
+	wchar_t report[] = L"--report";
+	wchar_t path[] = L"C:\\out.txt";
+	wchar_t* argv[] = { exe, silent, report, path };
+
+	expectTrue(hasFlag(4, argv, L"/silent"), "flag present");
+	expectTrue(hasFlag(4, argv, L"/SILENT"), "flag match ignores case");
+	expectFalse(hasFlag(4, argv, L"/detect-only"), "absent flag");
+	expectFalse(hasFlag(1, argv, L"setup.exe"), "argv[0] is not a flag");
+	expectEqual(wide(flagValue(4, argv, L"--report")), QStringLiteral("C:\\out.txt"),
+		"flag value returns the following argument");
+	expectTrue(flagValue(4, argv, L"C:\\out.txt") == nullptr,
+		"a trailing token has no value slot");
+}

--- a/Tests/EditorLogicTests/EditorLogicTestSupport.h
+++ b/Tests/EditorLogicTests/EditorLogicTestSupport.h
@@ -50,3 +50,7 @@ void testFilterCommandCatalogTemplateRoster();
 void testFilterCommandCatalogDescriptions();
 void testSharedRawBodyAndRoutingViewPredicates();
 void testVstChunkPathCandidates();
+void testAutoInstallerChannelMapping();
+void testAutoInstallerAssetGrammar();
+void testAutoInstallerChecksumParsing();
+void testAutoInstallerFlagScan();

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -2012,6 +2012,10 @@ int main(int argc, char** argv)
 		testFilterCommandCatalogDescriptions();
 		testSharedRawBodyAndRoutingViewPredicates();
 		testVstChunkPathCandidates();
+		testAutoInstallerChannelMapping();
+		testAutoInstallerAssetGrammar();
+		testAutoInstallerChecksumParsing();
+		testAutoInstallerFlagScan();
 
 		harness.report();
 		return EXIT_SUCCESS;

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -148,6 +148,7 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
     <ClCompile Include="PhaseCurveTests.cpp" />
     <ClCompile Include="BiQuadWidthConversionTests.cpp" />
     <ClCompile Include="ConfigFileCodecTests.cpp" />
+    <ClCompile Include="AutoInstallerLogicTests.cpp" />
     <ClCompile Include="FilterCommandCatalogTests.cpp" />
     <ClCompile Include="InfrastructureTests.cpp" />
     <ClCompile Include="..\..\Editor\ConfigFileCodec.cpp" />
@@ -181,6 +182,7 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
          not listed here: they live in Common.lib, which is now linked whole
          (see the Link settings above). Compiling them a second time would make
          every one of them a duplicate symbol. -->
+    <ClCompile Include="..\..\Installer\AutoInstallerLogic.cpp" />
     <ClCompile Include="..\..\UpdateChecker\UpdateInfoFormatter.cpp" />
     <ClCompile Include="..\..\UpdateChecker\VelopackUpdateInfo.cpp" />
   </ItemGroup>
@@ -193,6 +195,7 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
     <ClInclude Include="..\..\Editor\skins\SkinThemeData.h" />
     <ClInclude Include="..\..\Editor\import\ImportManifest.h" />
     <ClInclude Include="..\..\Editor\helpers\VstChunkScan.h" />
+    <ClInclude Include="..\..\Installer\AutoInstallerLogic.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCardModel.h" />
     <ClInclude Include="..\..\Editor\widgets\FilterCommandCatalog.h" />
     <ClInclude Include="..\..\Editor\widgets\EditableValueText.h" />

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj.filters
@@ -59,6 +59,12 @@
     <ClCompile Include="FilterCommandCatalogTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="AutoInstallerLogicTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Installer\AutoInstallerLogic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Editor\widgets\cards\ChannelSelectionModel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -101,6 +107,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Editor\helpers\VstChunkScan.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Installer\AutoInstallerLogic.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Editor\widgets\cards\ChannelSelectionModel.h">

--- a/UpdateChecker/VelopackUpdateInfo.cpp
+++ b/UpdateChecker/VelopackUpdateInfo.cpp
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <limits>
 
+#include "helpers/ReleaseAssetNames.h"
+
 namespace
 {
 QString normalizedVersion(QString version)
@@ -148,7 +150,8 @@ QString releasePageUrl(const QJsonDocument& githubReleaseDoc)
 
 QJsonObject newestFeedAsset(const QJsonDocument& feedDoc, const QString& channel, const QString& installedVersion)
 {
-	const QString packageId = QString("EqualizerAPO-XT-%0").arg(channel).toLower();
+	const QString packageId = QString::fromStdWString(
+		ReleaseAssetNames::velopackPackId(channel.toStdWString())).toLower();
 	QJsonObject bestAsset;
 	QString bestVersion;
 

--- a/docs/AutoDetectInstaller.md
+++ b/docs/AutoDetectInstaller.md
@@ -162,6 +162,11 @@ its own table, which is the loudest of these guards.
 - `Installer/Installer.vcxproj` builds the detector for `Win32` only. It has no
   external dependencies (just `winhttp`, `bcrypt`, `comctl32`, `shell32`), so it
   builds without FFTW/Qt/etc.
+- The decision logic (channel mapping, asset grammar, checksum parsing) lives
+  in `Installer/AutoInstallerLogic.{h,cpp}`, which EditorLogicTests compiles
+  directly, so PRs verify it without building the installer.
+- The avx2 leg of `Build-Solution.ps1` builds the whole binary on every PR; a
+  compile break no longer waits for release day.
 - The `create-release` job builds it (`/p:Platform=Win32 /p:Configuration=Release`)
   and uploads it to the release tag as `EqualizerAPO-XT-Setup.exe`, before the
   release notes step so the notes can feature it as the recommended download.
@@ -169,7 +174,7 @@ its own table, which is the loudest of these guards.
 ## Local verification
 
 ```
-Installer\Win32\Release\EqualizerAPO-XT-Setup.exe --detect-only
+Installer\Release\EqualizerAPO-XT-Setup.exe --detect-only
 ```
 
 `--detect-only` prints the resolved channel and the download URL and exits

--- a/helpers/ReleaseAssetNames.h
+++ b/helpers/ReleaseAssetNames.h
@@ -1,0 +1,39 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	The release asset-name grammar for C++ consumers, mirroring
+	.github/scripts/ReleaseAssets.psm1 (audit #250 F067). The channel appears
+	twice in the setup name because the Velopack pack id already embeds it and
+	vpk appends the channel again. ReleaseAssets.Tests.ps1 asserts this header
+	and the PowerShell module produce the same names, so a grammar change that
+	lands in only one language fails the Pester gate.
+
+	Header-only std C++ on purpose: the auto-detect installer is a standalone
+	32-bit binary that links no project library, and UpdateChecker compiles
+	under Qt - both can include this, neither can link Common.
+*/
+
+#pragma once
+
+#include <string>
+
+namespace ReleaseAssetNames
+{
+inline constexpr wchar_t productPrefix[] = L"EqualizerAPO-XT";
+inline constexpr wchar_t checksumsAssetName[] = L"SHA256SUMS.txt";
+
+inline std::wstring velopackPackId(const std::wstring& channel)
+{
+	return std::wstring(productPrefix) + L"-" + channel;
+}
+
+inline std::wstring setupAssetName(const std::wstring& channel)
+{
+	return velopackPackId(channel) + L"-" + channel + L"-Setup.exe";
+}
+
+inline std::wstring universalSetupAssetName()
+{
+	return std::wstring(productPrefix) + L"-Setup.exe";
+}
+}


### PR DESCRIPTION
감사 #250 후속 트랙 2의 전반부입니다(편성 기록: #250 코멘트). 릴리스에서만 실행되던 코드를 PR에서 검증 가능하게 만드는 세 건을 담습니다. 후반부(Tests.props, /arch·툴셋 호이스트)는 전체 매트릭스 검증이 필요해 별도 PR로 이어집니다.

## F067 — 자산 이름 문법을 언어당 한 곳으로

`EqualizerAPO-XT-<channel>-<channel>-Setup.exe` 문법이 2개 언어 6개 파일에 병렬 리터럴로 있었습니다. 이제 PowerShell은 `ReleaseAssets.psm1`(Publish-Release, Install-ReleaseBuild, New-ReleaseNotes가 소비), C++는 `helpers/ReleaseAssetNames.h`(AutoInstaller와 UpdateChecker가 소비)가 철자를 소유하고, `ReleaseAssets.Tests.ps1`이 두 언어의 철자를 서로 대조합니다. 한쪽에만 착지한 문법 변경은 Pester에서 실패합니다.

## F068 — 인라인 Velopack·의존성 스텝 추출

릴리스를 실제로 만드는 159줄 인라인 스텝과 97줄 의존성 스테이징 스텝이 스크립트+Pester 패턴 밖의 마지막 릴리스 필수 코드였습니다. `New-VelopackRelease.ps1`은 순수 -PlanOnly 단계에서 아티팩트→채널 해석(매니페스트 기반, F066), 재개 필터, 팩 정체성, 프레임워크 선택을 답하고 Pester가 이를 고정합니다. 특히 `avx10_1`→`x64-avx10-1`, ARM64 철자처럼 명명 규약 재파생이 틀렸을 지점들이 테스트에 박혔습니다. `Initialize-DepsEnvironment.ps1`은 deps 탐침-실패 지도를 소유합니다. 워크플로 스텝은 얇은 호출이 됐고, 인라인 스텝의 미사용 `$licensePath` 바인딩 하나만 삭제했으며 나머지는 축자 이식입니다.

## F056 — AutoInstaller를 PR 빌드·테스트 표면 안으로

자동 감지 설치기는 create-release에서만 빌드되어 PR이 깨뜨려도 다음 릴리스에야 드러났고, 판정 로직은 wWinMain TU에 헤더 없이 있어 테스트가 닿지 못했습니다. 판정(CPU→채널 매핑, 자산 문법, 체크섬 파싱, 플래그 스캔)을 `Installer/AutoInstallerLogic.{h,cpp}`로 갈라 EditorLogicTests가 직접 컴파일합니다(UpdateChecker 선례). CPUID/XGETBV 수집은 설치기에 남습니다. avx2 레그가 Win32 바이너리 전체를 PR마다 빌드하고(plan 노출, Pester 고정), Test-VariantSync 린트는 리터럴이 사는 곳을 따라갔습니다.

## 검증

- Pester **82/82**(신설 3스위트: 문법 모듈+양언어 동기, Velopack 계획, deps 지도).
- EditorLogicTests **2,917건**(신설 4스위트: 채널 우선순위 표, 문법 형태, 체크섬 배터리(BOM/바이너리 마커/CRLF/대소문자/기각), argv 스캔).
- Installer Win32 빌드 녹색, Test-VariantSync 녹색, YAML 파싱 확인.
- build.yml은 245줄 줄고 11줄 늘었습니다.

## 확인하지 못한 것

- 추출된 Velopack 스크립트의 실제 pack/upload 실행은 설계상 릴리스에서만 돕니다. 다음 버전 범프가 첫 라이브 실행이며, 계획 단계의 동등성은 Pester로만 고정했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
