### PR TITLE
ci: name the reused installer download with the canonical asset name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -866,7 +866,14 @@ jobs:
         # is per file hash, and an unsigned binary that re-hashes every release
         # restarts at zero reputation every time (the Wacatac.B!ml reports).
         # Any anomaly falls back to a fresh build. See the script's header.
-        $reusePath = Join-Path "${{ github.workspace }}" "reused-$assetName"
+        # gh release upload names the asset after the local file, so the
+        # reused copy must carry the canonical asset name. v2.39.0 first
+        # exercised this path and shipped the front door as
+        # "reused-EqualizerAPO-XT-Setup.exe" because the prefix was spelled
+        # into the file name; a subdirectory keeps the copy apart instead.
+        $reuseDir = Join-Path "${{ github.workspace }}" "reused-installer"
+        New-Item -ItemType Directory -Force -Path $reuseDir | Out-Null
+        $reusePath = Join-Path $reuseDir $assetName
         $decision = .\.github\scripts\Get-PreviousInstallerAsset.ps1 `
           -Repository "${{ github.repository }}" `
           -Tag $tag `
@@ -892,6 +899,10 @@ jobs:
 
         if (-not (Test-Path $setupExe)) {
           Write-Error "Auto-detect installer was not produced at $setupExe"
+          exit 1
+        }
+        if ((Split-Path $setupExe -Leaf) -ne $assetName) {
+          Write-Error "Installer file '$setupExe' must be named '$assetName'; gh release upload names the asset after the local file"
           exit 1
         }
 


### PR DESCRIPTION
## What happened

v2.39.0 was the first release to take the installer hash-reuse path (PR #287). The reuse itself worked: the previous release's byte-identical front door (`fc11e808...`) was downloaded and republished. But the download was written to `reused-<asset>` in the workspace root, and `gh release upload` names the asset after the local file, so the release carried **`reused-EqualizerAPO-XT-Setup.exe`**. The "Assert release completeness" gate caught it exactly as designed: `needsInstaller=True, needsChecksums=True, needsNotes=True`.

## Repair already done (release fixed in place)

- Re-uploaded the byte-identical file as `EqualizerAPO-XT-Setup.exe` (hash verified `fc11e808...`, same as v2.38.0 - reputation continuity preserved) and deleted the misnamed asset.
- Regenerated `SHA256SUMS.txt` with `New-ReleaseChecksums.ps1` (7 setup executables, canonical names).
- Regenerated the release notes with `New-ReleaseNotes.ps1` and edited the release body.
- `Publish-Release.ps1 -PassThru` now reports **complete=True** for v2.39.0.

## The fix

The reused copy now lands in `reused-installer\<asset>` so the uploaded asset carries the canonical name, and the step asserts `Split-Path -Leaf` equals the grammar's asset name before uploading - on both the reuse and fresh-build branches, so this failure class dies here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)