### PR TITLE
ci(capture): measure the ASIO entry once the probe reports a running stream

### DIFF
--- a/.github/scripts/Invoke-CaptureGate.ps1
+++ b/.github/scripts/Invoke-CaptureGate.ps1
@@ -654,10 +654,24 @@ if (-not (Test-Path -LiteralPath $asioProbe)) {
             Write-Host "-- $frames frames"
             $probeOut = [System.IO.Path]::GetTempFileName()
             $probeErr = [System.IO.Path]::GetTempFileName()
-            $probeProcess = Start-Process -FilePath $asioProbe -ArgumentList @("--target", "clsid:$($asioEntry.wrapperClsid)", "--wrapper", "static", "--processor", "passthrough", "--seconds", "14", "--sine", "1000", "--rate", "$impulseRate", "--frames", "$frames") -PassThru -NoNewWindow -RedirectStandardOutput $probeOut -RedirectStandardError $probeErr -WorkingDirectory $current
-            Start-Sleep -Seconds 4
+            $probeProcess = Start-Process -FilePath $asioProbe -ArgumentList @("--target", "clsid:$($asioEntry.wrapperClsid)", "--wrapper", "static", "--processor", "passthrough", "--seconds", "25", "--sine", "1000", "--rate", "$impulseRate", "--frames", "$frames") -PassThru -NoNewWindow -RedirectStandardOutput $probeOut -RedirectStandardError $probeErr -WorkingDirectory $current
+            # Measure only once the stream runs: the probe prints its latency
+            # line after createBuffers and start succeeded. The first probe
+            # starts the engine host cold, which on a busy runner took long
+            # enough for a fixed wait to open the window before the tone
+            # (-23.6 dB read once for that reason, 2405 switches all the same).
+            $deadline = (Get-Date).AddSeconds(40)
+            $streaming = $false
+            while ((Get-Date) -lt $deadline -and -not $probeProcess.HasExited) {
+                $soFar = Get-Content -LiteralPath $probeOut -Raw -ErrorAction SilentlyContinue
+                if ($soFar -and $soFar -match "latency input=") { $streaming = $true; break }
+                Start-Sleep -Milliseconds 250
+            }
+            if (-not $streaming) { Write-Host "the probe did not report a running stream within 40 s" }
+            # The bridge calibration (a dozen events) and its reopen, then settle.
+            Start-Sleep -Seconds 2
             $record = Measure-Cable ([pscustomobject]@{ Name = $name; Category = "default"; Raw = $false; ExpectGainDb = $asioEntryMeasurement.ExpectGainDb; ToleranceDb = $asioEntryMeasurement.ToleranceDb; Required = $required; Note = "$($asioEntryMeasurement.Note) ($frames frames)"; NoRender = $true }) "asio-entry"
-            $probeProcess.WaitForExit(30000) | Out-Null
+            $probeProcess.WaitForExit(45000) | Out-Null
             if (-not $probeProcess.HasExited) { try { $probeProcess.Kill() } catch {} }
             $probeText = (Get-Content -LiteralPath $probeOut -Raw -ErrorAction SilentlyContinue) + (Get-Content -LiteralPath $probeErr -Raw -ErrorAction SilentlyContinue)
             Remove-Item -LiteralPath $probeOut, $probeErr -Force -ErrorAction SilentlyContinue

--- a/Tests/AsioProbe/AsioProbe.cpp
+++ b/Tests/AsioProbe/AsioProbe.cpp
@@ -547,6 +547,9 @@ namespace
 		long inputLatency = 0, outputLatency = 0;
 		wrapper->getLatencies(&inputLatency, &outputLatency);
 		std::printf("latency input=%ld output=%ld frames\n", inputLatency, outputLatency);
+		// The gate waits for this line before it measures; with stdout in a
+		// file the CRT would otherwise hold it until exit.
+		std::fflush(stdout);
 		error = wrapper->start();
 		if (error != ASE_OK)
 		{


### PR DESCRIPTION
The v2.50.1 release run's capture gate read -23.6 dB on the 256-frame ASIO-entry measurement while the PR run read -20.0 dB with the identical 2405 switches: the window opened before the cold-started engine host had the stream running. The gate now waits for the probe's `latency` line (flushed as soon as createBuffers and start succeed), allows the bridge calibration, then measures; the probe runs 25 s. CI only; the release itself was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)