### PR TITLE
ci: drop the dead deviceString the EngineSetup migration left behind

### DIFF
--- a/Tests/AudioRegressionTests/AudioRegressionTests.cpp
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.cpp
@@ -769,7 +769,6 @@ bool runCase(const TestCase& tc, const Options& opts, bool& outFailed)
 		std::wstring deviceName = L"AudioRegressionTests";
 		std::wstring connectionName = L"File";
 		std::wstring deviceGuid = L"";
-		std::wstring deviceString = deviceName + L" " + connectionName + L" " + deviceGuid;
 		EngineSetup setup;
 		setup.deviceName = deviceName;
 		setup.connectionName = connectionName;


### PR DESCRIPTION
PR #259의 A6 마이그레이션이 setDeviceInfo 소비처만 제거하고 지역 변수 대입을 남겨 cppcheck 0-베이스라인 게이트가 잡았습니다(unreadVariable 1건). 해당 줄을 제거합니다.

이 1건은 #259의 PR 실행에서 실패로 보고됐으나 머지가 감시와 무조건 연쇄로 묶여 있어 먼저 나갔습니다. 게이트 판정이 옳았고, 연쇄 머지는 제 실수입니다 — 이후 머지는 결과 확인 뒤에만 실행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)