### PR TITLE
test(asio): make the ring and daemon suites independent of scheduling

### DIFF
--- a/Tests/AsioTests/DaemonTests.cpp
+++ b/Tests/AsioTests/DaemonTests.cpp
@@ -123,6 +123,10 @@ namespace
 		options.configPath = configPath;
 		options.readyTimeoutMs = 20000;
 		options.mode = Mode::Sync;
+		// This test compares bytes, not timing: the automatic deadline (a
+		// quarter period) is what the probe gate measures, and a loaded box
+		// misses it through the plain thread host.
+		options.deadlineUs = 20000000;
 
 		Capture inproc = runStream(std::make_unique<eapo::asio::InProcProcessor>(), options, 64, 40, 2, 2);
 		Capture daemon = runStream(std::make_unique<DaemonProcessor>(std::make_unique<ThreadHostLink>()), options, 64, 40, 2, 2);
@@ -143,6 +147,7 @@ namespace
 		options.configPath = configPath;
 		options.processInput = false;
 		options.mode = Mode::Sync;
+		options.deadlineUs = 20000000;   // shape, not timing (see above)
 
 		Capture sync = runStream(std::make_unique<DaemonProcessor>(std::make_unique<ThreadHostLink>()), options, 32, 10, 0, 1);
 		options.mode = Mode::Pipelined;

--- a/Tests/AsioTests/StreamRingTests.cpp
+++ b/Tests/AsioTests/StreamRingTests.cpp
@@ -349,6 +349,10 @@ namespace
 			}
 		}
 		harness.expect(allDone, "every previous block was complete and processed by the time the next was published");
+		// The adapter never waits for the block published last; the consumer
+		// drops it when Closing arrives first. Wait for it here so the count
+		// below does not depend on the consumer thread's scheduling.
+		harness.expect(producer.wait(Direction::Output, 50, 1000000) == RingWait::Done, "the last block completes when asked for");
 		producer.close();
 		consumer.join();
 		harness.expectEqual(consumer.served.load(), 50u, "all 50 blocks served");


### PR DESCRIPTION
## 무엇이 달라지나

`feat/asio` → `main` PR #314의 CI가 `StreamRingTests`에서 "all 50 blocks served: expected 50, got 49"로 실패했습니다. 제품 코드 결함이 아니라 테스트 두 곳의 스케줄링 의존입니다.

- **StreamRingTests 파이프라인 셰이프**: 50번째 블록을 게시한 뒤 49번째까지만 기다리고 `close()`를 불렀습니다. 링은 Closing이 먼저 오면 아직 집지 않은 블록을 버리므로(설계대로), 느린 러너에서는 49개만 서비스됩니다. 마지막 블록도 기다린 뒤 닫습니다.
- **DaemonTests 바이트 동일성·셰이프**: 동기 모드를 자동 마감(주기의 1/4 = 167~333 µs)으로 돌렸는데, 이 두 테스트는 바이트와 모양을 보는 것이지 타이밍 테스트가 아닙니다. 판정 문구는 이미 "20 s deadline"인데 `deadlineUs`가 빠져 있었습니다. 20초로 명시합니다. 타이밍 판정은 프로브 게이트에 그대로 있습니다.

## 검증

로컬 부하 상태에서 수정 전 `DaemonTests`가 20회 중 8회 실패(늦은 블록 1~80개)로 재현되었고, 수정 후 30회 직렬 + 4개 동시 3라운드 모두 통과. `git diff --check` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)