### PR TITLE
feat(release): install variants under friendly display names

### DIFF
--- a/.github/scripts/New-VelopackRelease.ps1
+++ b/.github/scripts/New-VelopackRelease.ps1
@@ -58,6 +58,9 @@ foreach ($artifact in $buildArtifacts) {
     if (-not $variantEntry) {
         throw "Artifact $($artifact.Name) has no matching variant in simd-variants.psd1"
     }
+    if (-not $variantEntry.Title) {
+        throw "Variant $($artifact.Name) has no Title in simd-variants.psd1; the display name is release content"
+    }
     $channel = $variantEntry.Channel
     $channelWork += [pscustomobject]@{
         ArtifactPath = $artifact.FullName
@@ -65,7 +68,7 @@ foreach ($artifact in $buildArtifacts) {
         Channel      = $channel
         Skipped      = $MissingChannels -notcontains $channel
         PackId       = Get-VelopackPackId -Channel $channel
-        PackTitle    = "EqualizerAPO-XT $variant"
+        PackTitle    = $variantEntry.Title
         Framework    = if ($variant -like "ARM64*" -or $variant -like "arm64*") { "vcredist143-arm64" } else { "vcredist143-x64" }
         PackDir      = Join-Path $WorkspaceRoot "velopack-input\$channel"
         OutputDir    = Join-Path $WorkspaceRoot "velopack-output\$channel"

--- a/.github/scripts/Tests/New-VelopackRelease.Tests.ps1
+++ b/.github/scripts/Tests/New-VelopackRelease.Tests.ps1
@@ -50,6 +50,26 @@ Describe "New-VelopackRelease.ps1 planning" {
         $plan.ReleaseName | Should -Be "EqualizerAPO-XT 9.9.9"
     }
 
+    It "packs under the manifest's display title" {
+        # The Start menu / Apps & Features name is manifest data (Title), not
+        # a string convention over the artifact name.
+        $tree = NewInputRoot @("EqualizerAPO-x64-avx2")
+        $plan = PlanFor $tree @("x64-avx2")
+        $expected = ((Import-PowerShellDataFile $manifestPath).Variants |
+            Where-Object { $_.Channel -eq "x64-avx2" }).Title
+        $expected | Should -Not -BeNullOrEmpty
+        $plan.Channels[0].PackTitle | Should -Be $expected
+    }
+
+    It "requires a distinct non-empty display title on every manifest variant" {
+        # Titles land as shortcut and Apps & Features names; a duplicate would
+        # make two side-by-side variants indistinguishable after install.
+        $titles = @((Import-PowerShellDataFile $manifestPath).Variants |
+            ForEach-Object { $_.Title })
+        $titles | ForEach-Object { $_ | Should -Not -BeNullOrEmpty }
+        @($titles | Sort-Object -Unique).Count | Should -Be $titles.Count
+    }
+
     It "skips channels the release already carries (resume)" {
         $tree = NewInputRoot @("EqualizerAPO-x64-avx2", "EqualizerAPO-x64-sse2")
         $plan = PlanFor $tree @("x64-sse2")

--- a/.github/simd-variants.psd1
+++ b/.github/simd-variants.psd1
@@ -26,6 +26,8 @@
 #                                            compiled into Installer/AutoInstaller.cpp
 #                                            drift from Variants[].Channel)
 #   - .github/scripts/New-ReleaseNotes.ps1  (release-channel guidance/sort table)
+#   - .github/scripts/New-VelopackRelease.ps1 (packs each channel under its
+#                                            Channel/Title identity)
 #
 #   NOT yet consumed: the .vcxproj files. Those keep their inline AVX2 default for
 #   local builds (CI always overrides per variant) and report the chosen value at
@@ -42,6 +44,14 @@
 #     QtArchFlag  /arch:* flag the .pro files compile with (matrix.qt_arch_flag).
 #                 $null when none is passed (sse2 baseline, ARM64).
 #     Channel     Velopack / EAPO_UPDATE_CHANNEL string (e.g. "x64-avx2", "arm64").
+#     Title       Human-facing name Velopack stamps on the install: the Start
+#                 menu/desktop shortcut, the Apps & Features entry and the
+#                 per-channel Setup window. Kept distinct per variant so a user
+#                 can tell which build is installed. Safe to rename between
+#                 releases: velopack 1.1.1's update apply rewrites the
+#                 uninstall entry and renames existing shortcuts (matched by
+#                 target path, not by name), so installed apps migrate to a
+#                 new Title on their next update without user action.
 #     Fftw        amd-fftw release asset zip ($null when built from vcpkg).
 #     Muparserx   muparserx release asset zip (always present).
 #     Sndfile     libsndfile release asset zip ($null when built from vcpkg).
@@ -85,6 +95,7 @@
             ArchFlag  = $null                                   # expands to "NotSet"
             QtArchFlag = $null                                  # baseline code generation
             Channel   = 'x64-sse2'
+            Title     = 'EQ APO XT'
             Fftw      = $null                                   # built from vcpkg
             # The avx2 zip is a SOURCE carrier here: CI recompiles muparserx from
             # parser/*.cpp with this variant's /arch flag (build.yml "Build
@@ -101,6 +112,7 @@
             ArchFlag  = 'AdvancedVectorExtensions'
             QtArchFlag = '/arch:AVX'
             Channel   = 'x64-avx'
+            Title     = 'EQ APO XT AVX'
             Fftw      = $null                                   # built from vcpkg
             # Source carrier, recompiled with /arch:AVX (see the sse2 note above).
             Muparserx = 'muparserx-msvc-release-x64-avx2.zip'
@@ -115,6 +127,7 @@
             ArchFlag  = 'AdvancedVectorExtensions2'
             QtArchFlag = '/arch:AVX2'
             Channel   = 'x64-avx2'
+            Title     = 'EQ APO XT AVX2'
             Fftw      = 'fftw-windows-release-x64-avx2.zip'
             Muparserx = 'muparserx-msvc-release-x64-avx2.zip'
             Sndfile   = 'libsndfile-x64-avx2.zip'
@@ -129,6 +142,7 @@
             ArchFlag  = 'AdvancedVectorExtensions512'
             QtArchFlag = '/arch:AVX512'
             Channel   = 'x64-avx512'
+            Title     = 'EQ APO XT AVX-512'
             Fftw      = 'fftw-windows-release-x64-avx512.zip'
             Muparserx = 'muparserx-msvc-release-x64-avx512.zip'
             Sndfile   = 'libsndfile-x64-avx512.zip'
@@ -142,6 +156,7 @@
             ArchFlag  = 'AdvancedVectorExtensions101'
             QtArchFlag = '/arch:AVX10.1'
             Channel   = 'x64-avx10-1'
+            Title     = 'EQ APO XT AVX10'
             Fftw      = 'fftw-windows-release-x64-avx10.zip'
             Muparserx = 'muparserx-msvc-release-x64-avx10.zip'
             Sndfile   = 'libsndfile-x64-avx10.zip'
@@ -155,6 +170,7 @@
             ArchFlag  = $null                                   # ARM64 passes no /arch override
             QtArchFlag = $null
             Channel   = 'arm64-neon'                            # matches the published Velopack channel
+            Title     = 'EQ APO XT Neon'
             Fftw      = 'fftw-windows-release-arm64.zip'
             Muparserx = 'muparserx-msvc-release-ARM64.zip'
             Sndfile   = 'libsndfile-arm64.zip'

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -8,6 +8,13 @@ TheFireKahuna의 equalizerAPO64 트리에서 포크된 뒤(마지막 업스트�
 
 ## Unreleased
 
+- **설치된 앱 이름이 읽기 좋아집니다.** 지금까지는 시작 메뉴, 바탕 화면
+  바로가기, '설치된 앱' 목록에 "EqualizerAPO-XT x64-avx2"처럼 표시되었습니다.
+  새로 설치하면 "EQ APO XT"(기본 SSE2 빌드), "EQ APO XT AVX",
+  "EQ APO XT AVX2", "EQ APO XT AVX-512", "EQ APO XT AVX10",
+  "EQ APO XT Neon"으로 표시됩니다. 기존 설치는 손댈 필요 없이 다음 업데이트
+  때 바로가기 이름과 앱 목록 항목이 함께 바뀝니다 ([#288](https://github.com/115dkk/EqualizerAPO-XT/pull/288)).
+
 ## v2.38.0 — 2026-08-19
 
 - **자동 감지 설치기에 제대로 된 창이 생겼습니다.** 밋밋한 Windows 진행

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ tags are clean `vX.Y.Z` names. Installers for every version are on the
 
 ## Unreleased
 
+- **The installed app has a readable name now.** It used to appear as
+  "EqualizerAPO-XT x64-avx2" in the Start menu, on the desktop shortcut and
+  in Apps & Features. New installs show up as "EQ APO XT" (baseline SSE2
+  build), "EQ APO XT AVX", "EQ APO XT AVX2", "EQ APO XT AVX-512",
+  "EQ APO XT AVX10" or "EQ APO XT Neon". Existing installs migrate by
+  themselves: the next update renames the shortcuts and rewrites the
+  Apps & Features entry ([#288](https://github.com/115dkk/EqualizerAPO-XT/pull/288)).
+
 ## v2.38.0 — 2026-08-19
 
 - **The auto-detect installer got a real window.** Instead of a bare Windows

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,6 +69,11 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 
 릴리스는 아직 코드 서명이 없어서, 갓 받은 파일을 Windows Defender/SmartScreen이 알 수 없는 파일로 표시할 수 있습니다(제보된 라벨은 제네릭 `Trojan:Win32/Wacatac.B!ml`로, 실제 분석 결과가 아니라 서명 없는 새 파일에 붙는 평판 판정입니다). 모든 자산은 릴리스의 `SHA256SUMS.txt`로 직접 검증할 수 있고, 자동 감지 설치기는 실행 전에 이 검증을 자동으로 수행합니다.
 
+설치하고 나면 시작 메뉴와 '설치된 앱' 목록에 **EQ APO XT** 뒤에 명령어 집합을
+붙인 이름으로 표시됩니다. 기본 SSE2 빌드는 "EQ APO XT"이고, 나머지는
+"EQ APO XT AVX", "EQ APO XT AVX2", "EQ APO XT AVX-512", "EQ APO XT AVX10",
+"EQ APO XT Neon"입니다.
+
 설치 후에는 Editor가 스스로 최신 상태를 유지합니다. 새 릴리스를 백그라운드에서 내려받아 두었다가 Editor를 닫을 때 적용합니다. 자세한 흐름은 [docs/VelopackUpdates.md](docs/VelopackUpdates.md)에 있습니다.
 
 ## 문서

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The recommended download is **EqualizerAPO-XT-Setup.exe**, an auto-detect instal
 
 Releases are not code-signed yet, so Windows Defender/SmartScreen can flag a fresh download as unknown (reports have used the generic `Trojan:Win32/Wacatac.B!ml` label - a reputation verdict on unsigned new files, not an actual analysis). Every asset can be checked against the release's `SHA256SUMS.txt`; the auto-detect installer does this automatically before anything runs.
 
+After installation the app appears in the Start menu and in Apps & Features
+as **EQ APO XT** plus its instruction set: the baseline SSE2 build is just
+"EQ APO XT", the others are "EQ APO XT AVX", "EQ APO XT AVX2",
+"EQ APO XT AVX-512", "EQ APO XT AVX10" and "EQ APO XT Neon".
+
 After installation the Editor keeps itself current: it downloads newer releases in the background and applies them when the Editor closes. The flow is documented in [docs/VelopackUpdates.md](docs/VelopackUpdates.md).
 
 ## Documentation

--- a/docs/SimdBuildMatrix.md
+++ b/docs/SimdBuildMatrix.md
@@ -5,14 +5,14 @@ runtime-dispatching one universal x64 binary.
 
 ## CI Variants
 
-| Matrix name | Platform | SIMD variant | MSBuild instruction set | Qt flag | Dependency release assets | Update channel |
-| --- | --- | --- | --- | --- | --- | --- |
-| `windows-x64-sse2` | `x64` | `sse2` | `NotSet` | none | vcpkg `fftw3[sse2,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `x64-sse2` |
-| `windows-x64-avx` | `x64` | `avx` | `AdvancedVectorExtensions` | `/arch:AVX` | vcpkg `fftw3[avx,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `x64-avx` |
-| `windows-x64-avx2` | `x64` | `avx2` | `AdvancedVectorExtensions2` | `/arch:AVX2` | `*-x64-avx2` | `x64-avx2` |
-| `windows-x64-avx512` | `x64` | `avx512` | `AdvancedVectorExtensions512` | `/arch:AVX512` | `*-x64-avx512` | `x64-avx512` |
-| `windows-x64-avx10_1` | `x64` | `avx10_1` | `AdvancedVectorExtensions101` | `/arch:AVX10.1` | `*-x64-avx10` | `x64-avx10-1` |
-| `windows-arm64` | `ARM64` | `neon` | none | none | `*-arm64` | `arm64-neon` |
+| Matrix name | Platform | SIMD variant | MSBuild instruction set | Qt flag | Dependency release assets | Update channel | Installed name |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `windows-x64-sse2` | `x64` | `sse2` | `NotSet` | none | vcpkg `fftw3[sse2,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `x64-sse2` | EQ APO XT |
+| `windows-x64-avx` | `x64` | `avx` | `AdvancedVectorExtensions` | `/arch:AVX` | vcpkg `fftw3[avx,threads]`, vcpkg `libsndfile`, rebuilt `muparserx` | `x64-avx` | EQ APO XT AVX |
+| `windows-x64-avx2` | `x64` | `avx2` | `AdvancedVectorExtensions2` | `/arch:AVX2` | `*-x64-avx2` | `x64-avx2` | EQ APO XT AVX2 |
+| `windows-x64-avx512` | `x64` | `avx512` | `AdvancedVectorExtensions512` | `/arch:AVX512` | `*-x64-avx512` | `x64-avx512` | EQ APO XT AVX-512 |
+| `windows-x64-avx10_1` | `x64` | `avx10_1` | `AdvancedVectorExtensions101` | `/arch:AVX10.1` | `*-x64-avx10` | `x64-avx10-1` | EQ APO XT AVX10 |
+| `windows-arm64` | `ARM64` | `neon` | none | none | `*-arm64` | `arm64-neon` | EQ APO XT Neon |
 
 The per-variant facts above are defined once in `.github/simd-variants.psd1`.
 Each variant ships as a Velopack package whose `packId` is
@@ -21,6 +21,15 @@ release Setup asset is named `EqualizerAPO-XT-<channel>-<channel>-Setup.exe`
 (for example `EqualizerAPO-XT-arm64-neon-arm64-neon-Setup.exe`). The
 channel-less `EqualizerAPO-XT-Setup.exe` on the same release is the
 auto-detect installer described in `docs/AutoDetectInstaller.md`.
+
+The "Installed name" column (`Title` in the manifest) is what the user sees
+after installation: the Start menu/desktop shortcut, the Apps & Features
+entry and the per-channel Setup window. It is display metadata only - the
+`packId`, the update channel and the install directory keep the
+`EqualizerAPO-XT-<channel>` identity. Renaming a Title is safe for existing
+installs: Velopack's update apply rewrites the uninstall registry entry and
+renames existing shortcuts (it finds them by target path, not by name), so
+installed apps pick up a new Title on their next update.
 
 ## Runtime Compatibility
 


### PR DESCRIPTION
## What changed

The installed app used to appear as **"EqualizerAPO-XT x64-avx2"** in the Start menu, on the desktop shortcut and in Apps & Features. Each variant now installs under a readable name:

| Channel | Installed name |
| --- | --- |
| x64-sse2 | EQ APO XT |
| x64-avx | EQ APO XT AVX |
| x64-avx2 | EQ APO XT AVX2 |
| x64-avx512 | EQ APO XT AVX-512 |
| x64-avx10-1 | EQ APO XT AVX10 |
| arm64-neon | EQ APO XT Neon |

The names live as a new `Title` field in `simd-variants.psd1` (single source of truth) and `New-VelopackRelease.ps1` passes them as `--packTitle` instead of deriving a string from the artifact folder name.

## Why existing installs migrate quietly

Verified against the pinned velopack **1.1.1** source:

- `apply_windows_impl.rs` calls `update_uninstall_entry(old, new)` on every update apply, which rewrites the Apps & Features `DisplayName` with the new title.
- The same apply path calls `create_or_update_manifest_lnks(new, Some(old))`; rename candidates are found **by shortcut target path, not by name** (`unsafe_find_best_rename_candidates`), then renamed to `<new title>.lnk`. Because matching is target-based, the rename also self-heals on later updates if one apply ever missed it.
- Uninstall removes shortcuts by scanning for targets under the install root, so an old-named shortcut can never be left behind as a corpse.

`packId`, update channel, asset names and the install directory are untouched (`EqualizerAPO-XT-<channel>`), so update feeds, delta packaging and the release resume logic see no difference.

## Verification

- Full local pester suite: 105/105 passed, including two new tests (plan takes `PackTitle` from the manifest; every variant needs a distinct non-empty `Title`).
- `git diff --check` clean.
- Real-world check happens on the release this PR produces: fresh installs get the new names immediately; installs updated from v2.38.0 and earlier get renamed on that update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)