### PR TITLE
ci(capture): gate the engine's small periods on the playback side with a convolution

### DIFF
--- a/.github/scripts/Invoke-CaptureGate.ps1
+++ b/.github/scripts/Invoke-CaptureGate.ps1
@@ -83,6 +83,21 @@ $installModes = @(
     [pscustomobject]@{ Name = "sfx-mfx"; Arguments = @("--install-mode", "sfx-mfx"); Required = $false }
     [pscustomobject]@{ Name = "lfx-gfx"; Arguments = @("--install-mode", "lfx-gfx"); Required = $false }
 )
+# The low-latency round (docs/architecture/wasapi-exclusive-study.md, section
+# 3): the APO on the cable's playback endpoint, a convolution in the config (a
+# unit impulse, so unity, but the one filter that notices the block length),
+# and the tone stream opened through IAudioClient3 at the engine's smallest
+# period, once fresh and once after a default-period stream already runs on
+# the endpoint, so the engine has to switch a running graph. A convolution
+# that goes silent there means the engine hands the post-mix APO blocks
+# shorter than the count it locked with. Skipped, and said so, when the
+# runner's cable declares no period below the default.
+$lowLatencyMeasurements = @(
+    [pscustomobject]@{ Name = "ll-default";         Category = "default"; Raw = $false; Period = "default"; HoldDefault = $false; ExpectGainDb = $PreampDb; ToleranceDb = $ToleranceDb; Required = $true; Note = "the convolution config at the default period" }
+    [pscustomobject]@{ Name = "ll-min";             Category = "default"; Raw = $false; Period = "min";     HoldDefault = $false; ExpectGainDb = $PreampDb; ToleranceDb = 3.0;          Required = $true; Note = "a fresh small-period stream reaches the convolution" }
+    [pscustomobject]@{ Name = "ll-min-switch";      Category = "default"; Raw = $false; Period = "min";     HoldDefault = $true;  ExpectGainDb = $PreampDb; ToleranceDb = 3.0;          Required = $true; Note = "the engine switches a running default-period graph to the small period" }
+    [pscustomobject]@{ Name = "ll-after-uninstall"; Category = "default"; Raw = $false; Period = "";        HoldDefault = $false; ExpectGainDb = 0.0;       ToleranceDb = 1.5;          Required = $true; Note = "the cable at unity after the playback-side uninstall" }
+)
 
 $plan = [pscustomobject]@{
     VbCableUrl = $VbCableUrl
@@ -92,6 +107,7 @@ $plan = [pscustomobject]@{
     PreampDb = $PreampDb
     Measurements = $measurements
     InstallModes = $installModes
+    LowLatency = $lowLatencyMeasurements
     StageRoot = $StageRoot
 }
 if ($PlanOnly) { return $plan }
@@ -114,6 +130,7 @@ $summary = [ordered]@{
     stage = $null
     apoHost = $null
     rounds = @()
+    lowLatency = $null
     measurements = @()
     failures = @()
 }
@@ -194,9 +211,9 @@ function Wait-CableEndpoints([int] $timeoutSeconds) {
     return $null
 }
 
-function Save-EndpointSnapshot([string] $captureGuid, [string] $phase) {
-    $keyPath = "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Capture\$captureGuid"
-    & reg export $keyPath (Join-Path $SnapshotDirectory "$phase-capture-endpoint.reg") /y | Out-Null
+function Save-EndpointSnapshot([string] $endpointGuid, [string] $phase, [string] $flow = "Capture") {
+    $keyPath = "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\$flow\$endpointGuid"
+    & reg export $keyPath (Join-Path $SnapshotDirectory "$phase-$($flow.ToLower())-endpoint.reg") /y | Out-Null
     & reg export "HKLM\SOFTWARE\EqualizerAPO" (Join-Path $SnapshotDirectory "$phase-equalizerapo.reg") /y 2>$null | Out-Null
     $global:LASTEXITCODE = 0
     $fx = Get-ItemProperty -Path "Registry::$keyPath\FxProperties" -ErrorAction SilentlyContinue
@@ -204,6 +221,53 @@ function Save-EndpointSnapshot([string] $captureGuid, [string] $phase) {
         $fx | Select-Object -Property * -ExcludeProperty PS* | ConvertTo-Json -Depth 3 |
             Out-File -FilePath (Join-Path $SnapshotDirectory "$phase-fxproperties.json") -Encoding utf8
     }
+}
+
+# 16-bit mono PCM, the first sample at full scale and the rest zero: the
+# identity for a convolution (-0.0003 dB), in a container libsndfile reads
+# without a codec.
+function Write-ImpulseWav([string] $path, [int] $rate, [int] $frames) {
+    $dataBytes = $frames * 2
+    $stream = [System.IO.File]::Create($path)
+    try {
+        $writer = New-Object System.IO.BinaryWriter($stream)
+        $writer.Write([byte[]][char[]]"RIFF"); $writer.Write([int32](36 + $dataBytes)); $writer.Write([byte[]][char[]]"WAVE")
+        $writer.Write([byte[]][char[]]"fmt "); $writer.Write([int32]16); $writer.Write([int16]1); $writer.Write([int16]1)
+        $writer.Write([int32]$rate); $writer.Write([int32]($rate * 2)); $writer.Write([int16]2); $writer.Write([int16]16)
+        $writer.Write([byte[]][char[]]"data"); $writer.Write([int32]$dataBytes)
+        $writer.Write([int16]32767)
+        for ($i = 1; $i -lt $frames; $i++) { $writer.Write([int16]0) }
+        $writer.Flush()
+    } finally {
+        $stream.Dispose()
+    }
+}
+
+# The effect chain an endpoint's FxProperties names, as "LFX=... GFX=...".
+function Get-EffectChain([string] $flow, [string] $endpointGuid) {
+    $fx = Get-ItemProperty -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\$flow\$endpointGuid\FxProperties" -ErrorAction SilentlyContinue
+    if (-not $fx) { return $null }
+    $slots = @()
+    foreach ($slot in @(@("LFX", "1"), @("GFX", "2"), @("SFX", "5"), @("MFX", "6"), @("EFX", "7"))) {
+        $property = $fx.PSObject.Properties["{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},$($slot[1])"]
+        if ($property -and $property.Value) { $slots += "$($slot[0])=$($property.Value)" }
+    }
+    return ($slots -join " ")
+}
+
+function Test-EqClsidLeft([string] $flow, [string] $endpointGuid) {
+    $fx = Get-ItemProperty -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\$flow\$endpointGuid\FxProperties" -ErrorAction SilentlyContinue
+    if (-not $fx) { return $false }
+    foreach ($property in $fx.PSObject.Properties) {
+        if ("$($property.Value)" -match "EACD2258-FCAC-4FF4-B36D-419E924A6D79|EC1CC9CE-FAED-4822-828A-82A81A6F018F") { return $true }
+    }
+    return $false
+}
+
+function Get-JsonField($json, [string] $name) {
+    if ($null -eq $json) { return $null }
+    $property = $json.PSObject.Properties[$name]
+    if ($property) { return $property.Value } else { return $null }
 }
 
 function Copy-Logs([string] $phase) {
@@ -225,6 +289,9 @@ function Measure-Cable($measurement, [string] $round = "") {
         "--tolerance-db", $measurement.ToleranceDb.ToString([cultureinfo]::InvariantCulture))
     if ($measurement.Category -ne "default") { $arguments += @("--category", $measurement.Category) }
     if ($measurement.Raw) { $arguments += "--raw" }
+    $period = if ($measurement.PSObject.Properties["Period"]) { [string]$measurement.Period } else { "" }
+    if ($period) { $arguments += @("--period", $period) }
+    if ($measurement.PSObject.Properties["HoldDefault"] -and $measurement.HoldDefault) { $arguments += "--hold-default" }
     $run = Invoke-Program $captureProbe $arguments 60
     $json = $null
     if ($run.StdOut) {
@@ -245,13 +312,32 @@ function Measure-Cable($measurement, [string] $round = "") {
         toneDb = if ($json) { $json.toneDb } else { $null }
         rmsDb = if ($json) { $json.rmsDb } else { $null }
         silentPackets = if ($json) { $json.silentPackets } else { $null }
+        rate = if ($json) { $json.rate } else { $null }
+        period = $period
+        renderPeriodFrames = Get-JsonField $json "renderPeriodFrames"
+        engineDefaultPeriodFrames = Get-JsonField $json "engineDefaultPeriodFrames"
+        engineMinPeriodFrames = Get-JsonField $json "engineMinPeriodFrames"
+        enginePeriodFrames = Get-JsonField $json "enginePeriodFrames"
+        holdEnginePeriodFrames = Get-JsonField $json "holdEnginePeriodFrames"
+        smallPeriodAvailable = $null
         passed = ($run.ExitCode -eq 0)
         note = $measurement.Note
     }
+    # A "min" request that came back at the default period says the driver
+    # declares no smaller one: nothing to judge, and the summary says so.
+    $noSmallPeriod = $false
+    if ($period -eq "min" -and $null -ne $record.engineMinPeriodFrames -and $null -ne $record.engineDefaultPeriodFrames) {
+        $record.smallPeriodAvailable = ([int]$record.engineMinPeriodFrames -lt [int]$record.engineDefaultPeriodFrames)
+        $noSmallPeriod = -not $record.smallPeriodAvailable
+        if ($noSmallPeriod) { $record.note = "$($measurement.Note); the driver declares no period below the default ($($record.engineDefaultPeriodFrames) frames), nothing to judge" }
+    }
     $summary.measurements += [pscustomobject]$record
-    $verdict = if ($record.passed) { "ok" } elseif ($measurement.Required) { "FAILED" } else { "noted" }
+    $verdict = if ($noSmallPeriod) { "skipped (no small period)" } elseif ($record.passed) { "ok" } elseif ($measurement.Required) { "FAILED" } else { "noted" }
     Write-Host ("measurement {0}: gain {1} dB (expected {2} +- {3}) -> {4}" -f $label, $record.gainDb, $measurement.ExpectGainDb, $measurement.ToleranceDb, $verdict)
-    if (-not $record.passed -and $measurement.Required -and $roundRequired) {
+    if ($period) {
+        Write-Host ("  playback period {0} frames (engine default {1}, min {2}); engine ran at {3}, held stream at {4}" -f $record.renderPeriodFrames, $record.engineDefaultPeriodFrames, $record.engineMinPeriodFrames, $record.enginePeriodFrames, $record.holdEnginePeriodFrames)
+    }
+    if (-not $record.passed -and $measurement.Required -and $roundRequired -and -not $noSmallPeriod) {
         Add-Failure ("{0}: the tone arrived at {1} dB, expected {2} +- {3} dB ({4})" -f $label, $record.gainDb, $measurement.ExpectGainDb, $measurement.ToleranceDb, $measurement.Note)
     }
     return $record
@@ -449,11 +535,66 @@ foreach ($mode in $installModes) {
 $roundRequired = $true
 
 # ---------------------------------------------------------------------------
+Write-Phase "low-latency: the playback endpoint, a convolution, the engine's smallest period"
+$baseline = $summary.measurements | Where-Object { $_.name -eq "baseline" } | Select-Object -First 1
+$impulseRate = if ($baseline -and $baseline.rate) { [int]$baseline.rate } else { 48000 }
+$impulse = Join-Path $configDir "gate-impulse.wav"
+Write-ImpulseWav $impulse $impulseRate 4096
+$lowLatencyConfig = "Preamp: $($PreampDb.ToString([cultureinfo]::InvariantCulture)) dB`r`nConvolution: gate-impulse.wav`r`n"
+[System.IO.File]::WriteAllText($configFile, $lowLatencyConfig, (New-Object System.Text.UTF8Encoding($false)))
+$lowLatency = [ordered]@{
+    config = $lowLatencyConfig.Trim()
+    impulseRate = $impulseRate
+    install = $null
+    installMode = $null
+    uninstall = $null
+    lockFrameCounts = @()
+    smallPeriodAvailable = $null
+}
+Write-Host "config now: $($lowLatencyConfig.Trim() -replace "`r`n", ' | ') (impulse at $impulseRate Hz)"
+
+$install = Invoke-Program (Join-Path $current "DeviceSelector.exe") @("--install-endpoint", $endpoints.Render) 300 $current
+$lowLatency.install = [ordered]@{ exitCode = $install.ExitCode; timedOut = $install.TimedOut }
+Save-EndpointSnapshot $endpoints.Render "60-low-latency-installed" "Render"
+$lowLatency.installMode = Get-EffectChain "Render" $endpoints.Render
+Write-Host "effect chain now (playback): $($lowLatency.installMode)"
+if ($install.ExitCode -ne 0) {
+    Add-Failure "low-latency/install: DeviceSelector --install-endpoint on the playback endpoint exited with $($install.ExitCode)"
+}
+Copy-Logs "60-low-latency-installed"
+
+Measure-Cable $lowLatencyMeasurements[0] "low-latency" | Out-Null
+Measure-Cable $lowLatencyMeasurements[1] "low-latency" | Out-Null
+Measure-Cable $lowLatencyMeasurements[2] "low-latency" | Out-Null
+Copy-Logs "70-low-latency-measured"
+# Every frame count the audio engine locked the DLL with, in order: the last
+# field of the trace line LockForProcess writes for its input connection.
+$apoLog = "C:\Windows\ServiceProfiles\LocalService\AppData\Local\Temp\EqualizerAPO.log"
+if (Test-Path -LiteralPath $apoLog) {
+    $lowLatency.lockFrameCounts = @(Select-String -LiteralPath $apoLog -Pattern "Input format in LockForProcess = \{.*, (\d+) \}" |
+        ForEach-Object { [int]$_.Matches[0].Groups[1].Value })
+}
+Write-Host "LockForProcess max frame counts, whole run: $($lowLatency.lockFrameCounts -join ' ')"
+$minRecord = $summary.measurements | Where-Object { $_.name -eq "low-latency/ll-min" } | Select-Object -First 1
+if ($minRecord) { $lowLatency.smallPeriodAvailable = $minRecord.smallPeriodAvailable }
+
+$uninstall = Invoke-Program (Join-Path $current "DeviceSelector.exe") @("--uninstall-endpoint", $endpoints.Render) 180 $current
+$eqLeftRender = Test-EqClsidLeft "Render" $endpoints.Render
+$lowLatency.uninstall = [ordered]@{ exitCode = $uninstall.ExitCode; eqClsidLeft = $eqLeftRender }
+Save-EndpointSnapshot $endpoints.Render "80-low-latency-uninstalled" "Render"
+if ($uninstall.ExitCode -ne 0) { Add-Failure "low-latency/uninstall: DeviceSelector --uninstall-endpoint on the playback endpoint exited with $($uninstall.ExitCode)" }
+if ($eqLeftRender) { Add-Failure "low-latency/uninstall: the playback endpoint's FxProperties still names an EQ APO CLSID" }
+Measure-Cable $lowLatencyMeasurements[3] "low-latency" | Out-Null
+Copy-Logs "80-low-latency-uninstalled"
+[System.IO.File]::WriteAllText($configFile, $config, (New-Object System.Text.UTF8Encoding($false)))
+$summary.lowLatency = [pscustomobject]$lowLatency
+
+# ---------------------------------------------------------------------------
 Write-Phase "summary"
 $summaryPath = Join-Path $SnapshotDirectory "capture-gate.json"
 [pscustomobject]$summary | ConvertTo-Json -Depth 6 | Out-File -FilePath $summaryPath -Encoding utf8
 $summary.rounds | Format-Table -AutoSize mode, installMode | Out-String | Write-Host
-$summary.measurements | Format-Table -AutoSize name, category, raw, expectGainDb, gainDb, passed, required | Out-String | Write-Host
+$summary.measurements | Format-Table -AutoSize name, category, raw, period, enginePeriodFrames, expectGainDb, gainDb, passed, required | Out-String | Write-Host
 if ($summary.failures.Count -gt 0) {
     Write-Host "capture gate FAILED:"
     $summary.failures | ForEach-Object { Write-Host "  - $_" }

--- a/.github/scripts/Tests/BuildScripts.Tests.ps1
+++ b/.github/scripts/Tests/BuildScripts.Tests.ps1
@@ -104,6 +104,21 @@ Describe "extracted build script decisions" {
         foreach ($named in @("sfx-efx", "sfx-mfx", "lfx-gfx")) {
             ($plan.InstallModes | Where-Object { $_.Name -eq $named }).Required | Should -BeFalse
         }
+        # The low-latency round: the playback side with a convolution in the
+        # config, the small period fresh and after a switch, both at the
+        # preamp and both gated (the script itself skips them, and says so,
+        # on a driver that declares no small period).
+        @($plan.LowLatency | ForEach-Object { $_.Name }) | Should -Be @("ll-default", "ll-min", "ll-min-switch", "ll-after-uninstall")
+        foreach ($name in @("ll-min", "ll-min-switch")) {
+            $m = $plan.LowLatency | Where-Object { $_.Name -eq $name }
+            $m.Period | Should -Be "min"
+            $m.ExpectGainDb | Should -Be $plan.PreampDb
+            $m.Required | Should -BeTrue
+        }
+        ($plan.LowLatency | Where-Object { $_.Name -eq "ll-min" }).HoldDefault | Should -BeFalse
+        ($plan.LowLatency | Where-Object { $_.Name -eq "ll-min-switch" }).HoldDefault | Should -BeTrue
+        ($plan.LowLatency | Where-Object { $_.Name -eq "ll-default" }).Period | Should -Be "default"
+        ($plan.LowLatency | Where-Object { $_.Name -eq "ll-after-uninstall" }).ExpectGainDb | Should -Be 0
     }
 
     It "builds only the two 32-bit ASIO DLLs for Win32" {

--- a/Tests/CaptureProbe/CaptureProbe.cpp
+++ b/Tests/CaptureProbe/CaptureProbe.cpp
@@ -60,6 +60,8 @@ struct Options
 	bool json = false;
 	bool list = false;
 	bool noRender = false;
+	std::wstring period;            // "", "default", "min" or a frame count: the playback stream's engine period
+	bool holdDefault = false;       // hold a silent default-period playback stream open before --period opens
 	bool haveExpectation = false;
 	double expectGainDb = 0.0;
 	double toleranceDb = 1.0;
@@ -75,6 +77,8 @@ void usage()
 		L"  --tone Hz --amp A         the sine played into the playback endpoint (1000, 0.5)\n"
 		L"  --category NAME           other|communications|speech|media|game-chat (stream category)\n"
 		L"  --raw                     ask for the raw signal processing mode\n"
+		L"  --period min|default|N    open the playback stream through IAudioClient3 at that engine period (frames)\n"
+		L"  --hold-default            first hold a silent playback stream at the default period, then open --period\n"
 		L"  --expect-gain-db X [--tolerance-db Y]  exit 2 unless tone gain is X +- Y\n"
 		L"  --json                    one JSON line on stdout\n"
 		L"Without --render/--capture the default endpoints are used.\n");
@@ -131,6 +135,10 @@ bool parse(int argc, wchar_t** argv, Options& o)
 		}
 		else if (a == L"--raw")
 			o.raw = true;
+		else if (a == L"--period" && next(v))
+			o.period = v;
+		else if (a == L"--hold-default")
+			o.holdDefault = true;
 		else if (a == L"--expect-gain-db" && next(v))
 		{
 			o.haveExpectation = true;
@@ -283,6 +291,90 @@ struct RenderJob
 	std::wstring failure;
 	unsigned rate = 0;
 	unsigned channels = 0;
+	std::wstring periodRequest;     // "", "default", "min" or frames (Options::period)
+	bool holdDefault = false;
+	unsigned defaultPeriod = 0;     // GetSharedModeEnginePeriod for the stream format, in frames
+	unsigned minPeriod = 0;
+	unsigned maxPeriod = 0;
+	unsigned requestedPeriod = 0;   // what InitializeSharedAudioStream was asked for; 0 = plain Initialize
+	unsigned enginePeriod = 0;      // GetCurrentSharedModeEnginePeriod once the tone stream runs
+	unsigned holdEnginePeriod = 0;  // the same while only the held default-period stream ran
+};
+
+unsigned currentEnginePeriod(IAudioClient* client)
+{
+	ComRelease<IAudioClient3> client3;
+	if (FAILED(client->QueryInterface(__uuidof(IAudioClient3), reinterpret_cast<void**>(&client3.p))))
+		return 0;
+	WAVEFORMATEX* format = nullptr;
+	UINT32 period = 0;
+	if (FAILED(client3.p->GetCurrentSharedModeEnginePeriod(&format, &period)))
+		return 0;
+	if (format)
+		CoTaskMemFree(format);
+	return period;
+}
+
+// A silent playback stream at the engine's default period, held open so
+// that a small-period stream opened afterwards makes the engine switch a
+// running graph instead of building a fresh one: the case a post-mix APO
+// locked at the default frame count has to survive.
+struct HeldStream
+{
+	ComRelease<IAudioClient> client;
+	ComRelease<IAudioRenderClient> render;
+	UINT32 bufferFrames = 0;
+
+	bool open(IMMDevice* device, const WAVEFORMATEXTENSIBLE& fmt, HRESULT& hr, std::wstring& failure)
+	{
+		hr = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr, reinterpret_cast<void**>(&client.p));
+		if (FAILED(hr))
+		{
+			failure = L"Activate(hold)";
+			return false;
+		}
+		hr = client.p->Initialize(AUDCLNT_SHAREMODE_SHARED,
+			AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+			2000000, 0, &fmt.Format, nullptr);
+		if (FAILED(hr))
+		{
+			failure = L"Initialize(hold)";
+			return false;
+		}
+		hr = client.p->GetService(__uuidof(IAudioRenderClient), reinterpret_cast<void**>(&render.p));
+		if (FAILED(hr))
+		{
+			failure = L"GetService(hold)";
+			return false;
+		}
+		client.p->GetBufferSize(&bufferFrames);
+		topUp();
+		hr = client.p->Start();
+		if (FAILED(hr))
+		{
+			failure = L"Start(hold)";
+			return false;
+		}
+		return true;
+	}
+
+	void topUp()
+	{
+		if (render.p == nullptr)
+			return;
+		UINT32 padding = 0;
+		if (FAILED(client.p->GetCurrentPadding(&padding)) || padding >= bufferFrames)
+			return;
+		BYTE* data = nullptr;
+		if (SUCCEEDED(render.p->GetBuffer(bufferFrames - padding, &data)))
+			render.p->ReleaseBuffer(bufferFrames - padding, AUDCLNT_BUFFERFLAGS_SILENT);
+	}
+
+	void stop()
+	{
+		if (client.p)
+			client.p->Stop();
+	}
 };
 
 void renderThread(RenderJob* job)
@@ -322,14 +414,84 @@ void renderThread(RenderJob* job)
 		CoTaskMemFree(mix);
 		job->rate = fmt.Format.nSamplesPerSec;
 		job->channels = fmt.Format.nChannels;
-		hr = client.p->Initialize(AUDCLNT_SHAREMODE_SHARED,
-			AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
-			2000000, 0, &fmt.Format, nullptr);
-		if (FAILED(hr))
+
+		HeldStream held;
+		if (job->holdDefault)
 		{
-			fail(L"Initialize(render)", hr);
-			CoUninitialize();
-			return;
+			std::wstring what;
+			if (!held.open(job->device, fmt, hr, what))
+			{
+				fail(what.c_str(), hr);
+				CoUninitialize();
+				return;
+			}
+			job->holdEnginePeriod = currentEnginePeriod(held.client.p);
+		}
+
+		HANDLE event = nullptr;
+		if (!job->periodRequest.empty())
+		{
+			ComRelease<IAudioClient3> client3;
+			hr = client.p->QueryInterface(__uuidof(IAudioClient3), reinterpret_cast<void**>(&client3.p));
+			if (FAILED(hr))
+			{
+				fail(L"QueryInterface(IAudioClient3)", hr);
+				held.stop();
+				CoUninitialize();
+				return;
+			}
+			UINT32 defaultPeriod = 0, fundamental = 0, minPeriod = 0, maxPeriod = 0;
+			hr = client3.p->GetSharedModeEnginePeriod(&fmt.Format, &defaultPeriod, &fundamental, &minPeriod, &maxPeriod);
+			if (FAILED(hr))
+			{
+				fail(L"GetSharedModeEnginePeriod", hr);
+				held.stop();
+				CoUninitialize();
+				return;
+			}
+			job->defaultPeriod = defaultPeriod;
+			job->minPeriod = minPeriod;
+			job->maxPeriod = maxPeriod;
+			UINT32 want = defaultPeriod;
+			if (job->periodRequest == L"min")
+				want = minPeriod;
+			else if (job->periodRequest != L"default")
+			{
+				want = (UINT32)_wtoi(job->periodRequest.c_str());
+				if (want < minPeriod)
+					want = minPeriod;
+				if (want > maxPeriod)
+					want = maxPeriod;
+				if (fundamental > 1)
+					want = ((want + fundamental - 1) / fundamental) * fundamental;
+			}
+			event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+			hr = client3.p->InitializeSharedAudioStream(AUDCLNT_STREAMFLAGS_EVENTCALLBACK, want, &fmt.Format, nullptr);
+			if (FAILED(hr))
+			{
+				fail(hr == AUDCLNT_E_ENGINE_PERIODICITY_LOCKED
+					? L"InitializeSharedAudioStream (another stream holds the engine at a different period)"
+					: L"InitializeSharedAudioStream", hr);
+				CloseHandle(event);
+				held.stop();
+				CoUninitialize();
+				return;
+			}
+			job->requestedPeriod = want;
+			client.p->SetEventHandle(event);
+		}
+		else
+		{
+			hr = client.p->Initialize(AUDCLNT_SHAREMODE_SHARED,
+				AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+				2000000, 0, &fmt.Format, nullptr);
+			if (FAILED(hr))
+			{
+				fail(L"Initialize(render)", hr);
+				held.stop();
+				CoUninitialize();
+				return;
+			}
 		}
 		UINT32 bufferFrames = 0;
 		client.p->GetBufferSize(&bufferFrames);
@@ -337,6 +499,9 @@ void renderThread(RenderJob* job)
 		if (FAILED(hr))
 		{
 			fail(L"GetService(IAudioRenderClient)", hr);
+			if (event)
+				CloseHandle(event);
+			held.stop();
 			CoUninitialize();
 			return;
 		}
@@ -357,26 +522,41 @@ void renderThread(RenderJob* job)
 			return true;
 		};
 
+		// A small period leaves a few milliseconds per wake-up; the tone
+		// thread must not lose them to a busy runner.
+		if (event)
+			SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
 		fill(bufferFrames);
 		hr = client.p->Start();
 		if (FAILED(hr))
 		{
 			fail(L"Start(render)", hr);
+			if (event)
+				CloseHandle(event);
+			held.stop();
 			CoUninitialize();
 			return;
 		}
+		job->enginePeriod = currentEnginePeriod(client.p);
 		job->started = true;
 		while (!job->stop)
 		{
+			if (event)
+				WaitForSingleObject(event, 1000);
+			else
+				Sleep(5);
 			UINT32 padding = 0;
 			if (FAILED(client.p->GetCurrentPadding(&padding)))
 				break;
 			const UINT32 available = bufferFrames - padding;
 			if (available > 0 && !fill(available))
 				break;
-			Sleep(5);
+			held.topUp();
 		}
 		client.p->Stop();
+		held.stop();
+		if (event)
+			CloseHandle(event);
 	}
 	CoUninitialize();
 }
@@ -527,6 +707,8 @@ int wmain(int argc, wchar_t** argv)
 			job.device = render.p;
 			job.tone = o.tone;
 			job.amplitude = o.amplitude;
+			job.periodRequest = o.period;
+			job.holdDefault = o.holdDefault;
 			renderer = std::thread(renderThread, &job);
 			while (!job.started)
 				Sleep(5);
@@ -639,9 +821,12 @@ int wmain(int argc, wchar_t** argv)
 			if (o.json)
 			{
 				printf("{\"capture\":\"%ls\",\"render\":\"%ls\",\"category\":\"%ls\",\"raw\":%s,\"rate\":%u,\"channels\":%u,"
-					"\"frames\":%llu,\"silentPackets\":%llu,\"rmsDb\":[",
+					"\"frames\":%llu,\"silentPackets\":%llu,"
+					"\"renderRate\":%u,\"renderPeriodFrames\":%u,\"engineDefaultPeriodFrames\":%u,\"engineMinPeriodFrames\":%u,"
+					"\"enginePeriodFrames\":%u,\"holdEnginePeriodFrames\":%u,\"rmsDb\":[",
 					captureLabel.c_str(), renderLabel.c_str(), o.categoryName.c_str(), o.raw ? "true" : "false",
-					rate, channels, counted, silentPackets);
+					rate, channels, counted, silentPackets,
+					job.rate, job.requestedPeriod, job.defaultPeriod, job.minPeriod, job.enginePeriod, job.holdEnginePeriod);
 				for (unsigned c = 0; c < channels; c++)
 					printf("%s%.2f", c ? "," : "", rmsDb[c]);
 				printf("],\"toneDb\":%.2f,\"expectedToneDb\":%.2f,\"gainDb\":%.2f}\n", toneDb, expectedToneDb, gainDb);
@@ -654,6 +839,10 @@ int wmain(int argc, wchar_t** argv)
 				for (unsigned c = 0; c < channels; c++)
 					printf(" %.2f", rmsDb[c]);
 				printf("\ntone %.0f Hz: %.2f dBFS, played at %.2f dBFS -> gain %.2f dB\n", o.tone, toneDb, expectedToneDb, gainDb);
+				if (job.requestedPeriod != 0)
+					printf("playback period %u frames at %u Hz (engine default %u, min %u); the engine ran at %u%s\n",
+						job.requestedPeriod, job.rate, job.defaultPeriod, job.minPeriod, job.enginePeriod,
+						job.holdDefault ? " after a held default-period stream" : "");
 			}
 			result = 0;
 			if (o.haveExpectation && std::fabs(gainDb - o.expectGainDb) > o.toleranceDb)

--- a/docs/features/capture.md
+++ b/docs/features/capture.md
@@ -96,3 +96,31 @@ does. On such a machine, `ApoHostProbe` against the microphone's GUID
 tells whether the DLL processes for it, and `CaptureProbe --capture
 "<microphone>"` with a tone played into the room tells whether the audio
 engine runs it.
+
+## The low-latency round
+
+The same gate has a round for the playback side and the engine's small
+buffers (`docs/architecture/wasapi-exclusive-study.md`, section 3). A
+low-latency application (a game, a DAW, a voice-chat app) asks for a small
+period through `IAudioClient3`, and every stream on that endpoint and mode
+moves to it; the APO stays in the path and simply gets shorter blocks. The
+one filter that notices is the convolution, which processes at the block
+length it was locked with and goes silent on any other. So the round puts a
+unit impulse (`gate-impulse.wav`, unity) behind the preamp, installs the APO
+on `CABLE Input`, and measures three ways with `CaptureProbe --period`:
+
+- `ll-default`: the convolution config at the default period, the reference.
+- `ll-min`: a fresh tone stream at the smallest period the driver declares.
+- `ll-min-switch`: a silent default-period stream is held open first
+  (`--hold-default`), then the small-period stream starts, so the engine has
+  to switch a running graph with a post-mix APO already locked at the
+  default count.
+
+Each is expected at the preamp. Silence in either small-period measurement
+means the engine hands the post-mix APO blocks shorter than the count it
+locked with, and the convolution needs to be made independent of the block
+length. The probe's JSON carries the engine's default and minimum periods
+and the period it actually ran at; the summary lists every `LockForProcess`
+frame count the DLL traced during the run. On a driver that declares no
+period below the default the two small-period measurements are recorded as
+skipped, not failed.


### PR DESCRIPTION
## What

The one thing the WASAPI study (#323) could not settle locally: when a low-latency application moves an endpoint to a small engine period, does the post-mix APO get re-locked, or does it receive blocks shorter than the count it locked with? Only the convolution filter can tell (it processes at the locked length and goes silent on any other), so this round puts a unit-impulse convolution behind the preamp and measures the cable's playback side at the default period, at the smallest period fresh, and at the smallest period after a running default-period stream is switched.

- `Tests/CaptureProbe`: `--period min|default|N` opens the tone stream through `IAudioClient3::InitializeSharedAudioStream` (event driven); `--hold-default` holds a silent default-period stream open first. The JSON reports the engine's default, minimum and actual periods.
- `Invoke-CaptureGate.ps1`: the `low-latency` round (`ll-default`, `ll-min`, `ll-min-switch`, `ll-after-uninstall`), the impulse file, the playback-side install/uninstall, and every `LockForProcess` frame count the DLL traced. A driver that declares no small period makes the two small-period measurements skipped, not failed.
- Pester pins the plan; `docs/features/capture.md` describes the round.

## Local check

On the maintainer's VB-CABLE (min 96 frames): `--period min` ran the engine at 96, `--hold-default` showed the held stream at 480 and the engine at 96 afterwards, 0 silent packets. The APO on that cable carries an all-commented config, so the convolution judgement itself comes from this PR's gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
