### PR TITLE
ci: dynamic memory gate for the test suites (ASan + AlignedMemory leak canary)

### DIFF
--- a/.github/scripts/Invoke-MemcheckTests.ps1
+++ b/.github/scripts/Invoke-MemcheckTests.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    CI's dynamic memory gate: rebuilds the runtime test suites with MSVC
+    AddressSanitizer and runs them; any heap violation or an unbalanced
+    AlignedMemory counter turns the job red.
+
+.DESCRIPTION
+    Two detection axes, because MSVC has no LeakSanitizer on Windows:
+
+    - AddressSanitizer (/fsanitize=address via /p:EnableASAN=true) reports
+      use-after-free, heap/stack overflows and double frees at the moment
+      they happen; the report aborts the process, so the run step fails.
+    - The AlignedMemory leak canary (Tests/AlignedMemoryGate.h) makes each
+      suite binary exit non-zero when engine buffer allocations do not
+      balance at the end of the run. It runs in every build flavor; this
+      job simply exercises it on the same binaries.
+
+    Build notes (mirrored from the local experiment, 2026-08-22):
+    - The prebuilt dependency libs (muparserx, libsndfile, FFTW) are not
+      ASan-instrumented, so the std container annotation checks must be
+      disabled (_DISABLE_STRING_ANNOTATION/_DISABLE_VECTOR_ANNOTATION via
+      the CL environment) or the link fails with LNK2038.
+    - Whole-program optimization is turned off; ASan and /GL disagree.
+    - Timing contracts skip themselves under ASan (__SANITIZE_ADDRESS__,
+      see SampleIoTests.cpp): instrumentation cost lands on the vectorized
+      candidate and would invert every ratio.
+    - The ASan runtime DLL ships in the VC toolset bin directory, which
+      Import-VsDevEnvironment puts on PATH before the run.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $WorkspaceRoot
+)
+
+$ErrorActionPreference = "Stop"
+Set-Location $WorkspaceRoot
+
+$libPaths = @($env:LIBSNDFILE_LIB, $env:MUPARSERX_LIB, $env:FFTW_LIB)
+$env:LIB = if ($env:LIB) { ($libPaths + $env:LIB) -join ";" } else { $libPaths -join ";" }
+$env:CL = "/D_DISABLE_STRING_ANNOTATION /D_DISABLE_VECTOR_ANNOTATION"
+
+$buildParams = @(
+    "/m", "/p:Configuration=Release", "/p:Platform=x64", "/t:rebuild",
+    "/p:EnableASAN=true", "/p:WholeProgramOptimization=false",
+    "/p:EnableEnhancedInstructionSet=AdvancedVectorExtensions2",
+    "/p:PlatformToolset=v145",
+    "/p:LIBSNDFILE_INCLUDE=$env:LIBSNDFILE_INCLUDE", "/p:LIBSNDFILE_LIB=$env:LIBSNDFILE_LIB",
+    "/p:FFTW_INCLUDE=$env:FFTW_INCLUDE", "/p:FFTW_LIB=$env:FFTW_LIB",
+    "/p:MUPARSERX_INCLUDE=$env:MUPARSERX_INCLUDE", "/p:MUPARSERX_LIB=$env:MUPARSERX_LIB",
+    "/p:TCLAP_ROOT=$env:TCLAP_ROOT", "/p:VST3_SDK=$env:VST3_SDK",
+    "/p:HIGHWAY_INCLUDE=$env:HIGHWAY_INCLUDE", "/p:QT_ROOT=$env:QT_ROOT"
+)
+
+# The suite exes plus everything they load: the companion VST modules must be
+# part of the same ASan build so their objects agree with the host's.
+$projects = @(
+    "SubwooferRoutingCore\SubwooferRoutingCore.vcxproj",
+    "Common.vcxproj",
+    "Tests\TestVst2Plugin\TestVst2Plugin.vcxproj",
+    "VST3\SubwooferRouting\SubwooferRoutingVst3.vcxproj",
+    "Tests\HybridConvTests\HybridConvTests.vcxproj",
+    "Tests\EngineOrchestrationTests\EngineOrchestrationTests.vcxproj",
+    "Tests\EditorLogicTests\EditorLogicTests.vcxproj"
+)
+foreach ($project in $projects) {
+    msbuild $project @buildParams
+    if ($LASTEXITCODE -ne 0) { throw "ASan build failed for $project" }
+}
+Remove-Item Env:CL
+
+$env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:MUPARSERX_LIB;$env:QT_ROOT\bin;$env:PATH"
+foreach ($name in @("HybridConvTests", "EngineOrchestrationTests", "EditorLogicTests")) {
+    $testExe = Join-Path $WorkspaceRoot "Tests\$name\x64\Release\$name.exe"
+    if (-not (Test-Path $testExe)) { throw "Test executable not found: $testExe" }
+    Write-Host "== memcheck: $name =="
+    & $testExe
+    if ($LASTEXITCODE -ne 0) { throw "$name failed under the memory gate" }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -668,6 +668,106 @@ jobs:
         path: cppcheck-report.txt
         retention-days: 30
 
+  # Dynamic memory gate: the runtime test suites rebuilt with MSVC
+  # AddressSanitizer (use-after-free, heap/stack overflow, double free =>
+  # the report aborts the process and the step fails) and run with the
+  # AlignedMemory leak canary each suite checks at exit
+  # (Tests/AlignedMemoryGate.h: a memleak of an engine buffer exits 1).
+  # MSVC has no LeakSanitizer on Windows, so full-heap leak detection is
+  # not available; the canary covers the engine-buffer class - the
+  # original convolution-tail bug class - deterministically instead.
+  # Build/run mechanics live in .github/scripts/Invoke-MemcheckTests.ps1.
+  memcheck:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v3
+      with:
+        msbuild-architecture: x64
+
+    - name: Resolve pinned dependency tags
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $manifest = Import-PowerShellDataFile -Path "${{ github.workspace }}\.github\simd-variants.psd1"
+        "VST3_TAG=$($manifest.Shared.Vst3Tag)" >> $env:GITHUB_ENV
+        "HIGHWAY_TAG=$($manifest.Shared.HighwayTag)" >> $env:GITHUB_ENV
+        "TCLAP_TAG=$($manifest.Shared.TclapTag)" >> $env:GITHUB_ENV
+
+    - name: Download dependency release assets
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        Import-Module "${{ github.workspace }}\.github\scripts\Provisioning.psm1" -Force
+
+        $manifest = Import-PowerShellDataFile -Path "${{ github.workspace }}\.github\simd-variants.psd1"
+        $downloads = Get-DependencyDownloadSpec -Manifest $manifest `
+          -DepsRoot "${{ github.workspace }}\deps" `
+          -Platform "x64" `
+          -Simd "avx2"
+        Invoke-DependencyDownload -Downloads $downloads `
+          -DownloadRoot "${{ github.workspace }}\deps\_downloads"
+
+    - name: Download TCLAP
+      uses: actions/checkout@v6
+      with:
+        repository: 115dkk/tclap
+        ref: ${{ env.TCLAP_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: deps/tclap
+
+    - name: Download VST3 pluginterfaces
+      uses: actions/checkout@v6
+      with:
+        repository: steinbergmedia/vst3_pluginterfaces
+        ref: ${{ env.VST3_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: deps/vst3sdk/pluginterfaces
+
+    - name: Download Highway
+      uses: actions/checkout@v6
+      with:
+        repository: google/highway
+        ref: ${{ env.HIGHWAY_TAG }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: deps/highway
+
+    - name: Setup dependency structures
+      shell: pwsh
+      run: |
+        .\.github\scripts\Initialize-DepsEnvironment.ps1 -DepsPath "${{ github.workspace }}\deps"
+
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    # EditorLogicTests links Qt6Core/Gui/Widgets; the other suites are Qt-free.
+    - name: Install Qt
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        Import-Module "${{ github.workspace }}\.github\scripts\Provisioning.psm1" -Force
+
+        $qtRoot = Install-QtSdk -WorkspaceRoot "${{ github.workspace }}" -Platform "x64"
+
+        echo "QT_ROOT=$qtRoot" >> $env:GITHUB_ENV
+        echo "$qtRoot\bin" >> $env:GITHUB_PATH
+
+    # Import-VsDevEnvironment puts the VC toolset bin on PATH, which is where
+    # the ASan runtime DLL (clang_rt.asan_dynamic-x86_64.dll) lives.
+    - name: Build and run the suites under the memory gate
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        . .\.github\scripts\Import-VsDevEnvironment.ps1
+        Import-VsDevEnvironment "x64"
+        & "${{ github.workspace }}\.github\scripts\Invoke-MemcheckTests.ps1" `
+          -WorkspaceRoot "${{ github.workspace }}"
+
   pester:
     # Unit-tests the release-keystone scripts the version-bump job runs:
     # Bump-Version.ps1 (the Conventional Commit -> SemVer mapping that decides

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ CI annotation도 작업 범위입니다. warning이나 notice가 다음 릴리�
 
 cppcheck job은 베이스라인 0 기준의 차단 게이트입니다. CI는 cppcheck 2.21.0을 태그 고정으로 소스 빌드해 쓰므로, 로컬에서도 같은 버전으로 build.yml의 cppcheck 호출 플래그를 그대로 사용하면 결과가 재현됩니다. 새 발견은 코드로 고치는 것이 기본이고, 정당한 거짓 양성만 근거 주석과 함께 inline 또는 job 수준 suppress로 처리합니다. 정책적으로 억제한 규칙(cstyleCast, shadow*, useStlAlgorithm, postfixOperator, noExplicitConstructor, LocalAllocCalled)의 근거는 build.yml의 주석에 있습니다.
 
+memcheck job은 동적 메모리 게이트입니다. 런타임 테스트 스위트를 MSVC AddressSanitizer(`/p:EnableASAN=true`, 컨테이너 주석 비활성, WPO 끔)로 재빌드해 실행하며, 힙 위반(use-after-free, 오버플로, 이중 해제)은 ASan 리포트가 프로세스를 중단시켜 Red가 됩니다. 엔진 버퍼 누수는 각 테스트 바이너리가 종료 시 검사하는 AlignedMemory 카나리아(Tests/AlignedMemoryGate.h)가 Red로 만듭니다. Windows MSVC에는 LeakSanitizer가 없어 전체 힙 누수 검출은 제공되지 않습니다. 성능 계약 테스트는 `__SANITIZE_ADDRESS__`에서 스스로 빠집니다. 빌드/실행 절차는 .github/scripts/Invoke-MemcheckTests.ps1에 있고, 로컬 재현도 같은 스크립트로 합니다(플래그 전환 시 /t:rebuild 필수).
+
 테스트를 건너뛰는 판단은 명시적인 이유가 있어야 합니다. GitHub-hosted x64 runner가 AVX-512/AVX10.1 실행을 보장하지 않아 `HybridConvTests` 실행을 건너뛰는 경우처럼, 빌드는 유지하되 런타임 실행만 제한합니다.
 
 회귀가 발견되면 먼저 재현 가능한 테스트나 검증 명령을 추가합니다. 오디오 처리 내부처럼 버그를 잡기 어려운 부분은 더 좁은 테스트를 먼저 만들고, 테스트가 가리키는 범위만 수정합니다.

--- a/Tests/AlignedMemoryGate.h
+++ b/Tests/AlignedMemoryGate.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of EqualizerAPO-XT.
+
+	The leak canary behind CI's memcheck gate. Every engine audio buffer -
+	filter state, convolution history, VST slot buffers - is allocated
+	through AlignedMemory, so a suite that ends with more alloc() than
+	free() calls has leaked a buffer the way the original convolution-tail
+	bug class does. MSVC's AddressSanitizer has no LeakSanitizer on Windows;
+	this covers the engine-buffer class of leaks deterministically instead,
+	in every build flavor.
+
+	Call from a suite binary's main() after every harness reported: by then
+	all filters and configurations must be destroyed, so the counters must
+	balance. The check is direction-agnostic (a mid-run counter reset while
+	buffers were live would show as more frees than allocations - that is a
+	test-hygiene bug worth failing on too).
+*/
+
+#pragma once
+
+#include <cstdio>
+
+#include "runtime/memory/AlignedMemory.h"
+
+namespace test
+{
+inline int reportAlignedMemoryBalance(const char* binaryName)
+{
+	const size_t allocated = AlignedMemory::allocationCountForTesting();
+	const size_t freed = AlignedMemory::freeCountForTesting();
+	if (allocated == freed)
+	{
+		std::printf("%s: aligned-memory balance OK (%zu allocations, all freed)\n",
+			binaryName, allocated);
+		return 0;
+	}
+	if (allocated > freed)
+		std::fprintf(stderr, "%s: MEMLEAK: %zu aligned buffer(s) still allocated at exit"
+			" (%zu allocated, %zu freed)\n",
+			binaryName, allocated - freed, allocated, freed);
+	else
+		std::fprintf(stderr, "%s: aligned-memory counters are skewed: %zu more frees than"
+			" allocations (a counter reset while buffers were live?)\n",
+			binaryName, freed - allocated);
+	return 1;
+}
+}

--- a/Tests/EditorLogicTests/EditorLogicTests.cpp
+++ b/Tests/EditorLogicTests/EditorLogicTests.cpp
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QStringList>
 
+#include "Tests/AlignedMemoryGate.h"
 #include "Tests/TestHarness.h"
 #include "EditorLogicTestSupport.h"
 
@@ -180,6 +181,8 @@ int main(int argc, char** argv)
 		testInstallerUiModelChannelDescriptions();
 
 		harness.report();
+		if (test::reportAlignedMemoryBalance("EditorLogicTests") != 0)
+			return EXIT_FAILURE;
 		return EXIT_SUCCESS;
 	}
 	catch (const std::exception& error)

--- a/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
+++ b/Tests/EngineOrchestrationTests/EngineOrchestrationTests.cpp
@@ -46,6 +46,7 @@
 #include "audio/io/SndfileRAII.h"
 #include "runtime/concurrency/SynchronizedState.h"
 #include "platform/windows/Win32Event.h"
+#include "Tests/AlignedMemoryGate.h"
 #include "Tests/TestHarness.h"
 #include "Tests/TestDirectory.h"
 
@@ -1202,7 +1203,7 @@ int runEngineOrchestrationTests()
 
 	removeTestDirectory();
 	harness.report();
-	return 0;
+	return test::reportAlignedMemoryBalance("EngineOrchestrationTests");
 }
 
 int main()

--- a/Tests/EngineOrchestrationTests/SampleIoTests.cpp
+++ b/Tests/EngineOrchestrationTests/SampleIoTests.cpp
@@ -285,5 +285,12 @@ void testStereoFloatConversionBeatsScalarReference(test::Harness& harness)
 void runSampleIoTests(test::Harness& harness)
 {
 	testConversionsMatchScalarReferenceBitExactly(harness);
+	// Timing contracts are meaningless under AddressSanitizer: the
+	// instrumentation cost lands on the vectorized candidate, not on the
+	// reference loop shape, so the ratio inverts regardless of the code
+	// under test. The memcheck CI leg builds with /fsanitize=address and
+	// still runs the bit-exactness half above.
+#ifndef __SANITIZE_ADDRESS__
 	testStereoFloatConversionBeatsScalarReference(harness);
+#endif
 }

--- a/Tests/HybridConvTests/HybridConvTests.cpp
+++ b/Tests/HybridConvTests/HybridConvTests.cpp
@@ -28,6 +28,7 @@
 #include "audio/io/SndfileRAII.h"
 #include "libHybridConv-0.1.1/libHybridConv_eapo.h"
 #include "Tests/TestHarness.h"
+#include "Tests/AlignedMemoryGate.h"
 
 // Forward declarations for the additional suites that share this binary's
 // main(); each runXxxTests() is defined in the correspondingly named
@@ -518,7 +519,7 @@ int runHybridConvTests()
 
 	cleanupFftwWisdomTest();
 	harness.report();
-	return 0;
+	return test::reportAlignedMemoryBalance("HybridConvTests");
 }
 
 int main()


### PR DESCRIPTION
## What changed

Per the maintainer's directive: CI had no dynamic memory checking on its test runs; this attaches one, with two axes.

**Violations (AddressSanitizer).** A new `memcheck` job rebuilds the runtime suites (HybridConvTests, EngineOrchestrationTests, EditorLogicTests, plus the companion VST modules they load) with MSVC `/fsanitize=address` and runs them. Use-after-free, heap/stack overflow and double free abort the process at the point of the violation, so the job goes red with the ASan report in the log.

**Leaks (AlignedMemory canary).** MSVC has no LeakSanitizer on Windows - full-heap leak detection is not available and this PR does not pretend otherwise. Instead, every suite binary now checks at exit that AlignedMemory allocations balance (`Tests/AlignedMemoryGate.h`, wired into all three mains, reusing the counters the allocator already carries). Every engine audio buffer - filter state, convolution history, VST slot buffers - goes through AlignedMemory, so this deterministically reds the engine-buffer leak class (the original convolution-tail bug class), in every build flavor, not just the memcheck job.

Build mechanics live in `.github/scripts/Invoke-MemcheckTests.ps1`: container annotations off (the prebuilt dependency libs are uninstrumented; LNK2038 otherwise), WPO off, `/t:rebuild` (flag switches must not mix objects), ASan runtime DLL via the VC toolset PATH. The SampleIoTests timing contract skips itself under `__SANITIZE_ADDRESS__` - instrumentation cost lands on the vectorized candidate and inverts the ratio regardless of the code under test; its bit-exactness half still runs.

## Verification (local, end to end)

- The exact script CI runs was rehearsed locally: all three suites green under ASan, `aligned-memory balance OK` on each (HybridConvTests 108 allocations, EngineOrchestrationTests 53, EditorLogicTests 1 - the InfrastructureTests counter reset balances back out).
- Negative test: a deliberately injected `AlignedMemory::alloc(64)` turned the run red with `MEMLEAK: 1 aligned buffer(s) still allocated at exit` and exit code 1, then was reverted.
- ASan runtime cost on these suites is small (HybridConvTests ~10 s locally).

## Not covered

- Leaks outside AlignedMemory (plain new/malloc, Qt objects) are not detected; that would need LeakSanitizer, which MSVC does not ship on Windows.
- AudioRegressionTests is not in the memcheck job yet (argument/reference plumbing); its binaries still get the canary.
- `Invoke-MemcheckTests.ps1` has no Pester plan-mode tests; it is a straight-line build+run script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)