### PR TITLE
fix: analysis dock settings reset + parse error reporting for the last four factories (audit #275)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,28 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- **'전체 전역 설정 초기화'가 이제 분석 도크의 보기 선택까지 실제로
+  초기화합니다.** 그래프 지표(Mag/Phase/GD)와 '기본 지연 포함' 토글이
+  초기화 동작(과 제거 정리)이 건드리지 않는 엉뚱한 레지스트리 위치에
+  저장되어 전체 초기화를 살아남았습니다. 이제 다른 모든 Editor 설정과
+  같은 곳에 저장되며, 기존 값은 시작 시 한 번 옮겨 옵니다
+  ([#277](https://github.com/115dkk/EqualizerAPO-XT/pull/277)).
+- **깨진 `Filter`·`IIR`·`Delay`·`Preamp` 줄이 무엇이 잘못됐는지 해당 줄
+  위에서 Editor가 보여 줍니다.** 이 네 명령 계열은 다른 명령들이 받은
+  줄 단위 파싱 보고 이전 세대라서, `Coefficients` 목록 누락 같은 실수가
+  느슨한 로그 한 줄로 흩어지거나 아무 말 없이 무시됐습니다. 이제 같은
+  줄 단위 채널로 보고되어 Editor가 정확한 줄을 표시하고, 로그에는 파일과
+  줄 번호가 함께 남습니다. `Include` 줄의 상대 경로가 260자에서 조용히
+  잘리던 문제도 함께 고쳤습니다
+  ([#277](https://github.com/115dkk/EqualizerAPO-XT/pull/277)).
+- **설치 파일에 Qt `generic/`·`networkinformation/` 플러그인 폴더가
+  다시 들어갑니다.** windeployqt는 일곱 개의 플러그인 폴더를 배포하는데
+  릴리스 파이프라인의 수기 업로드 목록이 다섯 개만 알고 있어, 두 폴더가
+  모든 릴리스에서 조용히 빠졌습니다. 폴더 목록을 매니페스트 한 곳으로
+  모았고, windeployqt가 목록에 없는 폴더를 내면 빌드가 시끄럽게
+  실패합니다
+  ([#276](https://github.com/115dkk/EqualizerAPO-XT/pull/276)).
+
 ## v2.37.2 — 2026-08-14
 
 - **Precision Minimal의 Copy·MultiConvolution 채널 토큰을 원색 칩에서

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- **"Reset all global preferences" now really resets the analysis dock's
+  view choices.** The graph metric (Mag/Phase/GD) and the "include base
+  delay" toggle were stored in a stray registry location that the reset
+  action (and uninstall cleanup) never touched, so they survived a full
+  reset. They now live with every other Editor preference; an existing
+  value is migrated over once on startup
+  ([#277](https://github.com/115dkk/EqualizerAPO-XT/pull/277)).
+- **Broken `Filter`, `IIR`, `Delay`, and `Preamp` lines now say what is
+  wrong, on the line, in the Editor.** These four command families predate
+  the per-line parse reporting the other commands got, so a typo like a
+  missing `Coefficients` list either logged a loose message or failed in
+  complete silence. They now report through the same per-line channel:
+  the Editor marks the exact line and the log records the reason with a
+  file and line stamp. An `Include` line's relative path also no longer
+  gets silently truncated at 260 characters
+  ([#277](https://github.com/115dkk/EqualizerAPO-XT/pull/277)).
+- **Installers ship the Qt `generic/` and `networkinformation/` plugin
+  folders again.** windeployqt deploys seven plugin folders, but the
+  release pipeline's hand-written upload list only knew five, so two were
+  silently missing from every release. The folder list now lives in one
+  manifest and the build fails loudly if windeployqt ever emits a folder
+  the list does not know
+  ([#276](https://github.com/115dkk/EqualizerAPO-XT/pull/276)).
+
 ## v2.37.2 — 2026-08-14
 
 - **Precision Minimal's Copy and MultiConvolution channel tokens are now

--- a/Common.vcxproj
+++ b/Common.vcxproj
@@ -374,6 +374,7 @@
     <ClInclude Include="services\registry\RegistryTransaction.h" />
     <ClInclude Include="platform\windows\WindowsVersion.h" />
     <ClInclude Include="services\logging\Logging.h" />
+    <ClInclude Include="services\logging\TaggedLogger.h" />
     <ClInclude Include="dsp\FftwRAII.h" />
     <ClInclude Include="dsp\FftwPlanningPolicy.h" />
     <ClInclude Include="runtime\memory\AlignedMemory.h" />
@@ -389,6 +390,7 @@
     <ClInclude Include="audio\io\SndfileRAII.h" />
     <ClInclude Include="text\WideString.h" />
     <ClInclude Include="platform\windows\TextEncoding.h" />
+    <ClInclude Include="platform\windows\ComSelfRegistration.h" />
     <ClInclude Include="platform\windows\Win32Error.h" />
     <ClInclude Include="parser\NumericText.h" />
     <ClInclude Include="vst\VSTPluginInstance.h" />
@@ -487,6 +489,7 @@
     <ClCompile Include="services\registry\IRegistry.cpp" />
     <ClCompile Include="services\registry\RegistryTransaction.cpp" />
     <ClCompile Include="platform\windows\WindowsVersion.cpp" />
+    <ClCompile Include="platform\windows\ComSelfRegistration.cpp" />
     <ClCompile Include="platform\windows\GuidText.cpp" />
     <ClCompile Include="services\logging\Logging.cpp" />
     <ClCompile Include="runtime\memory\AlignedMemory.cpp" />

--- a/DeviceSelector/DeviceSelector.pro
+++ b/DeviceSelector/DeviceSelector.pro
@@ -39,6 +39,7 @@ SOURCES += \
 	skins/RackDeviceSkin.cpp \
 	skins/MatrixDeviceSkin.cpp \
 	../services/windows/WindowsService.cpp \
+	../platform/windows/ComSelfRegistration.cpp \
 	../services/install/ApoRegistration.cpp \
 	../services/shell/StartMenuShortcuts.cpp \
 	../services/security/AudioEngineAccess.cpp \

--- a/DeviceSelector/DeviceSelector.vcxproj
+++ b/DeviceSelector/DeviceSelector.vcxproj
@@ -420,6 +420,7 @@
     <ClInclude Include="..\Editor\skins\SkinThemeData.h" />
     <ClCompile Include="..\Editor\helpers\QtAppBootstrap.cpp" />
     <ClCompile Include="..\services\windows\WindowsService.cpp" />
+    <ClCompile Include="..\platform\windows\ComSelfRegistration.cpp" />
     <ClCompile Include="..\services\install\ApoRegistration.cpp" />
     <ClCompile Include="..\services\shell\StartMenuShortcuts.cpp" />
     <ClCompile Include="..\services\security\AudioEngineAccess.cpp" />

--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -43,6 +43,7 @@ SOURCES += main.cpp\
 	../services/registry/IRegistry.cpp \
 	../services/registry/RegistryTransaction.cpp \
 	../platform/windows/WindowsVersion.cpp \
+	../platform/windows/ComSelfRegistration.cpp \
 	../platform/windows/GuidText.cpp \
 	../services/security/AudioEngineAccess.cpp \
 	../services/diagnostics/InstallDiagnostics.cpp \
@@ -329,8 +330,10 @@ SOURCES += main.cpp\
 HEADERS  += \
 	../platform/windows/FileSharingRetry.h \
 	../services/logging/Logging.h \
+	../services/logging/TaggedLogger.h \
 	../text/WideString.h \
 	../platform/windows/TextEncoding.h \
+	../platform/windows/ComSelfRegistration.h \
 	../platform/windows/Win32Error.h \
 	../parser/NumericText.h \
 	../services/registry/WindowsRegistry.h \

--- a/Editor/MainWindowParts/MainWindow.Analysis.cpp
+++ b/Editor/MainWindowParts/MainWindow.Analysis.cpp
@@ -22,6 +22,8 @@
 
 #include "Editor/analysis/AnalysisMetric.h"
 #include "Editor/analysis/AnalysisViewController.h"
+#include "Editor/helpers/EditorSettings.h"
+#include "services/registry/RegistryPaths.h"
 #include "Editor/widgets/EqGraphView.h"
 #include "Editor/widgets/SegmentedControl.h"
 #include "services/logging/Logging.h"
@@ -153,10 +155,30 @@ void MainWindow::setupAnalysisMetricControls()
 		tr("The analyzer removes the configuration's bulk delay before measuring, so a filter's own phase is readable. "
 		   "Switch this on to put that delay back into the reading."));
 
-	QSettings settings;
+	QSettings settings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat);
+	// One-time migration (audit #275 TD-01): these two keys used to be written
+	// through a default-constructed QSettings, which lands in Qt's fallback
+	// registry location instead of EDITOR_REGPATH. That store survived "Reset
+	// all global preferences" and uninstall cleanup. Carry an old value over
+	// once, then drop the stray store's copy.
+	{
+		QSettings legacy;
+		for (const char* key : {EditorSettings::Keys::AnalysisViewMetric,
+		                        EditorSettings::Keys::AnalysisIncludeLatency})
+		{
+			const QLatin1String keyString(key);
+			if (legacy.contains(keyString))
+			{
+				if (!settings.contains(keyString))
+					settings.setValue(keyString, legacy.value(keyString));
+				legacy.remove(keyString);
+			}
+		}
+	}
 	const AnalysisMetric metric = metricFromSettingName(
-		settings.value(QStringLiteral("analysis/viewMetric")).toString());
-	const bool includeLatency = settings.value(QStringLiteral("analysis/includeLatency"), false).toBool();
+		settings.value(QLatin1String(EditorSettings::Keys::AnalysisViewMetric)).toString());
+	const bool includeLatency = settings.value(
+		QLatin1String(EditorSettings::Keys::AnalysisIncludeLatency), false).toBool();
 
 	ui->analysisMetricSegment->setCurrentIndex(metricIndex(metric));
 	ui->includeBaseDelayCheckBox->setChecked(includeLatency);
@@ -174,12 +196,14 @@ void MainWindow::setupAnalysisMetricControls()
 		if (eqGraphView != nullptr)
 			eqGraphView->setMetric(chosen);
 		ui->includeBaseDelayCheckBox->setVisible(chosen != AnalysisMetric::MagnitudeDb);
-		QSettings().setValue(QStringLiteral("analysis/viewMetric"), metricSettingName(chosen));
+		QSettings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat)
+		.setValue(QLatin1String(EditorSettings::Keys::AnalysisViewMetric), metricSettingName(chosen));
 	});
 	connect(ui->includeBaseDelayCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
 		if (eqGraphView != nullptr)
 			eqGraphView->setIncludeLatency(checked);
-		QSettings().setValue(QStringLiteral("analysis/includeLatency"), checked);
+		QSettings(QString::fromWCharArray(EDITOR_REGPATH), QSettings::NativeFormat)
+		.setValue(QLatin1String(EditorSettings::Keys::AnalysisIncludeLatency), checked);
 	});
 
 	// A filter card can ask for a reading that makes its own filter legible.

--- a/Editor/helpers/EditorSettings.h
+++ b/Editor/helpers/EditorSettings.h
@@ -12,6 +12,12 @@ inline constexpr char Dark[] = "interface/dark";
 inline constexpr char LegacyRows[] = "interface/legacyRows";
 inline constexpr char NativeTitleBar[] = "interface/nativeTitleBar";
 inline constexpr char KnobGainRange[] = "interface/knobGainRange";
+// Analysis dock view choices. Stored under EDITOR_REGPATH like every other
+// preference; they briefly lived in Qt's default QSettings location, which
+// "Reset all global preferences" could not reach (audit #275 TD-01) - the
+// migration in MainWindow.Analysis.cpp moves old values over once.
+inline constexpr char AnalysisViewMetric[] = "analysis/viewMetric";
+inline constexpr char AnalysisIncludeLatency[] = "analysis/includeLatency";
 }
 
 struct SkinChoice

--- a/Tests/EditorLogicTests/EditorLogicTestSupport.h
+++ b/Tests/EditorLogicTests/EditorLogicTestSupport.h
@@ -65,6 +65,8 @@ void testUpdateSessionContainsApplyFailure();
 void testUpdateSessionKeepsPendingUpdateWhenElevationIsCancelled();
 void testUpdateCoordinatorReportsNoPendingRestart();
 void testUpdateCoordinatorContainsAdapterFailure();
+void testVelopackInstallRootFollowsTheCurrentLeafRule();
+void testElevatedCoordinatorArgumentHasOneSpelling();
 void testTheSkinRosterIsTheOneList();
 void testSkinTokensCarryExplicitMode();
 void testTokenSubstitutionOffersAnAlphaForm();

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -143,6 +143,8 @@ int main(int argc, char** argv)
 		testUpdateSessionKeepsPendingUpdateWhenElevationIsCancelled();
 		testUpdateCoordinatorReportsNoPendingRestart();
 		testUpdateCoordinatorContainsAdapterFailure();
+		testVelopackInstallRootFollowsTheCurrentLeafRule();
+		testElevatedCoordinatorArgumentHasOneSpelling();
 		testTheSkinRosterIsTheOneList();
 		testSkinTokensCarryExplicitMode();
 		testTokenSubstitutionOffersAnAlphaForm();

--- a/Tests/EditorLogicTests/UpdateSessionTests.cpp
+++ b/Tests/EditorLogicTests/UpdateSessionTests.cpp
@@ -11,6 +11,7 @@
 #include "EditorLogicTestSupport.h"
 
 #include "services/update/UpdateSession.h"
+#include "services/update/VelopackBootstrap.h"
 
 #include <memory>
 #include <optional>
@@ -244,4 +245,47 @@ void testUpdateSessionPublishesStagedVersionAfterJoin()
 		QString::fromStdWString(session.pendingUpdateVersion()),
 		QStringLiteral("9.9.9"),
 		QStringLiteral("the staged version survives worker shutdown"));
+}
+
+void testVelopackInstallRootFollowsTheCurrentLeafRule()
+{
+	// Audit #275 TD-29: the 'leaf "current" means its parent is the install
+	// root' rule is pure string logic; pin it here so the Velopack layout
+	// assumption cannot drift silently.
+	using VB = VelopackBootstrap;
+	expectEqual(
+		QString::fromStdWString(VB::installRootFromBinDir(L"C:\\Apps\\EqualizerAPO-XT\\current")),
+		QStringLiteral("C:\\Apps\\EqualizerAPO-XT"),
+		QStringLiteral("a bin dir whose leaf is 'current' resolves to its parent"));
+	expectEqual(
+		QString::fromStdWString(VB::installRootFromBinDir(L"C:\\Apps\\EqualizerAPO-XT\\CURRENT")),
+		QStringLiteral("C:\\Apps\\EqualizerAPO-XT"),
+		QStringLiteral("the leaf comparison is case-insensitive"));
+	expectEqual(
+		QString::fromStdWString(VB::installRootFromBinDir(L"C:/Apps/EqualizerAPO-XT/current")),
+		QStringLiteral("C:/Apps/EqualizerAPO-XT"),
+		QStringLiteral("forward slashes separate the leaf too"));
+	expectEqual(
+		QString::fromStdWString(VB::installRootFromBinDir(L"C:\\Apps\\EqualizerAPO-XT\\bin")),
+		QStringLiteral("C:\\Apps\\EqualizerAPO-XT\\bin"),
+		QStringLiteral("a non-Velopack layout is its own root"));
+	expectEqual(
+		QString::fromStdWString(VB::installRootFromBinDir(L"current")),
+		QStringLiteral("current"),
+		QStringLiteral("a bare path without separators stays as-is"));
+	expectTrue(
+		VB::installRootFromBinDir(std::wstring()).empty(),
+		QStringLiteral("an empty bin dir resolves to an empty root"));
+}
+
+void testElevatedCoordinatorArgumentHasOneSpelling()
+{
+	// Audit #275 TD-02: the parse side reads the narrow constant and the
+	// ShellExecuteExW side passes the wide one; both must be the same text.
+	const std::string narrow = VelopackBootstrap::kElevatedCoordinatorArgument;
+	const std::wstring wide = VelopackBootstrap::kElevatedCoordinatorArgumentW;
+	expectEqual(
+		QString::fromStdWString(wide),
+		QString::fromStdString(narrow),
+		QStringLiteral("the elevated coordinator argument has a single spelling"));
 }

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -933,9 +933,16 @@ void testParseErrorsAreReportedPerLineAndProseIsNot(test::Harness& harness)
 		"Channel:\n"                        // line 2: its own command, no channel
 		"Copy:\n"                           // line 3: its own command, no assignment
 		"GraphicEQ:\n"                      // line 4: its own command, no nodes
-		"remember to try 2 dB less here\n"  // line 5: prose, not an error
-		"copy: a note to self\n"            // line 6: wrong case, so prose
-		"Preamp: -3 dB\n");                 // line 7: fine, and must still run
+		// The pre-S7 factories joined the reporting generation in audit #275
+		// (TD-03); the four lines below used to fail in silence or log-only.
+		"Filter 1: ON PK Fc 1000 Hz\n"      // line 5: peaking without gain or Q
+		"Filter 2: ON IIR Order 2\n"        // line 6: IIR without coefficients (one report, not a BiQuad echo)
+		"Delay: quickly\n"                  // line 7: delay without a parsable amount
+		"Preamp: loud\n"                    // line 8: preamp without a parsable gain
+		"remember to try 2 dB less here\n"  // line 9: prose, not an error
+		"copy: a note to self\n"            // line 10: wrong case, so prose
+		"Filter 3: OFF PK Fc 99999999 Hz\n" // line 11: disabled, so a no-op rather than an error
+		"Preamp: -3 dB\n");                 // line 12: fine, and must still run
 
 	struct Collector : ConfigLoadTraceSink
 	{
@@ -962,16 +969,18 @@ void testParseErrorsAreReportedPerLineAndProseIsNot(test::Harness& harness)
 		errorLines.push_back(entry.line);
 	}
 
-	harness.requireEqual(errorLines.size(), size_t(4),
-		"one report per broken line, and none for the two lines that are prose");
-	harness.expect(errorLines[0] == 1 && errorLines[1] == 2 && errorLines[2] == 3 && errorLines[3] == 4,
-		"the reports land on the lines that are broken, in order");
+	harness.requireEqual(errorLines.size(), size_t(8),
+		"one report per broken line, none for the prose lines, none for the disabled filter, "
+		"and no BiQuad echo of the broken IIR line");
+	for (int line = 0; line < 8; line++)
+		harness.expectEqual(errorLines[(size_t)line], line + 1,
+			"the reports land on the lines that are broken, in order");
 
 	// The load kept going: half a configuration is still worth running, and a
 	// broken line must not take the working ones below it with it. loadConfig
 	// answers false only when the whole load failed.
 	harness.expect(engine.loadConfig(configPath),
-		"a configuration with four unusable lines still loads, because the working lines below them have to run");
+		"a configuration with eight unusable lines still loads, because the working lines below them have to run");
 }
 
 // Audit #250 A6/A3: the engine's registry surface (the config language's

--- a/devices/DeviceAPOInfo.cpp
+++ b/devices/DeviceAPOInfo.cpp
@@ -32,6 +32,7 @@
 
 #include "services/registry/WindowsRegistry.h"
 #include "platform/windows/ComPtr.h"
+#include "platform/windows/ComSelfRegistration.h"
 #include "platform/windows/Win32Resource.h"
 
 using std::make_shared;
@@ -137,17 +138,12 @@ bool DeviceAPOInfo::checkAPORegistration(bool fix, const IRegistry& registry)
 
 				// Self-register the COM in-proc server by calling its
 				// DllRegisterServer export directly instead of spawning
-				// regsvr32.exe (no extra process, no transient window).
-				// LOAD_WITH_ALTERED_SEARCH_PATH resolves the DLL's own
-				// dependencies relative to its directory.
-				winutil::UniqueModule module(LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH));
-				if (module)
-				{
-					using DllServerProc = HRESULT(__stdcall*)();
-					DllServerProc registerProc = reinterpret_cast<DllServerProc>(GetProcAddress(module.get(), "DllRegisterServer"));
-					if (registerProc != nullptr)
-						registerProc();
-				}
+				// regsvr32.exe (no extra process, no transient window). The
+				// shared helper logs every failure - this recovery branch is
+				// the path users actually hit, and it used to drop the
+				// HRESULT in silence (audit #275 TD-04). Best-effort here:
+				// the next registration check reports what is still missing.
+				winutil::selfRegisterComServer(L"DeviceAPOInfo", dllPath, false);
 			}
 		}
 	}

--- a/devices/VoicemeeterAPOInfo.cpp
+++ b/devices/VoicemeeterAPOInfo.cpp
@@ -420,11 +420,15 @@ void VoicemeeterAPOInfo::ensureVoicemeeterClientRunning()
 	winutil::UniqueHandle tokenHandle;
 	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
 		tokenHandle.put()))
-		throw RegistryError(L"Error in OpenProcessToken while taking ownership");
+		// Not a registry failure (audit #275 TD-07): these three calls adjust
+		// this process's own token so the PEB of the running client can be
+		// read. Reporting them as RegistryError sent readers of the log to
+		// the registry ownership code.
+		throw exception("Error in OpenProcessToken while enabling SeDebugPrivilege for the Voicemeeter client check");
 
 	LUID luid;
 	if (!LookupPrivilegeValue(nullptr, SE_DEBUG_NAME, &luid))
-		throw RegistryError(L"Error in LookupPrivilegeValue while taking ownership");
+		throw exception("Error in LookupPrivilegeValue while enabling SeDebugPrivilege for the Voicemeeter client check");
 
 	TOKEN_PRIVILEGES tp;
 	tp.PrivilegeCount = 1;
@@ -433,7 +437,7 @@ void VoicemeeterAPOInfo::ensureVoicemeeterClientRunning()
 
 	if (!AdjustTokenPrivileges(tokenHandle.get(), FALSE, &tp,
 		sizeof(TOKEN_PRIVILEGES), nullptr, nullptr))
-		throw RegistryError(L"Error in AdjustTokenPrivileges while taking ownership");
+		throw exception("Error in AdjustTokenPrivileges while enabling SeDebugPrivilege for the Voicemeeter client check");
 
 	winutil::UniqueModule module(LoadLibraryW(L"ntdll.dll"));
 	if (!module)

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -194,7 +194,10 @@ void FilterEngine::loadConfigFile(const wstring& path)
 				}
 				catch (const exception& e)
 				{
-					LogF(L"%S", e.what());
+					// Stamped like reportParseError's log line, so an exception
+					// escaping a factory is as locatable as a parse error
+					// (audit #275 TD-03).
+					LogF(L"%S (line %d of %s)", e.what(), load.traceLine, load.traceFile.c_str());
 				}
 
 				if (key == L"")

--- a/filters/BiQuadFilterFactory.cpp
+++ b/filters/BiQuadFilterFactory.cpp
@@ -91,11 +91,23 @@ BiQuadFilterFactory::BiQuadFilterFactory()
 {
 }
 
-bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& parameters, BiQuadCommand& out)
+bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& parameters, BiQuadCommand& out,
+	wstring* errorOut)
 {
 	// starts-with check (rfind at position 0), the pre-C++20 idiom
 	if (command.rfind(L"Filter", 0) != 0)
 		return false;
+
+	// Collected reasons for a recognized-but-malformed line. They reach the
+	// per-line trace through createFilter/reportParseError on the engine path,
+	// or the log for direct callers - previously each site logged on its own
+	// and the Editor could not mark the line (audit #275 TD-03).
+	wstring reason;
+	auto noteError = [&reason](const wstring& text) {
+		if (!reason.empty())
+			reason += L"; ";
+		reason += text;
+	};
 
 	// Conversion to period as decimal mark, if needed
 	parameters = numeric_text::normalizeDecimalComma(parameters);
@@ -111,7 +123,14 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	BiQuad::Type type;
 	if (!biquadTypeFromName(typeString, type))
 	{
-		if (typeString != L"None")
+		// "None" is a valid no-op line. "IIR" belongs to IIRFilterFactory,
+		// which runs at higher priority and reports its own parse errors, so
+		// a broken IIR line must not earn a second report here.
+		if (typeString == L"None" || typeString == L"IIR")
+			return false;
+		if (errorOut != nullptr)
+			*errorOut = L"unrecognized filter type \"" + typeString + L"\"";
+		else
 			LogFStatic(L"Invalid filter type %s", typeString.c_str());
 		return false;
 	}
@@ -139,7 +158,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	}
 	else
 	{
-		LogFStatic(L"No frequency given in filter string %s%s", typeString.c_str(), parameters.c_str());
+		noteError(L"no frequency given");
 		error = true;
 	}
 
@@ -160,7 +179,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	}
 	else if (type == BiQuad::PEAKING || type == BiQuad::LOW_SHELF || type == BiQuad::HIGH_SHELF)
 	{
-		LogFStatic(L"No gain given in filter string %s%s", typeString.c_str(), parameters.c_str());
+		noteError(L"no gain given");
 		error = true;
 	}
 
@@ -217,7 +236,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 			}
 			else if (order != 2)
 			{
-				LogFStatic(L"Order must be 1 or 2 in filter string %s%s", typeString.c_str(), parameters.c_str());
+				noteError(L"the order must be 1 or 2");
 				error = true;
 			}
 			orderWasExplicit = true;
@@ -237,8 +256,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 
 	if (!std::isfinite(freq) || !std::isfinite(gain) || !std::isfinite(bandwidthOrQOrS))
 	{
-		LogFStatic(L"Filter parameters must be finite in filter string %s%s",
-			typeString.c_str(), parameters.c_str());
+		noteError(L"filter parameters must be finite");
 		error = true;
 	}
 
@@ -246,7 +264,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	{
 		if (type == BiQuad::PEAKING || type == BiQuad::ALL_PASS)
 		{
-			LogFStatic(L"No Q or bandwidth given in filter string %s%s", typeString.c_str(), parameters.c_str());
+			noteError(L"no Q or bandwidth given");
 			error = true;
 		}
 		else if (type == BiQuad::LOW_PASS || type == BiQuad::HIGH_PASS || type == BiQuad::BAND_PASS)
@@ -273,7 +291,13 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	}
 
 	if (error)
+	{
+		if (errorOut != nullptr)
+			*errorOut = reason;
+		else
+			LogFStatic(L"%s in filter string %s%s", reason.c_str(), typeString.c_str(), parameters.c_str());
 		return false;
+	}
 
 	TraceFStatic(L"%s", stream.str().c_str());
 
@@ -291,8 +315,13 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 FilterVector BiQuadFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	BiQuadCommand cmd;
-	if (!parseCommand(command, parameters, cmd))
+	wstring error;
+	if (!parseCommand(command, parameters, cmd, &error))
+	{
+		if (!error.empty())
+			return reportParseError(command, error);
 		return {};
+	}
 
 	return singleFilter(makeFilter<BiQuadFilter>(
 		cmd.type, cmd.dbGain, cmd.freq, cmd.bandwidthOrQOrS, cmd.isBandwidthOrS, cmd.isCornerFreq));

--- a/filters/BiQuadFilterFactory.h
+++ b/filters/BiQuadFilterFactory.h
@@ -26,7 +26,7 @@
 #include "BiQuad.h"
 #include "BiQuadCommand.h"
 
-class BiQuadFilterFactory : public IFilterFactory
+class BiQuadFilterFactory : public ParseReportingFactory
 {
 public:
 	BiQuadFilterFactory();
@@ -38,7 +38,11 @@ public:
 	// without constructing a throwaway filter. Returns true when a valid BiQuad
 	// command was recognized. `parameters` may be altered in place (decimal-mark
 	// normalization), exactly as createFilter() did before.
-	static bool parseCommand(const std::wstring& command, std::wstring& parameters, BiQuadCommand& out);
+	// When `errorOut` is given, a recognized-but-malformed line fills it with
+	// the collected reasons (createFilter reports them through
+	// ParseReportingFactory); without it they go to the log, as before.
+	static bool parseCommand(const std::wstring& command, std::wstring& parameters, BiQuadCommand& out,
+		std::wstring* errorOut = nullptr);
 
 private:
 	static double getFreq(const std::wstring& freqString);

--- a/filters/DelayFilterFactory.cpp
+++ b/filters/DelayFilterFactory.cpp
@@ -30,8 +30,11 @@ REGISTER_FILTER_FACTORY(FilterFactoryPriority::Delay, DelayFilterFactory, L"Dela
 using std::vector;
 using std::wstring;
 
-bool DelayFilterFactory::parseCommand(const wstring& command, const wstring& parameters, DelayCommand& out)
+bool DelayFilterFactory::parseCommand(const wstring& command, const wstring& parameters, DelayCommand& out,
+	bool* malformed)
 {
+	if (malformed != nullptr)
+		*malformed = false;
 	if (command != L"Delay")
 		return false;
 
@@ -39,7 +42,11 @@ bool DelayFilterFactory::parseCommand(const wstring& command, const wstring& par
 	// open a card for a no-op line); the engine-only decisions below are the
 	// trace and the no-op gate.
 	if (!DelayCommand::parse(parameters, out))
+	{
+		if (malformed != nullptr)
+			*malformed = true;
 		return false;
+	}
 
 	// A 0-length delay is a no-op: it produces no filter so the chain avoids one
 	// virtual call and one ring-buffer update per block. Report it in the trace
@@ -57,8 +64,13 @@ bool DelayFilterFactory::parseCommand(const wstring& command, const wstring& par
 FilterVector DelayFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	DelayCommand cmd;
-	if (!parseCommand(command, parameters, cmd))
+	bool malformed = false;
+	if (!parseCommand(command, parameters, cmd, &malformed))
+	{
+		if (malformed)
+			return reportParseError(command, L"expected a delay like \"3.5 ms\" or \"160 samples\"");
 		return {};
+	}
 
 	return singleFilter(makeFilter<DelayFilter>(cmd.delay, cmd.isMs));
 }

--- a/filters/DelayFilterFactory.h
+++ b/filters/DelayFilterFactory.h
@@ -25,7 +25,7 @@
 #include "engine/IFilter.h"
 #include "DelayCommand.h"
 
-class DelayFilterFactory : public IFilterFactory
+class DelayFilterFactory : public ParseReportingFactory
 {
 public:
 	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
@@ -37,5 +37,9 @@ public:
 	// that should produce a DelayFilter (delay > 0 with a "ms" or "samples"
 	// unit). A 0-length delay is a no-op and an unknown/missing unit is
 	// rejected, so both return false, exactly as createFilter() decided before.
-	static bool parseCommand(const std::wstring& command, const std::wstring& parameters, DelayCommand& out);
+	// `malformed` (optional) is set when the command keyword was "Delay" but
+	// the parameter text did not parse - the case createFilter() reports as a
+	// parse error, as opposed to the deliberate no-op of a zero delay.
+	static bool parseCommand(const std::wstring& command, const std::wstring& parameters, DelayCommand& out,
+		bool* malformed = nullptr);
 };

--- a/filters/IIRFilterFactory.cpp
+++ b/filters/IIRFilterFactory.cpp
@@ -49,8 +49,22 @@ IIRFilterFactory::IIRFilterFactory()
 {
 }
 
-bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& parameters, IIRCommand& out)
+bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& parameters, IIRCommand& out,
+	wstring* error)
 {
+	// A recognized-but-malformed IIR line either fills `error` (engine path:
+	// createFilter turns it into a per-line parse report) or logs directly
+	// (legacy direct callers). The distinction from "not an IIR line" is the
+	// whole point: two of these branches used to return false in silence
+	// (audit #275 TD-03).
+	auto fail = [&](const wstring& reason) {
+		if (error != nullptr)
+			*error = reason;
+		else
+			LogFStatic(L"%s", reason.c_str());
+		return false;
+	};
+
 	// starts-with check (rfind at position 0), the pre-C++20 idiom
 	if (command.rfind(L"Filter", 0) != 0)
 		return false;
@@ -60,25 +74,23 @@ bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& param
 		return false;
 
 	if (!regex_search(parameters, match, regexOrder))
-		return false;
+		return fail(L"expected Order followed by the filter order");
 
 	wstring orderString = match.str(1);
 	unsigned order = wcstol(orderString.c_str(), nullptr, 10);
 	if (order < 1)
-	{
-		LogFStatic(L"Order %d not supported, must at least be 1", order);
-		return false;
-	}
+		return fail(L"the order must be at least 1");
 
 	if (!regex_search(parameters, match, regexCoefficients))
-		return false;
+		return fail(L"expected Coefficients followed by the b and a coefficient lists");
 
 	wstring coefficientsString = match.str(1);
 	vector<wstring> coefficientStrings = text::split(coefficientsString, L' ');
 	if (coefficientStrings.size() != (order + 1) * 2)
 	{
-		LogFStatic(L"Invalid number of coefficients. Expected %d coefficients instead of %d", (order + 1) * 2, coefficientStrings.size());
-		return false;
+		wstringstream reason;
+		reason << L"expected " << (order + 1) * 2 << L" coefficients instead of " << coefficientStrings.size();
+		return fail(reason.str());
 	}
 
 	out.order = order;
@@ -87,17 +99,11 @@ bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& param
 	{
 		double coefficient = numeric_text::parseDouble(coefficientString);
 		if (!std::isfinite(coefficient))
-		{
-			LogFStatic(L"IIR coefficients must be finite");
-			return false;
-		}
+			return fail(L"IIR coefficients must be finite");
 		out.coefficients.push_back(coefficient);
 	}
 	if (out.coefficients[order + 1] == 0.0)
-	{
-		LogFStatic(L"IIR a0 coefficient must not be zero");
-		return false;
-	}
+		return fail(L"the a0 coefficient must not be zero");
 
 	return true;
 }
@@ -105,8 +111,13 @@ bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& param
 FilterVector IIRFilterFactory::createFilter(const wstring& configPath, wstring& command, wstring& parameters)
 {
 	IIRCommand cmd;
-	if (!parseCommand(command, parameters, cmd))
+	wstring error;
+	if (!parseCommand(command, parameters, cmd, &error))
+	{
+		if (!error.empty())
+			return reportParseError(command, error);
 		return {};
+	}
 
 	wstringstream stream;
 	stream << L"Adding IIR filter of order " << cmd.order << " with coefficients";

--- a/filters/IIRFilterFactory.h
+++ b/filters/IIRFilterFactory.h
@@ -25,15 +25,17 @@
 #include "engine/IFilter.h"
 #include "IIRCommand.h"
 
-class IIRFilterFactory : public IFilterFactory
+class IIRFilterFactory : public ParseReportingFactory
 {
 public:
 	IIRFilterFactory();
 	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;
 
 	// Parses a "Filter:" IIR config line into an IIRCommand. This is the single
-	// owner of the IIR grammar; grammar errors (order below 1, wrong coefficient
-	// count) are reported through the log helpers, lines of other filter types
-	// just return false.
-	static bool parseCommand(const std::wstring& command, const std::wstring& parameters, IIRCommand& out);
+	// owner of the IIR grammar; lines of other filter types just return false.
+	// When `error` is given, a recognized-but-malformed IIR line fills it with
+	// the reason (createFilter reports it through ParseReportingFactory);
+	// without it the reason goes to the log, as before, for direct callers.
+	static bool parseCommand(const std::wstring& command, const std::wstring& parameters, IIRCommand& out,
+		std::wstring* error = nullptr);
 };

--- a/filters/IncludeFilterFactory.cpp
+++ b/filters/IncludeFilterFactory.cpp
@@ -18,7 +18,7 @@
 */
 
 #include "stdafx.h"
-#include <Shlwapi.h>
+#include <filesystem>
 
 #include "services/logging/Logging.h"
 #include "engine/FilterEngine.h"
@@ -59,19 +59,21 @@ FilterVector IncludeFilterFactory::createFilter(const wstring& configPath, wstri
 	{
 		const wstring& value = cmd.path;
 
+		// Same relative-path dialect as ConvolutionFilePath::resolve
+		// (audit #275 TD-06): relative to the including config file, resolved
+		// with std::filesystem. The previous Shlwapi variant went through a
+		// MAX_PATH buffer, so a long path was silently truncated.
+		namespace filesystem = std::filesystem;
+		const filesystem::path includedPath(value);
 		wstring includePath;
-		if (PathIsRelativeW(value.c_str()))
-		{
-			wchar_t filePath[MAX_PATH];
-			// Standard copy + truncate; _Copy_s is an MSVC-internal helper.
-			const size_t copyLength = configPath.copy(filePath, MAX_PATH - 1);
-			filePath[copyLength] = L'\0';
-			PathRemoveFileSpecW(filePath);
-			PathAppendW(filePath, value.c_str());
-			includePath = filePath;
-		}
+		if (includedPath.is_absolute())
+			includePath = includedPath.lexically_normal().wstring();
 		else
-			includePath = value;
+		{
+			filesystem::path basePath(configPath);
+			basePath.remove_filename();
+			includePath = (basePath / includedPath).lexically_normal().wstring();
+		}
 
 		if (recursionDepth >= RECURSION_LIMIT)
 			LogF(L"Skipping include of %s as recursion limit of %d has been reached", value.c_str(), RECURSION_LIMIT);

--- a/filters/PreampFilterFactory.cpp
+++ b/filters/PreampFilterFactory.cpp
@@ -84,7 +84,8 @@ FilterVector PreampFilterFactory::createFilter(const wstring& configPath, wstrin
 		}
 		else
 		{
-			LogF(L"Could not parse preamp value \"%s\"; no preamp was applied", text::trim(parameters).c_str());
+			return reportParseError(command,
+				L"could not parse the preamp value \"" + text::trim(parameters) + L"\"; no preamp was applied");
 		}
 	}
 

--- a/filters/PreampFilterFactory.h
+++ b/filters/PreampFilterFactory.h
@@ -25,7 +25,7 @@
 #include "engine/IFilter.h"
 #include "PreampCommand.h"
 
-class PreampFilterFactory : public IFilterFactory
+class PreampFilterFactory : public ParseReportingFactory
 {
 public:
 	FilterVector createFilter(const std::wstring& configPath, std::wstring& command, std::wstring& parameters) override;

--- a/platform/windows/ComSelfRegistration.cpp
+++ b/platform/windows/ComSelfRegistration.cpp
@@ -1,0 +1,39 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2026  EqualizerAPO-XT contributors
+*/
+
+#include "stdafx.h"
+
+#include "services/logging/Logging.h"
+#include "platform/windows/Win32Resource.h"
+#include "ComSelfRegistration.h"
+
+namespace winutil
+{
+HRESULT selfRegisterComServer(const wchar_t* logTag, const std::wstring& dllPath, bool unregister)
+{
+	winutil::UniqueModule module(LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH));
+	if (!module)
+	{
+		const DWORD lastError = GetLastError();
+		LogFStatic(L"[%s] LoadLibrary failed for %s (gle=%lu)", logTag, dllPath.c_str(), lastError);
+		return HRESULT_FROM_WIN32(lastError);
+	}
+
+	using DllServerProc = HRESULT (__stdcall*)();
+	const char* entryName = unregister ? "DllUnregisterServer" : "DllRegisterServer";
+	DllServerProc proc = reinterpret_cast<DllServerProc>(GetProcAddress(module.get(), entryName));
+	if (proc == nullptr)
+	{
+		const DWORD lastError = GetLastError();
+		LogFStatic(L"[%s] %S not found in %s (gle=%lu)", logTag, entryName, dllPath.c_str(), lastError);
+		return HRESULT_FROM_WIN32(lastError);
+	}
+
+	const HRESULT hr = proc();
+	if (FAILED(hr))
+		LogFStatic(L"[%s] %S failed for %s (hr=0x%08lX)", logTag, entryName, dllPath.c_str(), static_cast<unsigned long>(hr));
+	return hr;
+}
+}

--- a/platform/windows/ComSelfRegistration.h
+++ b/platform/windows/ComSelfRegistration.h
@@ -1,0 +1,28 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2026  EqualizerAPO-XT contributors
+*/
+
+#pragma once
+
+#include <string>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace winutil
+{
+	// Calls DllRegisterServer (or DllUnregisterServer) inside the given COM
+	// server DLL, in-process: LOAD_WITH_ALTERED_SEARCH_PATH resolves the DLL's
+	// own dependencies (FFTW, libsndfile, ...) relative to its directory, the
+	// way the audio engine and regsvr32 load it.
+	//
+	// One implementation for the two callers that used to carry their own
+	// copies (audit #275 TD-04): services/install/ApoRegistration and the
+	// recovery branch in devices/DeviceAPOInfo - the latter dropped the
+	// HRESULT and logged nothing, so the path users actually hit was the
+	// silent one. Every failure (load, missing export, failed entry point) is
+	// logged under `logTag`, and the entry point's HRESULT is returned so the
+	// caller can act on it.
+	HRESULT selfRegisterComServer(const wchar_t* logTag, const std::wstring& dllPath, bool unregister);
+}

--- a/services/install/ApoRegistration.cpp
+++ b/services/install/ApoRegistration.cpp
@@ -34,10 +34,11 @@
 #include "services/security/AudioEngineAccess.h"
 #include "devices/DeviceAPOInfo.h"
 #include "services/logging/Logging.h"
+#include "services/logging/TaggedLogger.h"
 #include "services/registry/WindowsRegistry.h"
 #include "services/windows/WindowsService.h"
 #include "services/shell/StartMenuShortcuts.h"
-#include "platform/windows/Win32Resource.h"
+#include "platform/windows/ComSelfRegistration.h"
 
 namespace
 {
@@ -53,39 +54,14 @@ using pathutil::joinPath;
 using pathutil::fileExists;
 using pathutil::createDirectoryRecursive;
 
-void logLine(const wchar_t* level, const wchar_t* format, ...)
-{
-	wchar_t buffer[1024];
-	va_list args;
-	va_start(args, format);
-	_vsnwprintf_s(buffer, _TRUNCATE, format, args);
-	va_end(args);
-	LogFStatic(L"[ApoRegistration] %s: %s", level, buffer);
-}
+constexpr logging::TaggedLogger logLine(L"ApoRegistration");
 }
 
 int ApoRegistration::registerComServer(const std::wstring& dllPath, bool unregister)
 {
-	// LOAD_WITH_ALTERED_SEARCH_PATH resolves EqualizerAPO.dll's own dependencies
-	// (FFTW, libsndfile, ...) relative to the DLL directory, matching how the
-	// audio engine and regsvr32 load it.
-	winutil::UniqueModule module(LoadLibraryExW(dllPath.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH));
-	if (!module)
-	{
-		logLine(L"ERR", L"LoadLibrary failed for %s (gle=%lu)", dllPath.c_str(), GetLastError());
-		return -1;
-	}
-
-	using DllServerProc = HRESULT(__stdcall*)();
-	const char* entryName = unregister ? "DllUnregisterServer" : "DllRegisterServer";
-	DllServerProc proc = reinterpret_cast<DllServerProc>(GetProcAddress(module.get(), entryName));
-
-	HRESULT hr = E_FAIL;
-	if (proc != nullptr)
-		hr = proc();
-	else
-		logLine(L"ERR", L"%S not found in %s (gle=%lu)", entryName, dllPath.c_str(), GetLastError());
-
+	// Shared with DeviceAPOInfo's recovery branch (audit #275 TD-04); the
+	// helper logs load/lookup/entry failures itself.
+	const HRESULT hr = winutil::selfRegisterComServer(L"ApoRegistration", dllPath, unregister);
 	return SUCCEEDED(hr) ? 0 : static_cast<int>(hr);
 }
 

--- a/services/logging/TaggedLogger.h
+++ b/services/logging/TaggedLogger.h
@@ -1,0 +1,48 @@
+/*
+    This file is part of EqualizerAPO, a system-wide equalizer.
+    Copyright (C) 2026  EqualizerAPO-XT contributors
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#pragma once
+
+#include <cstdarg>
+#include <cstdio>
+
+#include "Logging.h"
+
+namespace logging
+{
+// Formats "[Tag] LEVEL: message" log lines. The install/shell services used to
+// carry one private copy of this formatter each (audit #275); construct one
+// per file with its tag and the call sites read as before:
+//
+//     constexpr logging::TaggedLogger logLine(L"ApoRegistration");
+//     ...
+//     logLine(L"ERR", L"LoadLibrary failed for %s (gle=%lu)", path, gle);
+class TaggedLogger
+{
+public:
+	explicit constexpr TaggedLogger(const wchar_t* tag)
+		: tag(tag)
+	{
+	}
+
+	void operator ()(const wchar_t* level, const wchar_t* format, ...) const
+	{
+		wchar_t buffer[1024];
+		va_list args;
+		va_start(args, format);
+		_vsnwprintf_s(buffer, _TRUNCATE, format, args);
+		va_end(args);
+		LogFStatic(L"[%s] %s: %s", tag, level, buffer);
+	}
+
+private:
+	const wchar_t* tag;
+};
+}

--- a/services/shell/StartMenuShortcuts.cpp
+++ b/services/shell/StartMenuShortcuts.cpp
@@ -15,6 +15,7 @@
 
 #include "platform/windows/ComPtr.h"
 #include "services/logging/Logging.h"
+#include "services/logging/TaggedLogger.h"
 #include "platform/windows/WindowsPath.h"
 #include "platform/windows/Win32Resource.h"
 
@@ -27,15 +28,7 @@ using pathutil::createDirectoryRecursive;
 constexpr wchar_t kShortcutFolderName[] = L"EqualizerAPO-XT";
 constexpr wchar_t kDeviceSelectorShortcutFile[] = L"Device Selector.lnk";
 
-void logLine(const wchar_t* level, const wchar_t* format, ...)
-{
-	wchar_t buffer[1024];
-	va_list args;
-	va_start(args, format);
-	_vsnwprintf_s(buffer, _TRUNCATE, format, args);
-	va_end(args);
-	LogFStatic(L"[StartMenuShortcuts] %s: %s", level, buffer);
-}
+constexpr logging::TaggedLogger logLine(L"StartMenuShortcuts");
 
 std::wstring publicProgramsPath()
 {

--- a/services/update/VelopackBootstrap.cpp
+++ b/services/update/VelopackBootstrap.cpp
@@ -139,16 +139,7 @@ std::wstring VelopackBootstrap::currentBinDir()
 
 std::wstring VelopackBootstrap::installRoot()
 {
-	std::wstring bin = exeDirectory();
-	if (bin.empty())
-		return std::wstring();
-	size_t slash = bin.find_last_of(L"\\/");
-	if (slash == std::wstring::npos)
-		return bin;
-	std::wstring leaf = bin.substr(slash + 1);
-	if (_wcsicmp(leaf.c_str(), L"current") != 0)
-		return bin;
-	return bin.substr(0, slash);
+	return installRootFromBinDir(exeDirectory());
 }
 
 std::wstring VelopackBootstrap::updateExePath()
@@ -198,7 +189,7 @@ bool VelopackBootstrap::launchElevatedUpdateCoordinator()
 	info.fMask = SEE_MASK_NOASYNC;
 	info.lpVerb = L"runas";
 	info.lpFile = exePath;
-	info.lpParameters = L"--eapo-apply-update-elevated";
+	info.lpParameters = kElevatedCoordinatorArgumentW;
 	info.nShow = SW_HIDE;
 
 	if (ShellExecuteExW(&info))

--- a/services/update/VelopackBootstrap.h
+++ b/services/update/VelopackBootstrap.h
@@ -12,17 +12,43 @@
 
 #include <memory>
 #include <string>
+#include <wchar.h>
 
 class UpdateSession;
 
 // Process integration for the Editor's Velopack runtime. The long-lived update
 // state belongs to an UpdateSession owned by main.cpp; this Module only creates
 // the concrete SDK Adapter and handles the short-lived elevated coordinator.
+// Single spelling for the elevated-coordinator argument. The narrow constant
+// is what main.cpp parses; the wide constant is what ShellExecuteExW passes.
+// Both derive from this macro so they cannot drift apart (audit #275 TD-02).
+#define EAPO_ELEVATED_COORDINATOR_ARGUMENT "--eapo-apply-update-elevated"
+
 class VelopackBootstrap
 {
 public:
 	inline static constexpr char kElevatedCoordinatorArgument[] =
-		"--eapo-apply-update-elevated";
+		EAPO_ELEVATED_COORDINATOR_ARGUMENT;
+	inline static constexpr wchar_t kElevatedCoordinatorArgumentW[] =
+		L"" EAPO_ELEVATED_COORDINATOR_ARGUMENT;
+
+	// Pure path rule behind installRoot(): a Velopack install runs the binaries
+	// from <root>\current, so a bin directory whose leaf is "current" resolves
+	// to its parent and anything else is its own root. Header-inline so
+	// EditorLogicTests can pin the rule without linking the SDK adapter
+	// (audit #275 TD-29).
+	static std::wstring installRootFromBinDir(const std::wstring& binDir)
+	{
+		if (binDir.empty())
+			return std::wstring();
+		size_t slash = binDir.find_last_of(L"\\/");
+		if (slash == std::wstring::npos)
+			return binDir;
+		std::wstring leaf = binDir.substr(slash + 1);
+		if (_wcsicmp(leaf.c_str(), L"current") != 0)
+			return binDir;
+		return binDir.substr(0, slash);
+	}
 
 	static bool isFirstRun();
 	static bool isRestartingAfterUpdate();


### PR DESCRIPTION
## 무엇이 달라지나

이슈 #275 감사에서 사용자에게 보이는 결함 묶음을 처분합니다.

- **TD-01 (B2)**: 분석 도크의 지표·기본 지연 설정이 기본 생성 `QSettings`로 엉뚱한 레지스트리 위치에 저장되어 '전체 전역 설정 초기화'가 놓치던 결함을 고칩니다. `EDITOR_REGPATH`로 이전(기존 값 1회 마이그레이션)하고 두 키를 `EditorSettings::Keys`에 등재했습니다.
- **TD-03 (A2)**: BiQuad·IIR·Preamp·Delay 팩토리를 `ParseReportingFactory` 세대로 이행했습니다. IIR의 침묵 실패(Order/Coefficients 누락)와 Delay의 파싱 실패가 이제 줄 단위 trace로 보고되어 Editor가 해당 줄을 표시합니다. BiQuad는 IIR 타입을 면제해 깨진 IIR 줄에 보고가 두 번 달리지 않습니다. 디스패치 루프의 예외 로그에도 파일·줄 스탬프를 붙였습니다.
- **TD-02+TD-29 (C2)**: 승격 업데이트 인자의 이중 철자를 매크로 파생 한 곳으로 합치고, `installRoot()`의 'leaf가 current면 부모' 규칙을 순수 함수로 꺼내 EditorLogicTests에 고정했습니다.
- **TD-04 (C3)**: COM 자기등록 절차를 `platform/windows/ComSelfRegistration`으로 합쳤습니다. 사용자가 실제로 겪는 복구 분기(DeviceAPOInfo)가 HRESULT를 버리고 침묵하던 문제가 로그로 드러납니다.
- **TD-06**: Include 줄의 상대 경로 해석을 ConvolutionFilePath와 같은 std::filesystem 방언으로 맞춰 MAX_PATH 침묵 절단을 없앴습니다.
- **TD-07**: Voicemeeter의 토큰·권한 실패가 `RegistryError`(레지스트리 소유권 코드에서 복사된 문구)로 위장하던 것을 바로잡았습니다.
- **E-logLine**: ApoRegistration·StartMenuShortcuts의 사설 logLine 사본을 `logging::TaggedLogger`로 합쳤습니다.

## 확인

- 로컬 v145 x64(AVX2): Common·EqualizerAPO.dll·4개 테스트 프로젝트 빌드 성공
- EditorLogicTests 2977 / EngineOrchestrationTests 1212 / HybridConvTests 1635 검사 통과, AudioRegressionTests verify 31/31
- 확장된 trace 사례가 신규 4계열의 보고(줄 번호 순서, IIR 중복 보고 없음, OFF 줄 무보고)를 고정합니다
- Editor(qmake) 빌드는 로컬에서 돌리지 않았습니다. PR CI의 Qt 빌드로 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)