### PR TITLE
chore(design-sync): Claude Design 프로젝트 핀과 Qt 오프스크립트 규약 기록

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,6 @@
+{
+  "projectId": "dabe0a0e-3fc1-4d39-a5e7-aeeb712ceb57",
+  "projectName": "EqualizerAPO-XT Skins",
+  "shape": "offscript-qt",
+  "notes": "Qt Widgets C++ repo - outside the converter envelope. No React component bundle by decision (reimplementation forbidden). Uploads: tokens (SkinThemeData.cpp 5 skins x dark/light), fonts (Editor/fonts), guidelines (docs/skins/*.md), gallery captures as visual reference, styles.css + conventions README. No _ds_sync.json (no anchor; every sync re-verifies)."
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,71 @@
+# EqualizerAPO-XT Skins — 사용 규약
+
+이 프로젝트는 React 컴포넌트 번들이 아니다. Windows용 Qt Widgets 앱
+(EqualizerAPO-XT Editor)의 5스킨 디자인 시스템에서 토큰·폰트·헌법 문서·실제
+렌더 캡처만 동기화한 것이다. 화면은 일반 HTML/React 요소를 아래 토큰으로
+직접 스타일링해 짓고, 목표는 이 앱의 스킨 문법에 맞는 목업이다.
+
+## 셋업 (없으면 전부 무스타일)
+
+모든 토큰은 스킨 선택자 아래에서만 정의된다. 루트 요소에 반드시 두 속성을
+얹어라. 스킨은 `studio | minimal | soft | rack | matrix`, 모드는
+`dark | light`다.
+
+```html
+<div data-skin="matrix" data-mode="dark"> …화면 전체… </div>
+```
+
+## 토큰 어휘 (이 이름 그대로, 새 색 발명 금지)
+
+- 바탕: `--eapo-bg`(창 그라운드) `--eapo-surface` `--eapo-card`(카드 면)
+  `--eapo-card-hover` `--eapo-card-selected` `--eapo-surface-raised`
+  `--eapo-surface-sunken`(함몰 셀) `--eapo-graph`(그래프 그라운드)
+- 잉크: `--eapo-text` `--eapo-muted` `--eapo-border`
+  `--eapo-graph-grid-major` `--eapo-graph-grid-minor`
+- 상태색: `--eapo-accent`(체결·선택·호버) `--eapo-accent2`(보조/컷 방향)
+  `--eapo-success` `--eapo-warning` `--eapo-danger` `--eapo-focus-ring`
+- 구조: `--eapo-radius` `--eapo-row-height` `--eapo-group-indent`
+  `--eapo-card-rail-width`(matrix만 3px) `--eapo-font` `--eapo-mono`
+
+## 다섯 스킨의 성격 (구속 규칙 요약)
+
+- **studio**: 방송 콘솔. 라운드 8px, 블루/퍼플 듀얼 액센트.
+- **minimal**: 잉크 단색주의. 라운드 0, 본문까지 DM Mono, 상태는 색보다
+  형태(취소선·괄호·`!!`)로 말한다.
+- **soft**: 파스텔. 라운드 14px, 행 44px로 가장 여유, success/warning/danger
+  까지 파스텔 값이다.
+- **rack**: 하드웨어 랙. 라운드 3px, 황동(`--eapo-accent`) 새김, 패널 물성.
+- **matrix**: 라우팅 보드. **라운드 0·1px 룰만, 그림자/글로우 금지, AA 없는
+  크리스프 선.** 신호등 색은 상태 전용(장식 금지), 시안 액센트는
+  체결·선택·호버·신호 데이터 전용. 수치는 반드시 함몰 모노 박스 셀
+  (`--eapo-surface-sunken` + 1px `--eapo-border` + `--eapo-mono`). 카드
+  왼쪽에 3px 상태 레일(가동=`--eapo-success`, 바이패스=`--eapo-warning`),
+  카드 본문 밴드는 `--eapo-bg`로 통째 채운 한 장의 보드 패널이다.
+
+## 진실의 위치
+
+스타일 값은 `tokens/<skin>.css`(Qt 소스 SkinThemeData.cpp에서 추출한 출하
+값), 문법 규칙 전문은 `guidelines/<skin>.md`(한국어 헌법, 판례 포함), 실물
+비주얼은 `guidelines/captures/<skin>/*.png`(실제 Qt 앱의 오프스크린 렌더)다.
+스타일링 전에 대상 스킨의 헌법과 캡처를 먼저 읽어라.
+
+## 관용 스니펫 (matrix 문법의 카드 한 장)
+
+```html
+<div data-skin="matrix" data-mode="dark" style="padding:16px">
+  <div style="background:var(--eapo-card);border:1px solid var(--eapo-border);
+              border-left:3px solid var(--eapo-success);border-radius:0">
+    <div style="background:var(--eapo-card-hover);padding:6px 10px;
+                display:flex;gap:8px;align-items:center">
+      <span style="font-family:var(--eapo-mono);color:var(--eapo-muted);
+                   border:1px solid var(--eapo-border);padding:2px 6px">B3</span>
+      <b>Peaking</b>
+    </div>
+    <div style="background:var(--eapo-bg);border-top:1px solid var(--eapo-border);
+                padding:10px">
+      <span style="font-family:var(--eapo-mono);background:var(--eapo-surface-sunken);
+                   border:1px solid var(--eapo-border);padding:4px 8px">1,000.00 Hz</span>
+    </div>
+  </div>
+</div>
+```


### PR DESCRIPTION
## 무엇

claude.ai/design에 'EqualizerAPO-XT Skins' 프로젝트를 만들어 5스킨 디자인 언어를 동기화했습니다(오프스크립트: React 번들 없이 토큰·폰트·헌법·실캡처만). 이 PR은 그 동기화의 저장소 측 상태만 담습니다.

- `.design-sync/config.json` — 프로젝트 핀(projectId)과 오프스크립트 형상 기록. 다음 동기화가 같은 프로젝트를 찾아가게 합니다.
- `.design-sync/conventions.md` — 디자인 에이전트용 사용 규약(README 헤더로 업로드됨): data-skin/data-mode 셋업, --eapo-* 토큰 어휘, 5스킨 구속 규칙 요약, matrix 문법 스니펫.

업로드 자체는 완료: 토큰 5스킨×2모드(SkinThemeData.cpp 출하 값), 번들 폰트 12종+라이선스, 스킨 헌법 6문서, 실캡처 50장, 파운데이션 카드 6장. 프로젝트: https://claude.ai/design/p/dabe0a0e-3fc1-4d39-a5e7-aeeb712ceb57

🤖 Generated with [Claude Code](https://claude.com/claude-code)