### PR TITLE
refactor(engine): one load session, one init setup, a written channel contract (audit #250 A1+A5+A6)

### DIFF
--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -187,7 +187,6 @@ int main(int argc, char** argv)
 			wstring deviceName = StringHelper::toWString(devicenameArg.getValue(), CP_ACP);
 			wstring connectionName = StringHelper::toWString(connectionnameArg.getValue(), CP_ACP);
 			wstring deviceGuid = StringHelper::toWString(guidArg.getValue(), CP_ACP);
-			engine.setDeviceInfo(false, true, deviceName, connectionName, deviceGuid, deviceName + L" " + connectionName + L" " + deviceGuid);
 			wstring customConfigPath = StringHelper::toWString(configPathArg.getValue(), CP_ACP);
 			if (!customConfigPath.empty())
 			{
@@ -195,7 +194,21 @@ int main(int argc, char** argv)
 				if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY))
 					customConfigPath += L"\\config.txt";
 			}
-			engine.initialize(static_cast<float>(sampleRate), channelCount, channelCount, channelCount, channelMask, batchsize, customConfigPath);
+			// Audit #250 A6: the engine assembles the Device: match key from
+			// the parts (Benchmark's old hand-assembly had the name and
+			// connection reversed relative to production).
+			EngineSetup setup;
+			setup.sampleRate = static_cast<float>(sampleRate);
+			setup.inputChannelCount = channelCount;
+			setup.realChannelCount = channelCount;
+			setup.outputChannelCount = channelCount;
+			setup.channelMask = channelMask;
+			setup.maxFrameCount = batchsize;
+			setup.customPath = customConfigPath;
+			setup.deviceName = deviceName;
+			setup.connectionName = connectionName;
+			setup.deviceGuid = deviceGuid;
+			engine.initialize(setup);
 
 			double initTime = timer.stop();
 			if (!verbose)

--- a/Editor/AnalysisThread.cpp
+++ b/Editor/AnalysisThread.cpp
@@ -179,8 +179,19 @@ void AnalysisThread::run()
 		FilterEngine engine;
 		engine.setAnalysisMode(true);
 		engine.setLoadTraceSink(&traceCollector);
-		engine.setDeviceInfo(device->isInput(), true, device->getDeviceName(), device->getConnectionName(), device->getDeviceGuid(), device->getDeviceString());
-		engine.initialize(sampleRate, channelCount, channelCount, channelCount, channelMask, frameCount, configPath.toStdWString());
+		EngineSetup setup;
+		setup.sampleRate = sampleRate;
+		setup.inputChannelCount = channelCount;
+		setup.realChannelCount = channelCount;
+		setup.outputChannelCount = channelCount;
+		setup.channelMask = channelMask;
+		setup.maxFrameCount = frameCount;
+		setup.customPath = configPath.toStdWString();
+		setup.capture = device->isInput();
+		setup.deviceName = device->getDeviceName();
+		setup.connectionName = device->getConnectionName();
+		setup.deviceGuid = device->getDeviceGuid();
+		engine.initialize(setup);
 		engine.setLoadTraceSink(nullptr);
 		double initializationTime = (timer.nsecsElapsed() - startTime) / 1e6;
 

--- a/EqualizerAPO/EqualizerAPO.cpp
+++ b/EqualizerAPO/EqualizerAPO.cpp
@@ -235,7 +235,7 @@ HRESULT EqualizerAPO::Initialize(UINT32 cbDataSize, BYTE* pbyData)
 	{
 		LogF(L"Could not convert apo guid to guid string");
 	}
-	engine.setPreMix((apoGuid == EQUALIZERAPO_PRE_MIX_GUID) != 0);
+	engineSetup.preMix = (apoGuid == EQUALIZERAPO_PRE_MIX_GUID) != 0;
 
 	winutil::PropVariant var;
 	HRESULT hr = initStruct->pAPOEndpointProperties->GetValue(PKEY_AudioEndpoint_GUID, &var);
@@ -274,7 +274,11 @@ HRESULT EqualizerAPO::Initialize(UINT32 cbDataSize, BYTE* pbyData)
 		DeviceAPOInfo apoInfo;
 		if (apoInfo.load(deviceGuid))
 		{
-			engine.setDeviceInfo(apoInfo.isInput(), apoInfo.getCurrentInstallState().installPostMix, apoInfo.getDeviceName(), apoInfo.getConnectionName(), apoInfo.getDeviceGuid(), apoInfo.getDeviceString());
+			engineSetup.capture = apoInfo.isInput();
+			engineSetup.postMixInstalled = apoInfo.getCurrentInstallState().installPostMix;
+			engineSetup.deviceName = apoInfo.getDeviceName();
+			engineSetup.connectionName = apoInfo.getConnectionName();
+			engineSetup.deviceGuid = apoInfo.getDeviceGuid();
 
 			if (apoGuid == EQUALIZERAPO_PRE_MIX_GUID)
 				childApoGuid = apoInfo.getPreMixChildGuid();
@@ -537,7 +541,13 @@ HRESULT EqualizerAPO::LockForProcess(UINT32 u32NumInputConnections,
 
 	try
 	{
-		engine.initialize(outFormat.fFramesPerSecond, inFormat.dwSamplesPerFrame, realChannelCount, outFormat.dwSamplesPerFrame, channelMask, maxFrameCount);
+		engineSetup.sampleRate = outFormat.fFramesPerSecond;
+		engineSetup.inputChannelCount = inFormat.dwSamplesPerFrame;
+		engineSetup.realChannelCount = realChannelCount;
+		engineSetup.outputChannelCount = outFormat.dwSamplesPerFrame;
+		engineSetup.channelMask = channelMask;
+		engineSetup.maxFrameCount = maxFrameCount;
+		engine.initialize(engineSetup);
 	}
 	catch (const std::bad_alloc&)
 	{

--- a/EqualizerAPO/EqualizerAPO.h
+++ b/EqualizerAPO/EqualizerAPO.h
@@ -99,6 +99,10 @@ private:
 	long refCount;
 	IUnknown* pUnkOuter;
 	FilterEngine engine;
+	// Accumulates the engine facts across the APO lifecycle (premix at
+	// Initialize, device identity when the endpoint is known, stream format
+	// at LockForProcess) for the one initialize(setup) call (audit #250 A6).
+	EngineSetup engineSetup;
 	bool allowSilentBufferModification;
 
 	void resetChild();

--- a/Tests/AudioRegressionTests/AudioRegressionTests.cpp
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.cpp
@@ -568,8 +568,16 @@ std::vector<float> runEngineOverBlocks(const std::wstring& configPath, unsigned 
 	FilterEngine engine;
 	std::wstring deviceName = L"AudioRegressionTests";
 	std::wstring connectionName = L"File";
-	engine.setDeviceInfo(false, true, deviceName, connectionName, L"", deviceName + L" " + connectionName + L" ");
-	engine.initialize((float)sampleRate, channels, channels, channels, 0, blockFrames, configPath);
+	EngineSetup setup;
+	setup.sampleRate = (float)sampleRate;
+	setup.inputChannelCount = channels;
+	setup.realChannelCount = channels;
+	setup.outputChannelCount = channels;
+	setup.maxFrameCount = blockFrames;
+	setup.customPath = configPath;
+	setup.deviceName = deviceName;
+	setup.connectionName = connectionName;
+	engine.initialize(setup);
 	for (unsigned b = 0; b < blockCount; ++b)
 	{
 		size_t offset = (size_t)b * blockFrames * channels;
@@ -762,10 +770,19 @@ bool runCase(const TestCase& tc, const Options& opts, bool& outFailed)
 		std::wstring connectionName = L"File";
 		std::wstring deviceGuid = L"";
 		std::wstring deviceString = deviceName + L" " + connectionName + L" " + deviceGuid;
-		engine.setDeviceInfo(false, true, deviceName, connectionName, deviceGuid, deviceString);
+		EngineSetup setup;
+		setup.deviceName = deviceName;
+		setup.connectionName = connectionName;
+		setup.deviceGuid = deviceGuid;
 		// maxFrameCount is the block size, not the signal length: that is what the
 		// APO passes and what the convolution filters partition against.
-		engine.initialize((float)tc.sampleRate, tc.channels, tc.channels, tc.channels, 0, tc.blockFrames, configPath);
+		setup.sampleRate = (float)tc.sampleRate;
+		setup.inputChannelCount = tc.channels;
+		setup.realChannelCount = tc.channels;
+		setup.outputChannelCount = tc.channels;
+		setup.maxFrameCount = tc.blockFrames;
+		setup.customPath = configPath;
+		engine.initialize(setup);
 		for (unsigned offset = 0; offset < tc.frames; offset += tc.blockFrames)
 		{
 			const size_t sampleOffset = (size_t)offset * tc.channels;

--- a/Tests/EngineOrchestrationTests/ChannelInheritanceTests.cpp
+++ b/Tests/EngineOrchestrationTests/ChannelInheritanceTests.cpp
@@ -1,0 +1,114 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	The consumer half of the channel-inheritance contract (audit #250 A5,
+	documented at FilterInfo in FilterConfiguration.h): an empty
+	inChannels/outChannels vector means "reuse the pointer set the previous
+	filter left behind", and the non-in-place buffer rotation is exactly why
+	an empty outChannels is only sound between in-place neighbours. Until
+	FilterConfiguration became directly constructible (A2) this protocol was
+	guarded only by golden output hashes, which cannot distinguish
+	"inherited the pointers" from "recomputed identical indices".
+*/
+
+#include <vector>
+
+#include "engine/FilterConfiguration.h"
+#include "Tests/TestHarness.h"
+
+namespace
+{
+// Records the pointer sets process() hands it; the recording IS the
+// assertion surface.
+class RecordingFilter : public IFilter
+{
+public:
+	explicit RecordingFilter(bool inPlace)
+		: inPlace(inPlace)
+	{
+	}
+
+	bool getInPlace() override
+	{
+		return inPlace;
+	}
+
+	std::vector<std::wstring> initialize(float, unsigned,
+		std::vector<std::wstring> channelNames) override
+	{
+		return channelNames;
+	}
+
+	void process(double** output, double** input, unsigned) override
+	{
+		seenInput.assign(input, input + 2);
+		seenOutput.assign(output, output + 2);
+	}
+
+	bool inPlace;
+	std::vector<double*> seenInput;
+	std::vector<double*> seenOutput;
+};
+
+std::unique_ptr<FilterInfo> makeInfo(RecordingFilter*& outFilter, bool inPlace,
+	std::vector<size_t> inChannels, std::vector<size_t> outChannels)
+{
+	auto info = std::make_unique<FilterInfo>();
+	outFilter = MemoryHelper::construct<RecordingFilter>(inPlace);
+	info->filter = FilterPtr(outFilter);
+	info->inPlace = inPlace;
+	info->inChannels = std::move(inChannels);
+	info->outChannels = std::move(outChannels);
+	return info;
+}
+}
+
+void runChannelInheritanceTests(test::Harness& harness)
+{
+	// An in-place successor with empty vectors sees exactly the pointer set
+	// its predecessor saw - inheritance, not recomputation.
+	{
+		RecordingFilter* first = nullptr;
+		RecordingFilter* second = nullptr;
+		std::vector<std::unique_ptr<FilterInfo>> infos;
+		infos.push_back(makeInfo(first, true, { 0, 1 }, { 0, 1 }));
+		infos.push_back(makeInfo(second, true, {}, {}));
+
+		FilterConfiguration config(EngineStreamFormat{ 2, 2, 64 },
+			std::move(infos), 2);
+		std::vector<double> block(2 * 64, 0.25);
+		config.read(block.data(), 64);
+		config.process(64);
+
+		harness.require(first->seenInput.size() == 2 && second->seenInput.size() == 2,
+			"both recording filters ran");
+		harness.expect(second->seenInput == first->seenInput,
+			"empty inChannels inherits the predecessor's input pointers");
+		harness.expect(second->seenOutput == first->seenOutput,
+			"empty outChannels between in-place filters inherits the output pointers");
+	}
+
+	// The non-in-place rotation: the successor's inputs are the predecessor's
+	// OUTPUT buffers, which is why an empty outChannels may not follow a
+	// non-in-place filter - the pointers it would reuse were just swapped.
+	{
+		RecordingFilter* first = nullptr;
+		RecordingFilter* second = nullptr;
+		std::vector<std::unique_ptr<FilterInfo>> infos;
+		infos.push_back(makeInfo(first, false, { 0, 1 }, { 0, 1 }));
+		infos.push_back(makeInfo(second, true, { 0, 1 }, { 0, 1 }));
+
+		FilterConfiguration config(EngineStreamFormat{ 2, 2, 64 },
+			std::move(infos), 2);
+		std::vector<double> block(2 * 64, 0.25);
+		config.read(block.data(), 64);
+		config.process(64);
+
+		harness.require(first->seenInput.size() == 2 && second->seenInput.size() == 2,
+			"both recording filters ran (rotation case)");
+		harness.expect(first->seenOutput != first->seenInput,
+			"a non-in-place filter writes into the second buffer set");
+		harness.expect(second->seenInput == first->seenOutput,
+			"after the rotation the successor reads the predecessor's output buffers");
+	}
+}

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -45,6 +45,8 @@
 #include "helpers/Win32Event.h"
 #include "Tests/TestHarness.h"
 
+#include "FakeRegistry.h"
+
 namespace
 {
 void testDeviceApoRegistryVocabulary(test::Harness& harness)
@@ -247,8 +249,17 @@ void initializeEngine(FilterEngine& engine, unsigned sampleRate, unsigned channe
 	const std::wstring deviceName = L"EngineOrchestrationTests";
 	const std::wstring connectionName = L"File";
 	const std::wstring deviceGuid = L"";
-	engine.setDeviceInfo(false, true, deviceName, connectionName, deviceGuid, deviceName + L" " + connectionName);
-	engine.initialize((float)sampleRate, channels, channels, channels, 0, maxFrameCount, configPath);
+	EngineSetup setup;
+	setup.sampleRate = (float)sampleRate;
+	setup.inputChannelCount = channels;
+	setup.realChannelCount = channels;
+	setup.outputChannelCount = channels;
+	setup.maxFrameCount = maxFrameCount;
+	setup.customPath = configPath;
+	setup.deviceName = deviceName;
+	setup.connectionName = connectionName;
+	setup.deviceGuid = deviceGuid;
+	engine.initialize(setup);
 }
 
 // Processes one block of interleaved stereo DC input and returns the output.
@@ -739,8 +750,15 @@ void testInitialLoadUsesPublicationChannel(test::Harness& harness)
 
 	FilterEngine engine;
 	const std::wstring deviceName = L"EngineOrchestrationTests";
-	engine.setDeviceInfo(false, true, deviceName, L"File", L"", deviceName + L" File");
-	engine.initialize(48000.0f, 2, 2, 2, 0, 16, configPath);
+	EngineSetup setup;
+	setup.inputChannelCount = 2;
+	setup.realChannelCount = 2;
+	setup.outputChannelCount = 2;
+	setup.maxFrameCount = 16;
+	setup.customPath = configPath;
+	setup.deviceName = deviceName;
+	setup.connectionName = L"File";
+	engine.initialize(setup);
 
 	harness.expect(engine.hasStatefulOrTailFilters(),
 		"initial configuration bypassed the worker-to-RT publication channel");
@@ -787,8 +805,15 @@ void testEmptyConfigurationExpandsRenderChannels(test::Harness& harness)
 
 	FilterEngine engine;
 	const std::wstring deviceName = L"EngineOrchestrationTests";
-	engine.setDeviceInfo(false, true, deviceName, L"File", L"", deviceName + L" File");
-	engine.initialize(48000.0f, 2, 2, 8, 0, 16, configPath);
+	EngineSetup setup;
+	setup.inputChannelCount = 2;
+	setup.realChannelCount = 2;
+	setup.outputChannelCount = 8;
+	setup.maxFrameCount = 16;
+	setup.customPath = configPath;
+	setup.deviceName = deviceName;
+	setup.connectionName = L"File";
+	engine.initialize(setup);
 
 	constexpr unsigned frames = 4;
 	float input[frames * 2] = {
@@ -946,6 +971,41 @@ void testParseErrorsAreReportedPerLineAndProseIsNot(test::Harness& harness)
 		"a configuration with four unusable lines still loads, because the working lines below them have to run");
 }
 
+// Audit #250 A6/A3: the engine's registry surface (the config language's
+// readRegDWORD here) goes through the injected port, so a config that reads
+// the registry is deterministic under a fake - previously these functions
+// could only ever see the live machine.
+void testConfigRegistryReadsGoThroughThePort(test::Harness& harness)
+{
+	test::FakeRegistry registry;
+	const std::wstring key = L"HKEY_CURRENT_USER\\Software\\EapoPortTest";
+	registry.seedKey(key);
+	registry.seedDword(key, L"gain", 6);
+
+	const std::wstring configPath = writeConfig(harness, L"registry-port.txt",
+		"Eval: g=readRegDWORD(\"HKEY_CURRENT_USER\\\\Software\\\\EapoPortTest\", \"gain\")\n"
+		"Preamp: `-g` dB\n");
+	FilterEngine engine;
+	// The load resolves g = 6 from the seeded value and the preamp
+	// attenuates by 6 dB.
+	EngineSetup setup;
+	setup.sampleRate = 48000.0f;
+	setup.inputChannelCount = 2;
+	setup.realChannelCount = 2;
+	setup.outputChannelCount = 2;
+	setup.maxFrameCount = 16;
+	setup.customPath = configPath;
+	setup.deviceName = L"PortTest";
+	setup.connectionName = L"File";
+	setup.registry = &registry;
+	engine.initialize(setup);
+
+	const std::vector<float> output = processDcBlock(engine, 1.0f, 1.0f, 16);
+	const float expected = static_cast<float>(std::pow(10.0, -6.0 / 20.0));
+	harness.expect(std::fabs(output[(size_t)15 * 2] - expected) < 1e-4f,
+		"readRegDWORD resolves through the injected fake registry");
+}
+
 void testAnalysisFreezesDynamicVelvetAndLabelsTheSnapshot(
 	test::Harness& harness)
 {
@@ -983,6 +1043,7 @@ void runDeviceApoInfoTests(test::Harness& harness);
 void runRegistryTransactionTests(test::Harness& harness);
 void runInstallDiagnosticsTests(test::Harness& harness);
 void runApoRegistrationTests(test::Harness& harness);
+void runChannelInheritanceTests(test::Harness& harness);
 
 int runEngineOrchestrationTests()
 {
@@ -1023,6 +1084,7 @@ int runEngineOrchestrationTests()
 	runDeviceApoInfoTests(harness);
 	runInstallDiagnosticsTests(harness);
 	runApoRegistrationTests(harness);
+	runChannelInheritanceTests(harness);
 	testProcessWithoutConfigurationDoesNotCrash(harness);
 	testInitialLoadUsesPublicationChannel(harness);
 	testConfigSwapChannelPermitRoundTrip(harness);
@@ -1039,6 +1101,7 @@ int runEngineOrchestrationTests()
 	testRealBrirCrossfeed(harness);
 	testConfigLoadTrace(harness);
 	testParseErrorsAreReportedPerLineAndProseIsNot(harness);
+	testConfigRegistryReadsGoThroughThePort(harness);
 	testAnalysisFreezesDynamicVelvetAndLabelsTheSnapshot(harness);
 
 	removeTestDirectory();

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.vcxproj
@@ -226,6 +226,7 @@ if exist "$(MUPARSERX_LIB)\*.dll" copy /Y "$(MUPARSERX_LIB)\*.dll" "$(OutDir)"</
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ApoRegistrationTests.cpp" />
+    <ClCompile Include="ChannelInheritanceTests.cpp" />
     <ClCompile Include="ConfigurationFileReaderTests.cpp" />
     <ClCompile Include="DeviceApoInfoTests.cpp" />
     <ClCompile Include="EngineOrchestrationTests.cpp" />

--- a/Tests/HybridConvTests/SubwooferRoutingEngineTests.cpp
+++ b/Tests/HybridConvTests/SubwooferRoutingEngineTests.cpp
@@ -100,27 +100,17 @@ void initializeEngine(
 	unsigned channels,
 	unsigned channelMask)
 {
-	const std::wstring deviceName = L"SubwooferRoutingEngineTests";
-	const std::wstring connectionName = L"File";
-	const std::wstring deviceGuid;
-	const std::wstring deviceString =
-		deviceName + L" " + connectionName + L" " + deviceGuid;
-
-	engine.setDeviceInfo(
-		false,
-		true,
-		deviceName,
-		connectionName,
-		deviceGuid,
-		deviceString);
-	engine.initialize(
-		static_cast<float>(kSampleRate),
-		channels,
-		channels,
-		channels,
-		channelMask,
-		kBlockFrames,
-		configPath);
+	EngineSetup setup;
+	setup.sampleRate = static_cast<float>(kSampleRate);
+	setup.inputChannelCount = channels;
+	setup.realChannelCount = channels;
+	setup.outputChannelCount = channels;
+	setup.channelMask = channelMask;
+	setup.maxFrameCount = kBlockFrames;
+	setup.customPath = configPath;
+	setup.deviceName = L"SubwooferRoutingEngineTests";
+	setup.connectionName = L"File";
+	engine.initialize(setup);
 }
 
 // The input is deliberately taken by value so every engine receives an

--- a/VoicemeeterClient/VoicemeeterClient.cpp
+++ b/VoicemeeterClient/VoicemeeterClient.cpp
@@ -175,9 +175,17 @@ void VoicemeeterClient::handle(long nCommand, void* lpData, long nnn)
 		sampleRate.store(newSampleRate);
 		maxFrameCount.store(newMaxFrameCount);
 		engineState.withLock([&](const EngineState& state) {
-			for (const auto& engine : state.engines)
-				if (engine != nullptr)
-					engine->initialize(newSampleRate, 8, 8, 8, 0, newMaxFrameCount);
+			for (size_t i = 0; i < state.engines.size(); i++)
+				if (state.engines[i] != nullptr)
+				{
+					EngineSetup setup = state.engineSetups[i];
+					setup.sampleRate = newSampleRate;
+					setup.inputChannelCount = 8;
+					setup.realChannelCount = 8;
+					setup.outputChannelCount = 8;
+					setup.maxFrameCount = newMaxFrameCount;
+					state.engines[i]->initialize(setup);
+				}
 		});
 		VoicemeeterAPOInfo::saveVoicemeeterSampleRate((unsigned)audioInfo->samplerate);
 	}
@@ -313,12 +321,19 @@ void VoicemeeterClient::detectVoicemeeterType()
 				if (find(outputs.begin(), outputs.end(), output) != outputs.end())
 				{
 					auto engine = std::make_unique<FilterEngine>();
-					engine->setDeviceInfo(false, true, L"Voicemeeter", output, L"", L"Voicemeeter " + output);
+					// Audit #250 A6: the engine assembles the Device: match
+					// key from these parts. Device patterns match per word,
+					// so the assembled order change is behavior-neutral.
+					EngineSetup deviceSetup;
+					deviceSetup.deviceName = L"Voicemeeter";
+					deviceSetup.connectionName = output;
+					replacement.engineSetups.push_back(deviceSetup);
 					replacement.engines.push_back(std::move(engine));
 				}
 				else
 				{
 					replacement.engines.push_back(nullptr);
+					replacement.engineSetups.push_back(EngineSetup{});
 				}
 
 				replacement.idleSampleCounts.push_back(0);
@@ -331,9 +346,17 @@ void VoicemeeterClient::detectVoicemeeterType()
 				const unsigned currentMaxFrameCount = maxFrameCount.load();
 				if (currentSampleRate != 0.0f && currentMaxFrameCount != 0)
 				{
-					for (const auto& engine : replacement.engines)
-						if (engine != nullptr)
-							engine->initialize(currentSampleRate, 8, 8, 8, 0, currentMaxFrameCount);
+					for (size_t i = 0; i < replacement.engines.size(); i++)
+						if (replacement.engines[i] != nullptr)
+						{
+							EngineSetup setup = replacement.engineSetups[i];
+							setup.sampleRate = currentSampleRate;
+							setup.inputChannelCount = 8;
+							setup.realChannelCount = 8;
+							setup.outputChannelCount = 8;
+							setup.maxFrameCount = currentMaxFrameCount;
+							replacement.engines[i]->initialize(setup);
+						}
 				}
 				state = std::move(replacement);
 			});

--- a/VoicemeeterClient/VoicemeeterClient.h
+++ b/VoicemeeterClient/VoicemeeterClient.h
@@ -46,6 +46,9 @@ private:
 	struct EngineState
 	{
 		std::vector<std::unique_ptr<FilterEngine>> engines;
+		// Parallel to engines: the per-strip device identity, completed with
+		// the stream format at each (re)initialize (audit #250 A6).
+		std::vector<EngineSetup> engineSetups;
 		std::vector<int> idleSampleCounts;
 	};
 

--- a/engine/FilterConfiguration.h
+++ b/engine/FilterConfiguration.h
@@ -36,6 +36,23 @@ struct EngineStreamFormat
 	unsigned maxFrameCount = 0;
 };
 
+// The channel-inheritance contract (audit #250 A5), which used to exist only
+// as an unwritten agreement between FilterEngine::addFilters and
+// FilterConfiguration::process:
+//
+// An empty inChannels/outChannels vector does NOT mean "no channels". It
+// means "reuse the pointer set the previous filter left behind" - process()
+// simply skips refilling currentSamples/currentSamples2, so they still hold
+// the previous filter's channels. addFilters may only emit the empty vector
+// when it has proven the reuse is sound: for inChannels, the previous
+// filter's published channel set is identical to this filter's selection;
+// for outChannels, additionally BOTH filters are in-place, because the
+// non-in-place buffer rotation in process() swaps the very pointers an
+// empty outChannels would reuse. The previous load's last in-place flag
+// deliberately carries into the next load for the same reason.
+//
+// The three IFilter hooks (getAllChannels/getInPlace/getSelectChannels) are
+// the third leg of this protocol; their meaning is documented at IFilter.h.
 struct FilterInfo
 {
 	std::unique_ptr<IFilter, FilterDeleter> filter;

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -65,43 +65,30 @@ bool FilterEngine::loadConfig(const wstring& customPath)
 	lock_guard<mutex> lock(loadMutex);
 	timer.start();
 
-	// The factories build through these engine-owned scratch fields. Move the
-	// previous idle state aside so the whole load is transactional: any exception
-	// discards the partial filters/channel routing and restores registry watches,
-	// while the active configuration remains untouched.
-	auto savedFilterInfos = move(filterInfos);
-	auto savedCurrentChannelNames = move(currentChannelNames);
-	auto savedLastChannelNames = move(lastChannelNames);
-	auto savedLastNewChannelNames = move(lastNewChannelNames);
-	auto savedAllChannelNames = move(allChannelNames);
-	auto savedWatchRegistryKeys = move(watchRegistryKeys);
-	auto savedTraceFile = move(traceFile);
-	const int savedTraceLine = traceLine;
-	const bool savedLastInPlace = lastInPlace;
-	const bool savedFrozenDynamicAnalysis = frozenDynamicAnalysis;
-	frozenDynamicAnalysis = false;
+	// The factories build through the engine's load session. Move the previous
+	// idle session aside so the whole load is transactional: any exception
+	// discards the partial filters/channel routing and restores registry
+	// watches, while the active configuration remains untouched. Audit #250
+	// A1: the transaction is a move of one value - a field added to
+	// LoadSession is covered by construction, instead of by keeping a save
+	// block, a rollback lambda and the member list in step by hand.
+	LoadSession saved = move(load);
+	load = LoadSession{};
+	// The in-place-ness of the previous load's last filter deliberately
+	// carries across loads: the first filter's output-inheritance test in
+	// addFilters reads it (see the channel-inheritance contract in
+	// FilterConfiguration.h).
+	load.lastInPlace = saved.lastInPlace;
 
 	auto rollback = [&]() noexcept {
-		filterInfos = move(savedFilterInfos);
-		currentChannelNames = move(savedCurrentChannelNames);
-		lastChannelNames = move(savedLastChannelNames);
-		lastNewChannelNames = move(savedLastNewChannelNames);
-		allChannelNames = move(savedAllChannelNames);
-		watchRegistryKeys = move(savedWatchRegistryKeys);
-		traceFile = move(savedTraceFile);
-		traceLine = savedTraceLine;
-		lastInPlace = savedLastInPlace;
-		frozenDynamicAnalysis = savedFrozenDynamicAnalysis;
+		load = move(saved);
 	};
 
 	try
 	{
-		allChannelNames = ChannelHelper::getChannelNames(max(realChannelCount, outputChannelCount), channelMask);
+		load.allChannelNames = ChannelHelper::getChannelNames(max(realChannelCount, outputChannelCount), channelMask);
 
-		currentChannelNames = allChannelNames;
-		lastChannelNames.clear();
-		lastNewChannelNames.clear();
-		watchRegistryKeys.clear();
+		load.currentChannelNames = load.allChannelNames;
 		parser.beginLoad();
 
 		for (auto it = factories.cbegin(); it != factories.cend(); it++)
@@ -125,9 +112,9 @@ bool FilterEngine::loadConfig(const wstring& customPath)
 				addFilters(move(newFilters));
 		}
 
-		FilterConfigurationPtr config(MemoryHelper::construct<FilterConfiguration>(streamFormat(), move(filterInfos), (unsigned)allChannelNames.size()));
+		FilterConfigurationPtr config(MemoryHelper::construct<FilterConfiguration>(streamFormat(), move(load.filterInfos), (unsigned)load.allChannelNames.size()));
 
-		filterInfos.clear();
+		load.filterInfos.clear();
 
 		double loadTime = timer.stop();
 		TraceF(L"Finished loading configuration after %lf milliseconds", loadTime * 1000.0);
@@ -160,14 +147,14 @@ void FilterEngine::loadConfigFile(const wstring& path)
 	if (!inputStream.good())
 		return;
 
-	vector<wstring> savedChannelNames = currentChannelNames;
+	vector<wstring> savedChannelNames = load.currentChannelNames;
 	// Load-trace position: like the channel names, the position is saved and
 	// restored across the Include recursion so entries reported after a nested
 	// file returns are stamped with the outer file again.
-	wstring savedTraceFile = move(traceFile);
-	int savedTraceLine = traceLine;
-	traceFile = path;
-	traceLine = 0;
+	wstring savedTraceFile = move(load.traceFile);
+	int savedTraceLine = load.traceLine;
+	load.traceFile = path;
+	load.traceLine = 0;
 
 	for (auto it = factories.cbegin(); it != factories.cend(); it++)
 	{
@@ -180,7 +167,7 @@ void FilterEngine::loadConfigFile(const wstring& path)
 	const vector<wstring> decodedLines = ConfigurationFileReader::decodeLines(inputStream);
 	for (const wstring& line : decodedLines)
 	{
-		traceLine++;
+		load.traceLine++;
 
 		size_t pos = line.find(L':');
 		if (pos != wstring::npos)
@@ -230,9 +217,9 @@ void FilterEngine::loadConfigFile(const wstring& path)
 	}
 
 	// restore channels selected in outer configuration file
-	currentChannelNames = savedChannelNames;
-	traceFile = move(savedTraceFile);
-	traceLine = savedTraceLine;
+	load.currentChannelNames = savedChannelNames;
+	load.traceFile = move(savedTraceFile);
+	load.traceLine = savedTraceLine;
 }
 
 void FilterEngine::reportParseError(const wstring& command, const wstring& reason)
@@ -240,7 +227,7 @@ void FilterEngine::reportParseError(const wstring& command, const wstring& reaso
 	// The log line goes out whether or not a sink is attached: the APO runtime
 	// never attaches one, and a user whose Convolution line silently does nothing
 	// has to be able to find out why from the log.
-	LogF(L"%s: %s (line %d of %s)", command.c_str(), reason.c_str(), traceLine, traceFile.c_str());
+	LogF(L"%s: %s (line %d of %s)", command.c_str(), reason.c_str(), load.traceLine, load.traceFile.c_str());
 
 	ConfigLoadTraceEntry entry;
 	entry.kind = ConfigLoadTraceEntry::Kind::ParseError;
@@ -253,12 +240,12 @@ void FilterEngine::traceLoadEvent(ConfigLoadTraceEntry entry)
 {
 	if (traceSink == nullptr)
 		return;
-	entry.file = traceFile;
-	entry.line = traceLine;
+	entry.file = load.traceFile;
+	entry.line = load.traceLine;
 	traceSink->addEntry(entry);
 }
 
 void FilterEngine::watchRegistryKey(const std::wstring& key)
 {
-	watchRegistryKeys.insert(key);
+	load.watchRegistryKeys.insert(key);
 }

--- a/engine/FilterEngine.Runtime.cpp
+++ b/engine/FilterEngine.Runtime.cpp
@@ -63,46 +63,46 @@ void FilterEngine::addFilters(FilterVector filters)
 		filterInfo->filter = move(ownedFilter);
 		IFilter* filter = filterInfo->filter.get();
 		filterInfo->inPlace = filter->getInPlace();
-		vector<wstring> savedChannelNames = currentChannelNames;
+		vector<wstring> savedChannelNames = load.currentChannelNames;
 		bool allChannels = filter->getAllChannels();
 		if (allChannels)
-			currentChannelNames = allChannelNames;
+			load.currentChannelNames = load.allChannelNames;
 
-		if (lastChannelNames == currentChannelNames)
+		if (load.lastChannelNames == load.currentChannelNames)
 		{
 			filterInfo->inChannels.clear();
 		}
 		else
 		{
-			filterInfo->inChannels.resize(currentChannelNames.size());
+			filterInfo->inChannels.resize(load.currentChannelNames.size());
 
 			size_t c = 0;
-			for (vector<wstring>::iterator it2 = currentChannelNames.begin(); it2 != currentChannelNames.end(); it2++)
+			for (vector<wstring>::iterator it2 = load.currentChannelNames.begin(); it2 != load.currentChannelNames.end(); it2++)
 			{
-				vector<wstring>::iterator pos = find(allChannelNames.begin(), allChannelNames.end(), *it2);
-				if (pos == allChannelNames.end())
+				vector<wstring>::iterator pos = find(load.allChannelNames.begin(), load.allChannelNames.end(), *it2);
+				if (pos == load.allChannelNames.end())
 				{
-					// Defensive: every currentChannelNames entry should already be in
-					// allChannelNames (seeded from it, or a filter's own subset). If that
+					// Defensive: every load.currentChannelNames entry should already be in
+					// load.allChannelNames (seeded from it, or a filter's own subset). If that
 					// invariant is ever broken, append the name instead of storing a
 					// one-past-the-end index that process() would read out of bounds; the
 					// appended channel reads the zero-filled virtual range (silence).
 					// Mirrors the outChannels handling below.
-					filterInfo->inChannels[c++] = allChannelNames.size();
-					allChannelNames.push_back(*it2);
+					filterInfo->inChannels[c++] = load.allChannelNames.size();
+					load.allChannelNames.push_back(*it2);
 				}
 				else
 				{
-					filterInfo->inChannels[c++] = pos - allChannelNames.begin();
+					filterInfo->inChannels[c++] = pos - load.allChannelNames.begin();
 				}
 			}
 		}
 
-		lastChannelNames = currentChannelNames;
+		load.lastChannelNames = load.currentChannelNames;
 
-		vector<wstring> newChannelNames = filter->initialize(sampleRate, maxFrameCount, currentChannelNames);
+		vector<wstring> newChannelNames = filter->initialize(sampleRate, maxFrameCount, load.currentChannelNames);
 
-		if (filterInfo->inPlace && lastInPlace && lastNewChannelNames == newChannelNames)
+		if (filterInfo->inPlace && load.lastInPlace && load.lastNewChannelNames == newChannelNames)
 		{
 			filterInfo->outChannels.clear();
 		}
@@ -113,30 +113,30 @@ void FilterEngine::addFilters(FilterVector filters)
 			size_t c = 0;
 			for (vector<wstring>::iterator it2 = newChannelNames.begin(); it2 != newChannelNames.end(); it2++)
 			{
-				vector<wstring>::iterator pos = find(allChannelNames.begin(), allChannelNames.end(), *it2);
-				if (pos == allChannelNames.end())
+				vector<wstring>::iterator pos = find(load.allChannelNames.begin(), load.allChannelNames.end(), *it2);
+				if (pos == load.allChannelNames.end())
 				{
-					filterInfo->outChannels[c++] = allChannelNames.size();
-					allChannelNames.push_back(*it2);
+					filterInfo->outChannels[c++] = load.allChannelNames.size();
+					load.allChannelNames.push_back(*it2);
 				}
 				else
 				{
-					filterInfo->outChannels[c++] = pos - allChannelNames.begin();
+					filterInfo->outChannels[c++] = pos - load.allChannelNames.begin();
 				}
 			}
 		}
 
-		lastNewChannelNames = newChannelNames;
-		lastInPlace = filterInfo->inPlace;
-		if (!lastInPlace)
-			swap(lastChannelNames, lastNewChannelNames);
+		load.lastNewChannelNames = newChannelNames;
+		load.lastInPlace = filterInfo->inPlace;
+		if (!load.lastInPlace)
+			swap(load.lastChannelNames, load.lastNewChannelNames);
 
-		filterInfos.push_back(move(filterInfo));
+		load.filterInfos.push_back(move(filterInfo));
 
 		if (filter->getSelectChannels())
-			currentChannelNames = newChannelNames;
+			load.currentChannelNames = newChannelNames;
 		else
-			currentChannelNames = savedChannelNames;
+			load.currentChannelNames = savedChannelNames;
 	}
 }
 
@@ -181,8 +181,8 @@ void FilterEngine::notificationThread(FilterEngine* engine)
 				lock_guard<mutex> lock(engine->loadMutex);
 				snapshot.directory = engine->configPath;
 				snapshot.registryKeys.assign(
-					engine->watchRegistryKeys.begin(),
-					engine->watchRegistryKeys.end());
+					engine->load.watchRegistryKeys.begin(),
+					engine->load.watchRegistryKeys.end());
 				return snapshot;
 			},
 			[engine] {

--- a/engine/FilterEngine.cpp
+++ b/engine/FilterEngine.cpp
@@ -32,6 +32,7 @@
 #include <mpPackageStr.h>
 #include <mpPackageMatrix.h>
 
+#include "helpers/IRegistry.h"
 #include "helpers/RegistryHelper.h"
 #include "helpers/StringHelper.h"
 #include "helpers/LogHelper.h"
@@ -101,9 +102,9 @@ FilterEngine::~FilterEngine()
 	cleanupConfigurations();
 }
 
-void FilterEngine::setPreMix(bool preMix)
+IRegistry& FilterEngine::registryAccess() const
 {
-	this->preMix = preMix;
+	return registryPort != nullptr ? *registryPort : systemRegistry();
 }
 
 bool FilterEngine::hasStatefulOrTailFilters() const
@@ -118,24 +119,36 @@ bool FilterEngine::hasStatefulOrTailFilters() const
 	return !currentConfig->isAllStateless();
 }
 
-void FilterEngine::setDeviceInfo(bool capture, bool postMixInstalled, const wstring& deviceName, const wstring& connectionName, const wstring& deviceGuid, const wstring& deviceString)
+void FilterEngine::initialize(const EngineSetup& setup)
 {
-	this->capture = capture;
-	this->postMixInstalled = postMixInstalled;
-	this->deviceName = deviceName;
-	this->connectionName = connectionName;
-	this->deviceGuid = deviceGuid;
-	this->deviceString = deviceString;
-}
+	const float sampleRate = setup.sampleRate;
+	const unsigned inputChannelCount = setup.inputChannelCount;
+	const unsigned realChannelCount = setup.realChannelCount;
+	const unsigned outputChannelCount = setup.outputChannelCount;
+	unsigned channelMask = setup.channelMask;
+	const unsigned maxFrameCount = setup.maxFrameCount;
+	const wstring& customPath = setup.customPath;
 
-void FilterEngine::initialize(float sampleRate, unsigned inputChannelCount, unsigned realChannelCount, unsigned outputChannelCount, unsigned channelMask, unsigned maxFrameCount, const wstring& customPath)
-{
 	bool shouldLoadConfig = false;
 
 	{
 		lock_guard<mutex> lock(loadMutex);
 
 		cleanupConfigurations();
+
+		this->preMix = setup.preMix;
+		this->capture = setup.capture;
+		this->postMixInstalled = setup.postMixInstalled;
+		this->deviceName = setup.deviceName;
+		this->connectionName = setup.connectionName;
+		this->deviceGuid = setup.deviceGuid;
+		// One assembly of the Device: command's match key (audit #250 A6):
+		// connection name, device name, then the GUID when present - the
+		// spelling DeviceAPOInfo::getDeviceString always produced. Callers
+		// used to hand-assemble this in six different spellings.
+		this->deviceString = setup.connectionName + L" " + setup.deviceName
+			+ (setup.deviceGuid.empty() ? L"" : L" " + setup.deviceGuid);
+		this->registryPort = setup.registry;
 
 		this->sampleRate = sampleRate;
 		this->inputChannelCount = inputChannelCount;
@@ -172,7 +185,9 @@ void FilterEngine::initialize(float sampleRate, unsigned inputChannelCount, unsi
 
 		try
 		{
-			configPath = RegistryHelper::readValue(APP_REGPATH, L"ConfigPath");
+			// Through the port (audit #250 A6/A3): a test or embedded host
+			// that supplies a fake registry no longer touches live HKLM here.
+			configPath = registryAccess().readValue(APP_REGPATH, L"ConfigPath");
 		}
 		catch (const RegistryException& e)
 		{

--- a/engine/FilterEngine.h
+++ b/engine/FilterEngine.h
@@ -37,6 +37,38 @@
 
 struct ConfigLoadTraceEntry;
 class ConfigLoadTraceSink;
+class IRegistry;
+
+// Everything initialize() needs, in one value (audit #250 A6). The old shape
+// was three calls whose ordering lived only in comments (setPreMix and
+// setDeviceInfo before initialize) and whose adjacent same-typed parameters
+// were silently swappable; twelve call sites each re-assembled the ritual,
+// with six different spellings of the deviceString the Device: command
+// matches against. The engine now assembles deviceString from the parts
+// (connection name, device name, then the GUID when present - the
+// production spelling), and the config source is explicit instead of a
+// sentinel: an empty customPath means "the registry's ConfigPath, with the
+// change watcher" (the APO's mode); a caller-supplied path loads that file
+// and starts no watcher.
+struct EngineSetup
+{
+	float sampleRate = 48000.0f;
+	unsigned inputChannelCount = 0;
+	unsigned realChannelCount = 0;
+	unsigned outputChannelCount = 0;
+	unsigned channelMask = 0;
+	unsigned maxFrameCount = 0;
+	std::wstring customPath;
+	bool preMix = false;
+	bool capture = false;
+	bool postMixInstalled = true;
+	std::wstring deviceName;
+	std::wstring connectionName;
+	std::wstring deviceGuid;
+	// Registry port for the ConfigPath read and the config language's
+	// readRegString/readRegDWORD; null = the live registry.
+	IRegistry* registry = nullptr;
+};
 
 #pragma AVRT_VTABLES_BEGIN
 class FilterEngine
@@ -45,9 +77,11 @@ public:
 	FilterEngine();
 	~FilterEngine();
 
-	void setPreMix(bool preMix);
-	void setDeviceInfo(bool capture, bool postMixInstalled, const std::wstring& deviceName, const std::wstring& connectionName, const std::wstring& deviceGuid, const std::wstring& deviceString);
-	void initialize(float sampleRate, unsigned inputChannelCount, unsigned realChannelCount, unsigned outputChannelCount, unsigned channelMask, unsigned maxFrameCount, const std::wstring& customPath = L"");
+	void initialize(const EngineSetup& setup);
+	// The injected registry (audit #250 A6/A3): the live adapter unless the
+	// setup supplied a fake. Consumed by the ConfigPath read and the config
+	// language's readRegString/readRegDWORD.
+	IRegistry& registryAccess() const;
 	// Builds a complete configuration before publishing it. A failed load keeps
 	// the active configuration and returns false; no initialization exception is
 	// allowed to escape the configuration-loading boundary.
@@ -88,8 +122,8 @@ public:
 	// initialize(), so factories can freeze their dynamic state while loading.
 	void setAnalysisMode(bool enabled) {analysisMode = enabled;}
 	bool isAnalysisMode() const {return analysisMode;}
-	void markFrozenDynamicAnalysis() {frozenDynamicAnalysis = true;}
-	bool usedFrozenDynamicAnalysis() const {return frozenDynamicAnalysis;}
+	void markFrozenDynamicAnalysis() {load.frozenDynamicAnalysis = true;}
+	bool usedFrozenDynamicAnalysis() const {return load.frozenDynamicAnalysis;}
 	// Factories report an evaluation fact for the line currently being
 	// parsed; the engine stamps the file/line position. No-op without a sink.
 	void traceLoadEvent(ConfigLoadTraceEntry entry);
@@ -133,6 +167,9 @@ private:
 	std::wstring deviceGuid;
 	std::wstring deviceString;
 	std::wstring configPath;
+	// Set by initialize() from the setup; null until then (registryAccess()
+	// falls back to the live registry).
+	IRegistry* registryPort = nullptr;
 	float sampleRate = 0.0f;
 	// number of input channels that originally existed before child APO processing
 	unsigned inputChannelCount;
@@ -142,21 +179,38 @@ private:
 	unsigned channelMask = 0;
 	unsigned maxFrameCount = 0;
 
-	// only used during loading
+	// Pre-init inputs that survive across loads: the trace sink and analysis
+	// mode are attached before initialize() and describe every load that
+	// runs while attached.
 	ConfigLoadTraceSink* traceSink = nullptr;
 	bool analysisMode = false;
-	bool frozenDynamicAnalysis = false;
-	// Position of the line loadConfigFile is currently feeding to the
-	// factories; saved/restored across Include recursion like the channel
-	// names. Only meaningful while a sink is attached.
-	std::wstring traceFile;
-	int traceLine = 0;
-	std::vector<std::unique_ptr<FilterInfo>> filterInfos;
-	std::vector<std::wstring> currentChannelNames;
-	std::vector<std::wstring> lastChannelNames;
-	std::vector<std::wstring> lastNewChannelNames;
-	std::vector<std::wstring> allChannelNames;
-	bool lastInPlace = false;
+
+	// Everything a configuration load builds through, as one value (audit
+	// #250 A1). loadConfig's transaction is a move of the whole session -
+	// save it aside, build a fresh one, restore on any exception - so a
+	// field added here is transactional by construction instead of by
+	// keeping the save block, the rollback lambda and the member list in
+	// step by hand (frozenDynamicAnalysis once missed exactly that).
+	// watchRegistryKeys and frozenDynamicAnalysis are the two load results
+	// read after the load: the watcher thread snapshots the keys under
+	// loadMutex, and the Editor's analysis reads the freeze flag.
+	struct LoadSession
+	{
+		std::vector<std::unique_ptr<FilterInfo>> filterInfos;
+		std::vector<std::wstring> currentChannelNames;
+		std::vector<std::wstring> lastChannelNames;
+		std::vector<std::wstring> lastNewChannelNames;
+		std::vector<std::wstring> allChannelNames;
+		std::unordered_set<std::wstring> watchRegistryKeys;
+		// Position of the line loadConfigFile is currently feeding to the
+		// factories; saved/restored across Include recursion like the
+		// channel names. Only meaningful while a sink is attached.
+		std::wstring traceFile;
+		int traceLine = 0;
+		bool lastInPlace = false;
+		bool frozenDynamicAnalysis = false;
+	};
+	LoadSession load;
 	EngineParser parser;
 
 	ConfigSwapChannel<FilterConfigurationPtr> configChannel;
@@ -169,7 +223,6 @@ private:
 	std::mutex loadMutex;
 	PrecisionTimer timer;
 	std::thread notificationWorker;
-	std::unordered_set<std::wstring> watchRegistryKeys;
 	bool lastInputWasSilent;
 };
 #pragma AVRT_VTABLES_END

--- a/engine/IFilter.h
+++ b/engine/IFilter.h
@@ -32,6 +32,11 @@ class IFilter
 public:
 	virtual ~IFilter() {}
 
+	// These three hooks drive the channel-inheritance protocol in
+	// FilterEngine::addFilters; the full contract (what an empty
+	// inChannels/outChannels vector means and when it may be emitted) is
+	// documented at FilterInfo in FilterConfiguration.h.
+
 	// request to get all channel names instead of selection
 	virtual bool getAllChannels() {return false;}
 	// return false to request that output and input do not point to the same memory locations

--- a/parser/RegistryFunctions.cpp
+++ b/parser/RegistryFunctions.cpp
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "stdafx.h"
 #include <memory>
 #include "RegistryFunctions.h"
+#include "helpers/IRegistry.h"
 #include "../helpers/RegistryHelper.h"
 #include "../engine/FilterEngine.h"
 
@@ -46,7 +47,7 @@ void ReadRegStringFunction::Eval(ptr_val_type& ret, const ptr_val_type* arg, int
 
 	try
 	{
-		wstring value = RegistryHelper::readValue(key, valuename);
+		wstring value = engine->registryAccess().readValue(key, valuename);
 
 		*ret = value;
 
@@ -86,7 +87,7 @@ void ReadRegDWORDFunction::Eval(ptr_val_type& ret, const ptr_val_type* arg, int 
 
 	try
 	{
-		unsigned long value = RegistryHelper::readDWORDValue(key, valuename);
+		unsigned long value = engine->registryAccess().readDWORDValue(key, valuename);
 
 		*ret = (mup::int_type)value;
 


### PR DESCRIPTION
감사 #250 후속 트랙 4의 후반부입니다(전반부: #258 → v2.34.3).

## A1 — 로드 세션 값 객체

로드 한정 스크래치 10필드가 `LoadSession` 하나가 됐습니다. loadConfig의 트랜잭션은 손으로 쓰던 저장 블록 + 롤백 람다(같은 목록을 두 번 나열) 대신 세션 통째 이동/복원입니다. 필드를 추가하면 트랜잭션 포함이 구조적으로 보장됩니다(frozenDynamicAnalysis가 한 번 빠뜨렸던 바로 그 부류). 의도적 이월 한 건(직전 로드 마지막 필터의 in-place 플래그 — 채널 상속 계약이 읽음)만 주석 달린 한 줄로 남았습니다.

## A5 — 채널 상속 계약의 명문화 + 표적 테스트

'빈 in/outChannels = 직전 필터의 포인터 집합 재사용'이라는 규약과 addFilters가 그것을 내보낼 수 있는 조건(출력은 양쪽 모두 in-place여야 함 — 비-in-place 버퍼 회전이 재사용할 포인터를 뒤집기 때문)을 FilterInfo 헤더에 적고 IFilter의 훅 3개에서 참조합니다. A2로 가능해진 직접 구성 위에서 기록형 스텁 필터가 포인터 상속과 회전을 직접 단언합니다 — 골든 해시로는 '상속'과 '동일 재계산'을 구분할 수 없었습니다.

## A6 — 초기화 옵션 구조체 + Device: 키 조립 통일

setPreMix→setDeviceInfo→initialize 3단 의식(순서는 주석에만 존재, 인접 동형 매개변수는 조용히 뒤바뀜)이 `EngineSetup` 하나가 됐고, 12개 호출부가 여섯 철자로 손조립하던 Device: 매치 키를 엔진이 프로덕션 철자로 한 곳에서 조립합니다. Device: 패턴은 단어 단위 포함 매칭이라 철자 통일은 동작 중립입니다(DeviceCommand::matches로 확인). 설정 원천도 센티널 문자열 대신 명시적 의미를 갖습니다.

## 엔진 레지스트리 포트(트랙 3 이월분)

ConfigPath 읽기와 config 언어의 readRegString/readRegDWORD가 주입된 IRegistry(`EngineSetup.registry`, null=라이브)를 탑니다. 엔진 테스트가 라이브 HKLM을 만지지 않게 됐고, FakeRegistry에 시드한 DWORD가 Preamp 감쇠로 이어지는 결정적 테스트를 추가했습니다.

## 검증

- 전체 avx2 레그 녹색: EngineOrchestrationTests **1,193**(채널 상속 + 레지스트리 포트 스위트 포함) / EditorLogicTests 2,917 / HybridConvTests 1,635 / MultiConvolutionTests 5,361.
- 골든 오디오 회귀 **30/30 비트동일**.
- Editor 빌드 + 스킨 전환 게이트 녹색, 변경 TU cppcheck 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)