### PR TITLE
ci(audit): unlock the tech-debt-audit skill for the biweekly audit session

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -136,6 +136,19 @@ jobs:
           test -f "$HOME/.claude/skills/improve-codebase-architecture/SKILL.md"
           test -f "$HOME/.claude/skills/tech-debt-audit/SKILL.md"
 
+          # The vendored tech-debt-audit skill is locked with
+          # disable-model-invocation so interactive sessions never trigger a
+          # whole-repo audit by accident. This run's prompt explicitly says
+          # "Run /tech-debt-audit", and the model can only do that through the
+          # Skill tool, which the lock blocks (the 2026-08-15 audit had to
+          # improvise Part 2 without the skill). Unlock the installed copy
+          # only; the copy in the repository stays locked.
+          sed -i '/^disable-model-invocation:/d' "$HOME/.claude/skills/tech-debt-audit/SKILL.md"
+          if grep -q "disable-model-invocation" "$HOME/.claude/skills/tech-debt-audit/SKILL.md"; then
+            echo "::error::tech-debt-audit SKILL.md still carries disable-model-invocation after the unlock"
+            exit 1
+          fi
+
           echo "Installed Claude audit skills:"
           find "$HOME/.claude/skills" -maxdepth 2 -name SKILL.md -print
 


### PR DESCRIPTION
## What

Audit #275's Part 2 came with a caveat: the audit session could not actually run `/tech-debt-audit` because the vendored skill is locked with `disable-model-invocation: true`, so the Skill tool refused it and the session improvised a generic tech-debt audit from the prompt's summary of the requirements.

The lock itself is correct for interactive sessions - a whole-repo audit should never auto-trigger. But the biweekly audit workflow explicitly instructs the model to run the skill, and the Skill tool is the only way it can. The "Install audit skills" step now strips the `disable-model-invocation` line from the copy it installs into the runner's `$HOME/.claude/skills`, and fails loudly if the line survives the strip (so a frontmatter reshuffle cannot silently re-lock the audit). The copy in the repository stays locked.

`improve-codebase-architecture` carries no such lock and is untouched.

## Verification

- The workflow YAML parses (`yaml.safe_load`).
- The sed strip + grep assertion reproduces locally against the vendored SKILL.md: the line is removed and the guard passes.
- Not verified: an actual scheduled audit run; the next biweekly run is the real test, and its report should no longer carry the "skill was locked" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)