### PR TITLE
refactor(editor): extract row-GUI policy, heritage skin, and Editor coupling seams (audit #275 B4-B8)

### DIFF
--- a/Editor/Editor.pro
+++ b/Editor/Editor.pro
@@ -252,6 +252,7 @@ SOURCES += main.cpp\
 	SkinManager.cpp \
 	skins/ISkin.cpp \
 	skins/Skins.cpp \
+	skins/HeritageSkin.cpp \
 	skins/shared/SkinFileIcons.cpp \
 	skins/SkinThemeData.cpp \
 	widgets/AddCardRow.cpp \
@@ -306,6 +307,7 @@ SOURCES += main.cpp\
 	widgets/EqGraphView.cpp \
 	widgets/SegmentedControl.cpp \
 	widgets/FilterCardModel.cpp \
+	widgets/FilterRowGuiPolicy.cpp \
 	widgets/FilterCommandCatalog.cpp \
 	widgets/FilterCardRow.cpp \
 	widgets/FilterListModel.cpp \
@@ -524,6 +526,7 @@ HEADERS  += \
 	SkinManager.h \
 	skins/ISkin.h \
 	skins/Skins.h \
+	skins/HeritageSkin.h \
 	skins/shared/SkinFileIcons.h \
 	skins/shared/SkinChromeOverlay.h \
 	skins/shared/SkinPaint.h \
@@ -578,6 +581,7 @@ HEADERS  += \
 	widgets/EqGraphView.h \
 	widgets/SegmentedControl.h \
 	widgets/FilterCardModel.h \
+	widgets/FilterRowGuiPolicy.h \
 	widgets/FilterCommandCatalog.h \
 	widgets/FilterCardRow.h \
 	widgets/FilterListModel.h \

--- a/Editor/FilterTable.cpp
+++ b/Editor/FilterTable.cpp
@@ -48,6 +48,7 @@
 #include "Editor/widgets/AddCardRow.h"
 #include "Editor/widgets/FilterInsertSeam.h"
 #include "Editor/widgets/FilterCardModel.h"
+#include "Editor/widgets/FilterRowGuiPolicy.h"
 #include "Editor/widgets/FilterCardRow.h"
 #include "Editor/widgets/cards/CommentCardEditor.h"
 #include "Editor/widgets/cards/FilterCardEditorFactory.h"
@@ -62,8 +63,8 @@ using std::string;
 using std::vector;
 using std::wstring;
 
-FilterTable::FilterTable(MainWindow* mainWindow, QWidget* parent)
-	: QWidget(parent), mainWindow(mainWindow)
+FilterTable::FilterTable(QWidget* parent)
+	: QWidget(parent)
 {
 	gridLayout = new QGridLayout(this);
 
@@ -349,43 +350,33 @@ IFilterGUI* FilterTable::createRowGui(const QString& line, const FilterCardDescr
 		preparedDescriptor = &derivedDescriptor;
 	}
 
-	// A pure comment has no "command: parameters" shape (with or without an
-	// inner colon), so it never reaches the factories below. In card mode it
-	// still gets a real editor; the legacy path stays frozen (raw row).
-	if (renderMode == ModernCards && preparedDescriptor->type == QStringLiteral("comment"))
-		return new CommentCardEditor(line);
-
-	// Copy's maintained card editor is the skin routing view built directly by
-	// FilterCardRow. Channel propagation is handled by the row's Qt-free Copy
-	// domain logic, so a normal Copy row no longer needs a hidden heritage GUI.
-	// Dynamic Copy parameters still fall through: routing editors must not
-	// parse and rewrite inline expressions.
-	if (renderMode == ModernCards
-		&& FilterCardModel::opensRoutingView(*preparedDescriptor)
-		&& SkinManager::instance()->routingRenderer() != nullptr)
-		return nullptr;
-
 	int pos = line.indexOf(':');
-	if (pos == -1)
-		return nullptr;
-
 	// allow to use indentation
-	QString factoryKey = line.mid(0, pos).trimmed();
-	QString factoryValue = line.mid(pos + 1);
+	QString factoryKey = pos == -1 ? QString() : line.mid(0, pos).trimmed();
+	QString factoryValue = pos == -1 ? QString() : line.mid(pos + 1);
 
-	if (renderMode == ModernCards)
+	// The decision itself is pure and pinned by EditorLogicTests
+	// (FilterRowGuiPolicy, audit #275 B4); this function only constructs
+	// what was decided.
+	const RowGuiDecision decision = decideRowGui(renderMode == ModernCards, line,
+		preparedDescriptor,
+		SkinManager::instance()->routingRenderer() != nullptr,
+		pos != -1 && FilterCardEditorFactory::available(factoryKey, factoryValue));
+
+	switch (decision)
 	{
-		// Card editors take precedence, so ask them before running the legacy
-		// chain: constructing a legacy GUI only to replace and delete it would
-		// parse VSTPlugin state twice per rebuild. Safe to short-circuit because
-		// the card-covered factories keep no per-row state in createFilterGUI
-		// (their state is set in initialize()/startOfFile()). Commented lines
-		// ("# ...") do not match here and fall through to the chain, where
-		// CommentFilterGUIFactory strips the '#'; the post-chain lookup below
-		// then gives them the same card editor as their active form.
-		IFilterGUI* cardGui = FilterCardEditorFactory::create(this, factoryKey, factoryValue);
-		if (cardGui != nullptr)
-			return cardGui;
+	case RowGuiDecision::CommentCard:
+		return new CommentCardEditor(line);
+	case RowGuiDecision::SkinRoutingView:
+		// FilterCardRow builds the skin routing view; channel propagation is
+		// handled by the row's Qt-free Copy domain logic.
+		return nullptr;
+	case RowGuiDecision::RawRow:
+		return nullptr;
+	case RowGuiDecision::CardEditor:
+		return FilterCardEditorFactory::create(this, factoryKey, factoryValue);
+	case RowGuiDecision::LegacyChain:
+		break;
 	}
 
 	// Factory results are parentless until the selected row adopts them. Keep

--- a/Editor/FilterTable.h
+++ b/Editor/FilterTable.h
@@ -80,7 +80,7 @@ public:
 	// keeps compiling unchanged.
 	using Item = FilterListItem;
 
-	explicit FilterTable(MainWindow* mainWindow, QWidget* parent = 0);
+	explicit FilterTable(QWidget* parent = nullptr);
 	~FilterTable();
 	void initialize(QScrollArea* scrollArea, const QList<std::shared_ptr<AbstractAPOInfo>>& outputDevices, const QList<std::shared_ptr<AbstractAPOInfo>>& inputDevices);
 	void updateDeviceAndChannelMask(std::shared_ptr<AbstractAPOInfo> selectedDevice, int selectedChannelMask);
@@ -179,6 +179,12 @@ public:
 
 signals:
 	void linesChanged();
+	// The two calls FilterTable used to make through a stored MainWindow*
+	// (audit #275 B6) - the linesChanged shape, applied to the last two
+	// couplings, so the table stands without a MainWindow (offscreen gates,
+	// any future harness).
+	void configOpenRequested(const QString& path);
+	void analysisUpdateRequested();
 
 public slots:
 	void updateModel();
@@ -247,7 +253,6 @@ private:
 	// without recording the replacement as a new undo step.
 	void applyHistoryState(const QList<QString>& lines);
 
-	MainWindow* mainWindow;
 	QScrollArea* scrollArea = nullptr;
 	QGridLayout* gridLayout;
 	QLabel* insertArrow;

--- a/Editor/FilterTableParts/FilterTable.Clipboard.cpp
+++ b/Editor/FilterTableParts/FilterTable.Clipboard.cpp
@@ -153,9 +153,7 @@ void FilterTable::addActionTriggered()
 
 void FilterTable::openConfig(QString path)
 {
-	if (mainWindow == nullptr)
-		return;
-	mainWindow->load(path);
+	emit configOpenRequested(path);
 }
 
 void FilterTable::savePreferences()
@@ -204,7 +202,7 @@ void FilterTable::setScrollOffsets(int x, int y)
 
 void FilterTable::updateAnalysis()
 {
-	if (mainWindow != nullptr && isVisible())
-		mainWindow->startAnalysis();
+	if (isVisible())
+		emit analysisUpdateRequested();
 }
 

--- a/Editor/MainWindowParts/MainWindow.Device.cpp
+++ b/Editor/MainWindowParts/MainWindow.Device.cpp
@@ -128,7 +128,11 @@ FilterTable* MainWindow::addTab(QString title, QString tooltip, QString configPa
 	phaseTimer.start();
 	QScrollArea* scrollArea = new QScrollArea(ui->tabWidget);
 	scrollArea->setWidgetResizable(true);
-	FilterTable* filterTable = new FilterTable(this);
+	FilterTable* filterTable = new FilterTable();
+	connect(filterTable, &FilterTable::configOpenRequested,
+		this, [this](const QString& path) { load(path); });
+	connect(filterTable, &FilterTable::analysisUpdateRequested,
+		this, [this]() { startAnalysis(); });
 	scrollArea->setWidget(filterTable);
 	filterTable->setAcceptDrops(true);
 	filterTable->setFocusPolicy(Qt::WheelFocus);

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -1,4 +1,18 @@
 #include "SkinGallery.h"
+// For the two gates moved out of main.cpp (audit #275 B7): the VST
+// round-trip self test and the analysis layout probe.
+#include <optional>
+#include <unordered_map>
+#include <QBoxLayout>
+#include <QDockWidget>
+#include <QFileInfo>
+#include <QLocale>
+#include <QStyle>
+#include <QTimer>
+#include "filters/VSTPluginFilter.h"
+#include "filters/VSTPluginFilterFactory.h"
+#include "guis/VSTPluginFilterGUI.h"
+#include "MainWindow.h"
 #include "diagnostics/ToolbarPixelProbe.h"
 #include "widgets/MainToolbarKit.h"
 #include "SubwooferRouting/Preset.h"
@@ -833,7 +847,7 @@ QList<FilterCardRow*> buildRows(QScrollArea& scrollArea, const QString& configPa
 	// getPreferredWidth(). Without it the table never gets a real size and
 	// every row collapses to a few pixels.
 	scrollArea.setWidgetResizable(true);
-	FilterTable* table = new FilterTable(nullptr);
+	FilterTable* table = new FilterTable();
 	if (qEnvironmentVariableIsSet("EAPO_GALLERY_LEGACY"))
 		table->setRenderMode(FilterTable::LegacyRows);
 	scrollArea.setWidget(table);
@@ -2478,4 +2492,189 @@ int run(const QStringList& arguments)
 	std::fflush(nullptr);
 	std::_Exit(status);
 }
+}
+
+// Mechanical round-trip check for VST plugin data: parse a VSTPlugin line, feed
+// the parsed library, opaque state and options into the real VSTPluginFilterGUI,
+// call its store(), reparse the result and confirm ChunkData, parameters,
+// StereoInput and the hidden Input/Output contract survive. Returns 0 on success,
+// 1 on any loss.
+int SkinGallery::runVstRoundTripSelfTest()
+{
+	struct Case { const wchar_t* name = nullptr; std::wstring params; };
+	const Case cases[] = {
+		{ L"chunkData", L"Library \"fake plugin.dll\" ChunkData \"QUJDREVGR0g=\"" },
+		{ L"paramMap", L"Library fake.dll Gain 0.5 Mix 0.25 Width 1" },
+		{ L"paramMap-quoted-name", L"Library fake.dll \"Dry/Wet\" 0.75 Output 0.5" },
+		{ L"stereoInput-chunk", L"Library fake.dll StereoInput 1 ChunkData \"QUJDREVGR0g=\"" },
+		{ L"stereoInput-params", L"Library fake.dll StereoInput 1 Gain 0.5" },
+		{ L"busContract", L"Library fake.vst3 Input Stereo Output 7.1 Gain 0.5" }
+	};
+
+	int failures = 0;
+	for (const Case& c : cases)
+	{
+		VSTPluginFilterFactory factory;
+		std::wstring command = L"VSTPlugin";
+		std::wstring params = c.params;
+		FilterVector filters = factory.createFilter(L"", command, params);
+		if (filters.empty())
+		{
+			fprintf(stderr, "[VST selftest] %ls: parse produced no filter\n", c.name);
+			failures++;
+			continue;
+		}
+		VSTPluginFilter* f0 = static_cast<VSTPluginFilter*>(filters[0].get());
+		std::wstring chunk0 = f0->getChunkData();
+		std::unordered_map<std::wstring, float> map0 = f0->getParamMap();
+		const bool stereo0 = f0->getStereoInput();
+		const std::optional<VST3BusContract> bus0 = f0->getBusContract();
+
+		VSTPluginFilterGUI gui(f0->getLibrary(), chunk0, map0, stereo0, bus0);
+		QString outCommand, outParams;
+		gui.store(outCommand, outParams);
+
+		std::wstring command2 = outCommand.toStdWString();
+		std::wstring params2 = outParams.toStdWString();
+		FilterVector filters2 = factory.createFilter(L"", command2, params2);
+		if (filters2.empty())
+		{
+			fprintf(stderr, "[VST selftest] %ls: re-parse produced no filter (params='%ls')\n", c.name, params2.c_str());
+			failures++;
+			continue;
+		}
+		VSTPluginFilter* f1 = static_cast<VSTPluginFilter*>(filters2[0].get());
+		std::wstring chunk1 = f1->getChunkData();
+		std::unordered_map<std::wstring, float> map1 = f1->getParamMap();
+		const bool stereo1 = f1->getStereoInput();
+		const std::optional<VST3BusContract> bus1 = f1->getBusContract();
+		const bool sameBusContract = bus0.has_value() == bus1.has_value()
+			&& (!bus0 || (bus0->input == bus1->input && bus0->output == bus1->output));
+		bool ok = (chunk0 == chunk1) && (map0 == map1) && (stereo0 == stereo1) && sameBusContract;
+		if (!ok)
+		{
+			failures++;
+			fprintf(stderr, "[VST selftest] %ls: LOSS. chunk %ls->%ls, params %zu->%zu, stereoInput %d->%d, bus %d->%d\n",
+				c.name, chunk0.c_str(), chunk1.c_str(), map0.size(), map1.size(), stereo0 ? 1 : 0,
+				stereo1 ? 1 : 0, bus0 ? 1 : 0, bus1 ? 1 : 0);
+			for (auto& kv : map0)
+			{
+				auto it = map1.find(kv.first);
+				if (it == map1.end())
+					fprintf(stderr, "    dropped param '%ls'=%g\n", kv.first.c_str(), kv.second);
+				else if (it->second != kv.second)
+					fprintf(stderr, "    param '%ls' %g -> %g\n", kv.first.c_str(), kv.second, it->second);
+			}
+		}
+		else
+		{
+			fprintf(stderr, "[VST selftest] %ls: OK (chunk len %zu, %zu params preserved)\n",
+				c.name, chunk0.size(), map0.size());
+		}
+	}
+
+	fprintf(stderr, "[VST selftest] %s (%d failure(s))\n", failures == 0 ? "PASS" : "FAIL", failures);
+	return failures == 0 ? 0 : 1;
+}
+
+bool SkinGallery::armAnalysisLayoutProbe(MainWindow& window, const QString& screenshotPath)
+{
+	QDockWidget* dock = window.findChild<QDockWidget*>(QStringLiteral("analysisDockWidget"));
+	if (dock == nullptr)
+	{
+		fprintf(stderr, "Analysis layout test: required dock is missing\n");
+		return false;
+	}
+
+	window.showNormal();
+	window.resize(1024, 768);
+	dock->show();
+		QTimer::singleShot(750, &window, [&window, dock, screenshotPath]() {
+		fprintf(stderr,
+			"Analysis layout target: platform=%s style=%s dpr=%.2f locale=%s skin=%s dark=%d\n",
+			qPrintable(QGuiApplication::platformName()), qPrintable(qApp->style()->objectName()),
+			window.devicePixelRatioF(), qPrintable(QLocale().name()),
+			qPrintable(SkinManager::instance()->currentSkinId()),
+			SkinManager::instance()->isDark() ? 1 : 0);
+		QWidget* controls = window.findChild<QWidget*>(QStringLiteral("analysisControlBar"));
+		QWidget* graph = window.findChild<QWidget*>(QStringLiteral("ModernAnalysisGraph"));
+		QBoxLayout* layout = window.findChild<QBoxLayout*>(QStringLiteral("analysisDockLayout"));
+		const int centralWidth = window.centralWidget()->width();
+		const int dockWidth = dock->width();
+		const int controlsWidth = controls != nullptr ? controls->width() : -1;
+		const int graphWidth = graph != nullptr ? graph->width() : -1;
+		const bool centralProtected = centralWidth * 100 >= window.width() * 55;
+		const bool dockBounded = dockWidth * 100 <= window.width() * 45;
+		const bool graphUsable = graphWidth >= 300;
+		const bool controlsFill = controlsWidth >= graphWidth - 2;
+		const bool stacked = layout != nullptr && layout->direction() == QBoxLayout::TopToBottom;
+
+		bool screenshotSaved = screenshotPath.isEmpty();
+		if (!screenshotPath.isEmpty())
+		{
+			QFileInfo screenshotInfo(screenshotPath);
+			QDir().mkpath(screenshotInfo.absolutePath());
+			const QPixmap shot = window.grab();
+			screenshotSaved = shot.save(screenshotPath);
+		}
+
+		const bool rightPass = centralProtected && dockBounded && graphUsable
+			&& controlsFill && stacked && screenshotSaved;
+		fprintf(stderr,
+			"Analysis layout test (right): window=%dx%d central=%d dock=%d controls=%d graph=%d "
+			"centralProtected=%d dockBounded=%d graphUsable=%d controlsFill=%d stacked=%d screenshot=%d\n",
+			window.width(), window.height(), centralWidth, dockWidth, controlsWidth, graphWidth,
+			centralProtected ? 1 : 0, dockBounded ? 1 : 0, graphUsable ? 1 : 0,
+			controlsFill ? 1 : 0, stacked ? 1 : 0, screenshotSaved ? 1 : 0);
+
+		const bool bottomRequested = QMetaObject::invokeMethod(&window,
+			"on_graphPositionComboBox_currentIndexChanged", Qt::DirectConnection,
+			Q_ARG(int, 1));
+		QTimer::singleShot(250, &window, [&window, dock, rightPass, bottomRequested]() {
+			QWidget* bottomControls = window.findChild<QWidget*>(QStringLiteral("analysisControlBar"));
+			QBoxLayout* bottomLayout = window.findChild<QBoxLayout*>(QStringLiteral("analysisDockLayout"));
+			const bool bottomArea = window.dockWidgetArea(dock) == Qt::BottomDockWidgetArea;
+			const bool horizontal = bottomLayout != nullptr
+				&& bottomLayout->direction() == QBoxLayout::LeftToRight;
+			const bool compactControls = bottomControls != nullptr
+				&& bottomControls->maximumWidth() < QWIDGETSIZE_MAX
+				&& bottomControls->width() <= bottomControls->maximumWidth();
+			fprintf(stderr,
+				"Analysis layout test (bottom): area=%d horizontal=%d compactControls=%d\n",
+				bottomArea ? 1 : 0, horizontal ? 1 : 0, compactControls ? 1 : 0);
+			const bool bottomPass = bottomRequested && bottomArea
+				&& horizontal && compactControls;
+			const bool rightRestoreRequested = QMetaObject::invokeMethod(&window,
+				"on_graphPositionComboBox_currentIndexChanged", Qt::DirectConnection,
+				Q_ARG(int, 2));
+			QTimer::singleShot(250, &window,
+				[&window, dock, rightPass, bottomPass, rightRestoreRequested]() {
+					QWidget* restoredControls = window.findChild<QWidget*>(
+						QStringLiteral("analysisControlBar"));
+					QWidget* restoredGraph = window.findChild<QWidget*>(
+						QStringLiteral("ModernAnalysisGraph"));
+					QBoxLayout* restoredLayout = window.findChild<QBoxLayout*>(
+						QStringLiteral("analysisDockLayout"));
+					const bool rightRestored = rightRestoreRequested
+						&& window.dockWidgetArea(dock) == Qt::RightDockWidgetArea
+						&& restoredLayout != nullptr
+						&& restoredLayout->direction() == QBoxLayout::TopToBottom
+						&& restoredControls != nullptr && restoredGraph != nullptr
+						&& restoredControls->width() >= restoredGraph->width() - 2;
+					fprintf(stderr, "Analysis layout test (right restored): pass=%d\n",
+						rightRestored ? 1 : 0);
+					const int exitCode = rightPass && bottomPass && rightRestored ? 0 : 1;
+					bool holdOk = false;
+					const int requestedHold = qEnvironmentVariableIntValue(
+						"EAPO_ANALYSIS_LAYOUT_HOLD_MS", &holdOk);
+					const int holdMs = holdOk ? qBound(0, requestedHold, 30000) : 0;
+					if (holdMs > 0)
+						QTimer::singleShot(holdMs, &window,
+							[exitCode]() { QCoreApplication::exit(exitCode); });
+					else
+						QCoreApplication::exit(exitCode);
+				});
+		});
+	});
+	return true;
 }

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -946,7 +946,7 @@ int renderSkin(const QDir& outDir, const QString& skinId, const QString& configP
 		QScrollArea scrollArea;
 		scrollArea.resize(960, 720);
 		buildRows(scrollArea, configPath, { QStringLiteral("Preamp: -6 dB") });
-		FilterTable* table = qobject_cast<FilterTable*>(scrollArea.widget());
+		const FilterTable* table = qobject_cast<FilterTable*>(scrollArea.widget());
 		FilterPickerView* picker = SkinManager::instance()->createFilterPicker(nullptr);
 		picker->setEntries(table != nullptr ? table->filterPickerEntries() : QList<FilterPickerEntry>());
 		picker->adjustSize();

--- a/Editor/SkinGallery.h
+++ b/Editor/SkinGallery.h
@@ -17,6 +17,8 @@
 
 #include <QStringList>
 
+class MainWindow;
+
 namespace SkinGallery
 {
 // Entry point behind the Editor's --skin-gallery flag. arguments are the full
@@ -49,4 +51,15 @@ int runCardMoveTest(const QStringList& arguments);
 // the rendered card state, then that clicking an interactive control inside a
 // different card collapses a prior multi-selection onto that card.
 int runCardSelectionTest(const QStringList& arguments);
+
+// Entry point behind --selftest-vst: the VSTPlugin store()/parse round-trip
+// gate (opening and saving a line must never lose chunk data, parameters or
+// the bus contract). Lived inline in main.cpp before audit #275 B7.
+int runVstRoundTripSelfTest();
+
+// Entry point behind --analysis-layout-test: arms the timed probe over the
+// live MainWindow (dock geometry, right/bottom relayout, restore) and later
+// exits the event loop with the verdict. Returns false when the required
+// dock is missing, in which case the caller exits 1 immediately.
+bool armAnalysisLayoutProbe(MainWindow& window, const QString& screenshotPath);
 }

--- a/Editor/SkinManager.cpp
+++ b/Editor/SkinManager.cpp
@@ -8,6 +8,7 @@
 #include "Editor/helpers/CrashHandler.h"
 #include "skins/ISkin.h"
 #include "skins/Skins.h"
+#include "Editor/skins/HeritageSkin.h"
 #include "skins/SkinThemeData.h"
 
 SkinManager::SkinManager(QObject* parent)
@@ -52,34 +53,13 @@ void SkinManager::applyHeritage()
 	LogFStatic(L"Applying heritage presentation (legacy rows)");
 
 	heritageMode = true;
-	// Token donor and the base-class knob painter; nothing of the skin's own
-	// look survives below.
-	activeSkin = Skins::byId(QStringLiteral("studio"));
-	skinId = QStringLiteral("heritage");
+	// The heritage identity - classic light tokens, no QSS, no routing view,
+	// native toolbar/dialog, neutral base painters - lives in HeritageSkin
+	// (audit #275 B5); this method only does the app-level work.
+	activeSkin = heritageSkin();
+	skinId = activeSkin->id();
 	darkMode = false;
-
-	// Classic light values for the custom painters that consume tokens. The
-	// widget chrome itself comes from the native style, untouched by QSS.
-	SkinTokens tokens = activeSkin->tokens(false);
-	tokens.dark = false;
-	tokens.background = QStringLiteral("#f0f0f0");
-	tokens.surface = QStringLiteral("#ffffff");
-	tokens.surfaceRaised = QStringLiteral("#f5f5f5");
-	tokens.surfaceSunken = QStringLiteral("#e8e8e8");
-	tokens.card = QStringLiteral("#ffffff");
-	tokens.cardHover = QStringLiteral("#f0f6fc");
-	tokens.text = QStringLiteral("#000000");
-	tokens.mutedText = QStringLiteral("#606060");
-	tokens.border = QStringLiteral("#adadad");
-	tokens.graph = QStringLiteral("#ffffff");
-	tokens.graphGridMajor = QStringLiteral("#c8c8c8");
-	tokens.graphGridMinor = QStringLiteral("#e4e4e4");
-	tokens.accent = QStringLiteral("#0078d7");
-	tokens.accent2 = QStringLiteral("#2b88d8");
-	tokens.focusRing = QStringLiteral("#0078d7");
-	tokens.fontFamily = QStringLiteral("Segoe UI");
-	tokens.monoFontFamily = QStringLiteral("Consolas");
-	currentTokens = tokens;
+	currentTokens = activeSkin->tokens(false);
 
 	qApp->setStyleSheet(QString());
 	qApp->setPalette(qApp->style()->standardPalette());
@@ -141,20 +121,13 @@ void SkinManager::applySkin(const QString& newSkinId, bool dark)
 
 IRoutingRenderer* SkinManager::routingRenderer() const
 {
-	if (heritageMode)
-		return nullptr;
 	return activeSkin->routingRenderer();
 }
 
 void SkinManager::paintKnob(QPainter& painter, const QRect& rect, const KnobState& state) const
 {
-	if (heritageMode)
-	{
-		// The ISkin base implementation is exactly the heritage AudioKnob
-		// painter.
-		activeSkin->ISkin::paintKnob(painter, rect, state, currentTokens);
-		return;
-	}
+	// HeritageSkin inherits the base painter, which is exactly the heritage
+	// AudioKnob rendering; no conditional needed.
 	activeSkin->paintKnob(painter, rect, state, currentTokens);
 }
 
@@ -212,23 +185,11 @@ void SkinManager::paintGraphicEqPlot(QPainter& painter, const GraphicEQPlotState
 
 void SkinManager::paintAnalysisGraph(QPainter& painter, const AnalysisGraphState& state) const
 {
-	if (heritageMode)
-	{
-		// The neutral base rendering with the heritage tokens is the classic
-		// white analysis graph; no skin instrument leaks into legacy rows.
-		activeSkin->ISkin::paintAnalysisGraph(painter, state, currentTokens);
-		return;
-	}
 	activeSkin->paintAnalysisGraph(painter, state, currentTokens);
 }
 
 void SkinManager::paintSegmentedControl(QPainter& painter, const SegmentedControlState& state) const
 {
-	if (heritageMode)
-	{
-		activeSkin->ISkin::paintSegmentedControl(painter, state, currentTokens);
-		return;
-	}
 	activeSkin->paintSegmentedControl(painter, state, currentTokens);
 }
 
@@ -264,8 +225,6 @@ void SkinManager::paintTitleBarChrome(QPainter& painter, const QRect& rect) cons
 
 void SkinManager::styleMainToolbar(QToolBar* toolBar) const
 {
-	if (heritageMode)
-		return; // native toolbar: the .ui's classic icons stay in place
 	if (toolBar == nullptr)
 		return;
 	// Reset the shared mutable toolbar state before delegating so one skin's
@@ -277,7 +236,5 @@ void SkinManager::styleMainToolbar(QToolBar* toolBar) const
 
 void SkinManager::styleFileDialog(QFileDialog* dialog) const
 {
-	if (heritageMode)
-		return; // the dialog stays platform-native in heritage mode
 	activeSkin->styleFileDialog(dialog, currentTokens);
 }

--- a/Editor/main.cpp
+++ b/Editor/main.cpp
@@ -81,88 +81,8 @@
 
 namespace
 {
-// Mechanical round-trip check for VST plugin data: parse a VSTPlugin line, feed
-// the parsed library, opaque state and options into the real VSTPluginFilterGUI,
-// call its store(), reparse the result and confirm ChunkData, parameters,
-// StereoInput and the hidden Input/Output contract survive. Returns 0 on success,
-// 1 on any loss.
-int runVstRoundTripSelfTest()
-{
-	struct Case { const wchar_t* name = nullptr; std::wstring params; };
-	const Case cases[] = {
-		{ L"chunkData", L"Library \"fake plugin.dll\" ChunkData \"QUJDREVGR0g=\"" },
-		{ L"paramMap", L"Library fake.dll Gain 0.5 Mix 0.25 Width 1" },
-		{ L"paramMap-quoted-name", L"Library fake.dll \"Dry/Wet\" 0.75 Output 0.5" },
-		{ L"stereoInput-chunk", L"Library fake.dll StereoInput 1 ChunkData \"QUJDREVGR0g=\"" },
-		{ L"stereoInput-params", L"Library fake.dll StereoInput 1 Gain 0.5" },
-		{ L"busContract", L"Library fake.vst3 Input Stereo Output 7.1 Gain 0.5" }
-	};
-
-	int failures = 0;
-	for (const Case& c : cases)
-	{
-		VSTPluginFilterFactory factory;
-		std::wstring command = L"VSTPlugin";
-		std::wstring params = c.params;
-		FilterVector filters = factory.createFilter(L"", command, params);
-		if (filters.empty())
-		{
-			fprintf(stderr, "[VST selftest] %ls: parse produced no filter\n", c.name);
-			failures++;
-			continue;
-		}
-		VSTPluginFilter* f0 = static_cast<VSTPluginFilter*>(filters[0].get());
-		std::wstring chunk0 = f0->getChunkData();
-		std::unordered_map<std::wstring, float> map0 = f0->getParamMap();
-		const bool stereo0 = f0->getStereoInput();
-		const std::optional<VST3BusContract> bus0 = f0->getBusContract();
-
-		VSTPluginFilterGUI gui(f0->getLibrary(), chunk0, map0, stereo0, bus0);
-		QString outCommand, outParams;
-		gui.store(outCommand, outParams);
-
-		std::wstring command2 = outCommand.toStdWString();
-		std::wstring params2 = outParams.toStdWString();
-		FilterVector filters2 = factory.createFilter(L"", command2, params2);
-		if (filters2.empty())
-		{
-			fprintf(stderr, "[VST selftest] %ls: re-parse produced no filter (params='%ls')\n", c.name, params2.c_str());
-			failures++;
-			continue;
-		}
-		VSTPluginFilter* f1 = static_cast<VSTPluginFilter*>(filters2[0].get());
-		std::wstring chunk1 = f1->getChunkData();
-		std::unordered_map<std::wstring, float> map1 = f1->getParamMap();
-		const bool stereo1 = f1->getStereoInput();
-		const std::optional<VST3BusContract> bus1 = f1->getBusContract();
-		const bool sameBusContract = bus0.has_value() == bus1.has_value()
-			&& (!bus0 || (bus0->input == bus1->input && bus0->output == bus1->output));
-		bool ok = (chunk0 == chunk1) && (map0 == map1) && (stereo0 == stereo1) && sameBusContract;
-		if (!ok)
-		{
-			failures++;
-			fprintf(stderr, "[VST selftest] %ls: LOSS. chunk %ls->%ls, params %zu->%zu, stereoInput %d->%d, bus %d->%d\n",
-				c.name, chunk0.c_str(), chunk1.c_str(), map0.size(), map1.size(), stereo0 ? 1 : 0,
-				stereo1 ? 1 : 0, bus0 ? 1 : 0, bus1 ? 1 : 0);
-			for (auto& kv : map0)
-			{
-				auto it = map1.find(kv.first);
-				if (it == map1.end())
-					fprintf(stderr, "    dropped param '%ls'=%g\n", kv.first.c_str(), kv.second);
-				else if (it->second != kv.second)
-					fprintf(stderr, "    param '%ls' %g -> %g\n", kv.first.c_str(), kv.second, it->second);
-			}
-		}
-		else
-		{
-			fprintf(stderr, "[VST selftest] %ls: OK (chunk len %zu, %zu params preserved)\n",
-				c.name, chunk0.size(), map0.size());
-		}
-	}
-
-	fprintf(stderr, "[VST selftest] %s (%d failure(s))\n", failures == 0 ? "PASS" : "FAIL", failures);
-	return failures == 0 ? 0 : 1;
-}
+// The VST round-trip self test lives with the other offscreen gates in
+// SkinGallery.cpp (audit #275 B7).
 
 std::wstring executableDirectory()
 {
@@ -487,7 +407,7 @@ int main(int argc, char* argv[])
 		}
 
 		if (application.arguments().contains(QStringLiteral("--selftest-vst")))
-			return runVstRoundTripSelfTest();
+			return SkinGallery::runVstRoundTripSelfTest();
 
 		// Headless screenshot gallery (skin program). Runs before the registry
 		// skin/translator setup on purpose: the gallery applies each skin itself
@@ -597,104 +517,11 @@ int main(int argc, char* argv[])
 		bool firstRun = VelopackBootstrap::isFirstRun();
 		if (parser.isSet(analysisLayoutOption))
 		{
-			QDockWidget* dock = w.findChild<QDockWidget*>(QStringLiteral("analysisDockWidget"));
-			if (dock == nullptr)
-			{
-				fprintf(stderr, "Analysis layout test: required dock is missing\n");
+			// The probe itself lives with the other offscreen gates in
+			// SkinGallery.cpp (audit #275 B7); it arms the timers and later
+			// exits the event loop with the verdict.
+			if (!SkinGallery::armAnalysisLayoutProbe(w, parser.value(analysisLayoutOption)))
 				return 1;
-			}
-
-			w.showNormal();
-			w.resize(1024, 768);
-			dock->show();
-			const QString screenshotPath = parser.value(analysisLayoutOption);
-			QTimer::singleShot(750, &w, [&w, dock, screenshotPath]() {
-				fprintf(stderr,
-					"Analysis layout target: platform=%s style=%s dpr=%.2f locale=%s skin=%s dark=%d\n",
-					qPrintable(QGuiApplication::platformName()), qPrintable(qApp->style()->objectName()),
-					w.devicePixelRatioF(), qPrintable(QLocale().name()),
-					qPrintable(SkinManager::instance()->currentSkinId()),
-					SkinManager::instance()->isDark() ? 1 : 0);
-				QWidget* controls = w.findChild<QWidget*>(QStringLiteral("analysisControlBar"));
-				QWidget* graph = w.findChild<QWidget*>(QStringLiteral("ModernAnalysisGraph"));
-				QBoxLayout* layout = w.findChild<QBoxLayout*>(QStringLiteral("analysisDockLayout"));
-				const int centralWidth = w.centralWidget()->width();
-				const int dockWidth = dock->width();
-				const int controlsWidth = controls != nullptr ? controls->width() : -1;
-				const int graphWidth = graph != nullptr ? graph->width() : -1;
-				const bool centralProtected = centralWidth * 100 >= w.width() * 55;
-				const bool dockBounded = dockWidth * 100 <= w.width() * 45;
-				const bool graphUsable = graphWidth >= 300;
-				const bool controlsFill = controlsWidth >= graphWidth - 2;
-				const bool stacked = layout != nullptr && layout->direction() == QBoxLayout::TopToBottom;
-
-				bool screenshotSaved = screenshotPath.isEmpty();
-				if (!screenshotPath.isEmpty())
-				{
-					QFileInfo screenshotInfo(screenshotPath);
-					QDir().mkpath(screenshotInfo.absolutePath());
-					const QPixmap shot = w.grab();
-					screenshotSaved = shot.save(screenshotPath);
-				}
-
-				const bool rightPass = centralProtected && dockBounded && graphUsable
-					&& controlsFill && stacked && screenshotSaved;
-				fprintf(stderr,
-					"Analysis layout test (right): window=%dx%d central=%d dock=%d controls=%d graph=%d "
-					"centralProtected=%d dockBounded=%d graphUsable=%d controlsFill=%d stacked=%d screenshot=%d\n",
-					w.width(), w.height(), centralWidth, dockWidth, controlsWidth, graphWidth,
-					centralProtected ? 1 : 0, dockBounded ? 1 : 0, graphUsable ? 1 : 0,
-					controlsFill ? 1 : 0, stacked ? 1 : 0, screenshotSaved ? 1 : 0);
-
-				const bool bottomRequested = QMetaObject::invokeMethod(&w,
-					"on_graphPositionComboBox_currentIndexChanged", Qt::DirectConnection,
-					Q_ARG(int, 1));
-				QTimer::singleShot(250, &w, [&w, dock, rightPass, bottomRequested]() {
-					QWidget* bottomControls = w.findChild<QWidget*>(QStringLiteral("analysisControlBar"));
-					QBoxLayout* bottomLayout = w.findChild<QBoxLayout*>(QStringLiteral("analysisDockLayout"));
-					const bool bottomArea = w.dockWidgetArea(dock) == Qt::BottomDockWidgetArea;
-					const bool horizontal = bottomLayout != nullptr
-						&& bottomLayout->direction() == QBoxLayout::LeftToRight;
-					const bool compactControls = bottomControls != nullptr
-						&& bottomControls->maximumWidth() < QWIDGETSIZE_MAX
-						&& bottomControls->width() <= bottomControls->maximumWidth();
-					fprintf(stderr,
-						"Analysis layout test (bottom): area=%d horizontal=%d compactControls=%d\n",
-						bottomArea ? 1 : 0, horizontal ? 1 : 0, compactControls ? 1 : 0);
-					const bool bottomPass = bottomRequested && bottomArea
-						&& horizontal && compactControls;
-					const bool rightRestoreRequested = QMetaObject::invokeMethod(&w,
-						"on_graphPositionComboBox_currentIndexChanged", Qt::DirectConnection,
-						Q_ARG(int, 2));
-					QTimer::singleShot(250, &w,
-						[&w, dock, rightPass, bottomPass, rightRestoreRequested]() {
-							QWidget* restoredControls = w.findChild<QWidget*>(
-								QStringLiteral("analysisControlBar"));
-							QWidget* restoredGraph = w.findChild<QWidget*>(
-								QStringLiteral("ModernAnalysisGraph"));
-							QBoxLayout* restoredLayout = w.findChild<QBoxLayout*>(
-								QStringLiteral("analysisDockLayout"));
-							const bool rightRestored = rightRestoreRequested
-								&& w.dockWidgetArea(dock) == Qt::RightDockWidgetArea
-								&& restoredLayout != nullptr
-								&& restoredLayout->direction() == QBoxLayout::TopToBottom
-								&& restoredControls != nullptr && restoredGraph != nullptr
-								&& restoredControls->width() >= restoredGraph->width() - 2;
-							fprintf(stderr, "Analysis layout test (right restored): pass=%d\n",
-								rightRestored ? 1 : 0);
-							const int exitCode = rightPass && bottomPass && rightRestored ? 0 : 1;
-							bool holdOk = false;
-							const int requestedHold = qEnvironmentVariableIntValue(
-								"EAPO_ANALYSIS_LAYOUT_HOLD_MS", &holdOk);
-							const int holdMs = holdOk ? qBound(0, requestedHold, 30000) : 0;
-							if (holdMs > 0)
-								QTimer::singleShot(holdMs, &w,
-									[exitCode]() { QCoreApplication::exit(exitCode); });
-							else
-								QCoreApplication::exit(exitCode);
-						});
-				});
-			});
 		}
 		else if (parser.isSet(stormOption))
 			SkinSwitchStorm::run(w);  // storm sessions skip doChecks: its modal warnings would stall the timer

--- a/Editor/skins/HeritageSkin.cpp
+++ b/Editor/skins/HeritageSkin.cpp
@@ -1,0 +1,72 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "HeritageSkin.h"
+
+#include "Skins.h"
+
+QString HeritageSkin::id() const
+{
+	return QStringLiteral("heritage");
+}
+
+SkinTokens HeritageSkin::tokens(bool dark) const
+{
+	Q_UNUSED(dark);
+	// Classic light values for the custom painters that consume tokens. The
+	// widget chrome itself comes from the native style, untouched by QSS.
+	// Studio donates the values the block below does not overwrite (metrics,
+	// secondary hues), exactly as SkinManager::applyHeritage always did.
+	SkinTokens tokens = Skins::byId(QStringLiteral("studio"))->tokens(false);
+	tokens.dark = false;
+	tokens.background = QStringLiteral("#f0f0f0");
+	tokens.surface = QStringLiteral("#ffffff");
+	tokens.surfaceRaised = QStringLiteral("#f5f5f5");
+	tokens.surfaceSunken = QStringLiteral("#e8e8e8");
+	tokens.card = QStringLiteral("#ffffff");
+	tokens.cardHover = QStringLiteral("#f0f6fc");
+	tokens.text = QStringLiteral("#000000");
+	tokens.mutedText = QStringLiteral("#606060");
+	tokens.border = QStringLiteral("#adadad");
+	tokens.graph = QStringLiteral("#ffffff");
+	tokens.graphGridMajor = QStringLiteral("#c8c8c8");
+	tokens.graphGridMinor = QStringLiteral("#e4e4e4");
+	tokens.accent = QStringLiteral("#0078d7");
+	tokens.accent2 = QStringLiteral("#2b88d8");
+	tokens.focusRing = QStringLiteral("#0078d7");
+	tokens.fontFamily = QStringLiteral("Segoe UI");
+	tokens.monoFontFamily = QStringLiteral("Consolas");
+	return tokens;
+}
+
+QString HeritageSkin::qssResource(bool dark) const
+{
+	Q_UNUSED(dark);
+	return QString();
+}
+
+IRoutingRenderer* HeritageSkin::routingRenderer() const
+{
+	return nullptr;
+}
+
+void HeritageSkin::styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const
+{
+	// Native toolbar: the .ui's classic icons stay in place.
+	Q_UNUSED(toolBar);
+	Q_UNUSED(tokens);
+}
+
+void HeritageSkin::styleFileDialog(QFileDialog* dialog, const SkinTokens& tokens) const
+{
+	// The dialog stays platform-native in heritage mode.
+	Q_UNUSED(dialog);
+	Q_UNUSED(tokens);
+}
+
+ISkin* heritageSkin()
+{
+	static HeritageSkin instance;
+	return &instance;
+}

--- a/Editor/skins/HeritageSkin.h
+++ b/Editor/skins/HeritageSkin.h
@@ -1,0 +1,39 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	The heritage presentation as a skin (audit #275 B5). Heritage mode - the
+	frozen legacy-rows look - used to live as six special-case branches inside
+	SkinManager's forwarders, three of which literally called the ISkin base
+	implementation. That is the definition of a base-class skin: classic light
+	tokens, no QSS, no routing renderer, native toolbar and file dialog, and
+	the neutral base painters for everything else. This adapter says so in one
+	place, so the forwarders forward uniformly and adding a hook no longer
+	means asking "and what does heritage do?" inside SkinManager.
+
+	Deliberately not in SkinThemeData's roster: heritage is not a selectable
+	skin program, it is what the legacy-rows preference renders as. It has no
+	constitution under docs/skins/ for the same reason.
+*/
+
+#pragma once
+
+#include "ISkin.h"
+
+class HeritageSkin : public ISkin
+{
+public:
+	QString id() const override;
+	// Classic light values for the custom painters that consume tokens; the
+	// dark flag is ignored (heritage is the classic light look, always).
+	SkinTokens tokens(bool dark) const override;
+	// No QSS: the widget chrome comes from the native style.
+	QString qssResource(bool dark) const override;
+	// No skin routing view: Copy rows keep the legacy CopyFilterGUI.
+	IRoutingRenderer* routingRenderer() const override;
+	// Native toolbar and platform file dialog: the skin adds nothing.
+	void styleMainToolbar(QToolBar* toolBar, const SkinTokens& tokens) const override;
+	void styleFileDialog(QFileDialog* dialog, const SkinTokens& tokens) const override;
+};
+
+// The one instance, like the per-skin accessors in Skins.cpp.
+ISkin* heritageSkin();

--- a/Editor/widgets/FilterRowGuiPolicy.cpp
+++ b/Editor/widgets/FilterRowGuiPolicy.cpp
@@ -1,0 +1,42 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+*/
+
+#include "FilterRowGuiPolicy.h"
+
+#include "FilterCardModel.h"
+
+RowGuiDecision decideRowGui(bool modernCards, const QString& line,
+	const FilterCardDescriptor* descriptor,
+	bool routingRendererAvailable, bool cardEditorAvailable)
+{
+	if (modernCards)
+	{
+		// A pure comment has no "command: parameters" shape (with or without
+		// an inner colon), so it never reaches the factories. In card mode it
+		// still gets a real editor; the legacy path stays frozen (raw row).
+		if (descriptor->type == QStringLiteral("comment"))
+			return RowGuiDecision::CommentCard;
+
+		// Copy's maintained card editor is the skin routing view built
+		// directly by FilterCardRow. Dynamic Copy parameters do not open a
+		// routing view (opensRoutingView answers false for them): routing
+		// editors must not parse and rewrite inline expressions.
+		if (FilterCardModel::opensRoutingView(*descriptor) && routingRendererAvailable)
+			return RowGuiDecision::SkinRoutingView;
+	}
+
+	if (line.indexOf(':') == -1)
+		return RowGuiDecision::RawRow;
+
+	// Card editors take precedence over the legacy chain, so constructing a
+	// legacy GUI only to replace and delete it never happens for card-covered
+	// commands. Commented lines ("# ...") are not card-available under their
+	// written key and take the chain, where CommentFilterGUIFactory strips
+	// the '#'; the post-chain card retry then gives them the same card editor
+	// as their active form (a construction mechanic, not a decision).
+	if (modernCards && cardEditorAvailable)
+		return RowGuiDecision::CardEditor;
+
+	return RowGuiDecision::LegacyChain;
+}

--- a/Editor/widgets/FilterRowGuiPolicy.h
+++ b/Editor/widgets/FilterRowGuiPolicy.h
@@ -1,0 +1,43 @@
+/*
+	This file is part of EqualizerAPO-XT, a system-wide equalizer.
+
+	The row-GUI decision, as data (audit #275 B4): which editor a config line
+	gets - comment card, skin routing view, modern card editor, the legacy
+	factory chain, or the raw body - used to be decided inline across ninety
+	widget-bound lines of FilterTable::createRowGui, so the only thing that
+	could catch a policy regression was the offscreen pixel gate. Every input
+	is obtainable without widgets, so the decision lives here as a pure
+	function, EditorLogicTests pins it directly, and createRowGui only
+	constructs what was decided.
+*/
+
+#pragma once
+
+#include <QString>
+
+struct FilterCardDescriptor;
+
+enum class RowGuiDecision
+{
+	// Modern cards: a pure comment line gets the comment card editor.
+	CommentCard,
+	// Modern cards: the row hosts the active skin's routing view directly
+	// (createRowGui answers no GUI on purpose).
+	SkinRoutingView,
+	// Modern cards: a registered card editor answers the command directly.
+	CardEditor,
+	// Run the legacy factory chain. In modern mode the chain result is
+	// followed by the comment-stripped card retry; in legacy mode it is
+	// decorated. Both are construction mechanics, not decisions.
+	LegacyChain,
+	// No "command: parameters" shape: the raw body row.
+	RawRow,
+};
+
+// descriptor must be non-null when modernCards is true (it is unused in
+// legacy mode). routingRendererAvailable and cardEditorAvailable are the two
+// environment facts the caller resolves (active skin's renderer, card editor
+// registry); injecting them keeps the decision testable without either.
+RowGuiDecision decideRowGui(bool modernCards, const QString& line,
+	const FilterCardDescriptor* descriptor,
+	bool routingRendererAvailable, bool cardEditorAvailable);

--- a/Editor/widgets/cards/FilterCardEditorFactory.cpp
+++ b/Editor/widgets/cards/FilterCardEditorFactory.cpp
@@ -6,12 +6,12 @@
 #include "Editor/widgets/FilterCardModel.h"
 #include "FilterCardEditorRegistry.h"
 
-IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QString& command, const QString& parameters)
+bool FilterCardEditorFactory::available(const QString& command, const QString& parameters)
 {
 	// The roster lives in the card editors' own translation units via
 	// REGISTER_FILTER_CARD_EDITOR (see FilterCardEditorRegistry.h); this
-	// function is just the lookup, so adding a card does not mean editing
-	// an if-chain here.
+	// is just the lookup, so adding a card does not mean editing an
+	// if-chain here.
 	//
 	// The key is resolved by the engine's rule, not by a private one: that is
 	// what lets "Filter 1:" (REW's and Dirac's default spelling) reach the same
@@ -29,12 +29,19 @@ IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QStr
 	if (FilterCardModel::hasInlineExpressions(parameters))
 	{
 		if (!FilterCardEditorRegistry::supportsDynamicParameters(commandKeyword))
-			return nullptr;
+			return false;
 	}
 
-	FilterCardEditorCreator creator = FilterCardEditorRegistry::find(commandKeyword);
-	if (creator == nullptr)
+	return FilterCardEditorRegistry::find(commandKeyword) != nullptr;
+}
+
+IFilterGUI* FilterCardEditorFactory::create(FilterTable* filterTable, const QString& command, const QString& parameters)
+{
+	if (!available(command, parameters))
 		return nullptr;
+
+	FilterCardEditorCreator creator = FilterCardEditorRegistry::find(
+		FilterCardModel::canonicalCommand(command));
 	// The creator still sees the key as written, because the Filter entry is
 	// shared: IIRCardEditor hands it to IIRFilterFactory::parseCommand, which is
 	// what tells "Filter 1: ON IIR ..." apart from an ordinary BiQuad line and

--- a/Editor/widgets/cards/FilterCardEditorFactory.h
+++ b/Editor/widgets/cards/FilterCardEditorFactory.h
@@ -6,5 +6,11 @@ class QString;
 
 namespace FilterCardEditorFactory
 {
+	// Whether a registered card editor would answer this line: the canonical
+	// keyword resolves to a registry entry and the inline-expression guard
+	// admits it. Pure lookup, no construction - the widget-free half that
+	// decideRowGui (FilterRowGuiPolicy) consumes (audit #275 B4).
+	bool available(const QString& command, const QString& parameters);
+
 	IFilterGUI* create(FilterTable* filterTable, const QString& command, const QString& parameters);
 }

--- a/Tests/EditorLogicTests/EditorLogicTestSupport.h
+++ b/Tests/EditorLogicTests/EditorLogicTestSupport.h
@@ -27,6 +27,7 @@ void testFilterCardDescriptors();
 void testSubwooferRoutingDescriptors();
 void testSubwooferRoutingCrossoverRecipes();
 void testFilterCardDepths();
+void testRowGuiPolicyRoutesEachLineShape();
 void testFilterCardBuildPlans();
 void testConfigImport();
 void testLegacyMigrationScanAndPolicy();

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -105,6 +105,7 @@ int main(int argc, char** argv)
 	testSubwooferRoutingDescriptors();
 	testSubwooferRoutingCrossoverRecipes();
 		testFilterCardDepths();
+		testRowGuiPolicyRoutesEachLineShape();
 		testFilterCardBuildPlans();
 		testConfigImport();
 		testLegacyMigrationScanAndPolicy();

--- a/Tests/EditorLogicTests/EditorLogicTests.vcxproj
+++ b/Tests/EditorLogicTests/EditorLogicTests.vcxproj
@@ -145,6 +145,7 @@ if exist "$(LIBSNDFILE_LIB)\*.dll" copy /Y "$(LIBSNDFILE_LIB)\*.dll" "$(OutDir)"
     <ClCompile Include="..\..\services\security\AudioEngineAccess.cpp" />
     <ClCompile Include="..\..\Editor\helpers\VstChunkScan.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCardModel.cpp" />
+    <ClCompile Include="..\..\Editor\widgets\FilterRowGuiPolicy.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterCommandCatalog.cpp" />
     <ClCompile Include="..\..\Editor\widgets\FilterPickerModel.cpp" />
     <ClCompile Include="..\..\Editor\widgets\EditableValueText.cpp" />

--- a/Tests/EditorLogicTests/FilterCardModelTests.cpp
+++ b/Tests/EditorLogicTests/FilterCardModelTests.cpp
@@ -13,6 +13,7 @@
 #include <QVector>
 
 #include "Editor/widgets/FilterCardModel.h"
+#include "Editor/widgets/FilterRowGuiPolicy.h"
 #include "filters/FilterFactoryRegistry.h"
 
 #include "EditorLogicTestSupport.h"
@@ -369,4 +370,62 @@ void testFilterCardBuildPlans()
 		"build plan carries the enclosing channel selection");
 	expectEqual(plans[1].descriptor.scopeChannels, QStringList({ "L", "R" }),
 		"if head carries the enclosing channel selection");
+}
+
+// Audit #275 B4: the row-GUI decision used to live inline in the widget-bound
+// FilterTable::createRowGui, guarded only by the offscreen pixel gate. As a
+// pure function its policy is pinned here directly; the two environment facts
+// (routing renderer, card editor availability) are injected so every branch
+// is reachable without a skin or the card registry.
+void testRowGuiPolicyRoutesEachLineShape()
+{
+	const FilterCardDescriptor comment = FilterCardModel::describeLine(
+		QStringLiteral("# just a note to self"));
+	expectTrue(decideRowGui(true, QStringLiteral("# just a note to self"), &comment, true, false)
+		== RowGuiDecision::CommentCard,
+		QStringLiteral("modern cards give a pure comment the comment card"));
+	const FilterCardDescriptor prose = FilterCardModel::describeLine(
+		QStringLiteral("just a note to self"));
+	expectTrue(decideRowGui(true, QStringLiteral("just a note to self"), &prose, true, false)
+		== RowGuiDecision::RawRow,
+		QStringLiteral("colon-less prose stays a raw row even in modern cards"));
+	expectTrue(decideRowGui(false, QStringLiteral("just a note to self"), nullptr, true, false)
+		== RowGuiDecision::RawRow,
+		QStringLiteral("the frozen legacy path keeps prose as a raw row"));
+
+	const FilterCardDescriptor copy = FilterCardModel::describeLine(
+		QStringLiteral("Copy: L=R"));
+	expectTrue(decideRowGui(true, QStringLiteral("Copy: L=R"), &copy, true, false)
+		== RowGuiDecision::SkinRoutingView,
+		QStringLiteral("a static Copy line opens the skin routing view"));
+	expectTrue(decideRowGui(true, QStringLiteral("Copy: L=R"), &copy, false, true)
+		== RowGuiDecision::CardEditor,
+		QStringLiteral("without a routing renderer the Copy line falls to its card editor"));
+
+	const FilterCardDescriptor dynamicCopy = FilterCardModel::describeLine(
+		QStringLiteral("Copy: L=`x`*R"));
+	expectTrue(decideRowGui(true, QStringLiteral("Copy: L=`x`*R"), &dynamicCopy, true, false)
+		== RowGuiDecision::LegacyChain,
+		QStringLiteral("a dynamic Copy line must not open a routing editor"));
+
+	const FilterCardDescriptor preamp = FilterCardModel::describeLine(
+		QStringLiteral("Preamp: -3 dB"));
+	expectTrue(decideRowGui(true, QStringLiteral("Preamp: -3 dB"), &preamp, true, true)
+		== RowGuiDecision::CardEditor,
+		QStringLiteral("a card-covered command goes straight to its card editor"));
+	expectTrue(decideRowGui(true, QStringLiteral("Preamp: -3 dB"), &preamp, true, false)
+		== RowGuiDecision::LegacyChain,
+		QStringLiteral("an uncovered command runs the legacy chain"));
+	expectTrue(decideRowGui(false, QStringLiteral("Preamp: -3 dB"), nullptr, true, true)
+		== RowGuiDecision::LegacyChain,
+		QStringLiteral("legacy mode always runs the chain for command lines"));
+
+	// A commented command line is not card-available under its written key;
+	// the chain (which strips the '#') owns it, and the post-chain card retry
+	// is a construction mechanic outside this decision.
+	const FilterCardDescriptor commented = FilterCardModel::describeLine(
+		QStringLiteral("# Preamp: -3 dB"));
+	expectTrue(decideRowGui(true, QStringLiteral("# Preamp: -3 dB"), &commented, true, false)
+		== RowGuiDecision::LegacyChain,
+		QStringLiteral("a commented command line takes the chain toward the comment-stripped retry"));
 }

--- a/UpdateChecker/UpdateInfoFormatter.cpp
+++ b/UpdateChecker/UpdateInfoFormatter.cpp
@@ -5,6 +5,14 @@
 #include <QJsonObject>
 #include <QLocale>
 
+QString UpdateInfoFormatter::newestVersion(const QJsonDocument& doc)
+{
+	const QJsonArray versionsArray = doc.object().value("versions").toArray();
+	if (versionsArray.isEmpty())
+		return QString();
+	return versionsArray.first().toObject().value("version").toString();
+}
+
 QString UpdateInfoFormatter::releaseHtml(const QJsonDocument& doc, QString* newestVersion)
 {
 	if (newestVersion != nullptr)

--- a/UpdateChecker/UpdateInfoFormatter.h
+++ b/UpdateChecker/UpdateInfoFormatter.h
@@ -6,5 +6,11 @@
 class UpdateInfoFormatter
 {
 public:
-	static QString releaseHtml(const QJsonDocument& doc, QString* newestVersion);
+	// The newest (first-listed) version in the update document, or an empty
+	// string. Split from releaseHtml (audit #275 B8): the skipped-version
+	// check used to render the whole release HTML just to throw it away for
+	// this one value.
+	static QString newestVersion(const QJsonDocument& doc);
+
+	static QString releaseHtml(const QJsonDocument& doc, QString* newestVersion = nullptr);
 };

--- a/UpdateChecker/main.cpp
+++ b/UpdateChecker/main.cpp
@@ -154,9 +154,7 @@ int main(int argc, char* argv[])
 
 			if (autoMode && !skipVersion.isEmpty() && !updateDoc.isEmpty())
 			{
-				QString newestVersion;
-				UpdateInfoFormatter::releaseHtml(updateDoc, &newestVersion);
-				if (newestVersion == skipVersion)
+				if (UpdateInfoFormatter::newestVersion(updateDoc) == skipVersion)
 					updateDoc = QJsonDocument();
 			}
 


### PR DESCRIPTION
## What

The five structural findings from audit #275's Editor track, applied together because they share the FilterTable/SkinManager seam:

- **B4 - row-GUI policy.** The five-way decision buried in `FilterTable::createRowGui` (comment card / skin routing view / card editor / legacy chain / raw row) becomes the pure `FilterRowGuiPolicy::decideRowGui` (`Editor/widgets/FilterRowGuiPolicy.{h,cpp}`). `FilterCardEditorFactory::available()` splits out so the policy can ask availability without constructing. An EditorLogicTests case drives each line shape through the decider - including the premise check that prose without `#` parses as a raw text row, not a comment card.
- **B5 - heritage as a skin.** Heritage mode (the frozen legacy-rows look) lived as six special-case branches inside SkinManager's forwarders, three of which literally called the ISkin base implementation. It becomes `HeritageSkin`: classic light tokens (studio donor + the classic overrides), no QSS, no routing renderer, native toolbar and file dialog. The forwarders now delegate uniformly to `activeSkin`. Deliberately not in the roster: heritage is what the legacy-rows preference renders as, not a selectable skin.
- **B6 - FilterTable decoupled from MainWindow.** The constructor no longer takes a `MainWindow*`; FilterTable emits `configOpenRequested(QString)` / `analysisUpdateRequested()` and `MainWindow.Device.cpp` connects them. SkinGallery constructs a plain `FilterTable`.
- **B7 - self-test drivers out of main.cpp.** `runVstRoundTripSelfTest` and `armAnalysisLayoutProbe` move into SkinGallery next to the other offscreen-gate drivers.
- **B8 - UpdateChecker version extraction.** The inline JSON walk in UpdateChecker's `main` becomes `UpdateInfoFormatter::newestVersion(doc)`.

## Verification

- Editor qmake/nmake build clean on top of #282's token-injection forwarders (the stashed work re-merged onto current main without conflicts; heritage delegation and `create*(parent, tokens())` verified side by side in SkinManager).
- `EditorLogicTests` 3022 checks pass, including the new row-GUI policy case.
- Offscreen gates: `selftest-vst` PASS (the moved VST round-trip driver), `analysis-layout` PASS (the moved probe, right/bottom/restored), `skin-gallery` completes with 1460 PNGs under its own shot-count self-check - covering all five skins plus the heritage/legacy scenes that now render through HeritageSkin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)