### PR TITLE
ci(asio): give the pipelined run over the real host three attempts

### DIFF
--- a/.github/scripts/Invoke-AsioProbeGate.ps1
+++ b/.github/scripts/Invoke-AsioProbeGate.ps1
@@ -70,11 +70,18 @@ $runs = @(
             "--daemon", $hostExe, "--endpoint", "EAPO.ASIO.probe.gate", "--frames", "64", "--periods", "300",
             "--sample-type", "int32", "--deadline-us", "1000000", "--max-late", "0")
     },
+    # The one run with the real host process AND the pipelined mode, which by
+    # design lets a late period through unprocessed. On a hosted runner under
+    # load that turned the hash comparison into a coin toss (two failures on
+    # 2026-08-30, both "first period is not the engine's first period", both
+    # green on rerun with nothing changed). The run keeps its assertion and
+    # gets three attempts: a genuine regression fails all three.
     [pscustomobject]@{
         Name = "dll-daemon-exe-pipelined-float32-32"
         Arguments = @("--target", "dll:$fakeDll", "--wrapper", "dll:$wrapperDll", "--processor", "daemon", "--config", $config,
             "--daemon", $hostExe, "--endpoint", "EAPO.ASIO.probe.gate", "--frames", "32", "--periods", "400",
             "--sample-type", "float32", "--mode", "pipelined")
+        Attempts = 3
     },
     [pscustomobject]@{
         Name = "dll-passthrough-int24-128"
@@ -99,8 +106,14 @@ foreach ($required in @($probe, $fakeDll, $wrapperDll, $hostExe, $config)) {
 
 $env:PATH = "$env:FFTW_LIB;$env:LIBSNDFILE_LIB;$env:MUPARSERX_LIB;$env:PATH"
 foreach ($run in $runs) {
-    Write-Host "=== ASIO probe: $($run.Name) ==="
-    & $probe @($run.Arguments)
-    if ($LASTEXITCODE -ne 0) { throw "ASIO probe gate: $($run.Name) failed with exit code $LASTEXITCODE" }
+    $attempts = if ($run.PSObject.Properties["Attempts"]) { [int]$run.Attempts } else { 1 }
+    for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+        Write-Host "=== ASIO probe: $($run.Name)$(if ($attempts -gt 1) { " (attempt $attempt of $attempts)" }) ==="
+        & $probe @($run.Arguments)
+        if ($LASTEXITCODE -eq 0) { break }
+        if ($attempt -eq $attempts) { throw "ASIO probe gate: $($run.Name) failed with exit code $LASTEXITCODE" }
+        Write-Host "ASIO probe gate: $($run.Name) exited with $LASTEXITCODE; a timing-bound run, trying again"
+        Start-Sleep -Seconds 5
+    }
 }
 Write-Host "ASIO probe gate: $($runs.Count) runs passed"

--- a/.github/scripts/Tests/BuildScripts.Tests.ps1
+++ b/.github/scripts/Tests/BuildScripts.Tests.ps1
@@ -55,6 +55,16 @@ Describe "extracted build script decisions" {
                 $run.Arguments | Should -Contain "--max-late" -Because "$($run.Name) must refuse late blocks"
             }
         }
+        # The pipelined run over the real host process is timing-bound on a
+        # shared runner and gets more than one attempt; the deterministic
+        # runs get exactly one, so a regression in them cannot hide.
+        $pipelinedDll = $plan.Runs | Where-Object { $_.Name -eq "dll-daemon-exe-pipelined-float32-32" }
+        $pipelinedDll.Attempts | Should -BeGreaterThan 1
+        foreach ($run in $plan.Runs) {
+            if ($run.Arguments -contains "--max-late") {
+                ($run.PSObject.Properties["Attempts"]) | Should -BeNullOrEmpty -Because "$($run.Name) is deterministic"
+            }
+        }
     }
 
     It "lists the capture probes so every leg builds them" {


### PR DESCRIPTION
## 무엇을 하나

ASIO 프로브 게이트의 `dll-daemon-exe-pipelined-float32-32` 런이 2026-08-30 하루에 두 번(문서만 바꾼 커밋의 PR CI, v2.49.0 릴리스의 sse2 레그) 해시 불일치로 실패했고, 두 번 다 아무것도 바꾸지 않은 재실행에서 통과했습니다. 실제 호스트 프로세스와 pipelined 모드를 함께 쓰는 유일한 런이며, pipelined 모드는 설계상 늦은 주기를 미처리로 통과시키므로 공유 러너 부하에서 "첫 주기가 엔진의 첫 주기가 아님"이 됩니다.

단언은 그대로 두고 이 런에만 세 번의 시도를 줍니다. `--max-late 0`인 결정적 런들은 정확히 한 번만 돌아 회귀가 재시도 뒤에 숨지 못합니다. Pester가 이 구분을 고정합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)