### PR TITLE
ci: extract the six Editor offscreen gates and the checksum writer from build.yml (audit #275)

### DIFF
--- a/.github/scripts/Invoke-EditorOffscreenTest.ps1
+++ b/.github/scripts/Invoke-EditorOffscreenTest.ps1
@@ -1,0 +1,189 @@
+<#
+.SYNOPSIS
+    Runs one of the Editor's offscreen gates (self-tests and screenshot
+    galleries) with the shared headless preamble.
+
+.DESCRIPTION
+    Extracted from six inline build.yml steps (audit #275 D6/TD-24): every
+    gate repeated the same preamble - the velopack_libc SONAME copy, the
+    dependency PATH, the QT_QPA offscreen setup with the platform-plugin
+    search pointed at the full Qt install (without which the offscreen plugin
+    fails to load and Qt parks a fatal-error dialog forever on a headless
+    runner), stderr log capture for a GUI-subsystem binary, and the
+    Start-Process exit-code collection. The knowledge lived in six copies;
+    now it lives here once, and adding a gate is a table entry instead of a
+    YAML block.
+
+    The plan phase is pure: -PlanOnly answers which arguments, environment
+    additions and post-checks a gate would run with, for Pester.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $WorkspaceRoot,
+    [Parameter(Mandatory)]
+    [ValidateSet("selftest-vst", "skin-gallery", "skin-switch", "analysis-layout", "card-move", "card-selection")]
+    [string] $Gate,
+    [string] $Platform = "x64",
+    [switch] $PlanOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+$buildDir = Join-Path $WorkspaceRoot "build-Editor-$Platform\release"
+$editorExe = Join-Path $buildDir "Editor.exe"
+
+# Per-gate table. Env values are resolved lazily at execution; the plan lists
+# names and static values so tests can pin them.
+$gates = @{
+    "selftest-vst" = [pscustomobject]@{
+        Arguments  = @("--selftest-vst")
+        ExtraEnv   = @{}
+        LogPath    = $null
+        PostChecks = @()
+    }
+    "skin-gallery" = [pscustomobject]@{
+        Arguments  = @("--skin-gallery", (Join-Path $WorkspaceRoot "skin-gallery"))
+        # Deterministic VST bus scenes against the actually loaded ABI: the
+        # solution's test plugins provide accepted / auto / rejected VST3
+        # states and the VST2 stale-keys warning. A copy named Upmixer.vst3
+        # flips TestVst3Plugin into its Stereo -> 7.1 mode (filename-driven).
+        ExtraEnv   = @{
+            EAPO_GALLERY_VST3_PLUGIN  = Join-Path $WorkspaceRoot "Tests\TestVst3Plugin\$Platform\Release\TestVst3Plugin.vst3"
+            EAPO_GALLERY_VST2_PLUGIN  = Join-Path $WorkspaceRoot "Tests\TestVst2Plugin\$Platform\Release\TestVst2Plugin.dll"
+        }
+        LogPath    = $null
+        PostChecks = @("gallery-not-empty")
+    }
+    "skin-switch" = [pscustomobject]@{
+        Arguments  = @("--skin-switch-test")
+        # Keep the measured 100+ row card rebuild within a useful regression
+        # budget (see the historical notes in git for the 8s -> 5s tightening).
+        ExtraEnv   = @{
+            QT_FORCE_STDERR_LOGGING = "1"
+            EAPO_SWITCH_WARN_MS     = "2500"
+            EAPO_SWITCH_LIMIT_MS    = "5000"
+        }
+        LogPath    = Join-Path $WorkspaceRoot "skin-switch-test.log"
+        PostChecks = @()
+    }
+    "analysis-layout" = [pscustomobject]@{
+        Arguments  = @(
+            "--analysis-layout-test",
+            (Join-Path $WorkspaceRoot "analysis-layout\right-dock.png"),
+            (Join-Path $WorkspaceRoot "Setup\config\config.txt"))
+        ExtraEnv   = @{ QT_FORCE_STDERR_LOGGING = "1" }
+        LogPath    = Join-Path $WorkspaceRoot "analysis-layout\analysis-layout-test.log"
+        PostChecks = @("analysis-screenshot")
+    }
+    "card-move" = [pscustomobject]@{
+        Arguments  = @("--card-move-test")
+        # The limit sits below the measured full-rebuild cost on the hosted
+        # runner (1.4-1.6 s per move): a return to the rebuild fails the gate
+        # while leaving the incremental path 6x headroom for slow days.
+        ExtraEnv   = @{
+            QT_FORCE_STDERR_LOGGING = "1"
+            EAPO_MOVE_WARN_MS       = "250"
+            EAPO_MOVE_LIMIT_MS      = "1000"
+        }
+        LogPath    = Join-Path $WorkspaceRoot "card-move-test.log"
+        PostChecks = @()
+    }
+    "card-selection" = [pscustomobject]@{
+        Arguments  = @("--card-selection-test", (Join-Path $WorkspaceRoot "card-selection"))
+        ExtraEnv   = @{ QT_FORCE_STDERR_LOGGING = "1" }
+        LogPath    = Join-Path $WorkspaceRoot "card-selection\card-selection-test.log"
+        PostChecks = @()
+    }
+}
+
+$spec = $gates[$Gate]
+$plan = [pscustomobject]@{
+    Gate       = $Gate
+    EditorExe  = $editorExe
+    Arguments  = @($spec.Arguments)
+    ExtraEnv   = $spec.ExtraEnv
+    LogPath    = $spec.LogPath
+    PostChecks = @($spec.PostChecks)
+    # The import lib embeds the SONAME velopack_libc.dll (see Package-
+    # Artifacts); the gates run from the build dir, so the renamed DLL must
+    # sit next to Editor.exe. Idempotent, so every gate does it.
+    VelopackDllSource = Join-Path $WorkspaceRoot "deps\velopack_libc\lib\velopack_libc_win_${Platform}_msvc.dll".ToLowerInvariant()
+}
+if ($PlanOnly) {
+    return $plan
+}
+
+if (-not (Test-Path $editorExe)) {
+    throw "Editor executable not found at $editorExe"
+}
+
+Copy-Item $plan.VelopackDllSource -Destination (Join-Path $buildDir "velopack_libc.dll") -Force
+
+# Shared headless preamble. QT_QPA_PLATFORM_PLUGIN_PATH must point at the
+# full Qt install: windeployqt deploys only qwindows next to Editor.exe, and
+# the deployed Qt6Core.dll wins the DLL search, so without this the offscreen
+# plugin fails to load and Qt parks a fatal-error dialog forever.
+$env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
+$env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
+$env:QT_QPA_PLATFORM = "offscreen"
+foreach ($name in $spec.ExtraEnv.Keys) {
+    Set-Item -Path "env:$name" -Value $spec.ExtraEnv[$name]
+}
+
+if ($Gate -eq "skin-gallery") {
+    foreach ($fixture in @($env:EAPO_GALLERY_VST3_PLUGIN, $env:EAPO_GALLERY_VST2_PLUGIN)) {
+        if (-not (Test-Path $fixture)) {
+            throw "VST gallery fixture not found: $fixture"
+        }
+    }
+    $env:EAPO_GALLERY_VST3_UPMIXER = Join-Path ([System.IO.Path]::GetTempPath()) "Upmixer.vst3"
+    if ($env:RUNNER_TEMP) { $env:EAPO_GALLERY_VST3_UPMIXER = Join-Path $env:RUNNER_TEMP "Upmixer.vst3" }
+    Copy-Item $env:EAPO_GALLERY_VST3_PLUGIN -Destination $env:EAPO_GALLERY_VST3_UPMIXER -Force
+}
+
+if ($spec.LogPath) {
+    New-Item -ItemType Directory -Force -Path (Split-Path $spec.LogPath -Parent) | Out-Null
+}
+
+# Editor.exe is a GUI-subsystem binary; Start-Process -Wait is the reliable
+# way to collect its exit code from PowerShell, and stderr only carries
+# qWarning output when redirected (with QT_FORCE_STDERR_LOGGING where set).
+$startArgs = @{
+    FilePath     = $editorExe
+    ArgumentList = $plan.Arguments
+    PassThru     = $true
+    Wait         = $true
+    NoNewWindow  = $true
+}
+if ($spec.LogPath) {
+    $startArgs.RedirectStandardError = $spec.LogPath
+}
+$proc = Start-Process @startArgs
+
+if ($spec.LogPath -and (Test-Path $spec.LogPath)) {
+    Get-Content $spec.LogPath | Write-Host
+}
+if ($proc.ExitCode -ne 0) {
+    throw "Editor offscreen gate '$Gate' failed (exit code $($proc.ExitCode))"
+}
+
+foreach ($check in $plan.PostChecks) {
+    switch ($check) {
+        "gallery-not-empty" {
+            $outDir = $plan.Arguments[1]
+            $pngs = @(Get-ChildItem $outDir -Filter *.png)
+            Write-Host "Gallery wrote $($pngs.Count) PNGs"
+            # SkinGallery self-checks the exact shot count and exits non-zero
+            # on a mismatch; this only guards against an empty run.
+            if ($pngs.Count -lt 1) {
+                throw "Gallery produced no PNGs"
+            }
+        }
+        "analysis-screenshot" {
+            $shot = $plan.Arguments[1]
+            if (-not (Test-Path $shot)) {
+                throw "Analysis dock layout test produced no screenshot"
+            }
+        }
+    }
+}

--- a/.github/scripts/New-ReleaseChecksums.ps1
+++ b/.github/scripts/New-ReleaseChecksums.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Builds and uploads SHA256SUMS.txt for a release's setup executables.
+
+.DESCRIPTION
+    Extracted from the inline "Publish release checksums" step in build.yml
+    (audit #275 TD-24): the auto-detect installer refuses to run a downloaded
+    per-channel Setup.exe whose SHA-256 does not match this file
+    (Installer/AutoInstaller.cpp), so the file must list every *-Setup.exe
+    asset in the exact format the parser reads - and the parser was tested
+    while the writer was not. Format-ChecksumLines is the pure writer half
+    Pester pins: sha256sum-compatible lines, lowercase hex, two spaces, LF,
+    sorted by name, trailing newline.
+
+    The assets are re-downloaded from the release rather than hashed from
+    local build directories so the hashes cover exactly the bytes users get.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $Repository,
+    [Parameter(Mandatory)] [string] $Tag,
+    [Parameter(Mandatory)] [string] $WorkspaceRoot,
+    [switch] $PlanOnly
+)
+
+$ErrorActionPreference = "Stop"
+Import-Module (Join-Path $PSScriptRoot "ReleaseAssets.psm1") -Force
+
+function Format-ChecksumLines {
+    param(
+        # Hashtable of asset name -> SHA-256 hex (any case).
+        [Parameter(Mandatory)] [hashtable] $Hashes
+    )
+    $lines = foreach ($name in ($Hashes.Keys | Sort-Object)) {
+        "$($Hashes[$name].ToLowerInvariant())  $name"
+    }
+    (($lines -join "`n") + "`n")
+}
+
+if ($PlanOnly) {
+    return [pscustomobject]@{
+        ChecksumsAssetName = Get-ChecksumsAssetName
+        SumsPath           = Join-Path $WorkspaceRoot (Get-ChecksumsAssetName)
+        SetupAssetPattern  = '-Setup\.exe$'
+    }
+}
+
+$assetNames = @(gh release view $Tag --repo $Repository --json assets --jq '.assets[].name' |
+    Where-Object { $_ -match '-Setup\.exe$' })
+if ($assetNames.Count -eq 0) {
+    throw "No setup executables found on release $Tag; nothing to checksum."
+}
+
+$downloadDir = Join-Path $WorkspaceRoot "checksum-input"
+New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
+
+$hashes = @{}
+foreach ($name in $assetNames) {
+    gh release download $Tag --repo $Repository --pattern $name --dir $downloadDir --clobber
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to download release asset $name for checksumming"
+    }
+    $hash = (Get-FileHash -Path (Join-Path $downloadDir $name) -Algorithm SHA256).Hash
+    $hashes[$name] = $hash
+    Write-Host "$($hash.ToLowerInvariant())  $name"
+}
+
+$sumsPath = Join-Path $WorkspaceRoot (Get-ChecksumsAssetName)
+[System.IO.File]::WriteAllText($sumsPath, (Format-ChecksumLines -Hashes $hashes))
+
+gh release upload $Tag $sumsPath --clobber --repo $Repository
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to upload $(Get-ChecksumsAssetName) to release $Tag"
+}

--- a/.github/scripts/Tests/EditorOffscreenTest.Tests.ps1
+++ b/.github/scripts/Tests/EditorOffscreenTest.Tests.ps1
@@ -1,0 +1,83 @@
+Describe "Invoke-EditorOffscreenTest.ps1 planning" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot "..\Invoke-EditorOffscreenTest.ps1"
+        function PlanFor([string] $gate) {
+            & $scriptPath -WorkspaceRoot "C:\ws" -Gate $gate -Platform x64 -PlanOnly
+        }
+    }
+
+    It "targets the qmake build directory's Editor" {
+        (PlanFor "selftest-vst").EditorExe | Should -Be "C:\ws\build-Editor-x64\release\Editor.exe"
+    }
+
+    It "copies the velopack SONAME for every gate" {
+        foreach ($gate in @("selftest-vst", "skin-gallery", "skin-switch", "analysis-layout", "card-move", "card-selection")) {
+            (PlanFor $gate).VelopackDllSource |
+                Should -Be "C:\ws\deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll"
+        }
+    }
+
+    It "hands the gallery its deterministic VST fixtures and the empty-run check" {
+        $plan = PlanFor "skin-gallery"
+        $plan.Arguments | Should -Be @("--skin-gallery", "C:\ws\skin-gallery")
+        $plan.ExtraEnv["EAPO_GALLERY_VST3_PLUGIN"] |
+            Should -Be "C:\ws\Tests\TestVst3Plugin\x64\Release\TestVst3Plugin.vst3"
+        $plan.ExtraEnv["EAPO_GALLERY_VST2_PLUGIN"] |
+            Should -Be "C:\ws\Tests\TestVst2Plugin\x64\Release\TestVst2Plugin.dll"
+        $plan.PostChecks | Should -Contain "gallery-not-empty"
+    }
+
+    It "keeps the switch and move latency budgets" {
+        $switch = PlanFor "skin-switch"
+        $switch.ExtraEnv["EAPO_SWITCH_WARN_MS"] | Should -Be "2500"
+        $switch.ExtraEnv["EAPO_SWITCH_LIMIT_MS"] | Should -Be "5000"
+        $move = PlanFor "card-move"
+        $move.ExtraEnv["EAPO_MOVE_WARN_MS"] | Should -Be "250"
+        $move.ExtraEnv["EAPO_MOVE_LIMIT_MS"] | Should -Be "1000"
+    }
+
+    It "drives the analysis probe with the shipped sample config and demands the screenshot" {
+        $plan = PlanFor "analysis-layout"
+        $plan.Arguments[1] | Should -Be "C:\ws\analysis-layout\right-dock.png"
+        $plan.Arguments[2] | Should -Be "C:\ws\Setup\config\config.txt"
+        $plan.PostChecks | Should -Contain "analysis-screenshot"
+    }
+
+    It "captures stderr for the GUI-subsystem gates that log through qWarning" {
+        foreach ($gate in @("skin-switch", "analysis-layout", "card-move", "card-selection")) {
+            $plan = PlanFor $gate
+            $plan.LogPath | Should -Not -BeNullOrEmpty
+            $plan.ExtraEnv["QT_FORCE_STDERR_LOGGING"] | Should -Be "1"
+        }
+    }
+}
+
+Describe "New-ReleaseChecksums.ps1" {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot "..\New-ReleaseChecksums.ps1"
+        # Dot-source in a scriptblock cannot reach an advanced script's inner
+        # functions; instead run -PlanOnly for the surface, and reproduce the
+        # writer contract through a real invocation of Format-ChecksumLines by
+        # loading the script text's function into scope.
+        $scriptText = Get-Content $scriptPath -Raw
+        $functionText = [regex]::Match($scriptText,
+            'function Format-ChecksumLines \{[\s\S]*?\n\}').Value
+        Invoke-Expression $functionText
+    }
+
+    It "plans the grammar-derived checksum asset" {
+        $plan = & $scriptPath -Repository owner/repo -Tag v9.9.9 -WorkspaceRoot "C:\ws" -PlanOnly
+        $plan.ChecksumsAssetName | Should -Be "SHA256SUMS.txt"
+        $plan.SumsPath | Should -Be "C:\ws\SHA256SUMS.txt"
+    }
+
+    It "writes the exact format Installer/AutoInstaller.cpp parses" {
+        # sha256sum-compatible: lowercase hex, two spaces, LF, sorted, final LF.
+        $lines = Format-ChecksumLines -Hashes @{
+            "B-Setup.exe" = "ABCDEF0123"
+            "A-Setup.exe" = "0123ABCDEF"
+        }
+        $lines | Should -Be "0123abcdef  A-Setup.exe`nabcdef0123  B-Setup.exe`n"
+        $lines.Contains("`r") | Should -BeFalse
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,204 +429,76 @@ jobs:
 
     # The VSTPlugin store()/parse round-trip self-test: opening and saving a
     # line must never lose chunk data, parameters or the bus contract.
+    # The six Editor offscreen gates share one headless preamble (velopack
+    # SONAME copy, dependency PATH, QT_QPA offscreen setup with the platform-
+    # plugin search pointed at the full Qt install, stderr capture for a
+    # GUI-subsystem binary). It lived as six inline YAML copies; it now lives
+    # once in .github/scripts/Invoke-EditorOffscreenTest.ps1 (audit #275
+    # D6/TD-24), with -PlanOnly Pester coverage. Primary avx2 variant only:
+    # the gates exercise QSS/QPainter/widget behavior, which does not vary by
+    # SIMD variant.
+    #
+    # Gate notes (history lives with each gate's entry in the script):
+    # - skin-gallery publishes the judging material for the skin program
+    #   (issues #66-#68) and hard-fails on an empty run.
+    # - skin-switch replays MainWindow::skinSelected's exact sequence over a
+    #   100+ row config; both regression classes it guards (switch crashes,
+    #   seconds-per-switch repolish storms) have shipped before.
+    # - analysis-layout reproduces the right-dock placement at 1024x768 and
+    #   the bottom/back relayout.
+    # - card-move keeps the drag-move on the incremental splice path (a full
+    #   rebuild costs 1.4-1.6 s per move on this runner and fails the gate).
+    # - card-selection pins pointer-selection chrome across skins.
     - name: Run VST Editor self-test (offscreen)
       if: matrix.simd_variant == 'avx2'
       timeout-minutes: 3
       shell: pwsh
       run: |
-        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll" `
-          -Destination "build-Editor-x64\release\velopack_libc.dll" -Force
-        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
-        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
-        $env:QT_QPA_PLATFORM = "offscreen"
-        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
-          -ArgumentList @("--selftest-vst") -PassThru -Wait -NoNewWindow
-        if ($proc.ExitCode -ne 0) {
-          Write-Error "VST Editor self-test failed (exit code $($proc.ExitCode))"
-          exit 1
-        }
+        & .\.github\scripts\Invoke-EditorOffscreenTest.ps1 `
+          -WorkspaceRoot "${{ github.workspace }}" -Gate selftest-vst
 
-    # Offscreen skin gallery: proves the Editor renders every skin headless and
-    # publishes the judging material for the skin program (issues #66-#68).
-    # Primary avx2 variant only: the gallery is QSS/QPainter output and does
-    # not vary by SIMD variant.
+    # A hard step timeout on every gate: if the Editor ever blocks on a
+    # fatal-error dialog again, the job must fail in minutes, not hang for
+    # hours.
     - name: Run skin gallery (offscreen)
       if: matrix.simd_variant == 'avx2'
-      # A hard step timeout: if the Editor ever blocks on a fatal-error dialog
-      # again, the job must fail in minutes instead of hanging for hours.
       timeout-minutes: 10
       shell: pwsh
       run: |
-        # The import lib embeds the SONAME velopack_libc.dll (see the Package
-        # binaries step); the gallery runs from the build dir, so the renamed
-        # DLL must sit next to Editor.exe here too.
-        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll" `
-          -Destination "build-Editor-x64\release\velopack_libc.dll" -Force
+        & .\.github\scripts\Invoke-EditorOffscreenTest.ps1 `
+          -WorkspaceRoot "${{ github.workspace }}" -Gate skin-gallery -Platform "${{ matrix.platform }}"
 
-        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
-        # windeployqt deployed only the qwindows platform plugin next to
-        # Editor.exe, and the deployed Qt6Core.dll in the app dir wins the DLL
-        # search, which limits plugin resolution to the deployed set - the
-        # offscreen plugin then fails to load and Qt parks a fatal-error dialog
-        # forever on the headless runner. Point the platform-plugin search at
-        # the full Qt install instead (verified: without this the gallery
-        # hangs; with it, all 120 PNGs render).
-        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
-        $env:QT_QPA_PLATFORM = "offscreen"
-        # Deterministic VST bus scenes against the actually loaded ABI: the
-        # solution's test plugins provide accepted / auto / rejected VST3
-        # states and the VST2 stale-keys warning. A copy named Upmixer.vst3
-        # flips TestVst3Plugin into its Stereo -> 7.1 mode (filename-driven),
-        # which is the asymmetric accepted scene.
-        $env:EAPO_GALLERY_VST3_PLUGIN = "${{ github.workspace }}\Tests\TestVst3Plugin\${{ matrix.platform }}\Release\TestVst3Plugin.vst3"
-        $env:EAPO_GALLERY_VST2_PLUGIN = "${{ github.workspace }}\Tests\TestVst2Plugin\${{ matrix.platform }}\Release\TestVst2Plugin.dll"
-        $env:EAPO_GALLERY_VST3_UPMIXER = "$env:RUNNER_TEMP\Upmixer.vst3"
-        foreach ($fixture in @($env:EAPO_GALLERY_VST3_PLUGIN, $env:EAPO_GALLERY_VST2_PLUGIN)) {
-          if (-not (Test-Path $fixture)) {
-            Write-Error "VST gallery fixture not found: $fixture"
-            exit 1
-          }
-        }
-        Copy-Item $env:EAPO_GALLERY_VST3_PLUGIN -Destination $env:EAPO_GALLERY_VST3_UPMIXER -Force
-        $outDir = "${{ github.workspace }}\skin-gallery"
-        # Editor.exe is a GUI-subsystem binary; Start-Process -Wait is the
-        # reliable way to collect its exit code from PowerShell.
-        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
-          -ArgumentList @("--skin-gallery", $outDir) -PassThru -Wait -NoNewWindow
-        if ($proc.ExitCode -ne 0) {
-          Write-Error "Skin gallery failed (exit code $($proc.ExitCode))"
-          exit 1
-        }
-        $pngs = @(Get-ChildItem $outDir -Filter *.png)
-        Write-Host "Gallery wrote $($pngs.Count) PNGs"
-        # SkinGallery self-checks the shot count (skins x 2 modes x (rows x 3 +
-        # fixed chrome)) and exits non-zero on any mismatch, so the exit-code
-        # check above already catches a missing or extra shot. Adding a gallery
-        # row no longer needs a hard-coded count here; just guard against an
-        # empty run.
-        if ($pngs.Count -lt 1) {
-          Write-Error "Gallery produced no PNGs"
-          exit 1
-        }
-
-    # Live skin-switch robustness gate: replays MainWindow::skinSelected's
-    # exact sequence (clearRows -> applySkin -> palette -> updateGuis) over a
-    # 100+ row synthetic config, 3 rounds x 5 skins x 2 modes. Fails on a
-    # crash, a wrong resulting skin id, or a switch slower than the in-test
-    # ceiling - both regression classes (switch crashes, seconds-per-switch
-    # repolish storms) have shipped before. avx2 only, like the gallery: the
-    # switch path does not vary by SIMD variant.
     - name: Run skin switch test (offscreen)
       if: matrix.simd_variant == 'avx2'
       timeout-minutes: 10
       shell: pwsh
       run: |
-        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
-        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
-        $env:QT_QPA_PLATFORM = "offscreen"
-        # GUI-subsystem exe: qWarning only reaches redirected stderr with this set
-        $env:QT_FORCE_STDERR_LOGGING = "1"
-        # Keep the measured 100+ row card rebuild within a useful regression
-        # budget. The historical default (8 s) was a crash-storm guard; after
-        # the construct-in-place/no-repolish startup work the same rebuild
-        # runs in well under half the previous 4 s budget.
-        $env:EAPO_SWITCH_WARN_MS = "2500"
-        $env:EAPO_SWITCH_LIMIT_MS = "5000"
-        $log = "${{ github.workspace }}\skin-switch-test.log"
-        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
-          -ArgumentList @("--skin-switch-test") -PassThru -Wait -NoNewWindow `
-          -RedirectStandardError $log
-        if (Test-Path $log) { Get-Content $log | Write-Host }
-        if ($proc.ExitCode -ne 0) {
-          Write-Error "Skin switch test failed (exit code $($proc.ExitCode))"
-          exit 1
-        }
+        & .\.github\scripts\Invoke-EditorOffscreenTest.ps1 `
+          -WorkspaceRoot "${{ github.workspace }}" -Gate skin-switch
 
-    # Analysis dock layout gate: reproduces the right-side placement at the
-    # Editor's 1024x768 default, checks that the filter workspace keeps a
-    # usable majority, the controls fill the dock, and moving back to the
-    # bottom restores the compact horizontal control cell.
     - name: Run analysis dock layout test (offscreen)
       if: matrix.simd_variant == 'avx2'
       timeout-minutes: 5
       shell: pwsh
       run: |
-        Copy-Item "${{ github.workspace }}\deps\velopack_libc\lib\velopack_libc_win_x64_msvc.dll" `
-          -Destination "build-Editor-x64\release\velopack_libc.dll" -Force
-        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
-        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
-        $env:QT_QPA_PLATFORM = "offscreen"
-        $env:QT_FORCE_STDERR_LOGGING = "1"
-        $outDir = "${{ github.workspace }}\analysis-layout"
-        New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-        $shot = Join-Path $outDir "right-dock.png"
-        $log = Join-Path $outDir "analysis-layout-test.log"
-        $fixture = "${{ github.workspace }}\Setup\config\config.txt"
-        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
-          -ArgumentList @("--analysis-layout-test", $shot, $fixture) `
-          -PassThru -Wait -NoNewWindow -RedirectStandardError $log
-        if (Test-Path $log) { Get-Content $log | Write-Host }
-        if ($proc.ExitCode -ne 0) {
-          Write-Error "Analysis dock layout test failed (exit code $($proc.ExitCode))"
-          exit 1
-        }
-        if (-not (Test-Path $shot)) {
-          Write-Error "Analysis dock layout test produced no screenshot"
-          exit 1
-        }
+        & .\.github\scripts\Invoke-EditorOffscreenTest.ps1 `
+          -WorkspaceRoot "${{ github.workspace }}" -Gate analysis-layout
 
-    # Card drag-move latency gate: one card moved down and back up on a 100+
-    # row document, per skin x mode. Field report: a single card move cost
-    # 5-6 s on a 12600K because the internal drag-move rebuilt every card
-    # row; the incremental splice moves in 24-82 ms locally and well under
-    # the warning here. The limit sits below the measured full-rebuild cost
-    # on this runner (1.4-1.6 s per move), so a return to the rebuild fails
-    # the gate while leaving the incremental path 6x headroom for slow days.
     - name: Run card move test (offscreen)
       if: matrix.simd_variant == 'avx2'
       timeout-minutes: 10
       shell: pwsh
       run: |
-        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
-        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
-        $env:QT_QPA_PLATFORM = "offscreen"
-        # GUI-subsystem exe: qWarning only reaches redirected stderr with this set
-        $env:QT_FORCE_STDERR_LOGGING = "1"
-        $env:EAPO_MOVE_WARN_MS = "250"
-        $env:EAPO_MOVE_LIMIT_MS = "1000"
-        $log = "${{ github.workspace }}\card-move-test.log"
-        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
-          -ArgumentList @("--card-move-test") -PassThru -Wait -NoNewWindow `
-          -RedirectStandardError $log
-        if (Test-Path $log) { Get-Content $log | Write-Host }
-        if ($proc.ExitCode -ne 0) {
-          Write-Error "Card move test failed (exit code $($proc.ExitCode))"
-          exit 1
-        }
+        & .\.github\scripts\Invoke-EditorOffscreenTest.ps1 `
+          -WorkspaceRoot "${{ github.workspace }}" -Gate card-move
 
-    # Card pointer-selection gate: ordinary header clicks and clicks consumed
-    # by an in-card editor control must both leave one model selection, one
-    # focused item, and exactly one matching card chrome across every skin.
     - name: Run card selection test (offscreen)
       if: matrix.simd_variant == 'avx2'
       timeout-minutes: 5
       shell: pwsh
       run: |
-        $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:QT_ROOT\bin;$env:PATH"
-        $env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_ROOT\plugins\platforms"
-        $env:QT_QPA_PLATFORM = "offscreen"
-        $env:QT_FORCE_STDERR_LOGGING = "1"
-        $outDir = "${{ github.workspace }}\card-selection"
-        New-Item -ItemType Directory -Force -Path $outDir | Out-Null
-        $log = Join-Path $outDir "card-selection-test.log"
-        $proc = Start-Process -FilePath "build-Editor-x64\release\Editor.exe" `
-          -ArgumentList @("--card-selection-test", $outDir) `
-          -PassThru -Wait -NoNewWindow -RedirectStandardError $log
-        if (Test-Path $log) { Get-Content $log | Write-Host }
-        if ($proc.ExitCode -ne 0) {
-          Write-Error "Card selection test failed (exit code $($proc.ExitCode))"
-          exit 1
-        }
+        & .\.github\scripts\Invoke-EditorOffscreenTest.ps1 `
+          -WorkspaceRoot "${{ github.workspace }}" -Gate card-selection
 
     - name: Upload skin gallery
       if: matrix.simd_variant == 'avx2'
@@ -1016,38 +888,10 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $ErrorActionPreference = "Stop"
-        $tag = "${{ steps.version.outputs.tag }}"
-        $repo = "${{ github.repository }}"
-
-        $assetNames = @(gh release view $tag --repo $repo --json assets --jq '.assets[].name' |
-            Where-Object { $_ -match '-Setup\.exe$' })
-        if ($assetNames.Count -eq 0) {
-          throw "No setup executables found on release $tag; nothing to checksum."
-        }
-
-        $downloadDir = Join-Path "${{ github.workspace }}" "checksum-input"
-        New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
-
-        $lines = @()
-        foreach ($name in ($assetNames | Sort-Object)) {
-          gh release download $tag --repo $repo --pattern $name --dir $downloadDir --clobber
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to download release asset $name for checksumming"
-          }
-          $hash = (Get-FileHash -Path (Join-Path $downloadDir $name) -Algorithm SHA256).Hash.ToLowerInvariant()
-          $lines += "$hash  $name"
-          Write-Host "$hash  $name"
-        }
-
-        # sha256sum-compatible format: <lowercase-hex>, two spaces, <name>, LF.
-        $sumsPath = Join-Path "${{ github.workspace }}" "SHA256SUMS.txt"
-        [System.IO.File]::WriteAllText($sumsPath, (($lines -join "`n") + "`n"))
-
-        gh release upload $tag $sumsPath --clobber --repo $repo
-        if ($LASTEXITCODE -ne 0) {
-          exit $LASTEXITCODE
-        }
+        .\.github\scripts\New-ReleaseChecksums.ps1 `
+          -Repository "${{ github.repository }}" `
+          -Tag "${{ steps.version.outputs.tag }}" `
+          -WorkspaceRoot "${{ github.workspace }}"
 
     - name: Write release notes
       if: steps.version.outputs.needs_notes == 'true'


### PR DESCRIPTION
## 무엇이 달라지나

이슈 #275 D6/TD-24를 처분합니다.

- 여섯 오프스크린 게이트가 반복하던 인라인 서두(velopack SONAME 복사, 의존성 PATH, 헤드리스 행업을 막는 QT_QPA 플러그인 경로 지식, GUI 바이너리 stderr 캡처, Start-Process 종료 코드 수집)를 `Invoke-EditorOffscreenTest.ps1` 한 곳으로 모았습니다. `-PlanOnly` 순수 계획 단계가 있고, 게이트 표(인자·지연 예산·사후 검사)는 Pester가 고정합니다. YAML 스텝은 한 줄 호출이 됐고 게이트 추가 비용은 표 항목 하나입니다.
- `SHA256SUMS.txt` 작성기를 `New-ReleaseChecksums.ps1`로 추출했습니다. 파서(AutoInstaller.cpp)만 테스트되고 작성기는 무테스트였던 비대칭이 풀립니다. `Format-ChecksumLines` 순수 함수가 정확한 계약(소문자 hex·두 칸 공백·LF·정렬·마지막 개행)으로 고정됩니다.
- build.yml이 약 190줄 줄었습니다.

## 확인

- 신규 Pester 8/8 통과
- 추출된 selftest-vst 게이트를 로컬 Editor 빌드로 스크립트 경유 실행해 PASS 확인
- build.yml YAML 파싱 확인. 나머지 다섯 게이트의 실행 경로는 이 PR의 CI(avx2 leg)가 그대로 검증합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)