### PR TITLE
refactor: skin creation hooks carry their tokens (audit #275 B1)

### DIFF
--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -244,17 +244,17 @@ void SkinManager::paintVstBusFrame(QPainter& painter, const VstBusFrameState& st
 
 FilterPickerView* SkinManager::createFilterPicker(QWidget* parent) const
 {
-	return activeSkin->createFilterPicker(parent);
+	return activeSkin->createFilterPicker(parent, tokens());
 }
 
 ReferenceCardView* SkinManager::createReferenceCardView(const QString& kind, QWidget* parent) const
 {
-	return activeSkin->createReferenceCardView(kind, parent);
+	return activeSkin->createReferenceCardView(kind, parent, tokens());
 }
 
 SubwooferRoutingCardView* SkinManager::createSubwooferRoutingCardView(QWidget* parent) const
 {
-	return activeSkin->createSubwooferRoutingCardView(parent);
+	return activeSkin->createSubwooferRoutingCardView(parent, tokens());
 }
 
 void SkinManager::paintTitleBarChrome(QPainter& painter, const QRect& rect) const

--- a/Editor/SkinManager.h
+++ b/Editor/SkinManager.h
@@ -95,7 +95,7 @@ public:
 	void paintVstBusFrame(QPainter& painter, const VstBusFrameState& state) const;
 
 	// The "add filter" picker view for the active skin (ISkin::createFilterPicker).
-	FilterPickerView* createFilterPicker(QWidget* parent) const;
+	FilterPickerView* createFilterPicker(QWidget* parent) const;  // injects tokens()
 
 	// The reference-card body view for the active skin
 	// (ISkin::createReferenceCardView). kind is ReferenceCardState::kind.

--- a/Editor/skins/ISkin.cpp
+++ b/Editor/skins/ISkin.cpp
@@ -613,14 +613,18 @@ void ISkin::paintInsertSeam(QPainter& painter, const QRect& rect, const ListChro
 		Qt::AlignCenter, QStringLiteral("+"));
 }
 
-FilterPickerView* ISkin::createFilterPicker(QWidget* parent) const
+FilterPickerView* ISkin::createFilterPicker(QWidget* parent, const SkinTokens& tokens) const
 {
-	// Neutral default: the shared search-over-sections dropdown.
+	// Neutral default: the shared search-over-sections dropdown, styled by
+	// QSS rather than tokens.
+	Q_UNUSED(tokens);
 	return new DefaultFilterPickerView(parent);
 }
 
-ReferenceCardView* ISkin::createReferenceCardView(const QString& kind, QWidget* parent) const
+ReferenceCardView* ISkin::createReferenceCardView(const QString& kind, QWidget* parent,
+	const SkinTokens& tokens) const
 {
+	Q_UNUSED(tokens);
 	// Neutral default: the plain token-styled information hierarchy. kind is
 	// unused here because the neutral view derives everything from the state;
 	// skins that split their answer per kind branch on it.
@@ -628,8 +632,10 @@ ReferenceCardView* ISkin::createReferenceCardView(const QString& kind, QWidget* 
 	return new DefaultReferenceCardView(parent);
 }
 
-SubwooferRoutingCardView* ISkin::createSubwooferRoutingCardView(QWidget* parent) const
+SubwooferRoutingCardView* ISkin::createSubwooferRoutingCardView(QWidget* parent,
+	const SkinTokens& tokens) const
 {
+	Q_UNUSED(tokens);
 	return new DefaultSubwooferRoutingCardView(parent);
 }
 

--- a/Editor/skins/ISkin.h
+++ b/Editor/skins/ISkin.h
@@ -503,7 +503,12 @@ public:
 	// default (ISkin.cpp) is the neutral DefaultFilterPickerView: a search
 	// field over one sectioned list. Ownership passes to the caller via the
 	// usual QWidget parent mechanism.
-	virtual FilterPickerView* createFilterPicker(QWidget* parent) const;
+	//
+	// tokens is passed like every other hook's (audit #275 B1, the S3
+	// treatment): the views these hooks build used to reach for
+	// SkinManager::instance() in their constructors and paintEvents, which
+	// works only while the singleton happens to hold the skin being asked.
+	virtual FilterPickerView* createFilterPicker(QWidget* parent, const SkinTokens& tokens) const;
 
 	// The reference-card body view for rows that point at an external file
 	// (kind: "include", "convolution", "multiconvolution", "vst"). The host
@@ -513,12 +518,14 @@ public:
 	// of a palette swap. The default (ISkin.cpp) is the neutral
 	// DefaultReferenceCardView. Ownership passes to the caller via the usual
 	// QWidget parent mechanism.
-	virtual ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent) const;
+	virtual ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent,
+		const SkinTokens& tokens) const;
 
 	// The compact SubwooferRouting card body. The editor computes and owns the
 	// state and actions; the returned view owns their presentation. The
 	// default is DefaultSubwooferRoutingCardView.
-	virtual SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent) const;
+	virtual SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent,
+		const SkinTokens& tokens) const;
 
 	// Painted decoration over the custom title bar's QSS background (screws,
 	// grid texture, glows - whatever the skin's constitution calls for).

--- a/Editor/skins/matrix/MatrixSkin.cpp
+++ b/Editor/skins/matrix/MatrixSkin.cpp
@@ -20,19 +20,22 @@ IRoutingRenderer* MatrixSkin::routingRenderer() const
 	return &renderer;
 }
 
-FilterPickerView* MatrixSkin::createFilterPicker(QWidget* parent) const
+FilterPickerView* MatrixSkin::createFilterPicker(QWidget* parent, const SkinTokens& tokens) const
 {
-	return new MatrixFilterPickerView(parent);
+	return new MatrixFilterPickerView(tokens, parent);
 }
 
-ReferenceCardView* MatrixSkin::createReferenceCardView(const QString& kind, QWidget* parent) const
+ReferenceCardView* MatrixSkin::createReferenceCardView(const QString& kind, QWidget* parent,
+	const SkinTokens& tokens) const
 {
+	Q_UNUSED(tokens);
 	return new MatrixReferenceCardView(kind, parent);
 }
 
-SubwooferRoutingCardView* MatrixSkin::createSubwooferRoutingCardView(QWidget* parent) const
+SubwooferRoutingCardView* MatrixSkin::createSubwooferRoutingCardView(QWidget* parent,
+	const SkinTokens& tokens) const
 {
-	return new MatrixSubwooferRoutingCardView(parent);
+	return new MatrixSubwooferRoutingCardView(tokens, parent);
 }
 
 ISkin* matrixSkin()

--- a/Editor/skins/matrix/MatrixSkin.h
+++ b/Editor/skins/matrix/MatrixSkin.h
@@ -47,7 +47,9 @@ public:
 	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override;
 	void styleFileDialog(QFileDialog* dialog, const SkinTokens& tokens) const override;
 
-	FilterPickerView* createFilterPicker(QWidget* parent) const override;
-	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent) const override;
-	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent) const override;
+	FilterPickerView* createFilterPicker(QWidget* parent, const SkinTokens& tokens) const override;
+	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent,
+		const SkinTokens& tokens) const override;
+	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent,
+		const SkinTokens& tokens) const override;
 };

--- a/Editor/skins/matrix/cards/MatrixSubwooferRoutingCardView.cpp
+++ b/Editor/skins/matrix/cards/MatrixSubwooferRoutingCardView.cpp
@@ -47,8 +47,9 @@ qreal crispCoordinate(qreal logical, qreal devicePixelRatio)
 }
 
 MatrixSubwooferRoutingCardView::MatrixSubwooferRoutingCardView(
-	QWidget* parent)
-	: SubwooferRoutingCardView(parent)
+	const SkinTokens& tokens, QWidget* parent)
+	: SubwooferRoutingCardView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("MatrixSubwooferRoutingCardView"));
 
@@ -263,7 +264,7 @@ void MatrixSubwooferRoutingCardView::paintEvent(QPaintEvent* event)
 
 	const qreal devicePixelRatio =
 		painter.device()->devicePixelRatioF();
-	QColor ink(SkinManager::instance()->tokens().accent);
+	QColor ink(skinTokens.accent);
 	painter.setPen(QPen(ink, 1.0));
 
 	const qreal left = crispCoordinate(1.0, devicePixelRatio);

--- a/Editor/skins/matrix/cards/MatrixSubwooferRoutingCardView.h
+++ b/Editor/skins/matrix/cards/MatrixSubwooferRoutingCardView.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "Editor/widgets/cards/SubwooferRoutingCardView.h"
+#include "Editor/SkinTokens.h"
 
 class ElidedLabel;
 class QHBoxLayout;
@@ -23,7 +24,7 @@ class MatrixSubwooferRoutingCardView : public SubwooferRoutingCardView
 	Q_OBJECT
 
 public:
-	explicit MatrixSubwooferRoutingCardView(QWidget* parent = nullptr);
+	explicit MatrixSubwooferRoutingCardView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void addActionButton(QAbstractButton* button) override;
 
@@ -32,6 +33,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QWidget* makeReadoutColumn(const QString& caption, QLabel*& valueCell,
 		const QString& accessibleName, const QString& toolTip);
 

--- a/Editor/skins/matrix/picker/MatrixFilterPicker.cpp
+++ b/Editor/skins/matrix/picker/MatrixFilterPicker.cpp
@@ -40,8 +40,9 @@ int s(double pixel)
 }
 }
 
-MatrixFilterPickerView::MatrixFilterPickerView(QWidget* parent)
-	: FilterPickerView(parent)
+MatrixFilterPickerView::MatrixFilterPickerView(const SkinTokens& tokens, QWidget* parent)
+	: FilterPickerView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("MatrixFilterPicker"));
 	setFocusPolicy(Qt::StrongFocus);
@@ -385,7 +386,7 @@ QRect MatrixFilterPickerView::entryCellRect(int visibleRow) const
 
 QFont MatrixFilterPickerView::monoFont(double pointSize, bool bold, double letterSpacing) const
 {
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	QFont font(tokens.monoFontFamily);
 	font.setFamilies(QStringList()
 		<< tokens.monoFontFamily
@@ -401,7 +402,7 @@ QFont MatrixFilterPickerView::monoFont(double pointSize, bool bold, double lette
 void MatrixFilterPickerView::paintEvent(QPaintEvent* event)
 {
 	Q_UNUSED(event);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const QColor border(tokens.border);
 	const QColor accent(tokens.accent);
 	const QColor textColor(tokens.text);

--- a/Editor/skins/matrix/picker/MatrixFilterPicker.h
+++ b/Editor/skins/matrix/picker/MatrixFilterPicker.h
@@ -12,13 +12,14 @@
 #include <QVector>
 
 #include "Editor/widgets/FilterPickerView.h"
+#include "Editor/SkinTokens.h"
 
 class MatrixFilterPickerView : public FilterPickerView
 {
 	Q_OBJECT
 
 public:
-	explicit MatrixFilterPickerView(QWidget* parent = nullptr);
+	explicit MatrixFilterPickerView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void galleryShowcase(GalleryShowcase kind) override;
 
@@ -33,6 +34,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	// One insertable template, parked at a fixed coordinate of the board.
 	struct Cell
 	{

--- a/Editor/skins/matrix/routing/CrosspointMatrixRoutingRenderer.cpp
+++ b/Editor/skins/matrix/routing/CrosspointMatrixRoutingRenderer.cpp
@@ -14,8 +14,8 @@ using std::vector;
 
 CrosspointMatrixView::CrosspointMatrixView(const vector<Assignment>& assignments,
 	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-	QWidget* parent)
-	: RoutingView(parent),
+	QWidget* parent, const SkinTokens& tokens)
+	: RoutingView(parent), skinTokens(tokens),
 	// Seeding every device channel as a row keeps the grid editable even when
 	// the command references few (or no) channels; without it an emptied Copy
 	// could never be refilled from the GUI. Empty rows are skipped by the
@@ -60,7 +60,7 @@ void CrosspointMatrixView::updateMetrics()
 	// FrontBass and SourceLFE on the same board, and a pill narrower than
 	// its caption clipped it to fragments ("rontBas"). The caption font
 	// decides the width a column really needs.
-	QFont monoFont(SkinManager::instance()->tokens().monoFontFamily);
+	QFont monoFont(skinTokens.monoFontFamily);
 	monoFont.setPixelSize(11);
 	const QFontMetrics fm(monoFont);
 
@@ -160,7 +160,7 @@ static QColor mix(const QColor& c, int alpha)
 
 void CrosspointMatrixView::paintEvent(QPaintEvent*)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	QPainter p(this);
 	p.setRenderHint(QPainter::Antialiasing, false);
 	p.setRenderHint(QPainter::TextAntialiasing, true);
@@ -542,7 +542,8 @@ void CrosspointMatrixView::commitChannelEditor()
 }
 
 RoutingView* CrosspointMatrixRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent)
+	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent,
+	const SkinTokens& tokens)
 {
-	return new CrosspointMatrixView(assignments, channelNames, portModel, parent);
+	return new CrosspointMatrixView(assignments, channelNames, portModel, parent, tokens);
 }

--- a/Editor/skins/matrix/routing/CrosspointMatrixRoutingRenderer.h
+++ b/Editor/skins/matrix/routing/CrosspointMatrixRoutingRenderer.h
@@ -18,6 +18,7 @@
 #include "Editor/widgets/routing/CopyRoutingAdapter.h"
 #include "Editor/widgets/routing/IRoutingRenderer.h"
 #include "Editor/widgets/routing/RoutingFold.h"
+#include "Editor/SkinTokens.h"
 
 class CrosspointMatrixView : public RoutingView
 {
@@ -26,7 +27,7 @@ class CrosspointMatrixView : public RoutingView
 public:
 	CrosspointMatrixView(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent);
+		QWidget* parent, const SkinTokens& tokens);
 
 	std::vector<Assignment> assignments() const override;
 	void galleryShowcase(const QString& state) override;
@@ -41,6 +42,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	void rebuildMatrix();
 	void updateMetrics();
 	Assignment& rowAssignment(int outRow);
@@ -95,6 +97,6 @@ class CrosspointMatrixRoutingRenderer : public IRoutingRenderer
 public:
 	RoutingView* create(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent) override;
+		QWidget* parent, const SkinTokens& tokens) override;
 	const char* id() const override { return "crosspoint-matrix"; }
 };

--- a/Editor/skins/minimal/MinimalSkin.cpp
+++ b/Editor/skins/minimal/MinimalSkin.cpp
@@ -20,21 +20,25 @@ IRoutingRenderer* MinimalSkin::routingRenderer() const
 	static StepListRoutingRenderer renderer;
 	return &renderer;
 }
-FilterPickerView* MinimalSkin::createFilterPicker(QWidget* parent) const
+FilterPickerView* MinimalSkin::createFilterPicker(QWidget* parent, const SkinTokens& tokens) const
 {
 	// The add-filter dropdown as a numbered terminal index; see
 	// MinimalFilterPicker.h for the design.
-	return new MinimalFilterPickerView(parent);
+	return new MinimalFilterPickerView(tokens, parent);
 }
 // The reference bodies as one line of type; see
 // MinimalReferenceCardView.h.
-ReferenceCardView* MinimalSkin::createReferenceCardView(const QString& kind, QWidget* parent) const
+ReferenceCardView* MinimalSkin::createReferenceCardView(const QString& kind, QWidget* parent,
+	const SkinTokens& tokens) const
 {
+	Q_UNUSED(tokens);
 	return new MinimalReferenceCardView(kind, parent);
 }
 
-SubwooferRoutingCardView* MinimalSkin::createSubwooferRoutingCardView(QWidget* parent) const
+SubwooferRoutingCardView* MinimalSkin::createSubwooferRoutingCardView(QWidget* parent,
+	const SkinTokens& tokens) const
 {
+	Q_UNUSED(tokens);
 	return new MinimalSubwooferRoutingCardView(parent);
 }
 

--- a/Editor/skins/minimal/MinimalSkin.h
+++ b/Editor/skins/minimal/MinimalSkin.h
@@ -11,9 +11,11 @@ class MinimalSkin final : public ISkin
 public:
 	QString id() const override;
 	IRoutingRenderer* routingRenderer() const override;
-	FilterPickerView* createFilterPicker(QWidget* parent) const override;
-	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent) const override;
-	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent) const override;
+	FilterPickerView* createFilterPicker(QWidget* parent, const SkinTokens& tokens) const override;
+	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent,
+		const SkinTokens& tokens) const override;
+	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent,
+		const SkinTokens& tokens) const override;
 
 	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override;
 	void styleFileDialog(QFileDialog* dialog, const SkinTokens& tokens) const override;

--- a/Editor/skins/minimal/picker/MinimalFilterPicker.cpp
+++ b/Editor/skins/minimal/picker/MinimalFilterPicker.cpp
@@ -37,9 +37,9 @@ int sidePadding()
 	return GUIHelper::scale(10.0);
 }
 
-QFont pickerMonoFont(double pointSize, bool bold = false)
+QFont pickerMonoFont(const SkinTokens& tokens, double pointSize, bool bold = false)
 {
-	QFont font(SkinManager::instance()->tokens().monoFontFamily);
+	QFont font(tokens.monoFontFamily);
 	font.setPointSizeF(pointSize);
 	font.setBold(bold);
 	return font;
@@ -48,8 +48,9 @@ QFont pickerMonoFont(double pointSize, bool bold = false)
 
 // ── MinimalPickerIndexList ───────────────────────────────────────────────────
 
-MinimalPickerIndexList::MinimalPickerIndexList(QWidget* parent)
-	: QWidget(parent)
+MinimalPickerIndexList::MinimalPickerIndexList(const SkinTokens& tokens, QWidget* parent)
+	: QWidget(parent),
+	  skinTokens(tokens)
 {
 	setMouseTracking(true);
 }
@@ -120,11 +121,11 @@ int MinimalPickerIndexList::rowAt(const QPoint& pos) const
 void MinimalPickerIndexList::paintEvent(QPaintEvent* event)
 {
 	QPainter painter(this);
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	painter.fillRect(rect(), QColor(t.background));
 
-	QFont entryFont = pickerMonoFont(9.0);
-	QFont captionFont = pickerMonoFont(7.5, true);
+	QFont entryFont = pickerMonoFont(skinTokens, 9.0);
+	QFont captionFont = pickerMonoFont(skinTokens, 7.5, true);
 	captionFont.setLetterSpacing(QFont::AbsoluteSpacing, 1.5);
 	const QFontMetrics entryMetrics(entryFont);
 
@@ -246,8 +247,9 @@ void MinimalPickerIndexList::hoverFirstEntryForGallery()
 
 // ── MinimalFilterPickerView ──────────────────────────────────────────────────
 
-MinimalFilterPickerView::MinimalFilterPickerView(QWidget* parent)
-	: FilterPickerView(parent)
+MinimalFilterPickerView::MinimalFilterPickerView(const SkinTokens& tokens, QWidget* parent)
+	: FilterPickerView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("MinimalFilterPicker"));
 
@@ -292,7 +294,7 @@ MinimalFilterPickerView::MinimalFilterPickerView(QWidget* parent)
 	scrollArea->setWidgetResizable(true);
 	scrollArea->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
 	scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-	indexList = new MinimalPickerIndexList(scrollArea);
+	indexList = new MinimalPickerIndexList(skinTokens, scrollArea);
 	indexList->onEntryActivated = [this](int entryIndex)
 	{
 		emit entryChosen(entryIndex);
@@ -502,7 +504,7 @@ void MinimalFilterPickerView::paintEvent(QPaintEvent* event)
 	Q_UNUSED(event);
 	// The whole control sits in one square hairline frame; no other chrome.
 	QPainter painter(this);
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	painter.fillRect(rect(), QColor(t.background));
 	painter.setPen(QColor(t.border));
 	painter.drawRect(rect().adjusted(0, 0, -1, -1));

--- a/Editor/skins/minimal/picker/MinimalFilterPicker.h
+++ b/Editor/skins/minimal/picker/MinimalFilterPicker.h
@@ -16,6 +16,7 @@
 #include <QVector>
 
 #include "Editor/widgets/FilterPickerView.h"
+#include "Editor/SkinTokens.h"
 
 class QLabel;
 class QLineEdit;
@@ -35,7 +36,7 @@ public:
 		int entryIndex = -1;  // original index into the entries list; -1 = caption
 	};
 
-	explicit MinimalPickerIndexList(QWidget* parent = nullptr);
+	explicit MinimalPickerIndexList(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setRows(const QList<Row>& rows);
 	const QList<Row>& rows() const { return rowList; }
@@ -62,6 +63,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	int rowAt(const QPoint& pos) const;
 
 	QList<Row> rowList;
@@ -76,7 +78,7 @@ class MinimalFilterPickerView : public FilterPickerView
 	Q_OBJECT
 
 public:
-	explicit MinimalFilterPickerView(QWidget* parent = nullptr);
+	explicit MinimalFilterPickerView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void galleryShowcase(GalleryShowcase kind) override;
 	QSize sizeHint() const override;
@@ -87,6 +89,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QString sectionKey(const FilterPickerEntry& entry) const;
 	void rebuildDisplayNumbers();
 	void rebuildIndex();

--- a/Editor/skins/minimal/routing/StepListRoutingRenderer.cpp
+++ b/Editor/skins/minimal/routing/StepListRoutingRenderer.cpp
@@ -17,8 +17,8 @@ using std::vector;
 
 StepListView::StepListView(const vector<Assignment>& assignments,
 	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-	QWidget* parent)
-	: RoutingView(parent),
+	QWidget* parent, const SkinTokens& tokens)
+	: RoutingView(parent), skinTokens(tokens),
 	// Seed every device channel as a step so an emptied Copy can be refilled
 	// from the GUI; steps whose source sum stays empty are skipped by the
 	// serializer and never reach the config line. The fold decides which
@@ -64,9 +64,9 @@ void StepListView::galleryShowcase(const QString& state)
 	}
 }
 
-static QFont monoFont()
+static QFont monoFont(const SkinTokens& tokens)
 {
-	QFont f(SkinManager::instance()->tokens().monoFontFamily);
+	QFont f(tokens.monoFontFamily);
 	f.setPixelSize(12);
 	return f;
 }
@@ -113,7 +113,7 @@ static QColor channelInk(const QColor& base, bool dark)
 
 QSize StepListView::sizeHint() const
 {
-	QFontMetrics fm(monoFont());
+	QFontMetrics fm(monoFont(skinTokens));
 	int maxWidth = 220;
 	for (int row : fold.visibleRows)
 	{
@@ -143,10 +143,10 @@ QSize StepListView::minimumSizeHint() const
 
 void StepListView::paintEvent(QPaintEvent*)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	QPainter p(this);
 	p.setRenderHint(QPainter::TextAntialiasing, true);
-	const QFont mono = monoFont();
+	const QFont mono = monoFont(skinTokens);
 	p.setFont(mono);
 	QFontMetrics fm(mono);
 
@@ -576,7 +576,8 @@ void StepListView::commitChannelEditor()
 }
 
 RoutingView* StepListRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent)
+	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent,
+	const SkinTokens& tokens)
 {
-	return new StepListView(assignments, channelNames, portModel, parent);
+	return new StepListView(assignments, channelNames, portModel, parent, tokens);
 }

--- a/Editor/skins/minimal/routing/StepListRoutingRenderer.h
+++ b/Editor/skins/minimal/routing/StepListRoutingRenderer.h
@@ -19,6 +19,7 @@
 #include "Editor/widgets/routing/IRoutingRenderer.h"
 #include "Editor/widgets/routing/RoutingFold.h"
 #include "filters/CopyFilter.h"
+#include "Editor/SkinTokens.h"
 
 class StepListView : public RoutingView
 {
@@ -27,7 +28,7 @@ class StepListView : public RoutingView
 public:
 	StepListView(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent);
+		QWidget* parent, const SkinTokens& tokens);
 
 	std::vector<Assignment> assignments() const override;
 	void galleryShowcase(const QString& state) override;
@@ -42,6 +43,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	struct Hit { int row = 0; int summand = 0; QRect rect; };
 	struct AddHit { int row = 0; QRect rect; };
 
@@ -88,6 +90,6 @@ class StepListRoutingRenderer : public IRoutingRenderer
 public:
 	RoutingView* create(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent) override;
+		QWidget* parent, const SkinTokens& tokens) override;
 	const char* id() const override { return "step-list"; }
 };

--- a/Editor/skins/rack/RackSkin.cpp
+++ b/Editor/skins/rack/RackSkin.cpp
@@ -21,19 +21,21 @@ IRoutingRenderer* RackSkin::routingRenderer() const
 	return &renderer;
 }
 
-FilterPickerView* RackSkin::createFilterPicker(QWidget* parent) const
+FilterPickerView* RackSkin::createFilterPicker(QWidget* parent, const SkinTokens& tokens) const
 {
-	return new RackFilterPickerView(parent);
+	return new RackFilterPickerView(tokens, parent);
 }
 
-ReferenceCardView* RackSkin::createReferenceCardView(const QString& kind, QWidget* parent) const
+ReferenceCardView* RackSkin::createReferenceCardView(const QString& kind, QWidget* parent,
+	const SkinTokens& tokens) const
 {
-	return new RackReferenceCardView(kind, parent);
+	return new RackReferenceCardView(kind, tokens, parent);
 }
 
-SubwooferRoutingCardView* RackSkin::createSubwooferRoutingCardView(QWidget* parent) const
+SubwooferRoutingCardView* RackSkin::createSubwooferRoutingCardView(QWidget* parent,
+	const SkinTokens& tokens) const
 {
-	return new RackSubwooferRoutingCardView(parent);
+	return new RackSubwooferRoutingCardView(tokens, parent);
 }
 
 ISkin* rackSkin()

--- a/Editor/skins/rack/RackSkin.h
+++ b/Editor/skins/rack/RackSkin.h
@@ -45,7 +45,9 @@ public:
 	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override;
 	void styleFileDialog(QFileDialog* dialog, const SkinTokens& tokens) const override;
 
-	FilterPickerView* createFilterPicker(QWidget* parent) const override;
-	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent) const override;
-	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent) const override;
+	FilterPickerView* createFilterPicker(QWidget* parent, const SkinTokens& tokens) const override;
+	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent,
+		const SkinTokens& tokens) const override;
+	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent,
+		const SkinTokens& tokens) const override;
 };

--- a/Editor/skins/rack/cards/RackReferenceCardView.cpp
+++ b/Editor/skins/rack/cards/RackReferenceCardView.cpp
@@ -37,8 +37,8 @@ QString captionForKind(const QString& kind)
 
 // ---- RackEngravedLabel -----------------------------------------------------
 
-RackEngravedLabel::RackEngravedLabel(QWidget* parent)
-	: QWidget(parent)
+RackEngravedLabel::RackEngravedLabel(const SkinTokens& tokens, QWidget* parent)
+	: QWidget(parent), skinTokens(tokens)
 {
 	// Preferred keeps the shrink flag, so elidable printing survives narrow
 	// layouts instead of forcing a horizontal scrollbar (the 960px gate).
@@ -117,7 +117,7 @@ QFont RackEngravedLabel::engraveFont() const
 {
 	// The letter-spaced DM Sans approximation of condensed engraving type
 	// (rack.md), read from the live tokens at use time.
-	QFont font(SkinManager::instance()->tokens().fontFamily);
+	QFont font(skinTokens.fontFamily);
 	font.setPixelSize(pixelSize);
 	font.setBold(boldFace);
 	if (letterSpacing > 0.0)
@@ -154,7 +154,7 @@ void RackEngravedLabel::paintEvent(QPaintEvent*)
 
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const bool dark = skinIsDark(tokens);
 
 	QColor bodyInk;
@@ -237,9 +237,10 @@ void RackEngravedLabel::leaveEvent(QEvent* event)
 
 // ---- RackStatusLamp --------------------------------------------------------
 
-RackStatusLamp::RackStatusLamp(QWidget* parent)
+RackStatusLamp::RackStatusLamp(const SkinTokens& tokens, QWidget* parent)
 	: QWidget(parent)
-	, litColor(SkinManager::instance()->tokens().accent2)
+	, skinTokens(tokens)
+	, litColor(tokens.accent2)
 {
 	setFixedSize(GUIHelper::scale(QSize(20, 20)));
 }
@@ -255,7 +256,7 @@ void RackStatusLamp::paintEvent(QPaintEvent*)
 {
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const bool dark = skinIsDark(tokens);
 	const QPointF center = QRectF(rect()).center();
 	const qreal radius = qMin(width(), height()) / 2.0 - 4.5;
@@ -300,8 +301,8 @@ void RackStatusLamp::paintEvent(QPaintEvent*)
 
 // ---- RackLcdWindow ---------------------------------------------------------
 
-RackLcdWindow::RackLcdWindow(QWidget* parent)
-	: QWidget(parent)
+RackLcdWindow::RackLcdWindow(const SkinTokens& tokens, QWidget* parent)
+	: QWidget(parent), skinTokens(tokens)
 {
 	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 	setMaximumWidth(GUIHelper::scale(320.0));
@@ -319,7 +320,7 @@ void RackLcdWindow::setSegments(const QString& newText)
 
 QFont RackLcdWindow::segmentFont() const
 {
-	QFont font(SkinManager::instance()->tokens().monoFontFamily);
+	QFont font(skinTokens.monoFontFamily);
 	font.setPixelSize(10);
 	font.setBold(true);
 	font.setLetterSpacing(QFont::AbsoluteSpacing, 0.5);
@@ -348,7 +349,7 @@ void RackLcdWindow::paintEvent(QPaintEvent*)
 {
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const bool dark = skinIsDark(tokens);
 
 	// The display-window clause: an LCD set into the plate keeps its dark
@@ -382,8 +383,8 @@ void RackLcdWindow::paintEvent(QPaintEvent*)
 
 // ---- RackReferenceCardView -------------------------------------------------
 
-RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* parent)
-	: ReferenceCardView(parent)
+RackReferenceCardView::RackReferenceCardView(const QString& kind, const SkinTokens& tokens, QWidget* parent)
+	: ReferenceCardView(parent), skinTokens(tokens)
 {
 	QWidget* page = contentWidget();
 	rootLayout = new QHBoxLayout(page);
@@ -392,7 +393,7 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 
 	// The status lamp leads the face: on hardware the service lamp sits
 	// beside the label strip, and state is read from lamps before words.
-	lamp = new RackStatusLamp(page);
+	lamp = new RackStatusLamp(skinTokens, page);
 	rootLayout->addWidget(lamp, 0, Qt::AlignVCenter);
 
 	// The engraved label strip: function caption + stamped tags over the
@@ -409,7 +410,7 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 	captionLayout->setContentsMargins(0, 0, 0, 0);
 	captionLayout->setSpacing(6);
 
-	captionLabel = new RackEngravedLabel(captionRow);
+	captionLabel = new RackEngravedLabel(skinTokens, captionRow);
 	captionLabel->setPixelSize(8);
 	captionLabel->setLetterSpacing(2.0);
 	captionLabel->setInk(RackEngravedLabel::Ink::Muted);
@@ -423,7 +424,7 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 
 	// The absolute-path hazard as a stamped wireframe tag in warning ink
 	// (untranslated hardware marking).
-	absStamp = new RackEngravedLabel(captionRow);
+	absStamp = new RackEngravedLabel(skinTokens, captionRow);
 	absStamp->setPixelSize(8);
 	absStamp->setLetterSpacing(1.0);
 	absStamp->setInk(RackEngravedLabel::Ink::Warning);
@@ -434,7 +435,7 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 
 	// The service condition caption (NOT FOUND / EMPTY SLOT): one small
 	// engraving, never an alarm sentence across the plate.
-	serviceTag = new RackEngravedLabel(captionRow);
+	serviceTag = new RackEngravedLabel(skinTokens, captionRow);
 	serviceTag->setPixelSize(8);
 	serviceTag->setLetterSpacing(1.5);
 	serviceTag->setInk(RackEngravedLabel::Ink::Warning);
@@ -444,14 +445,14 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 	captionLayout->addStretch(1);
 	labelLayout->addWidget(captionRow);
 
-	nameLabel = new RackEngravedLabel(labelArea);
+	nameLabel = new RackEngravedLabel(skinTokens, labelArea);
 	nameLabel->setPixelSize(13);
 	nameLabel->setLetterSpacing(0.4);
 	nameLabel->setElideMode(Qt::ElideMiddle);
 	installNameActivation(nameLabel);
 	labelLayout->addWidget(nameLabel);
 
-	dirLabel = new RackEngravedLabel(labelArea);
+	dirLabel = new RackEngravedLabel(skinTokens, labelArea);
 	dirLabel->setPixelSize(10);
 	dirLabel->setBoldFace(false);
 	dirLabel->setInk(RackEngravedLabel::Ink::Muted);
@@ -459,7 +460,7 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 	dirLabel->setVisible(false);
 	labelLayout->addWidget(dirLabel);
 
-	statusLabel = new RackEngravedLabel(labelArea);
+	statusLabel = new RackEngravedLabel(skinTokens, labelArea);
 	statusLabel->setPixelSize(10);
 	statusLabel->setBoldFace(false);
 	statusLabel->setElideMode(Qt::ElideRight);
@@ -470,7 +471,7 @@ RackReferenceCardView::RackReferenceCardView(const QString& kind, QWidget* paren
 
 	// The impulse-response readout window sits between the label strip and
 	// the machine buttons, where hardware mounts its meters.
-	lcdWindow = new RackLcdWindow(page);
+	lcdWindow = new RackLcdWindow(skinTokens, page);
 	lcdWindow->setVisible(false);
 	rootLayout->addWidget(lcdWindow, 0, Qt::AlignVCenter);
 
@@ -548,7 +549,7 @@ void RackReferenceCardView::applyState(const ReferenceCardState& state)
 
 	// The lamp reads the reference's health: green = resolved, amber =
 	// service warning, red = broken/unreadable, dark dome = empty slot.
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	QColor lampColor(tokens.accent2);
 	bool lampLit = true;
 	if (state.missing)

--- a/Editor/skins/rack/cards/RackReferenceCardView.h
+++ b/Editor/skins/rack/cards/RackReferenceCardView.h
@@ -14,6 +14,7 @@
 #include <QFont>
 
 #include "Editor/widgets/cards/ReferenceCardView.h"
+#include "Editor/SkinTokens.h"
 
 class QHBoxLayout;
 
@@ -39,7 +40,7 @@ public:
 		Danger
 	};
 
-	explicit RackEngravedLabel(QWidget* parent = nullptr);
+	explicit RackEngravedLabel(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setText(const QString& newText);
 	void setInk(Ink newInk);
@@ -63,6 +64,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QFont engraveFont() const;
 
 	QString text;
@@ -86,7 +88,7 @@ class RackStatusLamp : public QWidget
 	Q_OBJECT
 
 public:
-	explicit RackStatusLamp(QWidget* parent = nullptr);
+	explicit RackStatusLamp(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setLamp(const QColor& color, bool newLit);
 
@@ -94,6 +96,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QColor litColor;
 	bool lit = false;
 };
@@ -108,7 +111,7 @@ class RackLcdWindow : public QWidget
 	Q_OBJECT
 
 public:
-	explicit RackLcdWindow(QWidget* parent = nullptr);
+	explicit RackLcdWindow(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setSegments(const QString& newText);
 
@@ -119,6 +122,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QFont segmentFont() const;
 	QString displayText() const;
 
@@ -130,7 +134,7 @@ class RackReferenceCardView : public ReferenceCardView
 	Q_OBJECT
 
 public:
-	explicit RackReferenceCardView(const QString& kind, QWidget* parent = nullptr);
+	explicit RackReferenceCardView(const QString& kind, const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void addLeadingWidget(QWidget* widget) override;
 	void placeBusStrip(QWidget* strip) override;
@@ -140,6 +144,7 @@ protected:
 	void applyState(const ReferenceCardState& state) override;
 
 private:
+	const SkinTokens skinTokens;
 	QHBoxLayout* rootLayout = nullptr;
 	QHBoxLayout* actionLayout = nullptr;
 	RackStatusLamp* lamp = nullptr;

--- a/Editor/skins/rack/cards/RackSubwooferRoutingCardView.cpp
+++ b/Editor/skins/rack/cards/RackSubwooferRoutingCardView.cpp
@@ -101,8 +101,9 @@ private:
 
 
 
-RackSubwooferRoutingCardView::RackSubwooferRoutingCardView(QWidget* parent)
-	: SubwooferRoutingCardView(parent)
+RackSubwooferRoutingCardView::RackSubwooferRoutingCardView(const SkinTokens& tokens, QWidget* parent)
+	: SubwooferRoutingCardView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("RackSubwooferRoutingCardView"));
 	setAutoFillBackground(false);
@@ -155,19 +156,19 @@ RackSubwooferRoutingCardView::RackSubwooferRoutingCardView(QWidget* parent)
 	instrumentLayout->setContentsMargins(0, 0, 0, 0);
 	instrumentLayout->setSpacing(GUIHelper::scale(8.0));
 
-	crossoverReadout = new RackCrossoverReadout(instrumentWidget);
+	crossoverReadout = new RackCrossoverReadout(skinTokens, instrumentWidget);
 	instrumentLayout->addWidget(
 		crossoverReadout,
 		1,
 		Qt::AlignVCenter);
 
-	lfeLamp = new RackLfeLamp(instrumentWidget);
+	lfeLamp = new RackLfeLamp(skinTokens, instrumentWidget);
 	instrumentLayout->addWidget(
 		lfeLamp,
 		0,
 		Qt::AlignVCenter);
 
-	headroomMeter = new RackHeadroomMeter(instrumentWidget);
+	headroomMeter = new RackHeadroomMeter(skinTokens, instrumentWidget);
 	instrumentLayout->addWidget(
 		headroomMeter,
 		2,
@@ -489,7 +490,7 @@ void RackSubwooferRoutingCardView::paintEvent(QPaintEvent* event)
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing, true);
 
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const bool dark = skinIsDark(tokens);
 	const QPalette::ColorGroup group = isEnabled()
 		? QPalette::Active
@@ -612,7 +613,7 @@ void RackSubwooferRoutingCardView::paintEvent(QPaintEvent* event)
 	}
 
 	const QString railText = QStringLiteral("SUBWOOFER ROUTING");
-	const QFont railFace = rackFont(7, true, 1.4);
+	const QFont railFace = rackFont(skinTokens, 7, true, 1.4);
 	const QFontMetrics railMetrics(railFace);
 	const qreal railTop =
 		screwInset + screwRadius + GUIHelper::scale(5.0);

--- a/Editor/skins/rack/cards/RackSubwooferRoutingCardView.h
+++ b/Editor/skins/rack/cards/RackSubwooferRoutingCardView.h
@@ -19,6 +19,7 @@
 #include <QWidget>
 
 #include "Editor/widgets/cards/SubwooferRoutingCardView.h"
+#include "Editor/SkinTokens.h"
 
 class QAbstractButton;
 class QHBoxLayout;
@@ -35,7 +36,7 @@ class RackCrossoverReadout : public QWidget
 	Q_OBJECT
 
 public:
-	explicit RackCrossoverReadout(QWidget* parent = nullptr);
+	explicit RackCrossoverReadout(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setReadout(const QString& newCaption,
 		const QString& newPrimary,
@@ -48,6 +49,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QFont captionFont() const;
 	QFont valueFont() const;
 
@@ -61,7 +63,7 @@ class RackLfeLamp : public QWidget
 	Q_OBJECT
 
 public:
-	explicit RackLfeLamp(QWidget* parent = nullptr);
+	explicit RackLfeLamp(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setLfeState(bool newPreserved, double newGainDb);
 
@@ -72,6 +74,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QFont captionFont() const;
 	QFont valueFont() const;
 
@@ -84,7 +87,7 @@ class RackHeadroomMeter : public QWidget
 	Q_OBJECT
 
 public:
-	explicit RackHeadroomMeter(QWidget* parent = nullptr);
+	explicit RackHeadroomMeter(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void setHeadroom(bool newAutomatic, double newTrimDb);
 
@@ -95,6 +98,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QFont captionFont() const;
 	QFont scaleFont() const;
 
@@ -108,7 +112,7 @@ class RackSubwooferRoutingCardView : public SubwooferRoutingCardView
 	Q_OBJECT
 
 public:
-	explicit RackSubwooferRoutingCardView(QWidget* parent = nullptr);
+	explicit RackSubwooferRoutingCardView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void addActionButton(QAbstractButton* button) override;
 
@@ -118,6 +122,7 @@ protected:
 	void resizeEvent(QResizeEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	void updateResponsiveLayout();
 
 	QWidget* headerWidget = nullptr;

--- a/Editor/skins/rack/cards/RackSubwooferRoutingDetail.cpp
+++ b/Editor/skins/rack/cards/RackSubwooferRoutingDetail.cpp
@@ -38,9 +38,8 @@ QColor enabledInk(const QWidget* widget, const QColor& color, int enabledAlpha)
 		widget->isEnabled() ? enabledAlpha : qMin(enabledAlpha, 90));
 }
 
-QFont rackFont(int pixelSize, bool bold, qreal letterSpacing)
+QFont rackFont(const SkinTokens& tokens, int pixelSize, bool bold, qreal letterSpacing)
 {
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
 	QFont font(tokens.fontFamily);
 	font.setPixelSize(pixelSize);
 	font.setBold(bold);
@@ -51,9 +50,8 @@ QFont rackFont(int pixelSize, bool bold, qreal letterSpacing)
 	return font;
 }
 
-QFont rackMonoFont(int pixelSize, bool bold, qreal letterSpacing)
+QFont rackMonoFont(const SkinTokens& tokens, int pixelSize, bool bold, qreal letterSpacing)
 {
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
 	QFont font(tokens.monoFontFamily);
 
 	if (tokens.monoFontFamily.isEmpty())

--- a/Editor/skins/rack/cards/RackSubwooferRoutingDetail.h
+++ b/Editor/skins/rack/cards/RackSubwooferRoutingDetail.h
@@ -12,14 +12,15 @@
 class QPainter;
 class QRectF;
 class QWidget;
+struct SkinTokens;
 
 namespace RackSubwooferRoutingDetail
 {
 qreal physicalPixel(const QWidget* widget);
 qreal crispCoordinate(const QWidget* widget, qreal value);
 QColor enabledInk(const QWidget* widget, const QColor& color, int enabledAlpha = 255);
-QFont rackFont(int pixelSize, bool bold, qreal letterSpacing = 0.0);
-QFont rackMonoFont(int pixelSize, bool bold, qreal letterSpacing = 0.0);
+QFont rackFont(const SkinTokens& tokens, int pixelSize, bool bold, qreal letterSpacing = 0.0);
+QFont rackMonoFont(const SkinTokens& tokens, int pixelSize, bool bold, qreal letterSpacing = 0.0);
 QString fittedText(const QString& text, const QFont& font, qreal availableWidth);
 QString formattedDb(double value);
 void drawEngravedText(QPainter& painter, const QWidget* widget, const QRectF& rect,

--- a/Editor/skins/rack/cards/RackSubwooferRoutingInstruments.cpp
+++ b/Editor/skins/rack/cards/RackSubwooferRoutingInstruments.cpp
@@ -34,8 +34,8 @@ using namespace RackSubwooferRoutingDetail;
 
 // ---- RackCrossoverReadout -------------------------------------------------
 
-RackCrossoverReadout::RackCrossoverReadout(QWidget* parent)
-	: QWidget(parent)
+RackCrossoverReadout::RackCrossoverReadout(const SkinTokens& tokens, QWidget* parent)
+	: QWidget(parent), skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("RackBassCrossoverReadout"));
 	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
@@ -69,12 +69,12 @@ void RackCrossoverReadout::setReadout(
 
 QFont RackCrossoverReadout::captionFont() const
 {
-	return rackFont(8, true, 1.5);
+	return rackFont(skinTokens, 8, true, 1.5);
 }
 
 QFont RackCrossoverReadout::valueFont() const
 {
-	return rackMonoFont(12, true, 0.3);
+	return rackMonoFont(skinTokens, 12, true, 0.3);
 }
 
 QSize RackCrossoverReadout::sizeHint() const
@@ -113,7 +113,7 @@ void RackCrossoverReadout::paintEvent(QPaintEvent* event)
 	QWidget::paintEvent(event);
 
 	QPainter painter(this);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const QColor textInk(tokens.text);
 	const QColor mutedInk(tokens.mutedText);
 
@@ -185,8 +185,8 @@ void RackCrossoverReadout::paintEvent(QPaintEvent* event)
 
 // ---- RackLfeLamp ----------------------------------------------------------
 
-RackLfeLamp::RackLfeLamp(QWidget* parent)
-	: QWidget(parent)
+RackLfeLamp::RackLfeLamp(const SkinTokens& tokens, QWidget* parent)
+	: QWidget(parent), skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("RackBassLfeLamp"));
 	setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -221,12 +221,12 @@ void RackLfeLamp::setLfeState(bool newPreserved, double newGainDb)
 
 QFont RackLfeLamp::captionFont() const
 {
-	return rackFont(8, true, 1.4);
+	return rackFont(skinTokens, 8, true, 1.4);
 }
 
 QFont RackLfeLamp::valueFont() const
 {
-	return rackMonoFont(8, true, 0.2);
+	return rackMonoFont(skinTokens, 8, true, 0.2);
 }
 
 QSize RackLfeLamp::sizeHint() const
@@ -248,7 +248,7 @@ void RackLfeLamp::paintEvent(QPaintEvent* event)
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing, true);
 
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const QPalette::ColorGroup group = isEnabled()
 		? QPalette::Active
 		: QPalette::Disabled;
@@ -418,8 +418,8 @@ void RackLfeLamp::paintEvent(QPaintEvent* event)
 
 // ---- RackHeadroomMeter ----------------------------------------------------
 
-RackHeadroomMeter::RackHeadroomMeter(QWidget* parent)
-	: QWidget(parent)
+RackHeadroomMeter::RackHeadroomMeter(const SkinTokens& tokens, QWidget* parent)
+	: QWidget(parent), skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("RackBassHeadroomMeter"));
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -456,12 +456,12 @@ void RackHeadroomMeter::setHeadroom(bool newAutomatic, double newTrimDb)
 
 QFont RackHeadroomMeter::captionFont() const
 {
-	return rackMonoFont(9, true, 0.3);
+	return rackMonoFont(skinTokens, 9, true, 0.3);
 }
 
 QFont RackHeadroomMeter::scaleFont() const
 {
-	return rackMonoFont(7, false);
+	return rackMonoFont(skinTokens, 7, false);
 }
 
 QSize RackHeadroomMeter::sizeHint() const
@@ -483,7 +483,7 @@ void RackHeadroomMeter::paintEvent(QPaintEvent* event)
 	QWidget::paintEvent(event);
 
 	QPainter painter(this);
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const QColor textInk(tokens.text);
 	const QColor mutedInk(tokens.mutedText);
 	const QColor accentInk(tokens.accent);

--- a/Editor/skins/rack/picker/RackFilterPicker.cpp
+++ b/Editor/skins/rack/picker/RackFilterPicker.cpp
@@ -129,10 +129,12 @@ void paintLed(QPainter& painter, const QPointF& center, qreal radius, const QCol
 class RackFilterPickerDelegate : public QStyledItemDelegate
 {
 public:
-	explicit RackFilterPickerDelegate(QObject* parent = nullptr)
-		: QStyledItemDelegate(parent)
+	RackFilterPickerDelegate(const SkinTokens& tokens, QObject* parent)
+		: QStyledItemDelegate(parent), skinTokens(tokens)
 	{
 	}
+
+	const SkinTokens skinTokens;
 
 	QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
 	{
@@ -143,7 +145,7 @@ public:
 
 	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
 	{
-		const SkinTokens& tokens = SkinManager::instance()->tokens();
+		const SkinTokens& tokens = skinTokens;
 		const bool dark = skinIsDark(tokens);
 
 		painter->save();
@@ -233,12 +235,12 @@ private:
 };
 }
 
-RackFilterPickerView::RackFilterPickerView(QWidget* parent)
-	: FilterPickerView(parent)
+RackFilterPickerView::RackFilterPickerView(const SkinTokens& tokens, QWidget* parent)
+	: FilterPickerView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("RackFilterPicker"));
 
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
 	const bool dark = skinIsDark(tokens);
 
 	QVBoxLayout* layout = new QVBoxLayout(this);
@@ -280,7 +282,7 @@ RackFilterPickerView::RackFilterPickerView(QWidget* parent)
 		"QListWidget#RackFilterPickerList { background: transparent; border: 0; }"
 		"QListWidget#RackFilterPickerList::item { background: transparent; padding: 0; border: 0; }"));
 	listWidget->viewport()->setMouseTracking(true);
-	listWidget->setItemDelegate(new RackFilterPickerDelegate(listWidget));
+	listWidget->setItemDelegate(new RackFilterPickerDelegate(skinTokens, listWidget));
 	layout->addWidget(listWidget, 1);
 	bindListPicker(searchEdit, listWidget, OriginalIndexRole, [this]() { rebuildList(); });
 
@@ -392,7 +394,7 @@ void RackFilterPickerView::paintEvent(QPaintEvent* event)
 {
 	Q_UNUSED(event);
 
-	const SkinTokens& tokens = SkinManager::instance()->tokens();
+	const SkinTokens& tokens = skinTokens;
 	const bool dark = skinIsDark(tokens);
 
 	QPainter painter(this);

--- a/Editor/skins/rack/picker/RackFilterPicker.h
+++ b/Editor/skins/rack/picker/RackFilterPicker.h
@@ -11,6 +11,7 @@
 #include <QList>
 
 #include "Editor/widgets/FilterPickerView.h"
+#include "Editor/SkinTokens.h"
 
 class QLineEdit;
 class QListWidget;
@@ -20,7 +21,7 @@ class RackFilterPickerView : public FilterPickerView
 	Q_OBJECT
 
 public:
-	explicit RackFilterPickerView(QWidget* parent = nullptr);
+	explicit RackFilterPickerView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void galleryShowcase(GalleryShowcase kind) override;
 
@@ -31,6 +32,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	void rebuildList();
 
 	QLineEdit* searchEdit = nullptr;

--- a/Editor/skins/rack/routing/HardwarePatchbayRoutingRenderer.cpp
+++ b/Editor/skins/rack/routing/HardwarePatchbayRoutingRenderer.cpp
@@ -14,8 +14,8 @@ using std::vector;
 
 HardwarePatchbayView::HardwarePatchbayView(const vector<Assignment>& assignments,
 	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-	QWidget* parent)
-	: RoutingView(parent),
+	QWidget* parent, const SkinTokens& tokens)
+	: RoutingView(parent), skinTokens(tokens),
 	// Seed every device channel as a row so an emptied Copy can be refilled
 	// from the GUI; empty rows are skipped by the serializer. The fold below
 	// decides which seeded rows are actually mounted on the panel.
@@ -55,7 +55,7 @@ void HardwarePatchbayView::updateMetrics()
 	// FrontBass and SourceLFE on the same panel, and an engraved label
 	// longer than its column was clipped to fragments ("ntBass"). The
 	// engraving font decides the width a column really needs.
-	QFont label(SkinManager::instance()->tokens().monoFontFamily);
+	QFont label(skinTokens.monoFontFamily);
 	label.setPixelSize(11);
 	label.setLetterSpacing(QFont::AbsoluteSpacing, 1);
 	const QFontMetrics fm(label);
@@ -146,8 +146,8 @@ static QColor a8(const QColor& c, int a) { QColor r = c; r.setAlpha(a); return r
 
 void HardwarePatchbayView::paintEvent(QPaintEvent*)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
-	const bool dark = SkinManager::instance()->isDark();
+	const SkinTokens& t = skinTokens;
+	const bool dark = skinTokens.dark;
 	QPainter p(this);
 	p.setRenderHint(QPainter::Antialiasing, true);
 
@@ -594,7 +594,8 @@ void HardwarePatchbayView::commitChannelEditor()
 }
 
 RoutingView* HardwarePatchbayRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent)
+	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent,
+	const SkinTokens& tokens)
 {
-	return new HardwarePatchbayView(assignments, channelNames, portModel, parent);
+	return new HardwarePatchbayView(assignments, channelNames, portModel, parent, tokens);
 }

--- a/Editor/skins/rack/routing/HardwarePatchbayRoutingRenderer.h
+++ b/Editor/skins/rack/routing/HardwarePatchbayRoutingRenderer.h
@@ -22,6 +22,7 @@
 #include "Editor/widgets/routing/CopyRoutingAdapter.h"
 #include "Editor/widgets/routing/IRoutingRenderer.h"
 #include "Editor/widgets/routing/RoutingFold.h"
+#include "Editor/SkinTokens.h"
 
 class HardwarePatchbayView : public RoutingView
 {
@@ -30,7 +31,7 @@ class HardwarePatchbayView : public RoutingView
 public:
 	HardwarePatchbayView(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent);
+		QWidget* parent, const SkinTokens& tokens);
 
 	std::vector<Assignment> assignments() const override;
 	void galleryShowcase(const QString& state) override;
@@ -45,6 +46,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	void rebuildMatrix();
 	void updateMetrics();
 	Assignment& rowAssignment(int outRow);
@@ -100,6 +102,6 @@ class HardwarePatchbayRoutingRenderer : public IRoutingRenderer
 public:
 	RoutingView* create(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent) override;
+		QWidget* parent, const SkinTokens& tokens) override;
 	const char* id() const override { return "hardware-patchbay"; }
 };

--- a/Editor/skins/soft/SoftSkin.cpp
+++ b/Editor/skins/soft/SoftSkin.cpp
@@ -22,21 +22,23 @@ IRoutingRenderer* SoftSkin::routingRenderer() const
 }
 
 // A rounded menu card picker (soft/picker/SoftFilterPicker.cpp).
-FilterPickerView* SoftSkin::createFilterPicker(QWidget* parent) const
+FilterPickerView* SoftSkin::createFilterPicker(QWidget* parent, const SkinTokens& tokens) const
 {
-	return new SoftFilterPickerView(parent);
+	return new SoftFilterPickerView(tokens, parent);
 }
 
 // The reference rows in the consumer-settings grammar
 // (soft/cards/SoftReferenceCardView.cpp).
-ReferenceCardView* SoftSkin::createReferenceCardView(const QString& kind, QWidget* parent) const
+ReferenceCardView* SoftSkin::createReferenceCardView(const QString& kind, QWidget* parent,
+	const SkinTokens& tokens) const
 {
-	return new SoftReferenceCardView(kind, parent);
+	return new SoftReferenceCardView(kind, tokens, parent);
 }
 
-SubwooferRoutingCardView* SoftSkin::createSubwooferRoutingCardView(QWidget* parent) const
+SubwooferRoutingCardView* SoftSkin::createSubwooferRoutingCardView(QWidget* parent,
+	const SkinTokens& tokens) const
 {
-	return new SoftSubwooferRoutingCardView(parent);
+	return new SoftSubwooferRoutingCardView(tokens, parent);
 }
 
 // Window chrome: deliberately NO paintTitleBarChrome override. The

--- a/Editor/skins/soft/SoftSkin.h
+++ b/Editor/skins/soft/SoftSkin.h
@@ -13,9 +13,11 @@ class SoftSkin final : public ISkin
 public:
 	QString id() const override;
 	IRoutingRenderer* routingRenderer() const override;
-	FilterPickerView* createFilterPicker(QWidget* parent) const override;
-	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent) const override;
-	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent) const override;
+	FilterPickerView* createFilterPicker(QWidget* parent, const SkinTokens& tokens) const override;
+	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent,
+		const SkinTokens& tokens) const override;
+	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent,
+		const SkinTokens& tokens) const override;
 
 	QString cardFrameStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override;
 	QString cardHeaderStyle(const CommandRowInfo& info, const SkinTokens& tokens) const override;

--- a/Editor/skins/soft/cards/SoftReferenceCardView.cpp
+++ b/Editor/skins/soft/cards/SoftReferenceCardView.cpp
@@ -54,13 +54,15 @@ QString kindIconResource(const QString& kind)
 class SoftReferenceTile : public QWidget
 {
 public:
-	explicit SoftReferenceTile(QWidget* parent = nullptr)
-		: QWidget(parent)
+	explicit SoftReferenceTile(const SkinTokens& tokens, QWidget* parent = nullptr)
+		: QWidget(parent), skinTokens(tokens)
 	{
 		setObjectName(QStringLiteral("SoftReferenceTile"));
 		configurePaintOnlyChrome(this);
 		setFixedSize(GUIHelper::scale(QSize(34, 34)));
 	}
+
+	const SkinTokens skinTokens;
 
 	void setAppearance(const QColor& pastel, const QString& newIconResource, bool alert)
 	{
@@ -76,7 +78,7 @@ protected:
 		QPainter painter(this);
 		painter.setRenderHint(QPainter::Antialiasing);
 
-		const SkinTokens& t = SkinManager::instance()->tokens();
+		const SkinTokens& t = skinTokens;
 		const qreal side = qMin(width(), height());
 		QRectF tileRect((width() - side) / 2.0, (height() - side) / 2.0, side, side);
 		tileRect.adjust(1.0, 1.0, -1.0, -1.0);
@@ -127,10 +129,10 @@ private:
 	bool showAlert = false;
 };
 
-SoftReferenceCardView::SoftReferenceCardView(const QString& kind, QWidget* parent)
-	: ReferenceCardView(parent), cardKind(kind)
+SoftReferenceCardView::SoftReferenceCardView(const QString& kind, const SkinTokens& tokens, QWidget* parent)
+	: ReferenceCardView(parent), skinTokens(tokens), cardKind(kind)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	const bool dark = skinIsDark(t);
 
 	QWidget* page = contentWidget();
@@ -140,7 +142,7 @@ SoftReferenceCardView::SoftReferenceCardView(const QString& kind, QWidget* paren
 		GUIHelper::scale(2.0), GUIHelper::scale(6.0));
 	rootLayout->setSpacing(GUIHelper::scale(12.0));
 
-	tile = new SoftReferenceTile(page);
+	tile = new SoftReferenceTile(skinTokens, page);
 	rootLayout->addWidget(tile, 0, Qt::AlignVCenter);
 
 	QWidget* textColumn = new QWidget(page);
@@ -274,7 +276,7 @@ void SoftReferenceCardView::addLeadingWidget(QWidget* widget)
 	// above the body tray with its arrow visible; disabled it keeps only a
 	// dashed outline - a sleeping slot, not an alarm. The inner line edit
 	// rides flat inside the pill.
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	widget->setStyleSheet(QStringLiteral(
 		"QComboBox { background: %1; color: %2; border: 1px solid %3; border-radius: 13px;"
 		" padding: 2px 18px 2px 10px; min-height: 22px; font-weight: 600; }"
@@ -302,7 +304,7 @@ void SoftReferenceCardView::placeBusStrip(QWidget* strip)
 
 void SoftReferenceCardView::applyState(const ReferenceCardState& state)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	const bool dark = skinIsDark(t);
 	const QString kind = state.kind.isEmpty() ? cardKind : state.kind;
 

--- a/Editor/skins/soft/cards/SoftReferenceCardView.h
+++ b/Editor/skins/soft/cards/SoftReferenceCardView.h
@@ -12,6 +12,7 @@
 #include <QString>
 
 #include "Editor/widgets/cards/ReferenceCardView.h"
+#include "Editor/SkinTokens.h"
 
 class ElidedLabel;
 class QAbstractButton;
@@ -24,7 +25,7 @@ class SoftReferenceCardView : public ReferenceCardView
 	Q_OBJECT
 
 public:
-	explicit SoftReferenceCardView(const QString& kind, QWidget* parent = nullptr);
+	explicit SoftReferenceCardView(const QString& kind, const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void addLeadingWidget(QWidget* widget) override;
 	void placeBusStrip(QWidget* strip) override;
@@ -34,6 +35,7 @@ protected:
 	void applyState(const ReferenceCardState& state) override;
 
 private:
+	const SkinTokens skinTokens;
 	void rebuildChips(const QStringList& readout);
 	void styleBrowseButton();
 

--- a/Editor/skins/soft/cards/SoftSubwooferRoutingCardView.cpp
+++ b/Editor/skins/soft/cards/SoftSubwooferRoutingCardView.cpp
@@ -44,8 +44,9 @@ QString decibels(double value)
 }
 
 SoftSubwooferRoutingCardView::SoftSubwooferRoutingCardView(
-	QWidget* parent)
-	: SubwooferRoutingCardView(parent)
+	const SkinTokens& tokens, QWidget* parent)
+	: SubwooferRoutingCardView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("SoftSubwooferRoutingCardView"));
 
@@ -218,7 +219,7 @@ void SoftSubwooferRoutingCardView::paintEvent(QPaintEvent* event)
 	// Focus is a quiet halo, not a hard ring (this skin's focused grammar).
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing, true);
-	QColor halo(SkinManager::instance()->tokens().focusRing);
+	QColor halo(skinTokens.focusRing);
 	halo.setAlpha(90);
 	painter.setPen(QPen(halo, 3.0));
 	painter.setBrush(Qt::NoBrush);

--- a/Editor/skins/soft/cards/SoftSubwooferRoutingCardView.h
+++ b/Editor/skins/soft/cards/SoftSubwooferRoutingCardView.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "Editor/widgets/cards/SubwooferRoutingCardView.h"
+#include "Editor/SkinTokens.h"
 
 class QAbstractButton;
 class QHBoxLayout;
@@ -27,7 +28,7 @@ class SoftSubwooferRoutingCardView : public SubwooferRoutingCardView
 	Q_OBJECT
 
 public:
-	explicit SoftSubwooferRoutingCardView(QWidget* parent = nullptr);
+	explicit SoftSubwooferRoutingCardView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void addActionButton(QAbstractButton* button) override;
 
@@ -36,6 +37,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	QLabel* makeFactPill();
 
 	QLabel* headlineLabel = nullptr;

--- a/Editor/skins/soft/picker/SoftFilterPicker.cpp
+++ b/Editor/skins/soft/picker/SoftFilterPicker.cpp
@@ -145,7 +145,12 @@ QString softCaption(const QString& line)
 class SoftPickerDelegate : public QStyledItemDelegate
 {
 public:
-	using QStyledItemDelegate::QStyledItemDelegate;
+	SoftPickerDelegate(const SkinTokens& tokens, QObject* parent)
+		: QStyledItemDelegate(parent), skinTokens(tokens)
+	{
+	}
+
+	const SkinTokens skinTokens;
 
 	QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override
 	{
@@ -166,8 +171,8 @@ public:
 
 	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
 	{
-		const SkinTokens& t = SkinManager::instance()->tokens();
-		const bool dark = SkinManager::instance()->isDark();
+		const SkinTokens& t = skinTokens;
+		const bool dark = skinTokens.dark;
 		const QString title = index.data(TitleRole).toString();
 
 		painter->save();
@@ -352,8 +357,9 @@ private:
 };
 }
 
-SoftFilterPickerView::SoftFilterPickerView(QWidget* parent)
-	: FilterPickerView(parent)
+SoftFilterPickerView::SoftFilterPickerView(const SkinTokens& tokens, QWidget* parent)
+	: FilterPickerView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("SoftFilterPicker"));
 
@@ -378,7 +384,7 @@ SoftFilterPickerView::SoftFilterPickerView(QWidget* parent)
 	listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	listWidget->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 	listWidget->setUniformItemSizes(false);
-	listWidget->setItemDelegate(new SoftPickerDelegate(listWidget));
+	listWidget->setItemDelegate(new SoftPickerDelegate(skinTokens, listWidget));
 	layout->addWidget(listWidget, 1);
 	bindListPicker(searchEdit, listWidget, EntryIndexRole, [this]() { rebuildList(); });
 
@@ -391,7 +397,7 @@ void SoftFilterPickerView::entriesChanged()
 {
 	entryMonograms = softMonograms(pickerEntries());
 	sectionColors.clear();
-	const bool dark = SkinManager::instance()->isDark();
+	const bool dark = skinTokens.dark;
 	for (const FilterPickerEntry& entry : pickerEntries())
 	{
 		const QString section = entry.path.isEmpty() ? tr("General") : entry.path.join(QStringLiteral(" / "));
@@ -463,7 +469,7 @@ void SoftFilterPickerView::rebuildList()
 		const QString& section = match.section;
 
 		const QColor tint = sectionColors.value(section,
-			sectionPastel(0, SkinManager::instance()->isDark()));
+			sectionPastel(0, skinTokens.dark));
 		if (!sectionStarted || section != currentSection)
 		{
 			sectionStarted = true;
@@ -525,8 +531,8 @@ QSize SoftFilterPickerView::sizeHint() const
 void SoftFilterPickerView::paintEvent(QPaintEvent* event)
 {
 	Q_UNUSED(event);
-	const SkinTokens& t = SkinManager::instance()->tokens();
-	const bool dark = SkinManager::instance()->isDark();
+	const SkinTokens& t = skinTokens;
+	const bool dark = skinTokens.dark;
 
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing);

--- a/Editor/skins/soft/picker/SoftFilterPicker.h
+++ b/Editor/skins/soft/picker/SoftFilterPicker.h
@@ -13,6 +13,7 @@
 #include <QStringList>
 
 #include "Editor/widgets/FilterPickerView.h"
+#include "Editor/SkinTokens.h"
 
 class QLineEdit;
 class QListWidget;
@@ -22,7 +23,7 @@ class SoftFilterPickerView : public FilterPickerView
 	Q_OBJECT
 
 public:
-	explicit SoftFilterPickerView(QWidget* parent = nullptr);
+	explicit SoftFilterPickerView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void galleryShowcase(GalleryShowcase kind) override;
 
@@ -33,6 +34,7 @@ protected:
 	void paintEvent(QPaintEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	void rebuildList();
 
 	// Per-entry tile monograms, parallel to pickerEntries(); computed once per

--- a/Editor/skins/soft/routing/BlockChipRoutingRenderer.cpp
+++ b/Editor/skins/soft/routing/BlockChipRoutingRenderer.cpp
@@ -17,8 +17,8 @@ using std::vector;
 
 BlockChipView::BlockChipView(const vector<Assignment>& assignments,
 	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-	QWidget* parent)
-	: RoutingView(parent),
+	QWidget* parent, const SkinTokens& tokens)
+	: RoutingView(parent), skinTokens(tokens),
 	// Seed every device channel as an equation block so an emptied Copy can be
 	// refilled from the GUI; blocks whose source sum stays empty are skipped by
 	// the serializer and never reach the config line. The fold decides which
@@ -64,16 +64,16 @@ void BlockChipView::galleryShowcase(const QString& state)
 	}
 }
 
-static QFont uiFont(int px)
+static QFont uiFont(const SkinTokens& tokens, int px)
 {
-	QFont f(SkinManager::instance()->tokens().fontFamily);
+	QFont f(tokens.fontFamily);
 	f.setPixelSize(px);
 	return f;
 }
 
 QSize BlockChipView::sizeHint() const
 {
-	QFontMetrics fm(uiFont(13));
+	QFontMetrics fm(uiFont(skinTokens, 13));
 	int maxW = 240;
 	for (int row : fold.visibleRows)
 	{
@@ -98,7 +98,7 @@ static QColor alpha(const QColor& c, int a) { QColor r = c; r.setAlpha(a); retur
 
 void BlockChipView::paintEvent(QPaintEvent*)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	QPainter p(this);
 	p.setRenderHint(QPainter::Antialiasing, true);
 	const int radius = qMax(8, t.borderRadius);
@@ -132,7 +132,7 @@ void BlockChipView::paintEvent(QPaintEvent*)
 		p.setBrush(destCol);
 		p.drawRoundedRect(QRect(block.left() + 6, y, 5, blockH), 2, 2);
 
-		QFont big = uiFont(14);
+		QFont big = uiFont(skinTokens, 14);
 		big.setBold(true);
 		p.setFont(big);
 		QFontMetrics bfm(big);
@@ -144,7 +144,7 @@ void BlockChipView::paintEvent(QPaintEvent*)
 		p.drawText(QRect(x, y, 16, blockH), Qt::AlignCenter, QStringLiteral("="));
 		x += 22;
 
-		QFont chipFont = uiFont(13);
+		QFont chipFont = uiFont(skinTokens, 13);
 		p.setFont(chipFont);
 		QFontMetrics fm(chipFont);
 
@@ -248,7 +248,7 @@ void BlockChipView::paintEvent(QPaintEvent*)
 	// step) and the dashed "add channel" chip (the not-hardware-backed
 	// grammar shared with the per-block [+]).
 	const int y = gap + fold.visibleRows.size() * (blockH + gap);
-	QFont chipFont = uiFont(12);
+	QFont chipFont = uiFont(skinTokens, 12);
 	p.setFont(chipFont);
 	QFontMetrics fm(chipFont);
 	int x = 8;
@@ -521,7 +521,8 @@ void BlockChipView::commitChannelEditor()
 }
 
 RoutingView* BlockChipRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent)
+	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent,
+	const SkinTokens& tokens)
 {
-	return new BlockChipView(assignments, channelNames, portModel, parent);
+	return new BlockChipView(assignments, channelNames, portModel, parent, tokens);
 }

--- a/Editor/skins/soft/routing/BlockChipRoutingRenderer.h
+++ b/Editor/skins/soft/routing/BlockChipRoutingRenderer.h
@@ -19,6 +19,7 @@
 #include "Editor/widgets/routing/IRoutingRenderer.h"
 #include "Editor/widgets/routing/RoutingFold.h"
 #include "filters/CopyFilter.h"
+#include "Editor/SkinTokens.h"
 
 class BlockChipView : public RoutingView
 {
@@ -27,7 +28,7 @@ class BlockChipView : public RoutingView
 public:
 	BlockChipView(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent);
+		QWidget* parent, const SkinTokens& tokens);
 
 	std::vector<Assignment> assignments() const override;
 	void galleryShowcase(const QString& state) override;
@@ -42,6 +43,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 
 private:
+	const SkinTokens skinTokens;
 	struct Hit { int row = 0; int summand = 0; QRect rect; };
 	struct AddHit { int row = 0; QRect rect; };
 	void refold();
@@ -88,6 +90,6 @@ class BlockChipRoutingRenderer : public IRoutingRenderer
 public:
 	RoutingView* create(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent) override;
+		QWidget* parent, const SkinTokens& tokens) override;
 	const char* id() const override { return "block-chip"; }
 };

--- a/Editor/skins/studio/StudioSkin.cpp
+++ b/Editor/skins/studio/StudioSkin.cpp
@@ -20,19 +20,22 @@ IRoutingRenderer* StudioSkin::routingRenderer() const
 	return &renderer;
 }
 
-FilterPickerView* StudioSkin::createFilterPicker(QWidget* parent) const
+FilterPickerView* StudioSkin::createFilterPicker(QWidget* parent, const SkinTokens& tokens) const
 {
-	return new StudioFilterPickerView(parent);
+	return new StudioFilterPickerView(tokens, parent);
 }
 
-ReferenceCardView* StudioSkin::createReferenceCardView(const QString& kind, QWidget* parent) const
+ReferenceCardView* StudioSkin::createReferenceCardView(const QString& kind, QWidget* parent,
+	const SkinTokens& tokens) const
 {
+	Q_UNUSED(tokens);
 	return new StudioReferenceCardView(kind, parent);
 }
 
-SubwooferRoutingCardView* StudioSkin::createSubwooferRoutingCardView(QWidget* parent) const
+SubwooferRoutingCardView* StudioSkin::createSubwooferRoutingCardView(QWidget* parent,
+	const SkinTokens& tokens) const
 {
-	return new StudioSubwooferRoutingCardView(parent);
+	return new StudioSubwooferRoutingCardView(tokens, parent);
 }
 
 ISkin* studioSkin()

--- a/Editor/skins/studio/StudioSkin.h
+++ b/Editor/skins/studio/StudioSkin.h
@@ -11,9 +11,11 @@ class StudioSkin final : public ISkin
 public:
 	QString id() const override;
 	IRoutingRenderer* routingRenderer() const override;
-	FilterPickerView* createFilterPicker(QWidget* parent) const override;
-	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent) const override;
-	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent) const override;
+	FilterPickerView* createFilterPicker(QWidget* parent, const SkinTokens& tokens) const override;
+	ReferenceCardView* createReferenceCardView(const QString& kind, QWidget* parent,
+		const SkinTokens& tokens) const override;
+	SubwooferRoutingCardView* createSubwooferRoutingCardView(QWidget* parent,
+		const SkinTokens& tokens) const override;
 
 	void paintTitleBarChrome(QPainter& painter, const QRect& rect, const SkinTokens& tokens) const override;
 	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override;

--- a/Editor/skins/studio/cards/StudioSubwooferRoutingCardView.cpp
+++ b/Editor/skins/studio/cards/StudioSubwooferRoutingCardView.cpp
@@ -41,8 +41,9 @@ void repolish(QWidget* widget)
 }
 
 StudioSubwooferRoutingCardView::StudioSubwooferRoutingCardView(
-	QWidget* parent)
-	: SubwooferRoutingCardView(parent)
+	const SkinTokens& tokens, QWidget* parent)
+	: SubwooferRoutingCardView(parent),
+	  skinTokens(tokens)
 {
 	setObjectName(QStringLiteral("StudioSubwooferRoutingCardView"));
 
@@ -266,7 +267,7 @@ void StudioSubwooferRoutingCardView::paintEvent(QPaintEvent* event)
 	// ring in the skin's focus colour on the card's single 8px radius.
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing, true);
-	QColor ring(SkinManager::instance()->tokens().focusRing);
+	QColor ring(skinTokens.focusRing);
 	ring.setAlpha(170);
 	painter.setPen(QPen(ring, 1.0));
 	painter.setBrush(Qt::NoBrush);

--- a/Editor/skins/studio/cards/StudioSubwooferRoutingCardView.h
+++ b/Editor/skins/studio/cards/StudioSubwooferRoutingCardView.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "Editor/widgets/cards/SubwooferRoutingCardView.h"
+#include "Editor/SkinTokens.h"
 
 class ElidedLabel;
 class QAbstractButton;
@@ -29,7 +30,7 @@ class StudioSubwooferRoutingCardView : public SubwooferRoutingCardView
 	Q_OBJECT
 
 public:
-	explicit StudioSubwooferRoutingCardView(QWidget* parent = nullptr);
+	explicit StudioSubwooferRoutingCardView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void addActionButton(QAbstractButton* button) override;
 
@@ -41,6 +42,7 @@ private:
 	QWidget* makeReadoutCell(const QString& caption, QLabel*& valueLabel,
 		bool primary, const QString& accessibleName, const QString& toolTip);
 
+	const SkinTokens skinTokens;
 	QHBoxLayout* actionLayout = nullptr;
 	QLabel* validityChip = nullptr;
 	QLabel* layoutLabel = nullptr;

--- a/Editor/skins/studio/picker/StudioFilterPicker.cpp
+++ b/Editor/skins/studio/picker/StudioFilterPicker.cpp
@@ -233,11 +233,11 @@ private:
 };
 }
 
-StudioFilterPickerView::StudioFilterPickerView(QWidget* parent)
+StudioFilterPickerView::StudioFilterPickerView(const SkinTokens& tokens, QWidget* parent)
 	: FilterPickerView(parent)
 {
 	setObjectName(QStringLiteral("StudioFilterPicker"));
-	skinTokens = SkinManager::instance()->tokens();
+	skinTokens = tokens;
 	// The hooks convention: studio's dark background is near-black, so
 	// luminance is an unambiguous mode proxy (see Skins.cpp).
 	dark = skinIsDark(skinTokens);

--- a/Editor/skins/studio/picker/StudioFilterPicker.h
+++ b/Editor/skins/studio/picker/StudioFilterPicker.h
@@ -22,7 +22,7 @@ class StudioFilterPickerView : public FilterPickerView
 	Q_OBJECT
 
 public:
-	explicit StudioFilterPickerView(QWidget* parent = nullptr);
+	explicit StudioFilterPickerView(const SkinTokens& tokens, QWidget* parent = nullptr);
 
 	void galleryShowcase(GalleryShowcase kind) override;
 

--- a/Editor/skins/studio/routing/LightTraceRoutingRenderer.cpp
+++ b/Editor/skins/studio/routing/LightTraceRoutingRenderer.cpp
@@ -29,8 +29,8 @@ int sc(int px) { return GUIHelper::scale(px); }
 
 StudioRoutingView::StudioRoutingView(const vector<Assignment>& assignments,
 	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-	QWidget* parent)
-	: RoutingView(parent), portModel(portModel),
+	QWidget* parent, const SkinTokens& tokens)
+	: RoutingView(parent), skinTokens(tokens), portModel(portModel),
 	// Targets the command referenced stay on the glass for the whole session,
 	// even if their last trace is deleted.
 	pinnedChannels(RoutingFold::referencedTargets(assignments))
@@ -82,7 +82,7 @@ QString StudioRoutingView::chipLabel(bool inputRow, int index) const
 
 void StudioRoutingView::relayout()
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	const int chipH = sc(22);
 	const int gap = sc(10);
 	const int marginX = sc(12);
@@ -299,7 +299,7 @@ QSize StudioRoutingView::minimumSizeHint() const
 
 void StudioRoutingView::paintEvent(QPaintEvent*)
 {
-	const SkinTokens& t = SkinManager::instance()->tokens();
+	const SkinTokens& t = skinTokens;
 	const bool dark = skinIsDark(t);
 	const bool lit = isEnabled();
 	QPainter p(this);
@@ -906,7 +906,8 @@ void StudioRoutingView::commitChannelEditor()
 }
 
 RoutingView* LightTraceRoutingRenderer::create(const vector<Assignment>& assignments,
-	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent)
+	const vector<std::wstring>& channelNames, const RoutingPortModel& portModel, QWidget* parent,
+	const SkinTokens& tokens)
 {
-	return new StudioRoutingView(assignments, channelNames, portModel, parent);
+	return new StudioRoutingView(assignments, channelNames, portModel, parent, tokens);
 }

--- a/Editor/skins/studio/routing/LightTraceRoutingRenderer.h
+++ b/Editor/skins/studio/routing/LightTraceRoutingRenderer.h
@@ -24,6 +24,7 @@
 #include "Editor/widgets/routing/IRoutingRenderer.h"
 #include "Editor/widgets/routing/RoutingFold.h"
 #include "Editor/widgets/routing/StudioRoutingModel.h"
+#include "Editor/SkinTokens.h"
 
 class StudioRoutingView : public RoutingView
 {
@@ -32,7 +33,7 @@ class StudioRoutingView : public RoutingView
 public:
 	StudioRoutingView(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent);
+		QWidget* parent, const SkinTokens& tokens);
 
 	std::vector<Assignment> assignments() const override;
 	void galleryShowcase(const QString& state) override;
@@ -55,6 +56,7 @@ private slots:
 	void commitChannelEditor();
 
 private:
+	const SkinTokens skinTokens;
 	struct TraceShape
 	{
 		QPainterPath path;   // the visible curve
@@ -118,6 +120,6 @@ class LightTraceRoutingRenderer : public IRoutingRenderer
 public:
 	RoutingView* create(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent) override;
+		QWidget* parent, const SkinTokens& tokens) override;
 	const char* id() const override { return "light-trace"; }
 };

--- a/Editor/widgets/FilterCardRow.cpp
+++ b/Editor/widgets/FilterCardRow.cpp
@@ -233,7 +233,8 @@ FilterCardRow::FilterCardRow(FilterTable* table, int number, FilterTable::Item* 
 		std::vector<std::wstring> channelNames = table->getChannelNames();
 		// Copy uses the default port model: symmetric sources/targets seeded
 		// from the device channels, with editable factors.
-		routingView = routingRenderer->create(routingAssignments, channelNames, RoutingPortModel(), editorContainer);
+		routingView = routingRenderer->create(routingAssignments, channelNames, RoutingPortModel(), editorContainer,
+			SkinManager::instance()->tokens());
 
 		QScrollArea* routingScroll = new QScrollArea(editorContainer);
 		routingScroll->setObjectName(QStringLiteral("FilterCardEditorScroll"));

--- a/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
+++ b/Editor/widgets/cards/MultiConvolutionCardEditor.cpp
@@ -219,7 +219,8 @@ void MultiConvolutionCardEditor::rebuildRoutingView()
 	RoutingPortModel portModel;
 	portModel.fixedSources = MultiConvolutionRoutingAdapter::sourcePorts(fileChannelCount, mappings);
 
-	routingView = renderer->create(assignments, targets, portModel, this);
+	routingView = renderer->create(assignments, targets, portModel, this,
+		SkinManager::instance()->tokens());
 	routingLayout->addWidget(routingView);
 	connect(routingView, SIGNAL(routingChanged()), this, SLOT(routingEdited()));
 }

--- a/Editor/widgets/routing/IRoutingRenderer.h
+++ b/Editor/widgets/routing/IRoutingRenderer.h
@@ -20,6 +20,8 @@
 
 #include "filters/CopyFilter.h"
 
+struct SkinTokens;
+
 // Base class for every per-skin routing widget. The host (FilterCardRow for
 // Copy, MultiConvolutionCardEditor for MultiConvolution) connects
 // routingChanged() and reads back assignments() to serialise edits.
@@ -101,10 +103,12 @@ public:
 	// channel layout in scope (used for target seeding / labelling); it may be
 	// empty when channels are not yet known. portModel selects between Copy's
 	// symmetric behaviour (default) and a fixed-source command such as
-	// MultiConvolution.
+	// MultiConvolution. tokens is the building skin's palette; the views used
+	// to pull SkinManager::instance() mid-paint instead (audit #275 B1), and
+	// rows rebuild on every skin switch, so construction injection is safe.
 	virtual RoutingView* create(const std::vector<Assignment>& assignments,
 		const std::vector<std::wstring>& channelNames, const RoutingPortModel& portModel,
-		QWidget* parent) = 0;
+		QWidget* parent, const SkinTokens& tokens) = 0;
 
 	// Short identifier, mainly for diagnostics.
 	virtual const char* id() const = 0;

--- a/Editor/widgets/subwooferrouting/SubwooferRoutingEditorDialog.cpp
+++ b/Editor/widgets/subwooferrouting/SubwooferRoutingEditorDialog.cpp
@@ -983,7 +983,8 @@ void SubwooferRoutingEditorDialog::rebuildBassSendRoutingView()
 			model->state()),
 		bassPathTargets(model->state()),
 		portModel,
-		bassSendRoutingLayout->parentWidget());
+		bassSendRoutingLayout->parentWidget(),
+		SkinManager::instance()->tokens());
 	bassSendRoutingLayout->addWidget(bassSendRoutingView);
 
 	connect(bassSendRoutingView, &RoutingView::routingChanged,
@@ -1031,7 +1032,8 @@ void SubwooferRoutingEditorDialog::rebuildOutputRoutingView()
 			model->state()),
 		physicalTargets(model->state()),
 		portModel,
-		outputRoutingLayout->parentWidget());
+		outputRoutingLayout->parentWidget(),
+		SkinManager::instance()->tokens());
 	outputRoutingLayout->addWidget(outputRoutingView);
 
 	connect(outputRoutingView, &RoutingView::routingChanged,


### PR DESCRIPTION
## 무엇이 달라지나

이슈 #275 B1을 처분합니다. `ISkin`의 생성 훅 4계열(`createFilterPicker`, `createReferenceCardView`, `createSubwooferRoutingCardView`, 라우팅 렌더러의 `create()`)에 `const SkinTokens&`를 통과시켰습니다. S3(PR #242)가 `prepareCommandRow`에 한 것과 같은 처치의 마지막 확장입니다.

- 이 훅들이 만드는 뷰 47곳이 생성자·paintEvent에서 `SkinManager::instance()`를 되짚었습니다. 싱글턴이 우연히 지금 물어본 스킨을 들고 있을 때만 맞는 값이 나오는 구조였고, 행은 스킨 전환마다 재구성되므로 생성자 주입이 안전합니다.
- SkinManager 포워더가 `tokens()`를 주입하므로 바깥 호출자는 무변경. 렌더러 직접 호출 3곳(FilterCardRow, MultiConvolutionCardEditor, SubwooferRoutingEditorDialog)은 빌드 시점의 활성 토큰을 전달합니다.
- 모든 관련 뷰가 `const SkinTokens` 멤버를 갖습니다: 픽커(+델리게이트), 레퍼런스 카드(rack의 각인 라벨/램프/LCD 헬퍼, soft 타일 포함), 서브우퍼 카드(rack 계기 클러스터와 rackFont/rackMonoFont 헬퍼 포함), 라우팅 뷰 5종. `isDark()`는 `tokens.dark`로.
- skins/ 안에 남은 SkinManager 사용 2곳은 토큰 풀이 아닙니다(skinChanged 리페인트 구독, SkinChromeOverlay 소유자 검사).

## 확인 — 픽셀 동일성 증명

오프스크린 갤러리 1460장을 변경 전/후 빌드로 각각 렌더해 SHA-256 비교했습니다.

- 전/후 차이 32장 = **알려진 비결정 집합과 정확히 일치** (filedialog 씬 10장 + studio 레퍼런스 카드 씬 22장)
- 같은 빌드(변경 후)로 두 번 렌더해도 **정확히 같은 32장**이 서로 다름 → 실행 간 노이즈임을 증명
- 비결정 집합 밖 1428장 전부 바이트 동일, 전/후 실질 차이 **0장**

로컬 v145 x64 Editor(qmake) 빌드 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)