### PR TITLE
docs(asio): record the real-device registration check, mark the README item merged

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -32,10 +32,12 @@ EqualizerAPO-XT는 Windows용 시스템 전체 이퀄라이저인 [Equalizer APO
 5. 프로그래밍 계열 설정 명령(`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`) 전용 에디터 — 완료. 다섯 스킨이 분석 판정으로 블록을 각자의 계기로 표현하고, 픽커가 이 명령들을 삽입하며, 계수 직접 입력 IIR 줄과 백틱 인라인 식이 든 줄도 각자의 카드를 유지합니다([#178](https://github.com/115dkk/EqualizerAPO-XT/pull/178), [#182](https://github.com/115dkk/EqualizerAPO-XT/pull/182), [#183](https://github.com/115dkk/EqualizerAPO-XT/pull/183), [#184](https://github.com/115dkk/EqualizerAPO-XT/pull/184)).
 6. 서브우퍼 라우팅([#246](https://github.com/115dkk/EqualizerAPO-XT/issues/246)) — 핵심 기능은 완료됐습니다. `SubwooferRouting:` 명령, MIT SubwooferRoutingCore DSP 라이브러리, 독립 실행형 VST3 플러그인, 4.1 호스트 협상 수정, 다섯 스킨 각각의 카드 계기, 그리고 두 라우팅 행렬과 응답 뷰를 갖춘 전체 편집기까지 들어갔습니다. 남은 후속 작업은 연결된 프로필 파일로의 변경 사항 되쓰기(현재는 행을 인라인 상태로 전환), audition/solo 오버라이드, 새 문자열의 한국어 번역, 전용 VST3 편집기 화면(현재는 호스트의 일반 파라미터 화면)입니다.
 7. VST3 버스 레이아웃 명시([#216](https://github.com/115dkk/EqualizerAPO-XT/issues/216)) — 비대칭 입출력, 4.1, 엄격한 실패 처리, VST2에서의 조용한 무시를 포함한 백엔드 `VSTPlugin:` `Input`/`Output` 문법과 결정적 호스트 테스트를 마쳤습니다. Qt Editor에도 플러그인 이름 옆에 Input/Output 선택기가 들어갔습니다. 다섯 스킨이 각자의 시각 언어로 그리고, 판정 램프가 실제 체결된 버스를 알려 주며, VST2 잠금·잔존 키 제거와 구형 `StereoInput` 이전까지 처리합니다([#265](https://github.com/115dkk/EqualizerAPO-XT/pull/265)). 이번 라운드에서는 협상된 슬롯에 임의 설정 채널을 넣는 슬롯별 채널 채우기(`InputChannels`/`OutputChannels`, 지정하지 않은 채널은 그대로 통과)와 레거시 행의 Input/Output 드롭다운이 들어갔고([#290](https://github.com/115dkk/EqualizerAPO-XT/pull/290)), 채우기 목록의 편집기가 모든 스킨에 들어갔습니다. 카드 안의 레일 두 줄이 슬롯별 채널 드롭다운을 들고 라인의 `Channel:`/`Copy:` 흐름을 따르며, 양쪽 레일이 있으면 접기 스위치가 붙고, 레거시 표시에는 콤보 행이 들어갑니다([#292](https://github.com/115dkk/EqualizerAPO-XT/pull/292)).
-8. ASIO([#310](https://github.com/115dkk/EqualizerAPO-XT/issues/310)) — 래퍼
-   드라이버, 엔진 호스트 프로세스, 둘 사이의 링, 장치 기록, CI 게이트가 들어갔고
-   CI의 가짜 드라이버와 로컬의 Topping USB Audio Device로 검증했습니다. 남은 것은
-   더 많은 DAW에서의 구동입니다.
+8. ASIO([#310](https://github.com/115dkk/EqualizerAPO-XT/issues/310)) —
+   머지됐습니다([#314](https://github.com/115dkk/EqualizerAPO-XT/pull/314)). 래퍼
+   드라이버, 엔진 호스트 프로세스, 둘 사이의 링, 장치 기록, 장치 선택기 옵션, CI
+   게이트가 들어갔고, CI의 가짜 드라이버와 Topping USB Audio Device(장치 선택기로
+   항목을 등록한 뒤 DAW가 여는 방식 그대로 열어서)로 검증했습니다. 남은 것은
+   더 많은 DAW에서의 구동과 ARM64 기기에서 x64 DAW가 읽을 x64 항목입니다.
 
 ## 주요 기능
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ Current work areas:
 5. Editors for the programmatic config commands (`If:`/`ElseIf:`/`Else:`/`EndIf:`/`Eval:`) — complete. Each skin presents blocks with its own instrument driven by the analysis run, the picker inserts the vocabulary, custom-coefficient IIR lines have their own card, and lines with inline `` `expression` `` parameters keep their card in a dynamic mode ([#178](https://github.com/115dkk/EqualizerAPO-XT/pull/178), [#182](https://github.com/115dkk/EqualizerAPO-XT/pull/182), [#183](https://github.com/115dkk/EqualizerAPO-XT/pull/183), [#184](https://github.com/115dkk/EqualizerAPO-XT/pull/184)).
 6. Subwoofer routing ([#246](https://github.com/115dkk/EqualizerAPO-XT/issues/246)) — the core feature set is complete: the `SubwooferRouting:` command, the MIT SubwooferRoutingCore DSP library, the standalone VST3 plugin, the 4.1 host-negotiation fix, the Editor card with a per-skin instrument in every skin, and the full editor dialog with both routing matrices and a response view. Remaining follow-ups: writing changes back to a linked profile file (the dialog currently converts the row to inline state), audition/solo overrides, Korean translations for the new strings, and a custom VST3 editor view (hosts show their generic parameter panel).
 7. Explicit VST3 bus layouts ([#216](https://github.com/115dkk/EqualizerAPO-XT/issues/216)) — the backend `VSTPlugin:` `Input`/`Output` syntax and deterministic host tests are complete, including asymmetric layouts, 4.1, strict failure passthrough, and quiet VST2 ignore semantics. The Qt Editor now carries Input/Output selectors beside the plugin name in every skin's own visual language, with a verdict lamp for the actually negotiated bus, VST2 lock/repair handling, and the legacy `StereoInput` migration ([#265](https://github.com/115dkk/EqualizerAPO-XT/pull/265)). The current round adds per-slot channel fill (`InputChannels`/`OutputChannels` place arbitrary config channels into the negotiated slots, untouched channels pass through) and plain Input/Output dropdowns in the legacy row ([#290](https://github.com/115dkk/EqualizerAPO-XT/pull/290)). The fill lists now have their editor in every skin: two rails inside the card with per-slot channel dropdowns that follow the line's `Channel:`/`Copy:` flow, a fold switch when both rails exist, and combo rows in the legacy presentation ([#292](https://github.com/115dkk/EqualizerAPO-XT/pull/292)).
-8. ASIO ([#310](https://github.com/115dkk/EqualizerAPO-XT/issues/310)) — the
+8. ASIO ([#310](https://github.com/115dkk/EqualizerAPO-XT/issues/310)) —
+   merged ([#314](https://github.com/115dkk/EqualizerAPO-XT/pull/314)): the
    wrapper driver, the engine host process, the ring between them, the device
-   records and the CI gate are in, verified with a fake driver on CI and a
-   Topping USB Audio Device locally. Remaining: runs under more DAWs.
+   records, the Device Selector options and the CI gate. Verified with a fake
+   driver on CI and, on a Topping USB Audio Device, by registering the entry
+   through the Device Selector and opening it the way a DAW does. Remaining:
+   runs under more DAWs, and the x64 entry for x64 DAWs on ARM64 machines.
 
 ## Features
 

--- a/docs/architecture/asio-host-study.md
+++ b/docs/architecture/asio-host-study.md
@@ -463,6 +463,8 @@ struct alignas(64) RingHeader
 
 **폐기한 제안: 시스템 사운드를 ASIO로 유도.** AudioSrv/audiodg는 엔드포인트를 커널 드라이버로만 알고 ASIO 드라이버는 응용 프로그램이 로드하는 사용자 모드 COM 객체라, 서비스 쪽 설정으로는 렌더 스트림을 ASIO로 보낼 길이 없다. 가능한 구조는 가상 재생 장치(커널 드라이버, attestation 서명 필수) + 호스트의 브리지뿐이며 Voicemeeter가 그 구조다. 얻는 것(비트 퍼펙트 아님, 지연은 가상 장치 주기만큼 증가)에 비해 무거워 메인테이너가 폐기했다(2026-08-29). 다시 제안하지 않는다.
 
+**실기기 등록 검증(2026-08-29 21:23).** 장치 선택기(UAC)로 Topping USB Audio Device의 재생 행을 기본값으로 체크해 등록했다. 남은 것은 HKLM의 래퍼 기록(`ProcessOutput=1`, `Mode=1`, `DeadlinePercent=25`, `AutoStart=0`, `Register32=0`), `SOFTWARE\ASIO\Topping USB Audio Device (EQ APO XT)` 항목, 64비트 CLSID `{35614A11-8E23-4043-A85F-EF11D467090D}`(32비트 뷰는 옵션이 꺼져 있어 없음)이다. 이어서 프로브를 DAW 대역으로 삼아 `--target clsid:{래퍼 CLSID} --wrapper static --processor passthrough --seconds 10 --tone`으로 등록된 래퍼를 COM으로 열었다. 설치 폴더의 `EqualizerAPOHost.exe`가 자동으로 떠서 `\\.\pipe\EAPO.ASIO.1`, linger 60 s로 응답했고, 48 kHz·64프레임으로 10초 동안 7501 스위치를 전부 처리했으며(호스트 로그 `out 7501 in 0 blocks`), 보고 지연은 입력 112·출력 232프레임, HKCU facts(48000 Hz, 출력 2채널, 64프레임)가 게시됐다. 실제 DAW로 연 것은 아니며, 이 검증은 DAW가 거치는 것과 같은 COM 경로를 프로브가 대신 밟은 것이다.
+
 **남은 일:** 실제 DAW 여러 종에서의 구동, ARM64 기기에서 x64 DAW가 읽을 x64 래퍼 항목.
 
 ## 11. 구현 순서


### PR DESCRIPTION
실기기 등록 검증 기록입니다. 장치 선택기(UAC)로 Topping USB Audio Device의 항목을 등록한 뒤, 프로브가 DAW가 거치는 COM 경로로 등록된 래퍼를 열어 설치 폴더의 엔진 호스트가 자동으로 뜨고 10초 7501 버퍼를 전부 처리한 것을 연구 문서 12절에 남겼습니다. README 두 언어의 진행 목록 8번은 머지됨(#314)으로 바꾸고 남은 일(더 많은 DAW, ARM64의 x64 항목)을 적었습니다.

문서만 바뀌므로 버전은 오르지 않습니다. #314의 릴리스 run이 끝난 뒤에 합칩니다(버전 범프 커밋의 push와 겹치지 않도록).

🤖 Generated with [Claude Code](https://claude.com/claude-code)