### PR TITLE
ci: close the release pipeline's silent-failure points (audit #275)

### DIFF
--- a/.github/scripts/New-BuildMatrix.ps1
+++ b/.github/scripts/New-BuildMatrix.ps1
@@ -19,7 +19,10 @@
 #>
 param(
   [Parameter(Mandatory = $true)]
-  [string]$EventName
+  [string]$EventName,
+  # Return the expanded matrix as an object (for Pester) in addition to the
+  # GITHUB_OUTPUT lines (audit #275 TD-33).
+  [switch]$PassThru
 )
 
 $ErrorActionPreference = "Stop"
@@ -91,4 +94,11 @@ Write-Host "Runner-executable x64 variants: $compareJson"
 if ($env:GITHUB_OUTPUT) {
   "matrix=$json" >> $env:GITHUB_OUTPUT
   "runner_executable_variants=$compareJson" >> $env:GITHUB_OUTPUT
+}
+
+if ($PassThru) {
+  [pscustomobject]@{
+    Matrix                   = $matrix
+    RunnerExecutableVariants = @($compareVariants)
+  }
 }

--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -23,16 +23,17 @@ Import-Module (Join-Path $PSScriptRoot "ReleaseAssets.psm1") -Force
 
 # Release-channel table for the SIMD/architecture builds. The channel KEYS are the
 # single source of truth in .github/simd-variants.psd1 (Variants[].Channel); the
-# Pattern / SortOrder / Guidance columns are release-notes-specific and stay here.
-# Order matters: Get-ChannelFromAssetName matches Pattern values top to bottom,
-# so more specific patterns (e.g. avx10/avx512/avx2) must precede broader ones (avx).
+# SortOrder / Guidance columns are release-notes-specific and stay here.
+# Classification no longer pattern-matches (audit #275): Get-ChannelFromAssetName
+# compares against the exact names the ReleaseAssets.psm1 grammar computes, so
+# there is no ordering sensitivity between e.g. avx and avx2.
 $ChannelTable = [ordered]@{
-  "arm64-neon"  = @{ Pattern = "arm64";                      SortOrder = 40;  Guidance = "Windows on ARM64 devices." }
-  "x64-sse2"    = @{ Pattern = "sse2|baseline";              SortOrder = 5;   Guidance = "Baseline 64-bit Intel/AMD systems. Pick this for older x64 CPUs that do not support AVX." }
-  "x64-avx10-1" = @{ Pattern = "avx10-1|avx10_1";            SortOrder = 30;  Guidance = "64-bit Intel/AMD systems with AVX10.1 support. Note: CI compiles but cannot execute this instruction set on its hosted runners, so this build skips the runtime audio tests that the sse2/avx/avx2 builds pass." }
-  "x64-avx512"  = @{ Pattern = "avx512";                     SortOrder = 20;  Guidance = "64-bit Intel/AMD systems where you specifically want the AVX-512 build. Note: CI compiles but cannot execute this instruction set on its hosted runners, so this build skips the runtime audio tests that the sse2/avx/avx2 builds pass." }
-  "x64-avx2"    = @{ Pattern = "avx2";                       SortOrder = 10;  Guidance = "Most 64-bit Intel/AMD systems with AVX2. Use this if you are unsure which x64 build to pick." }
-  "x64-avx"     = @{ Pattern = "(^|[-_.])avx($|[-_.])";      SortOrder = 8;   Guidance = "64-bit Intel/AMD systems with AVX, but not AVX2." }
+  "arm64-neon"  = @{ SortOrder = 40;  Guidance = "Windows on ARM64 devices." }
+  "x64-sse2"    = @{ SortOrder = 5;   Guidance = "Baseline 64-bit Intel/AMD systems. Pick this for older x64 CPUs that do not support AVX." }
+  "x64-avx10-1" = @{ SortOrder = 30;  Guidance = "64-bit Intel/AMD systems with AVX10.1 support. Note: CI compiles but cannot execute this instruction set on its hosted runners, so this build skips the runtime audio tests that the sse2/avx/avx2 builds pass." }
+  "x64-avx512"  = @{ SortOrder = 20;  Guidance = "64-bit Intel/AMD systems where you specifically want the AVX-512 build. Note: CI compiles but cannot execute this instruction set on its hosted runners, so this build skips the runtime audio tests that the sse2/avx/avx2 builds pass." }
+  "x64-avx2"    = @{ SortOrder = 10;  Guidance = "Most 64-bit Intel/AMD systems with AVX2. Use this if you are unsure which x64 build to pick." }
+  "x64-avx"     = @{ SortOrder = 8;   Guidance = "64-bit Intel/AMD systems with AVX, but not AVX2." }
 }
 
 # Fail loudly if the manifest's channel set drifts from this table, so a new or
@@ -93,9 +94,17 @@ function Get-ChannelFromAssetName {
     [string]$AssetName
   )
 
-  $lowerName = $AssetName.ToLowerInvariant()
-  foreach ($channel in $ChannelTable.Keys) {
-    if ($lowerName -match $ChannelTable[$channel].Pattern) {
+  # Exact names from the grammar module (setup, feed), and the pack-id prefix
+  # for the versioned nupkgs. Longest pack id first so e.g. x64-avx cannot
+  # claim an x64-avx2 nupkg by prefix.
+  $byPackIdLength = @($ChannelTable.Keys | Sort-Object `
+    { (Get-VelopackPackId -Channel $_).Length } -Descending)
+  foreach ($channel in $byPackIdLength) {
+    if ($AssetName -ieq (Get-SetupAssetName -Channel $channel)) { return $channel }
+    if ($AssetName -ieq (Get-FeedAssetName -Channel $channel)) { return $channel }
+    if ($AssetName -match '\.nupkg$' -and
+        $AssetName.StartsWith("$(Get-VelopackPackId -Channel $channel)-", `
+          [System.StringComparison]::OrdinalIgnoreCase)) {
       return $channel
     }
   }
@@ -344,7 +353,10 @@ $builtVariantsPhrase = if ($manifestChannels.Count -gt 0) {
 } else {
   "installers for every SIMD/architecture channel"
 }
-[void]$lines.Add("The linked workflow builds $builtVariantsPhrase. It runs EditorLogicTests on every build variant, and runs HybridConvTests, EngineOrchestrationTests, and AudioRegressionTests (plus a cross-variant output comparison) where the GitHub-hosted runner can execute the target instruction set.")
+# EditorLogicTests sits behind the same CanExecute gate as the other suites
+# since it started linking Common.lib whole-archive (Build-Solution.ps1), so
+# it must not be advertised as running on every variant (audit #275 TD-34).
+[void]$lines.Add("The linked workflow builds $builtVariantsPhrase. It runs EditorLogicTests, HybridConvTests, EngineOrchestrationTests, and AudioRegressionTests (plus a cross-variant output comparison) on the variants whose instruction set the GitHub-hosted runner can execute; the remaining variants are compile-verified.")
 [void]$lines.Add("")
 [void]$lines.Add("Release page: [$Tag]($releaseUrl)")
 

--- a/.github/scripts/New-VelopackRelease.ps1
+++ b/.github/scripts/New-VelopackRelease.ps1
@@ -73,28 +73,40 @@ foreach ($artifact in $buildArtifacts) {
 }
 
 $plan = [pscustomobject]@{
-    VpkVersion    = $manifest.Shared.VelopackVpkVersion
-    ReleaseName   = "EqualizerAPO-XT $PackVersion"
-    RepoUrl       = "https://github.com/$Repository"
-    Channels      = @($channelWork)
-    NeedsSource   = [bool]$NeedsSource
-    SourceZipPath = Join-Path $WorkspaceRoot (Get-SourceZipAssetName -PackVersion $PackVersion)
+    VpkVersion      = $manifest.Shared.VelopackVpkVersion
+    ReleaseName     = "EqualizerAPO-XT $PackVersion"
+    RepoUrl         = "https://github.com/$Repository"
+    Channels        = @($channelWork)
+    NeedsSource     = [bool]$NeedsSource
+    SourceZipPath   = Join-Path $WorkspaceRoot (Get-SourceZipAssetName -PackVersion $PackVersion)
+    # Single source: Shared.QtPluginFolders in simd-variants.psd1, shared with
+    # the Package-Artifacts.ps1 staging assertion (audit #275 TD-11).
+    QtPluginFolders = @($manifest.Shared.QtPluginFolders)
 }
 if ($PlanOnly) {
     return $plan
 }
 
 dotnet tool install -g vpk --version $plan.VpkVersion
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { throw "dotnet tool install vpk $($plan.VpkVersion) failed with exit code $LASTEXITCODE" }
 $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
 
+# Required payload. These used to sit behind Test-Path guards, so a moved
+# Setup\config or icon shipped a package silently missing its sample configs
+# (audit #275 TD-11): every file below is release content, so a miss is an
+# error, not a skip.
 $iconPath = Join-Path $WorkspaceRoot "Editor\icons\app-icon.ico"
 $configSource = Join-Path $WorkspaceRoot "Setup\config"
 $extrasSource = @(
     (Join-Path $WorkspaceRoot "Setup\Configuration tutorial (online).url"),
     (Join-Path $WorkspaceRoot "Setup\Configuration reference (online).url")
 )
-$qtPluginFolders = @('iconengines', 'imageformats', 'platforms', 'styles', 'tls')
+foreach ($required in (@($iconPath, $configSource) + $extrasSource)) {
+    if (-not (Test-Path $required)) {
+        throw "Required release payload is missing: $required"
+    }
+}
+$qtPluginFolders = $plan.QtPluginFolders
 $mainExe = "Editor.exe"
 
 foreach ($work in $plan.Channels) {
@@ -128,16 +140,12 @@ foreach ($work in $plan.Channels) {
         }
     }
 
-    # Bundle the sample configs and shortcuts
-    if (Test-Path $configSource) {
-        $configTarget = Join-Path $work.PackDir "config"
-        New-Item -ItemType Directory -Force -Path $configTarget | Out-Null
-        Copy-Item -Path (Join-Path $configSource "*") -Destination $configTarget -Recurse -Force
-    }
+    # Bundle the sample configs and shortcuts (existence asserted above)
+    $configTarget = Join-Path $work.PackDir "config"
+    New-Item -ItemType Directory -Force -Path $configTarget | Out-Null
+    Copy-Item -Path (Join-Path $configSource "*") -Destination $configTarget -Recurse -Force
     foreach ($extra in $extrasSource) {
-        if (Test-Path $extra) {
-            Copy-Item -Path $extra -Destination $work.PackDir -Force
-        }
+        Copy-Item -Path $extra -Destination $work.PackDir -Force
     }
 
     if (-not (Test-Path (Join-Path $work.PackDir $mainExe))) {
@@ -168,13 +176,27 @@ foreach ($work in $plan.Channels) {
         '--noPortable',
         '--skipVeloAppCheck'
     )
-    if (Test-Path $iconPath) {
-        $packArgs += @('--icon', $iconPath)
-    }
+    $packArgs += @('--icon', $iconPath)
 
     Write-Host "vpk $($packArgs -join ' ')"
     vpk @packArgs
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if ($LASTEXITCODE -ne 0) { throw "vpk pack failed for channel $($work.Channel) with exit code $LASTEXITCODE" }
+
+    # The asset-name grammar (ReleaseAssets.psm1) rests on the observation
+    # that vpk names its outputs <packId>-<channel>-Setup.exe and
+    # releases.<channel>.json. Publish-Release.ps1's missing-channel resume
+    # matches release assets against that grammar, so if a VelopackVpkVersion
+    # bump ever changes the naming, every channel would read as missing forever.
+    # Assert the contract right where the files are produced (audit #275
+    # TD-12) instead.
+    foreach ($expected in @((Get-SetupAssetName -Channel $work.Channel),
+                            (Get-FeedAssetName -Channel $work.Channel))) {
+        if (-not (Test-Path (Join-Path $work.OutputDir $expected))) {
+            throw ("vpk pack did not produce '$expected' in $($work.OutputDir). " +
+                "The vpk naming convention has drifted from ReleaseAssets.psm1; " +
+                "align the grammar before releasing.")
+        }
+    }
 
     vpk upload github `
         --repoUrl $plan.RepoUrl `
@@ -186,10 +208,10 @@ foreach ($work in $plan.Channels) {
         --releaseName $plan.ReleaseName `
         --tag $Tag `
         --targetCommitish $TargetCommit
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if ($LASTEXITCODE -ne 0) { throw "vpk upload failed for channel $($work.Channel) with exit code $LASTEXITCODE" }
 }
 
 if ($plan.NeedsSource) {
     gh release upload $Tag $plan.SourceZipPath --clobber --repo $Repository
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if ($LASTEXITCODE -ne 0) { throw "Source zip upload failed with exit code $LASTEXITCODE" }
 }

--- a/.github/scripts/Package-Artifacts.ps1
+++ b/.github/scripts/Package-Artifacts.ps1
@@ -3,6 +3,7 @@ param(
     [Parameter(Mandatory)] [string] $WorkspaceRoot,
     [Parameter(Mandatory)] [ValidateSet("x64", "ARM64")] [string] $Platform,
     [Parameter(Mandatory)] [string] $SimdVariant,
+    [string] $ManifestPath = (Join-Path $PSScriptRoot "..\simd-variants.psd1"),
     [switch] $PlanOnly
 )
 
@@ -18,10 +19,16 @@ $vst3PluginModule = "VST3\SubwooferRouting\$Platform\Release\EapoXtSubwooferRout
 $vst3PluginLicense = "VST3\SubwooferRouting\LICENSE"
 $vst3BundleArch = if ($Platform -eq "ARM64") { "arm64-win" } else { "x86_64-win" }
 $excludeExtensions = @(".obj", ".res", ".log", ".tlog", ".iobj", ".ipdb", ".ilk", ".pdb")
+# The Qt plugin folder list lives in the manifest (Shared.QtPluginFolders) so
+# the packaging assertion below and New-VelopackRelease.ps1's qt\ relocation
+# cannot drift apart (audit #275 TD-11: generic/ and networkinformation/ were
+# deployed by windeployqt but silently missing from releases).
+$qtPluginFolders = @((Import-PowerShellDataFile $ManifestPath).Shared.QtPluginFolders)
 $plan = [pscustomobject]@{
     ArtifactName = $artifactName
     RequiredFiles = $requiredFiles
     ExcludedExtensions = $excludeExtensions
+    QtPluginFolders = $qtPluginFolders
 }
 if ($PlanOnly) { return $plan }
 
@@ -51,16 +58,30 @@ foreach ($app in @("Editor", "DeviceSelector", "UpdateChecker")) {
     $buildDir = Join-Path $WorkspaceRoot "build-$app-$Platform\release"
     $exe = Join-Path $buildDir "$app.exe"
     if (-not (Test-Path $exe)) { throw "$app.exe not built" }
-    Get-ChildItem -Path $buildDir -Recurse | Where-Object {
-        $_.PSIsContainer -or $excludeExtensions -notcontains $_.Extension.ToLowerInvariant()
+    # Files only: directories materialize with their first file, so the
+    # object-mirror folders (whose contents the extension filter drops
+    # entirely) never appear as empty directories in the artifact. That keeps
+    # the artifact directory uploadable as a whole.
+    Get-ChildItem -Path $buildDir -Recurse -File | Where-Object {
+        $excludeExtensions -notcontains $_.Extension.ToLowerInvariant()
     } | ForEach-Object {
         $relative = $_.FullName.Substring($buildDir.Length + 1)
         $target = Join-Path $artifactPath $relative
-        if ($_.PSIsContainer) {
-            New-Item -ItemType Directory -Force -Path $target | Out-Null
-        } else {
-            New-Item -ItemType Directory -Force -Path (Split-Path $target -Parent) | Out-Null
-            Copy-Item -LiteralPath $_.FullName -Destination $target -Force
-        }
+        New-Item -ItemType Directory -Force -Path (Split-Path $target -Parent) | Out-Null
+        Copy-Item -LiteralPath $_.FullName -Destination $target -Force
     }
+}
+
+# Every DLL-carrying folder in the artifact must be a known Qt plugin folder
+# (VST3\ carries the .vst3 bundle, not DLLs). When windeployqt starts emitting
+# a folder this manifest list does not know, fail here - the alternative is a
+# release where that plugin family is silently absent on user machines.
+$unknownDllFolders = @(Get-ChildItem -Path $artifactPath -Directory | Where-Object {
+    $qtPluginFolders -notcontains $_.Name -and
+    @(Get-ChildItem -Path $_.FullName -Recurse -File -Filter "*.dll").Count -gt 0
+} | ForEach-Object { $_.Name })
+if ($unknownDllFolders.Count -gt 0) {
+    throw ("Artifact folders carry DLLs but are not in Shared.QtPluginFolders " +
+        "(.github/simd-variants.psd1): $($unknownDllFolders -join ', '). " +
+        "Add them to the manifest so releases relocate them under qt\.")
 }

--- a/.github/scripts/Tests/Get-VersionPart.Tests.ps1
+++ b/.github/scripts/Tests/Get-VersionPart.Tests.ps1
@@ -1,0 +1,31 @@
+Describe "Get-VersionPart" {
+    # Audit #275 TD-33 follow-up: the canonical version.h parser feeds both the
+    # version-bump job and create-release, but had no direct test.
+    BeforeAll {
+        . (Join-Path $PSScriptRoot "..\Get-VersionPart.ps1")
+        $script:sampleLines = @(
+            '#pragma once',
+            '#define MAJOR 2',
+            '#define MINOR 34',
+            '  #define REVISION 4',
+            '#define VERSION_STR "2.34.4"'
+        )
+    }
+
+    It "reads each numeric component from provided lines" {
+        Get-VersionPart -Name "MAJOR" -Lines $sampleLines | Should -Be 2
+        Get-VersionPart -Name "MINOR" -Lines $sampleLines | Should -Be 34
+        Get-VersionPart -Name "REVISION" -Lines $sampleLines | Should -Be 4
+    }
+
+    It "throws on a missing component instead of returning a default" {
+        { Get-VersionPart -Name "PATCH" -Lines $sampleLines } | Should -Throw "*PATCH*"
+    }
+
+    It "parses the repository's actual version.h" {
+        $lines = Get-Content (Join-Path $PSScriptRoot "..\..\..\version.h")
+        Get-VersionPart -Name "MAJOR" -Lines $lines | Should -BeGreaterOrEqual 1
+        Get-VersionPart -Name "MINOR" -Lines $lines | Should -BeGreaterOrEqual 0
+        Get-VersionPart -Name "REVISION" -Lines $lines | Should -BeGreaterOrEqual 0
+    }
+}

--- a/.github/scripts/Tests/New-BuildMatrix.Tests.ps1
+++ b/.github/scripts/Tests/New-BuildMatrix.Tests.ps1
@@ -1,0 +1,70 @@
+Describe "New-BuildMatrix.ps1" {
+    # Audit #275 TD-33: the PR filter and the sse2 -> NotSet arch expansion
+    # decide what a pull request gates on and which /arch every CI compile
+    # gets, but neither decision had a test.
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot "..\New-BuildMatrix.ps1"
+        $manifestPath = Join-Path $PSScriptRoot "..\..\simd-variants.psd1"
+        $manifest = Import-PowerShellDataFile $manifestPath
+        # Keep the script's GITHUB_OUTPUT writes out of the real step output
+        # when these tests run inside an Actions job.
+        $script:savedGithubOutput = $env:GITHUB_OUTPUT
+        $env:GITHUB_OUTPUT = $null
+    }
+
+    AfterAll {
+        $env:GITHUB_OUTPUT = $script:savedGithubOutput
+    }
+
+    It "expands every manifest variant on push" {
+        $result = & $scriptPath -EventName push -PassThru
+        @($result.Matrix.include).Count | Should -Be @($manifest.Variants).Count
+        @($result.Matrix.name) | Should -Be @($manifest.Variants.Name)
+    }
+
+    It "builds only the primary variant on pull requests" {
+        $result = & $scriptPath -EventName pull_request -PassThru
+        $included = @($result.Matrix.include)
+        $included.Count | Should -Be 1
+        $included[0].primary | Should -BeTrue
+        $primaryName = @($manifest.Variants | Where-Object { $_.Primary })[0].Name
+        $included[0].name | Should -Be $primaryName
+    }
+
+    It "expands a missing x64 ArchFlag to the explicit NotSet sentinel" {
+        # sse2 must never fall back to the project files' local AVX2 default.
+        $result = & $scriptPath -EventName push -PassThru
+        $x64Entries = @($result.Matrix.include | Where-Object { $_.platform -eq 'x64' })
+        $x64Entries.Count | Should -BeGreaterThan 0
+        foreach ($entry in $x64Entries) {
+            $entry.arch_flag | Should -Not -BeNullOrEmpty
+        }
+        $sse2 = @($x64Entries | Where-Object { $_.simd_variant -eq 'sse2' })[0]
+        $sse2.arch_flag | Should -Be 'NotSet'
+    }
+
+    It "gives ARM64 entries no arch_flag key" {
+        $result = & $scriptPath -EventName push -PassThru
+        $arm = @($result.Matrix.include | Where-Object { $_.platform -eq 'ARM64' })
+        $arm.Count | Should -BeGreaterThan 0
+        foreach ($entry in $arm) {
+            $entry.PSObject.Properties.Name | Should -Not -Contain 'arch_flag'
+        }
+    }
+
+    It "carries the manifest channel on every entry" {
+        $result = & $scriptPath -EventName push -PassThru
+        foreach ($entry in @($result.Matrix.include)) {
+            $expected = @($manifest.Variants | Where-Object { $_.Name -eq $entry.name })[0].Channel
+            $entry.channel | Should -Be $expected
+        }
+    }
+
+    It "derives the runner-executable comparison list from the full manifest even on pull requests" {
+        $result = & $scriptPath -EventName pull_request -PassThru
+        $expected = @($manifest.Variants |
+            Where-Object { $_.Platform -eq 'x64' -and $_.RunnerCanExecute } |
+            ForEach-Object { $_.Simd })
+        @($result.RunnerExecutableVariants) | Should -Be $expected
+    }
+}

--- a/.github/scripts/Tests/New-ReleaseNotes.Tests.ps1
+++ b/.github/scripts/Tests/New-ReleaseNotes.Tests.ps1
@@ -17,7 +17,12 @@ Describe "New-ReleaseNotes.ps1" {
                 )
                 foreach ($channel in $channels) {
                     $assets += @{ name = "EqualizerAPO-XT-$channel-$channel-Setup.exe"; size = 10; browser_download_url = "https://example/$channel" }
+                    $assets += @{ name = "releases.$channel.json"; size = 10; browser_download_url = "https://example/$channel-feed" }
                 }
+                # Prefix neighbours: exact/prefix classification must not let
+                # x64-avx claim the x64-avx2 nupkg or vice versa (audit #275).
+                $assets += @{ name = "EqualizerAPO-XT-x64-avx-9.9.9-full.nupkg"; size = 10; browser_download_url = "https://example/avx-full" }
+                $assets += @{ name = "EqualizerAPO-XT-x64-avx2-9.9.9-full.nupkg"; size = 10; browser_download_url = "https://example/avx2-full" }
                 return (@{ assets = $assets } | ConvertTo-Json -Depth 5 -Compress)
             }
             if ($joined.Contains("releases?per_page")) {
@@ -57,7 +62,10 @@ Describe "New-ReleaseNotes.ps1" {
         $notes = Get-Content $output -Raw
         foreach ($channel in (Import-PowerShellDataFile $manifestPath).Variants.Channel) {
             $notes | Should -Match ([regex]::Escape("Manual installer for the $channel channel."))
+            $notes | Should -Match ([regex]::Escape("Velopack update feed for the $channel channel."))
         }
+        $notes | Should -Match ([regex]::Escape("Velopack full package for the x64-avx channel."))
+        $notes | Should -Match ([regex]::Escape("Velopack full package for the x64-avx2 channel."))
         $notes | Should -Match "x64-avx10-1-x64-avx10-1-Setup.exe"
         $notes | Should -Match "Changes since"
         $notes | Should -Match "A tested change"

--- a/.github/scripts/Tests/New-VelopackRelease.Tests.ps1
+++ b/.github/scripts/Tests/New-VelopackRelease.Tests.ps1
@@ -21,6 +21,16 @@ Describe "New-VelopackRelease.ps1 planning" {
         }
     }
 
+    It "carries the Qt plugin folder list from the shared manifest" {
+        # Audit #275 TD-11: the qt\ relocation list and the packaging
+        # assertion must be the same list, spelled once in the manifest.
+        $tree = NewInputRoot @("EqualizerAPO-x64-avx2")
+        $plan = PlanFor $tree @("x64-avx2")
+        $expected = @((Import-PowerShellDataFile $manifestPath).Shared.QtPluginFolders)
+        $expected.Count | Should -BeGreaterThan 0
+        @($plan.QtPluginFolders) | Should -Be $expected
+    }
+
     It "resolves channels from the manifest, not a naming convention" {
         $tree = NewInputRoot @("EqualizerAPO-x64-avx10_1", "EqualizerAPO-ARM64-neon")
         $plan = PlanFor $tree @("x64-avx10-1", "arm64-neon")

--- a/.github/scripts/Tests/ReleaseAssets.Tests.ps1
+++ b/.github/scripts/Tests/ReleaseAssets.Tests.ps1
@@ -31,6 +31,23 @@ Describe "ReleaseAssets grammar module" {
         $header | Should -Match ([regex]::Escape('std::wstring(productPrefix) + L"-Setup.exe"'))
     }
 
+    It "stays in step with the installer project's TargetName and resource metadata" {
+        # Audit #275 TD-14: the universal installer name is also spelled by the
+        # MSBuild TargetName and the .rc version block. build.yml derives its
+        # path from the grammar module, so these two are the remaining
+        # spellings; a TargetName change must fail here, not on release day.
+        $expected = Get-UniversalSetupAssetName
+        $expectedBase = [System.IO.Path]::GetFileNameWithoutExtension($expected)
+
+        $vcxproj = Get-Content (Join-Path $PSScriptRoot "..\..\..\Installer\Installer.vcxproj") -Raw
+        $vcxproj -match '<TargetName>([^<]+)</TargetName>' | Should -BeTrue
+        $Matches[1] | Should -Be $expectedBase
+
+        $rc = Get-Content (Join-Path $PSScriptRoot "..\..\..\Installer\AutoInstaller.rc") -Raw
+        $rc -match '"OriginalFilename",\s*"([^"]+)"' | Should -BeTrue
+        $Matches[1] | Should -Be $expected
+    }
+
     It "yields well-formed names for every manifest channel" {
         $manifest = Import-PowerShellDataFile (Join-Path $PSScriptRoot "..\..\simd-variants.psd1")
         foreach ($channel in @($manifest.Variants.Channel)) {

--- a/.github/simd-variants.psd1
+++ b/.github/simd-variants.psd1
@@ -164,6 +164,14 @@
     )
 
     Shared = @{
+        # Qt plugin folders windeployqt deploys next to the Qt apps. Spelled
+        # once here: Package-Artifacts.ps1 asserts the staged artifact carries
+        # no DLL folder outside this list (so a new windeployqt folder fails
+        # the build instead of silently missing from releases), and
+        # New-VelopackRelease.ps1 relocates exactly these folders under qt\
+        # (Editor.exe calls addLibraryPath("qt")).
+        QtPluginFolders     = @('generic', 'iconengines', 'imageformats',
+                                'networkinformation', 'platforms', 'styles', 'tls')
         # velopack_libc ships as a single cross-platform zip attached to the
         # velopack/velopack release. The asset name is velopack_libc_<version>.zip.
         VelopackLibcVersion = '1.1.1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      regenerate_references:
+        # Audit #275 TD-08: seeding used to switch on the mere absence of
+        # references/cases.json, so deleting or renaming the reference set
+        # silently turned the verify gate into a re-record. Seeding is now an
+        # explicit, logged decision; see
+        # Tests/AudioRegressionTests/references/README.md before using it.
+        description: 'Re-record AudioRegressionTests references instead of verifying against them'
+        type: boolean
+        default: false
 
 # Serialize runs per ref. On main this queues release pipelines so two quick
 # merges can't both try to create the same release (which raced to a 403 on the
@@ -351,28 +361,34 @@ jobs:
         $hasRefs = Test-Path (Join-Path $repoRefDir "cases.json")
         # The primary (reference-seeding) variant is flagged in simd-variants.psd1.
         $isPrimary = "${{ matrix.primary }}" -eq "true"
+        # Seeding is an explicit workflow_dispatch decision (audit #275 TD-08).
+        # Empty on push/pull_request events, which therefore always verify.
+        $regenerate = "${{ inputs.regenerate_references }}" -eq "true"
 
         Push-Location "${{ github.workspace }}\Tests\AudioRegressionTests"
         try {
-          if ($hasRefs) {
-            Write-Host "Reference set present in tree; running verify mode for variant '$variant'"
-            & $exe --variant $variant --config-dir configs --ref-dir references --out-dir output
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "AudioRegressionTests verify failed for variant '$variant'"
-              exit $LASTEXITCODE
+          if ($regenerate) {
+            if ($isPrimary) {
+              Write-Host "::warning::regenerate_references was requested; primary variant '$variant' is RE-RECORDING the golden references instead of verifying against them. See Tests/AudioRegressionTests/references/README.md before committing the result."
+            } else {
+              Write-Host "::warning::regenerate_references was requested; recording variant output only (non-primary variant '$variant')"
             }
-          } elseif ($isPrimary) {
-            Write-Host "No reference set in tree; primary variant '$variant' will record fresh references"
             & $exe --variant $variant --config-dir configs --ref-dir references --out-dir output --generate-references
             if ($LASTEXITCODE -ne 0) {
-              Write-Error "AudioRegressionTests reference generation failed"
+              Write-Error "AudioRegressionTests reference generation failed for variant '$variant'"
               exit $LASTEXITCODE
             }
           } else {
-            Write-Host "No reference set in tree; recording variant output only (non-primary variant)"
-            & $exe --variant $variant --config-dir configs --ref-dir references --out-dir output --generate-references
+            if (-not $hasRefs) {
+              # Never fall back to seeding implicitly: a deleted or renamed
+              # reference set must fail the gate, not re-record it.
+              Write-Error "references/cases.json is missing and regenerate_references was not requested. Restore the committed reference set, or dispatch the workflow with regenerate_references=true if re-recording is genuinely intended."
+              exit 1
+            }
+            Write-Host "Running verify mode for variant '$variant'"
+            & $exe --variant $variant --config-dir configs --ref-dir references --out-dir output
             if ($LASTEXITCODE -ne 0) {
-              Write-Error "AudioRegressionTests output recording failed for variant '$variant'"
+              Write-Error "AudioRegressionTests verify failed for variant '$variant'"
               exit $LASTEXITCODE
             }
           }
@@ -672,20 +688,16 @@ jobs:
           -SimdVariant "${{ matrix.simd_variant }}"
 
 
-    # Upload artifacts
+    # Upload artifacts. Package-Artifacts.ps1 curates the artifact directory
+    # (extension filter + Qt-plugin-folder assertion against the manifest's
+    # Shared.QtPluginFolders), so the whole directory is the payload; keeping a
+    # second folder list here is how generic/ and networkinformation/ went
+    # silently missing from releases (audit #275 TD-11).
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7
       with:
         name: EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}
-        path: |
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/*.dll
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/*.exe
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/iconengines/
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/imageformats/
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/platforms/
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/styles/
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/tls/
-          ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}/VST3/
+        path: ${{ github.workspace }}\artifacts\EqualizerAPO-${{ matrix.platform }}-${{ matrix.simd_variant }}\
         if-no-files-found: error
         retention-days: 90
 
@@ -926,7 +938,11 @@ jobs:
       run: |
         Import-Module .\.github\scripts\ReleaseAssets.psm1
         $sourceZip = Join-Path "${{ github.workspace }}" (Get-SourceZipAssetName -PackVersion "${{ steps.version.outputs.pack_version }}")
-        git archive --format=zip --output="$sourceZip" HEAD
+        # Archive the explicit release SHA (the bumped commit), not HEAD:
+        # HEAD is only correct because the checkout step above happens to use
+        # the same ref, and a drift there would silently ship pre-bump source
+        # (audit #275 TD-13).
+        git archive --format=zip --output="$sourceZip" "${{ needs.version-bump.outputs.bumped_sha || github.sha }}"
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
         }
@@ -974,7 +990,11 @@ jobs:
           exit $LASTEXITCODE
         }
 
-        $setupExe = "${{ github.workspace }}\Installer\Release\EqualizerAPO-XT-Setup.exe"
+        # Asset name from the grammar module, not a fourth literal spelling
+        # (audit #275 TD-14). ReleaseAssets.Tests.ps1 keeps the vcxproj
+        # TargetName and the .rc OriginalFilename aligned with the grammar.
+        Import-Module .\.github\scripts\ReleaseAssets.psm1
+        $setupExe = Join-Path "${{ github.workspace }}\Installer\Release" (Get-UniversalSetupAssetName)
         if (-not (Test-Path $setupExe)) {
           Write-Error "Auto-detect installer was not produced at $setupExe"
           exit 1
@@ -1057,3 +1077,26 @@ jobs:
         if ($LASTEXITCODE -ne 0) {
           exit $LASTEXITCODE
         }
+
+    # Every step above is gated on a `needs_*` output consumed as a string, so
+    # a renamed output would skip its step while the job stays green (audit
+    # #275 TD-09). Re-running the planner and demanding a complete release
+    # turns that whole failure class into a job failure.
+    - name: Assert release completeness
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $plan = .\.github\scripts\Publish-Release.ps1 `
+          -Repository "${{ github.repository }}" `
+          -Tag "${{ steps.version.outputs.tag }}" `
+          -PackVersion "${{ steps.version.outputs.pack_version }}" `
+          -PassThru
+        if (-not $plan.Complete) {
+          throw ("Release ${{ steps.version.outputs.tag }} is incomplete after the release steps ran: " +
+            "missing channels='$($plan.MissingChannels -join ',')', " +
+            "needsSource=$($plan.NeedsSource), needsInstaller=$($plan.NeedsInstaller), " +
+            "needsChecksums=$($plan.NeedsChecksums), needsNotes=$($plan.NeedsNotes). " +
+            "A release step was skipped or its outputs drifted; see Publish-Release.ps1.")
+        }
+        Write-Host "Release ${{ steps.version.outputs.tag }} is complete."

--- a/Tests/AudioRegressionTests/references/README.md
+++ b/Tests/AudioRegressionTests/references/README.md
@@ -21,6 +21,11 @@ regenerating from a whole-buffer run and letting the blocked comparison prove
 invariance again, rather than regenerating in block mode - the latter would
 silently discard the evidence.
 
+CI never regenerates implicitly: the build workflow verifies against the
+committed set and fails if `cases.json` is missing. Re-recording on CI requires
+dispatching `build.yml` with the `regenerate_references` input set to true,
+which logs a warning on the run so the decision is visible.
+
 Note that `blockFrames` must divide `frames`. `ConvolutionFilter` freezes its
 block length at `initialize()` and mutes any block of a different size, so a
 short final block would silence the tail instead of testing it. The harness


### PR DESCRIPTION
## 무엇이 달라지나

이슈 #275 기술 부채 감사의 '조용한 실패' 묶음을 처분합니다. 릴리스·회귀 파이프라인이 조용히 어긋날 수 있던 자리 전부를 시끄러운 실패로 바꿉니다.

- **TD-08**: 골든 기준값 재생성이 `references/cases.json` 존재 여부가 아니라 명시적 `workflow_dispatch` 입력(`regenerate_references`)으로만 켜집니다. 기준값 파일이 사라지면 이제 게이트가 실패합니다.
- **TD-09**: `create-release` 잡 끝에 `Publish-Release.ps1`을 다시 돌려 `complete=true`를 요구하는 최종 검증 단계를 둡니다. `needs_*` 출력 이름이 표류해 릴리스 단계가 스킵되는 부류 전체가 잡 실패로 바뀝니다.
- **TD-11**: Qt 플러그인 폴더 목록을 `simd-variants.psd1`(Shared.QtPluginFolders) 한 곳으로 모읍니다. **기존 표류를 함께 수정합니다**: windeployqt가 배포하는 `generic/`·`networkinformation/`이 다섯 폴더 목록에 없어 지금까지 모든 릴리스에서 조용히 빠졌습니다. Package-Artifacts가 목록 밖 DLL 폴더를 실패로 만들고, build.yml은 큐레이션된 아티팩트 디렉터리를 통째로 업로드합니다. 필수 payload(샘플 설정, 바로 가기, 아이콘)는 없으면 throw합니다.
- **TD-12**: `vpk pack` 직후 산출물 이름을 ReleaseAssets 문법과 대조합니다. vpk 명명이 바뀌면 pack 시점에 실패합니다.
- **TD-13**: 소스 zip이 `HEAD` 대신 명시적 bumped SHA를 아카이브합니다.
- **TD-14**: build.yml의 설치기 경로를 `Get-UniversalSetupAssetName`에서 파생시키고, vcxproj `TargetName`과 .rc `OriginalFilename`을 Pester lint로 문법에 고정합니다.
- **TD-33**: `New-BuildMatrix.ps1`에 `-PassThru`를 더해 PR 필터, sse2→NotSet 확장, 비교 목록에 Pester를 붙입니다. `Get-VersionPart`도 직접 테스트를 얻습니다.
- **TD-34**: 릴리스 노트가 EditorLogicTests를 '모든 변형에서 돈다'고 주장하던 틀린 문장을 고칩니다.
- 릴리스 노트 채널 분류를 순서 민감한 정규식에서 문법 정확 일치(긴 pack id 우선)로 바꿉니다.
- `New-VelopackRelease.ps1`의 원시 명령 실패 처리를 throw로 통일합니다.

`Test-VariantSync.ps1`·`Test-SkinModules.ps1` 자체에 대한 테스트는 넣지 않았습니다. 두 스크립트는 lint 게이트로서 매 PR CI에서 직접 실행되어 실패가 이미 시끄럽고, lint의 lint는 회수가 작다고 판단했습니다.

## 확인

- 로컬 Pester 전체 93/93 통과 (신규 New-BuildMatrix 6건, Get-VersionPart 3건, 확장된 ReleaseAssets·New-VelopackRelease·New-ReleaseNotes 포함)
- build.yml YAML 파싱 확인
- 릴리스 실행 경로(vpk 실호출)는 로컬에서 재현하지 못했습니다. 다음 릴리스에서 완결 검증 단계가 실제로 통과하는지 감시가 필요합니다.

Closes 없음 (이슈 #275는 캠페인 전체 완료 후 닫습니다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)