### PR TITLE
refactor(engine): stream-format ctor and one convolver mute diagnostic (audit #250 A2+A4)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,13 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- **Hilbert 필터가 조용해지면 이제 로그에 남습니다.** 스트림 블록 크기가
+  바뀌면 convolver들은 오디오 스레드에서 재초기화하는 대신 무음으로
+  빠지는데, Convolution/MultiConvolution은 이를 보고했지만 Hilbert는
+  '소리는 사라지고 로그는 비어 있는' 상태였습니다. 이제 셋이 진단을
+  공유하고 필터가 정리될 때 무음 사실을 보고합니다
+  ([#258](https://github.com/115dkk/EqualizerAPO-XT/pull/258)).
+
 ## v2.34.2 — 2026-08-08
 
 - **장치 선택기의 UAC를 거절해도 창이 한 번 더 뜨지 않습니다.** 메뉴나 문제

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- **A Hilbert line that goes silent now says so in the log.** When the
+  stream's block size changes, convolvers mute rather than re-initialize
+  on the audio thread; Convolution and MultiConvolution reported that,
+  Hilbert did not - "sound gone, log empty". All three now share one
+  diagnostic and report the mute when the filter winds down
+  ([#258](https://github.com/115dkk/EqualizerAPO-XT/pull/258)).
+
 ## v2.34.2 — 2026-08-08
 
 - **Declining the Device Selector's UAC prompt no longer pops a second

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -368,6 +368,7 @@
     <ClInclude Include="libHybridConv-0.1.1\HcAlignedStorage.h" />
     <ClInclude Include="helpers\FileSharingRetry.h" />
     <ClInclude Include="helpers\GainIterator.h" />
+    <ClInclude Include="filters\ConvolverMuteDiagnostics.h" />
     <ClInclude Include="helpers\ClsidRegistration.h" />
     <ClInclude Include="helpers\IRegistry.h" />
     <ClInclude Include="helpers\RegistryTransaction.h" />

--- a/Common.vcxproj.filters
+++ b/Common.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="helpers\ClsidRegistration.h">
       <Filter>helpers</Filter>
     </ClInclude>
+    <ClInclude Include="filters\ConvolverMuteDiagnostics.h">
+      <Filter>filters</Filter>
+    </ClInclude>
     <ClInclude Include="helpers\IRegistry.h">
       <Filter>helpers</Filter>
     </ClInclude>

--- a/Tests/EngineOrchestrationTests/SampleIoTests.cpp
+++ b/Tests/EngineOrchestrationTests/SampleIoTests.cpp
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -28,10 +27,7 @@
 #define NOMINMAX
 #endif
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-
 #include "engine/FilterConfiguration.h"
-#include "engine/FilterEngine.h"
 #include "Tests/TestHarness.h"
 
 namespace
@@ -49,43 +45,19 @@ double nextSample(unsigned long long& state)
 	return static_cast<double>(scrambled >> 11) / static_cast<double>(1ULL << 53) * 2.0 - 1.0;
 }
 
-// An engine initialized from an empty temp config; FilterConfiguration only
-// needs its channel counts and max frame count.
-struct IoFixture
+// Audit #250 A2: FilterConfiguration takes the three stream facts directly,
+// so these tests no longer boot a FilterEngine (with its temp config file,
+// registry read and factory registry) per channel count.
+EngineStreamFormat formatFor(unsigned channels)
 {
-	FilterEngine engine;
-	std::wstring configPath;
-
-	IoFixture(test::Harness& harness, unsigned channels)
-	{
-		wchar_t tempPath[MAX_PATH] = {};
-		DWORD len = GetTempPathW(MAX_PATH, tempPath);
-		std::wstring dir = (len > 0 && len < MAX_PATH) ? tempPath : L".\\";
-		configPath = dir + L"SampleIoTests-" + std::to_wstring(GetCurrentProcessId()) + L".txt";
-		std::ofstream stream(configPath, std::ios::binary | std::ios::trunc);
-		stream << "# empty\n";
-		stream.close();
-		if (!stream)
-			harness.fail("could not write SampleIoTests temp config");
-
-		const std::wstring deviceName = L"SampleIoTests";
-		engine.setDeviceInfo(false, true, deviceName, L"File", L"", deviceName + L" File");
-		engine.initialize(48000.0f, channels, channels, channels, 0, maxFrames, configPath);
-	}
-
-	~IoFixture()
-	{
-		DeleteFileW(configPath.c_str());
-	}
-};
+	return EngineStreamFormat{ channels, channels, maxFrames };
+}
 
 // Every conversion path must match the naive scalar loop bit for bit.
 void testConversionsMatchScalarReferenceBitExactly(test::Harness& harness)
 {
 	for (unsigned channels : {1u, 2u, 3u, 4u, 6u, 8u})
 	{
-		IoFixture fixture(harness, channels);
-
 		for (unsigned frames : {480u, 61u})
 		{
 			char label[96];
@@ -100,7 +72,7 @@ void testConversionsMatchScalarReferenceBitExactly(test::Harness& harness)
 			}
 
 			// readFloatInterleaved: planar double result vs scalar promote.
-			FilterConfiguration config(&fixture.engine, {}, channels);
+			FilterConfiguration config(formatFor(channels), {}, channels);
 			config.readFloatInterleaved(floatIn.data(), frames);
 			double** planar = config.getOutputSamples();
 			bool readFloatOk = true;
@@ -225,8 +197,7 @@ void testStereoFloatConversionBeatsScalarReference(test::Harness& harness)
 	constexpr bool gateWrite = true;
 	constexpr double requiredRatio = 2.4;
 #endif
-	IoFixture fixture(harness, channels);
-	FilterConfiguration config(&fixture.engine, {}, channels);
+	FilterConfiguration config(formatFor(channels), {}, channels);
 
 	std::vector<float> input((size_t)frames * channels);
 	std::vector<float> output((size_t)frames * channels);

--- a/Tests/HybridConvTests/HilbertVelvetTests.cpp
+++ b/Tests/HybridConvTests/HilbertVelvetTests.cpp
@@ -11,10 +11,13 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <cstdio>
+#include <string>
 #include <vector>
 
 #include "filters/HilbertCommand.h"
 #include "filters/HilbertFilter.h"
+#include "helpers/LogHelper.h"
 #include "filters/VelvetCommand.h"
 #include "filters/velvet/Processor.h"
 #include "Tests/TestHarness.h"
@@ -247,6 +250,50 @@ void testVelvetDynamicRenewalIsFiniteAndSmooth()
 	harness.expectTrue(largestStep < 2.0,
 		"equal-power renewal avoids discontinuous kernel replacement");
 }
+
+// Audit #250 A4: a mismatched block used to mute Hilbert's shifted channels
+// with no diagnostics at all; the shared convolver bookkeeping now reports
+// it on destruction like the other convolvers' cleanup().
+void testHilbertMismatchIsLoggedOnDestruction()
+{
+	FILE* logFile = nullptr;
+	if (tmpfile_s(&logFile) != 0 || logFile == nullptr)
+	{
+		harness.fail("could not create mismatch log capture");
+		return;
+	}
+	LogHelper::useStream(logFile, false, true, false);
+
+	{
+		HilbertCommand command;
+		harness.require(HilbertCommand::parse(L"Hilbert",
+			L"Shift=ALL Direction=-90", command), "Hilbert mute-test command parses");
+		HilbertFilter filter(command);
+		filter.initialize(48000.0f, 512, { L"L", L"R" });
+
+		constexpr unsigned shortBlock = 256;
+		std::vector<double> inL(shortBlock, 0.25), inR(shortBlock, 0.25);
+		std::vector<double> outL(shortBlock, 1.0), outR(shortBlock, 1.0);
+		double* input[] = { inL.data(), inR.data() };
+		double* output[] = { outL.data(), outR.data() };
+		filter.process(output, input, shortBlock);
+		harness.expectTrue(outL[0] == 0.0,
+			"a mismatched Hilbert block mutes the shifted channel");
+	}
+
+	std::fflush(logFile);
+	std::rewind(logFile);
+	std::wstring log;
+	wchar_t buffer[1024];
+	while (std::fgetws(buffer, 1024, logFile) != nullptr)
+		log.append(buffer);
+	std::fclose(logFile);
+	LogHelper::useStream(stdout, true, true, false);
+
+	const std::wstring marker = HilbertFilter::kFrameCountMismatchLogPrefix;
+	harness.expectTrue(log.find(marker) != std::wstring::npos,
+		"Hilbert frame-count mismatch is logged on destruction");
+}
 }
 
 void runHilbertVelvetTests()
@@ -257,5 +304,6 @@ void runHilbertVelvetTests()
 	testVelvetIsNormalizedAndDecorrelated();
 	testVelvetStreamIsBlockSizeInvariant();
 	testVelvetDynamicRenewalIsFiniteAndSmooth();
+	testHilbertMismatchIsLoggedOnDestruction();
 	harness.report();
 }

--- a/Tests/HybridConvTests/MultiConvolutionTests.cpp
+++ b/Tests/HybridConvTests/MultiConvolutionTests.cpp
@@ -16,6 +16,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#include "filters/ConvolutionFilter.h"
 #include "filters/MultiConvolutionCommand.h"
 #include "filters/MultiConvolutionFilter.h"
 #include "helpers/SndfileRAII.h"
@@ -123,6 +124,55 @@ void assertMismatchIsLoggedAndProfiled()
 		"MultiConvolution frame-count mismatch is logged");
 	harness.expectTrue(first != std::string::npos && log.find(marker, first + marker.size()) == std::string::npos,
 		"MultiConvolution mismatch detail is logged only once per instance");
+}
+
+// The Convolution sibling of the assertion above, colocated to reuse the IR
+// fixture and log-capture pattern (audit #250 A4: one shared diagnostics type
+// now covers all three convolvers, and each filter's prefix constant is its
+// observable contract).
+void assertConvolutionMismatchIsLogged()
+{
+	FILE* logFile = nullptr;
+	if (tmpfile_s(&logFile) != 0 || logFile == nullptr)
+	{
+		harness.fail("could not create convolution mismatch log capture");
+		return;
+	}
+	LogHelper::useStream(logFile, false, true, false);
+
+	{
+		vector<double> ir(frameLength, 0.0);
+		ir[0] = 1.0;
+		wstring irFile = createMultiChannelIr({ ir });
+		ConvolutionFilter filter(irFile);
+		filter.initialize((float)sampleRate, frameLength, vector<wstring>{ L"L" });
+		DeleteFileW(irFile.c_str());
+
+		constexpr unsigned shortBlock = frameLength / 2;
+		vector<double> in(shortBlock, 0.1);
+		vector<double> out(shortBlock, 1.0);
+		double* input[] = { in.data() };
+		double* output[] = { out.data() };
+		filter.process(output, input, shortBlock);
+		filter.process(output, input, shortBlock);
+		harness.expectTrue(out[0] == 0.0, "a mismatched Convolution block is muted");
+	}
+
+	std::fflush(logFile);
+	std::rewind(logFile);
+	std::wstring log;
+	wchar_t buffer[1024];
+	while (std::fgetws(buffer, static_cast<int>(std::size(buffer)), logFile) != nullptr)
+		log.append(buffer);
+	std::fclose(logFile);
+	LogHelper::useStream(stdout, true, true, false);
+
+	const std::wstring marker = ConvolutionFilter::kFrameCountMismatchLogPrefix;
+	const size_t first = log.find(marker);
+	harness.expectTrue(first != std::string::npos,
+		"Convolution frame-count mismatch is logged");
+	harness.expectTrue(first != std::string::npos && log.find(marker, first + marker.size()) == std::string::npos,
+		"Convolution mismatch detail is logged only once per instance");
 }
 
 // First tracer bullet for the mapping semantics: "L=0+1" convolves channel L's
@@ -511,6 +561,7 @@ void assertCommandSerializeRoundTrips()
 void runMultiConvolutionTests()
 {
 	assertMismatchIsLoggedAndProfiled();
+	assertConvolutionMismatchIsLogged();
 	assertMappingConvolvesTargetsOwnSignal();
 	assertEachMappingWritesItsOwnOutput();
 	assertSimpleFormUsesEveryIrChannel();

--- a/engine/FilterConfiguration.cpp
+++ b/engine/FilterConfiguration.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <typeinfo>
 
-#include "FilterEngine.h"
 #include "FilterConfiguration.h"
 #include "helpers/PerfProfile.h"
 
@@ -29,12 +28,12 @@
 
 namespace hn = hwy::HWY_NAMESPACE;
 
-FilterConfiguration::FilterConfiguration(const FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount)
+FilterConfiguration::FilterConfiguration(const EngineStreamFormat& format, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount)
 {
 	this->allChannelCount = allChannelCount;
-	realChannelCount = engine->getRealChannelCount();
-	outputChannelCount = engine->getOutputChannelCount();
-	unsigned maxFrameCount = engine->getMaxFrameCount();
+	realChannelCount = format.realChannelCount;
+	outputChannelCount = format.outputChannelCount;
+	unsigned maxFrameCount = format.maxFrameCount;
 
 	allSamplesData.resize(static_cast<size_t>(allChannelCount) * maxFrameCount);
 	allSamples2Data.resize(static_cast<size_t>(allChannelCount) * maxFrameCount);

--- a/engine/FilterConfiguration.h
+++ b/engine/FilterConfiguration.h
@@ -25,7 +25,16 @@
 
 #include "IFilter.h"
 
-class FilterEngine;
+// The stream facts a FilterConfiguration is built for (audit #250 A2). The
+// constructor used to take a FilterEngine* and read exactly these three
+// values once; taking the values themselves lets tests build a configuration
+// without an engine, a config file or a registry read.
+struct EngineStreamFormat
+{
+	unsigned realChannelCount = 0;
+	unsigned outputChannelCount = 0;
+	unsigned maxFrameCount = 0;
+};
 
 struct FilterInfo
 {
@@ -49,7 +58,7 @@ struct FilterInfo
 class FilterConfiguration
 {
 public:
-	FilterConfiguration(const FilterEngine* engine, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount);
+	FilterConfiguration(const EngineStreamFormat& format, std::vector<std::unique_ptr<FilterInfo>> filterInfos, unsigned allChannelCount);
 	~FilterConfiguration();
 
 	void read(double* input, unsigned frameCount);

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -125,7 +125,7 @@ bool FilterEngine::loadConfig(const wstring& customPath)
 				addFilters(move(newFilters));
 		}
 
-		FilterConfigurationPtr config(MemoryHelper::construct<FilterConfiguration>(this, move(filterInfos), (unsigned)allChannelNames.size()));
+		FilterConfigurationPtr config(MemoryHelper::construct<FilterConfiguration>(streamFormat(), move(filterInfos), (unsigned)allChannelNames.size()));
 
 		filterInfos.clear();
 

--- a/engine/FilterEngine.cpp
+++ b/engine/FilterEngine.cpp
@@ -168,7 +168,7 @@ void FilterEngine::initialize(float sampleRate, unsigned inputChannelCount, unsi
 		// same release/acquire handoff as a later reload.
 		configChannel.reset(FilterConfigurationPtr(
 			MemoryHelper::construct<FilterConfiguration>(
-				this, vector<std::unique_ptr<FilterInfo>>(), deviceChannelCount)));
+				streamFormat(), vector<std::unique_ptr<FilterInfo>>(), deviceChannelCount)));
 
 		try
 		{

--- a/engine/FilterEngine.h
+++ b/engine/FilterEngine.h
@@ -72,6 +72,8 @@ public:
 	unsigned getChannelMask() const {return channelMask;}
 	float getSampleRate() const {return sampleRate;}
 	unsigned getMaxFrameCount() const {return maxFrameCount;}
+	// The three stream facts a FilterConfiguration is built for (audit #250 A2).
+	EngineStreamFormat streamFormat() const {return {realChannelCount, outputChannelCount, maxFrameCount};}
 	// Crossfade length in samples for a configuration swap, set by initialize().
 	// Exposed so tests exercise the real value instead of re-deriving the
 	// sampleRate / 100 formula.

--- a/filters/ConvolutionFilter.cpp
+++ b/filters/ConvolutionFilter.cpp
@@ -27,6 +27,7 @@
 #include <windows.h>
 #include <fftw3.h>
 
+#include "ConvolverMuteDiagnostics.h"
 #include "helpers/LogHelper.h"
 #include "helpers/MemoryHelper.h"
 #include "helpers/ParallelExecutor.h"
@@ -41,14 +42,8 @@ using std::wstring;
 
 namespace
 {
-	// Running total of process() calls that took the frameCount-mismatch mute path
-	// across all ConvolutionFilter instances, plus the first mismatching block size
-	// seen. The mute path runs on the audio thread, so it may only bump these two
-	// relaxed atomics; cleanup() turns them into the log line, off the real-time
-	// path. Both are process-wide, like the mismatch condition itself: the engine
-	// hands every convolution filter of a configuration the same block size.
-	std::atomic<unsigned long long> muteCallCount{ 0 };
-	std::atomic<unsigned> firstMuteFrameCount{ 0 };
+	// Audit #250 A4: the shared bookkeeping; see ConvolverMuteDiagnostics.h.
+	ConvolverMuteDiagnostics muteDiagnostics;
 }
 
 ConvolutionFilter::ConvolutionFilter(const wstring& filename)
@@ -97,13 +92,7 @@ void ConvolutionFilter::process(double** output, double** input, unsigned frameC
 		// for every line, and this branch fires exactly when the stream can least
 		// afford blocking I/O on the audio thread (a format change, a device switch).
 		// cleanup() formats and writes the same information.
-		muteCallCount.fetch_add(1, std::memory_order_relaxed);
-		if (!frameCountMismatchLogged)
-		{
-			// Keep the block size that first failed; the deferred report needs it.
-			firstMuteFrameCount.store(frameCount, std::memory_order_relaxed);
-			frameCountMismatchLogged = true;
-		}
+		muteDiagnostics.recordMute(frameCount, frameCountMismatchLogged);
 		for (unsigned i = 0; i < channelCount; i++)
 			memset(output[i], 0, sizeof(double) * frameCount);
 		return;
@@ -128,9 +117,9 @@ void ConvolutionFilter::cleanup()
 	// It runs before the members are cleared, so the initialized block size is
 	// still available, and only for instances that actually muted.
 	if (frameCountMismatchLogged)
-		LogF(L"ConvolutionFilter: frameCount %u differs from initialized %u; output muted (audio-thread re-init skipped) [mute calls: %llu total]",
-			firstMuteFrameCount.load(std::memory_order_relaxed), filterFrameCount,
-			muteCallCount.load(std::memory_order_relaxed));
+		LogF(kConvolverMuteReportFormat, kFrameCountMismatchLogPrefix,
+			muteDiagnostics.firstMuteFrameCount.load(std::memory_order_relaxed), filterFrameCount,
+			muteDiagnostics.muteCallCount.load(std::memory_order_relaxed));
 
 	// HConvSingleArray::reset() runs the exact close-then-free sequence; assigning
 	// nullptr makes the teardown automatic and idempotent.

--- a/filters/ConvolutionFilter.h
+++ b/filters/ConvolutionFilter.h
@@ -31,6 +31,11 @@ class ConvolutionFilter : public IFilter
 public:
 	ConvolutionFilter(const std::wstring& filename);
 	virtual ~ConvolutionFilter();
+	// The deferred mute diagnostic's prefix is part of the filter's
+	// observable contract (HybridConvTests pins it), like
+	// MultiConvolutionFilter's (audit F058t).
+	static constexpr const wchar_t* kFrameCountMismatchLogPrefix =
+		L"ConvolutionFilter: frameCount";
 	bool getInPlace() override { return true; }
 	std::vector<std::wstring> initialize(float sampleRate, unsigned maxFrameCount, std::vector<std::wstring> channelNames) override;
 	void process(double** output, double** input, unsigned frameCount) override;

--- a/filters/ConvolverMuteDiagnostics.h
+++ b/filters/ConvolverMuteDiagnostics.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	Shared mute-path diagnostics for the convolver family (audit #250 A4).
+	When process() sees a block size other than the one the convolver was
+	initialized for, it mutes rather than re-initializing on the audio
+	thread; Convolution and MultiConvolution each carried a verbatim copy of
+	the bookkeeping (two relaxed atomics bumped on the RT path, one deferred
+	log line in cleanup()) and Hilbert, the third convolver, muted with no
+	diagnostics at all. One type, three filters.
+
+	The atomics are per-filter-class (one instance per translation unit,
+	like the statics they replace) and process-wide: the engine hands every
+	convolver of a configuration the same block size, so the counts describe
+	the process, while the first-mismatch flag stays per filter instance so
+	each instance reports once. The report itself is written by the filter's
+	own cleanup() through LogF, so the log context remains the filter's.
+*/
+
+#pragma once
+
+#include <atomic>
+
+struct ConvolverMuteDiagnostics
+{
+	// Running total of process() calls that took the mute path, plus the
+	// first mismatching block size seen. RT-safe: relaxed bumps, no I/O.
+	std::atomic<unsigned long long> muteCallCount{ 0 };
+	std::atomic<unsigned> firstMuteFrameCount{ 0 };
+
+	void recordMute(unsigned frameCount, bool& firstMismatchSeen) noexcept
+	{
+		muteCallCount.fetch_add(1, std::memory_order_relaxed);
+		if (!firstMismatchSeen)
+		{
+			// Keep the block size that first failed; the deferred report needs it.
+			firstMuteFrameCount.store(frameCount, std::memory_order_relaxed);
+			firstMismatchSeen = true;
+		}
+	}
+};
+
+// One wording for the deferred report; each filter passes its own prefix
+// constant (pinned by HybridConvTests) and its initialized block size.
+constexpr const wchar_t* kConvolverMuteReportFormat =
+	L"%s %u differs from initialized %u; output muted (audio-thread re-init skipped) [mute calls: %llu total]";

--- a/filters/HilbertFilter.cpp
+++ b/filters/HilbertFilter.cpp
@@ -6,9 +6,16 @@
 #include <complex>
 #include <set>
 
+#include "ConvolverMuteDiagnostics.h"
 #include "helpers/ChannelHelper.h"
 #include "helpers/LogHelper.h"
 #include "helpers/PerfProfile.h"
+
+namespace
+{
+// Audit #250 A4: the shared bookkeeping; see ConvolverMuteDiagnostics.h.
+ConvolverMuteDiagnostics muteDiagnostics;
+}
 
 namespace
 {
@@ -91,6 +98,16 @@ HilbertFilter::HilbertFilter(const HilbertCommand& command)
 {
 }
 
+HilbertFilter::~HilbertFilter()
+{
+	// Deferred report of the mute path process() took on the audio thread,
+	// like the other convolvers' cleanup(); only for instances that muted.
+	if (frameCountMismatchLogged)
+		LogF(kConvolverMuteReportFormat, kFrameCountMismatchLogPrefix,
+			muteDiagnostics.firstMuteFrameCount.load(std::memory_order_relaxed), filterFrameCount,
+			muteDiagnostics.muteCallCount.load(std::memory_order_relaxed));
+}
+
 std::vector<std::wstring> HilbertFilter::initialize(float sampleRate,
 	unsigned maxFrameCount, std::vector<std::wstring> channelNames)
 {
@@ -140,6 +157,13 @@ void HilbertFilter::process(double** output, double** input, unsigned frameCount
 
 	const bool convolverReady = filters != nullptr
 		&& frameCount == filterFrameCount;
+	if (filters != nullptr && frameCount != filterFrameCount)
+	{
+		// No logging here (audio thread); the destructor writes the deferred
+		// report, like the other convolvers (audit #250 A4 - this mute used
+		// to be silent).
+		muteDiagnostics.recordMute(frameCount, frameCountMismatchLogged);
+	}
 	for (size_t unit = 0; unit < shifted.size(); ++unit)
 	{
 		double* out = output[shifted[unit]];

--- a/filters/HilbertFilter.h
+++ b/filters/HilbertFilter.h
@@ -17,6 +17,12 @@ class HilbertFilter : public IFilter
 {
 public:
 	explicit HilbertFilter(const HilbertCommand& command);
+	~HilbertFilter();
+	// The deferred mute diagnostic's prefix is part of the filter's
+	// observable contract (HybridConvTests pins it), like the other
+	// convolvers' (audit #250 A4 - Hilbert used to mute silently).
+	static constexpr const wchar_t* kFrameCountMismatchLogPrefix =
+		L"HilbertFilter: frameCount";
 	bool getAllChannels() override { return true; }
 	bool getInPlace() override { return false; }
 	std::vector<std::wstring> initialize(float sampleRate, unsigned maxFrameCount,
@@ -33,5 +39,6 @@ private:
 	unsigned delayOffset = 0;
 	unsigned channelCount = 0;
 	unsigned filterFrameCount = 0;
+	bool frameCountMismatchLogged = false;
 };
 #pragma AVRT_VTABLES_END

--- a/filters/MultiConvolutionFilter.cpp
+++ b/filters/MultiConvolutionFilter.cpp
@@ -32,6 +32,7 @@
 #include "helpers/MemoryHelper.h"
 #include "helpers/ParallelExecutor.h"
 #include "helpers/PerfProfile.h"
+#include "ConvolverMuteDiagnostics.h"
 #include "MultiConvolutionFilter.h"
 
 using std::find;
@@ -40,12 +41,9 @@ using std::wstring;
 
 namespace
 {
-	// Mute-path diagnostics, written from the audio thread and read in cleanup().
-	// process() may only bump these relaxed atomics; the log line that describes
-	// them is written off the real-time path. See ConvolutionFilter.cpp for the
-	// same pair.
-	std::atomic<unsigned long long> multiMuteCallCount{ 0 };
-	std::atomic<unsigned> multiFirstMuteFrameCount{ 0 };
+	// Audit #250 A4: the shared bookkeeping; see ConvolverMuteDiagnostics.h.
+	// Per-class instance, like ConvolutionFilter's and HilbertFilter's.
+	ConvolverMuteDiagnostics muteDiagnostics;
 }
 
 MultiConvolutionFilter::MultiConvolutionFilter(const vector<MultiConvolutionCommand::Mapping>& mappings, const wstring& filename)
@@ -192,13 +190,7 @@ void MultiConvolutionFilter::process(double** output, double** input, unsigned f
 		// No logging here. LogHelper opens, writes and closes %TEMP%\EqualizerAPO.log
 		// for every line, and this branch fires exactly when the stream can least
 		// afford blocking I/O on the audio thread. cleanup() writes the same line.
-		multiMuteCallCount.fetch_add(1, std::memory_order_relaxed);
-		if (!frameCountMismatchLogged)
-		{
-			// Keep the block size that first failed; the deferred report needs it.
-			multiFirstMuteFrameCount.store(frameCount, std::memory_order_relaxed);
-			frameCountMismatchLogged = true;
-		}
+		muteDiagnostics.recordMute(frameCount, frameCountMismatchLogged);
 	}
 
 	// libHybridConv fixes its block length at hcInitSingle time, so a block of
@@ -244,10 +236,9 @@ void MultiConvolutionFilter::cleanup()
 	// It runs before the members are cleared so the initialized block size is
 	// still available.
 	if (frameCountMismatchLogged)
-		LogF(L"%s %u differs from initialized %u; output muted (audio-thread re-init skipped) [mute calls: %llu total]",
-			kFrameCountMismatchLogPrefix,
-			multiFirstMuteFrameCount.load(std::memory_order_relaxed), filterFrameCount,
-			multiMuteCallCount.load(std::memory_order_relaxed));
+		LogF(kConvolverMuteReportFormat, kFrameCountMismatchLogPrefix,
+			muteDiagnostics.firstMuteFrameCount.load(std::memory_order_relaxed), filterFrameCount,
+			muteDiagnostics.muteCallCount.load(std::memory_order_relaxed));
 	frameCountMismatchLogged = false;
 
 	// HConvSingleArray::reset() runs the close-then-free sequence.


### PR DESCRIPTION
감사 #250 후속 트랙 4의 전반부입니다(편성 기록: #250 코멘트). 후반부(A1 로드 세션, A5 계약, A6 초기화 옵션 + 엔진 레지스트리 포트)는 별도 PR로 이어집니다.

## A2 — FilterConfiguration이 스트림 형식을 값으로 받습니다

생성자가 FilterEngine*를 받아 unsigned 세 개를 한 번 읽는 게 전부였는데, 그 매개변수 타입이 모든 테스트에 엔진 부팅(임시 설정 파일 + HKLM 읽기 + 팩토리 레지스트리 생성)을 강제했습니다. 이제 `EngineStreamFormat{real, output, maxFrames}`를 받고, SampleIoTests는 구조체 리터럴로 구성해 채널 수당 엔진 하나씩 총 6개의 엔진·임시 파일·레지스트리 읽기가 스위트에서 사라졌습니다. FilterConfiguration.cpp의 FilterEngine.h include도 제거됐습니다.

## A4 — convolver 가족의 뮤트 진단 통일 + Hilbert의 무음 뮤트 해소

frameCount 불일치 시의 북키핑(오디오 스레드에서 relaxed 원자 2개만 증가, 로그는 cleanup에서 지연 기록)이 Convolution/MultiConvolution에 축자 쌍둥이로 있었고, 같은 뮤트 조건을 가진 세 번째 convolver인 Hilbert는 **진단이 아예 없어** 포맷 변경으로 조용해져도 로그에 아무것도 남지 않았습니다. `ConvolverMuteDiagnostics`가 북키핑과 문구를 소유하고, 각 필터는 클래스별 인스턴스(프로세스 전역 카운트 + 인스턴스별 1회 보고, 기존과 동일)를 유지하며 자기 LogF로 보고합니다. Convolution의 접두사도 MultiConvolution처럼 상수로 내보내(F058t), Hilbert는 기록·소멸 시 보고의 전체 처리를 새로 얻었습니다. 기존 쌍둥이의 로그 문구는 불변입니다.

## 검증

- 전체 avx2 레그 녹색: EngineOrchestrationTests 1,186 / EditorLogicTests 2,917 / HybridConvTests 1,635 / MultiConvolutionTests **5,361**(+3: Convolution 불일치 보고 신설 테스트) / HilbertVelvetTests **4,132**(Hilbert 소멸 시 보고 신설 테스트 포함).
- 골든 오디오 회귀 **30/30 비트동일** — 뮤트 동작 자체는 불변, 가시성만 늘었습니다.
- 변경 TU cppcheck 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)