### PR TITLE
refactor: sweep the tree onto the C++20 vocabulary

### DIFF
--- a/Benchmark/Benchmark.cpp
+++ b/Benchmark/Benchmark.cpp
@@ -30,8 +30,8 @@
 #include <fstream>
 #include <algorithm>
 #include <numeric>
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <numbers>
 #include <string>
 #include <vector>
 #include <tclap/CmdLine.h>
@@ -155,7 +155,7 @@ int main(int argc, char** argv)
 			for (unsigned i = 0; i < frameCount; i++)
 			{
 				double t = i * 1.0 / sampleRate;
-				float s = static_cast<float>(sin(((sweepFrom + sweepDiff * (t / length) / 2) * t) * 2 * M_PI));
+				float s = static_cast<float>(sin(((sweepFrom + sweepDiff * (t / length) / 2) * t) * 2 * std::numbers::pi_v<double>));
 
 				for (unsigned j = 0; j < channelCount; j++)
 					buf[i * channelCount + j] = s;

--- a/DeviceSelector/skins/StudioDeviceSkin.cpp
+++ b/DeviceSelector/skins/StudioDeviceSkin.cpp
@@ -26,6 +26,7 @@
 #include <QLinearGradient>
 #include <QPainterPath>
 #include <QtMath>
+#include <numbers>
 
 #include "Editor/skins/shared/SkinPaint.h"
 
@@ -288,7 +289,7 @@ public:
 		{
 			const double bandW = slab.width() * 0.32;
 			const double bandX = slab.left() - bandW + s.hover * (slab.width() + 2.0 * bandW);
-			const int gleam = qRound(qSin(M_PI * s.hover) * (dark ? 30 : 16));
+			const int gleam = qRound(qSin(std::numbers::pi_v<double> * s.hover) * (dark ? 30 : 16));
 			const QColor ray = dark ? QColor(255, 255, 255) : accent;
 			QLinearGradient sweep(QPointF(bandX - bandW * 0.5, slab.top()), QPointF(bandX + bandW * 0.5, slab.bottom()));
 			sweep.setColorAt(0.0, withAlpha(ray, 0));

--- a/Editor/SkinGallery.cpp
+++ b/Editor/SkinGallery.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "SkinGallery.h"
+#include <numbers>
 // For the two gates moved out of main.cpp (audit #275 B7): the VST
 // round-trip self test and the analysis layout probe.
 #include <optional>
@@ -767,11 +768,6 @@ std::shared_ptr<const AnalysisResponse> galleryAnalysisResponse()
 // coefficients. Flat in magnitude by construction, so it is the fixture that
 // makes the phase and group-delay shots show something a magnitude plot cannot:
 // a full turn of phase around 1 kHz and a delay peak sitting on it.
-// Spelled out rather than reached for through M_PI, which only exists when
-// _USE_MATH_DEFINES was defined before the first header that pulls math.h in -
-// an ordering constraint no translation unit this large should have to keep.
-constexpr double Pi = 3.14159265358979323846;
-
 std::shared_ptr<const AnalysisResponse> galleryAllPassResponse()
 {
 	auto response = std::make_shared<AnalysisResponse>();
@@ -785,7 +781,7 @@ std::shared_ptr<const AnalysisResponse> galleryAllPassResponse()
 	biquad.getCoefficients(packed, b0);
 	for (size_t i = 0; i < response->bins.size(); i++)
 	{
-		const double omega = 2.0 * Pi * response->frequencyOf(i) / response->sampleRate;
+		const double omega = 2.0 * std::numbers::pi_v<double> * response->frequencyOf(i) / response->sampleRate;
 		const std::complex<double> z1 = std::polar(1.0, -omega);
 		const std::complex<double> z2 = z1 * z1;
 		response->bins[i] = (b0 + packed[0] * z1 + packed[1] * z2)

--- a/Editor/analysis/ResponseCurveBuilder.cpp
+++ b/Editor/analysis/ResponseCurveBuilder.cpp
@@ -4,14 +4,12 @@
 	SPDX-License-Identifier: GPL-2.0-or-later
 */
 
-// Before anything that reaches <math.h>: M_PI is only declared when this is
-// defined at the point math.h is first processed.
-#define _USE_MATH_DEFINES
 
 #include "ResponseCurveBuilder.h"
 
 #include <algorithm>
 #include <cmath>
+#include <numbers>
 #include <limits>
 
 #include <QtGlobal>
@@ -109,10 +107,10 @@ BinSeries unwrappedPhase(const AnalysisResponse& response, bool includeLatency)
 		if (continuing)
 		{
 			const double step = raw - previousRaw;
-			if (step > M_PI)
-				offset -= 2.0 * M_PI;
-			else if (step < -M_PI)
-				offset += 2.0 * M_PI;
+			if (step > std::numbers::pi_v<double>)
+				offset -= 2.0 * std::numbers::pi_v<double>;
+			else if (step < -std::numbers::pi_v<double>)
+				offset += 2.0 * std::numbers::pi_v<double>;
 		}
 		else
 		{
@@ -123,7 +121,7 @@ BinSeries unwrappedPhase(const AnalysisResponse& response, bool includeLatency)
 		}
 		double value = raw + offset;
 		if (includeLatency)
-			value -= 2.0 * M_PI * response.frequencyOf(static_cast<size_t>(i)) * latency;
+			value -= 2.0 * std::numbers::pi_v<double> * response.frequencyOf(static_cast<size_t>(i)) * latency;
 		series.values[i] = value;
 		series.valid[i] = true;
 		previousRaw = raw;
@@ -166,7 +164,7 @@ BinSeries groupDelayMs(const AnalysisResponse& response, const BinSeries& phase)
 		if (!usable)
 			continue;
 		const double slope = (phase.values[right] - phase.values[left]) / ((right - left) * binHz);
-		series.values[i] = -slope / (2.0 * M_PI) * 1000.0;
+		series.values[i] = -slope / (2.0 * std::numbers::pi_v<double>) * 1000.0;
 		series.valid[i] = true;
 	}
 	return series;
@@ -471,7 +469,7 @@ AnalysisCurve buildAnalysisCurve(const AnalysisResponse& response, const Analysi
 		{
 			series = phase;
 			for (int i = 0; i < binCount; i++)
-				series.values[i] *= 180.0 / M_PI;
+				series.values[i] *= 180.0 / std::numbers::pi_v<double>;
 		}
 		else
 		{

--- a/Editor/guis/BiQuadFilterGUI.cpp
+++ b/Editor/guis/BiQuadFilterGUI.cpp
@@ -17,8 +17,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <numbers>
 #include <QStandardItemModel>
 
 #include "Editor/guis/BiQuadWidthConversion.h"
@@ -82,7 +82,7 @@ BiQuadFilterGUI::BiQuadFilterGUI(const BiQuadCommand& command)
 	if (type == BiQuad::PEAKING)
 		ui->qComboBox->setCurrentIndex(command.isBandwidthOrS ? 1 : 0);
 	else if (type == BiQuad::LOW_PASS || type == BiQuad::HIGH_PASS || type == BiQuad::BAND_PASS)
-		ui->qComboBox->setCurrentIndex(command.bandwidthOrQOrS == M_SQRT1_2 ? 0 : 1);
+		ui->qComboBox->setCurrentIndex(command.bandwidthOrQOrS == std::numbers::sqrt2_v<double> / 2.0 ? 0 : 1);
 	else if ((type == BiQuad::LOW_SHELF || type == BiQuad::HIGH_SHELF))
 		ui->qComboBox->setCurrentIndex(command.isBandwidthOrS ? (command.bandwidthOrQOrS == 0.9 || command.isCornerFreq ? 0 : 1) : (command.isCornerFreq ? 1 : 2));
 	else if (type == BiQuad::NOTCH)
@@ -334,7 +334,7 @@ void BiQuadFilterGUI::on_qComboBox_currentIndexChanged(int index)
 	{
 		BiQuad::Type type = (BiQuad::Type)ui->typeComboBox->currentData().toInt();
 		if (type == BiQuad::LOW_PASS || type == BiQuad::HIGH_PASS || type == BiQuad::BAND_PASS)
-			ui->qSpinBox->setValue(M_SQRT1_2);
+			ui->qSpinBox->setValue(std::numbers::sqrt2_v<double> / 2.0);
 		else if (type == BiQuad::LOW_SHELF || type == BiQuad::HIGH_SHELF)
 			ui->qSpinBox->setValue(0.9);
 		else if (type == BiQuad::NOTCH)

--- a/Editor/guis/BiQuadWidthConversion.cpp
+++ b/Editor/guis/BiQuadWidthConversion.cpp
@@ -4,11 +4,11 @@
 	SPDX-License-Identifier: GPL-2.0-or-later
 */
 
-#define _USE_MATH_DEFINES
 
 #include "BiQuadWidthConversion.h"
 
 #include <cmath>
+#include <numbers>
 
 namespace BiQuadWidth
 {
@@ -16,7 +16,7 @@ double bandwidthFromQ(double q)
 {
 	if (!(q > 0.0) || !std::isfinite(q))
 		return 0.0;
-	return 2.0 / M_LN2 * std::asinh(1.0 / (2.0 * q));
+	return 2.0 / std::numbers::ln2_v<double> * std::asinh(1.0 / (2.0 * q));
 }
 
 double qFromBandwidth(double octaves)
@@ -39,19 +39,19 @@ double defaultQ(BiQuad::Type type)
 	switch (type)
 	{
 	case BiQuad::ALL_PASS:
-		return M_SQRT1_2;
+		return std::numbers::sqrt2_v<double> / 2.0;
 	case BiQuad::PEAKING:
 		return 10.0;
 	case BiQuad::LOW_PASS:
 	case BiQuad::HIGH_PASS:
 	case BiQuad::BAND_PASS:
-		return M_SQRT1_2;
+		return std::numbers::sqrt2_v<double> / 2.0;
 	case BiQuad::NOTCH:
 		return 30.0;
 	case BiQuad::LOW_SHELF:
 	case BiQuad::HIGH_SHELF:
 		return 0.9;
 	}
-	return M_SQRT1_2;
+	return std::numbers::sqrt2_v<double> / 2.0;
 }
 }

--- a/Editor/guis/ChannelFilterGUIDialog.cpp
+++ b/Editor/guis/ChannelFilterGUIDialog.cpp
@@ -87,7 +87,7 @@ ChannelFilterGUIDialog::ChannelFilterGUIDialog(QWidget* parent, const QStringLis
 		{
 			channelIndex++;
 			bool checked = false;
-			remainingChannelNames.erase(remove(remainingChannelNames.begin(), remainingChannelNames.end(), channelName.toStdWString()), remainingChannelNames.end());
+			std::erase(remainingChannelNames, channelName.toStdWString());
 			if (remainingSelectedChannels.removeOne(channelName))
 				checked = true;
 			else if (channelName == "LFE" && remainingSelectedChannels.removeOne("SUB"))

--- a/Editor/guis/CopyFilterGUIForm.cpp
+++ b/Editor/guis/CopyFilterGUIForm.cpp
@@ -193,9 +193,9 @@ vector<Assignment> CopyFilterGUIForm::buildAssignments(QWidget* pressedButton)
 	}
 
 	// remove empty assignments (can be caused by remove button)
-	assignments.erase(remove_if(assignments.begin(), assignments.end(), [](Assignment assignment) {
+	std::erase_if(assignments, [](Assignment assignment) {
 		return assignment.sourceSum.empty();
-	}), assignments.end());
+	});
 
 	return assignments;
 }

--- a/Editor/guis/VSTPluginFilterGUI.cpp
+++ b/Editor/guis/VSTPluginFilterGUI.cpp
@@ -44,13 +44,10 @@
 #include "VSTPluginFilterGUI.h"
 #include "ui_VSTPluginFilterGUI.h"
 
-using std::bind;
 using std::replace;
 using std::string;
 using std::unordered_map;
 using std::wstring;
-using std::placeholders::_1;
-using std::placeholders::_2;
 
 VSTPluginFilterGUI::VSTPluginFilterGUI(std::shared_ptr<VSTPluginLibrary> library, const std::wstring& chunkData, const std::unordered_map<std::wstring, float>& paramMap,
 	bool stereoInput, const std::optional<VST3BusContract>& busContract,
@@ -440,7 +437,7 @@ void VSTPluginFilterGUI::initPlugin()
 			if (effect->initialize())
 			{
 				effect->setLanguage(QLocale().language() == QLocale::German ? 2 : 1);
-				effect->setAutomateFunc(bind(&VSTPluginFilterGUI::onAutomate, this));
+				effect->setAutomateFunc([this]() { onAutomate(); });
 
 				color = Qt::black;
 				text = QString::fromStdWString(effect->getName());
@@ -551,7 +548,7 @@ void VSTPluginFilterGUI::on_embedAction_toggled(bool checked)
 
 			if (embedPlugin())
 			{
-				effect->setSizeWindowFunc(bind(&VSTPluginFilterGUI::onSizeWindow, this, _1, _2));
+				effect->setSizeWindowFunc([this](int width, int height) { onSizeWindow(width, height); });
 				connect(QAbstractEventDispatcher::instance(), SIGNAL(aboutToBlock()), SLOT(on_idle()));
 			}
 			else

--- a/Editor/guis/VSTPluginFilterGUIDialog.cpp
+++ b/Editor/guis/VSTPluginFilterGUIDialog.cpp
@@ -21,10 +21,6 @@
 #include "VSTPluginFilterGUIDialog.h"
 #include "ui_VSTPluginFilterGUIDialog.h"
 
-using std::bind;
-using std::placeholders::_1;
-using std::placeholders::_2;
-
 VSTPluginFilterGUIDialog::VSTPluginFilterGUIDialog(QWidget* parent, VSTPluginInstance* effect, bool autoApply)
 	: QDialog(parent, Qt::WindowCloseButtonHint),
 	ui(std::make_unique<Ui::VSTPluginFilterGUIDialog>()),
@@ -46,7 +42,7 @@ VSTPluginFilterGUIDialog::VSTPluginFilterGUIDialog(QWidget* parent, VSTPluginIns
 	effect->startEditing(hwnd, &width, &height, scaleFactor);
 
 	ui->frame->setFixedSize(width, height);
-	effect->setSizeWindowFunc(bind(&VSTPluginFilterGUIDialog::onSizeWindow, this, _1, _2));
+	effect->setSizeWindowFunc([this](int width, int height) { onSizeWindow(width, height); });
 }
 
 VSTPluginFilterGUIDialog::~VSTPluginFilterGUIDialog()

--- a/Editor/widgets/FilterListModel.cpp
+++ b/Editor/widgets/FilterListModel.cpp
@@ -149,9 +149,9 @@ void FilterListModel::removeItems(const QSet<FilterListItem*>& itemsToRemove)
 	selectedSet.swap(newSelectedSet);
 	focusedItem = newFocusedItem;
 	selectionStartItem = newSelectionStartItem;
-	ownedItems.erase(std::remove_if(ownedItems.begin(), ownedItems.end(), [&itemsToRemove](const auto& ownedItem) {
+	std::erase_if(ownedItems, [&itemsToRemove](const auto& ownedItem) {
 		return itemsToRemove.contains(ownedItem.get());
-	}), ownedItems.end());
+	});
 }
 
 QList<FilterListItem*> FilterListModel::insertLines(const QStringList& lines, const QList<QVariantMap>& prefsList, int dropRow)
@@ -281,9 +281,9 @@ void FilterListModel::deleteSelected()
 	itemList.swap(newItemList);
 	focusedItem = newFocusedItem;
 	selectionStartItem = newSelectionStartItem;
-	ownedItems.erase(std::remove_if(ownedItems.begin(), ownedItems.end(), [&removedItems](const auto& ownedItem) {
+	std::erase_if(ownedItems, [&removedItems](const auto& ownedItem) {
 		return removedItems.contains(ownedItem.get());
-	}), ownedItems.end());
+	});
 }
 
 void FilterListModel::selectOnly(FilterListItem* item)

--- a/Editor/widgets/routing/SubwooferRoutingRoutingAdapter.cpp
+++ b/Editor/widgets/routing/SubwooferRoutingRoutingAdapter.cpp
@@ -228,7 +228,7 @@ void SubwooferRoutingRoutingAdapter::applyBassSendAssignments(
 		const std::optional<std::string> target =
 			fromWideId(assignment.targetChannel);
 		if (!target.has_value()
-			|| bassPathIds.find(*target) == bassPathIds.end())
+			|| !bassPathIds.contains(*target))
 		{
 			continue;
 		}
@@ -245,7 +245,7 @@ void SubwooferRoutingRoutingAdapter::applyBassSendAssignments(
 			const std::optional<std::string> source =
 				fromWideId(summand.channel);
 			if (!source.has_value()
-				|| groups.find(*source) == groups.end())
+				|| !groups.contains(*source))
 			{
 				continue;
 			}
@@ -401,7 +401,7 @@ void SubwooferRoutingRoutingAdapter::applyOutputAssignments(
 		const std::optional<std::string> target =
 			fromWideId(assignment.targetChannel);
 		if (!target.has_value()
-			|| physicalChannels.find(*target) == physicalChannels.end()
+			|| !physicalChannels.contains(*target)
 			|| !seenTargets.insert(*target).second)
 		{
 			continue;
@@ -418,7 +418,7 @@ void SubwooferRoutingRoutingAdapter::applyOutputAssignments(
 				assignmentFactorToDb(summand);
 
 			if (!source.has_value() || !gainDb.has_value()
-				|| pathIds.find(*source) == pathIds.end())
+				|| !pathIds.contains(*source))
 			{
 				continue;
 			}
@@ -445,7 +445,7 @@ void SubwooferRoutingRoutingAdapter::applyOutputAssignments(
 
 	for (const EditedOutput& edited : editedOutputs)
 	{
-		if (existingTargets.find(edited.target) != existingTargets.end())
+		if (existingTargets.contains(edited.target))
 			continue;
 
 		subroute::OutputMatrixEntry output;

--- a/Editor/widgets/subwooferrouting/SubwooferRoutingResponseView.cpp
+++ b/Editor/widgets/subwooferrouting/SubwooferRoutingResponseView.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "SubwooferRoutingResponseView.h"
+#include <numbers>
 
 #include <algorithm>
 #include <cmath>
@@ -63,7 +64,7 @@ double biquadMagnitude(
 	double sampleRate)
 {
 	const double omega =
-		2.0 * 3.14159265358979323846 * frequencyHz / sampleRate;
+		2.0 * std::numbers::pi_v<double> * frequencyHz / sampleRate;
 	const std::complex<double> z1 =
 		std::exp(std::complex<double>(0.0, -omega));
 	const std::complex<double> z2 = z1 * z1;

--- a/Installer/AutoInstallerLogic.cpp
+++ b/Installer/AutoInstallerLogic.cpp
@@ -106,7 +106,7 @@ std::wstring expectedHashFromChecksums(const std::string& text, const std::wstri
 
 	// Skip a UTF-8 byte order mark, in case the generator wrote one.
 	size_t lineStart = 0;
-	if (text.size() >= 3 && text.compare(0, 3, "\xEF\xBB\xBF") == 0)
+	if (text.starts_with("\xEF\xBB\xBF"))
 		lineStart = 3;
 
 	while (lineStart < text.size())

--- a/Installer/InstallerWindow.cpp
+++ b/Installer/InstallerWindow.cpp
@@ -10,6 +10,7 @@
 */
 
 #include "InstallerWindow.h"
+#include <numbers>
 
 #include <d2d1.h>
 #include <dwrite.h>
@@ -180,8 +181,8 @@ void drawSpinner(const RenderContext& ctx, D2D1_POINT_2F center, float radius,
 	brush->SetColor(kColorBarTrack);
 	ctx.target->DrawEllipse(D2D1::Ellipse(center, radius, radius), brush, 1.8f);
 
-	const float startAngle = ctx.animPhase * 2.0f * 3.14159265f;
-	const float sweep = 0.55f * 3.14159265f;
+	const float startAngle = ctx.animPhase * 2.0f * std::numbers::pi_v<float>;
+	const float sweep = 0.55f * std::numbers::pi_v<float>;
 	const D2D1_POINT_2F start = D2D1::Point2F(
 		center.x + radius * std::cos(startAngle), center.y + radius * std::sin(startAngle));
 	const D2D1_POINT_2F end = D2D1::Point2F(

--- a/SubwooferRoutingCore/src/Compiler.cpp
+++ b/SubwooferRoutingCore/src/Compiler.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "SubwooferRouting/Compiler.h"
+#include <numbers>
 
 #include <algorithm>
 #include <cmath>
@@ -20,7 +21,6 @@ namespace subroute
 namespace
 {
 
-constexpr double kPi = 3.141592653589793238462643383279502884;
 constexpr double kMaximumDelaySeconds = 10.0;
 
 void addDiagnostic(
@@ -348,7 +348,7 @@ BiquadCoefficients makeBiquad(
 	const BiquadFilter& filter,
 	double sampleRate)
 {
-	const double omega = 2.0 * kPi * filter.frequencyHz / sampleRate;
+	const double omega = 2.0 * std::numbers::pi_v<double> * filter.frequencyHz / sampleRate;
 	const double cosine = std::cos(omega);
 	const double sine = std::sin(omega);
 	const double amplitude = std::pow(10.0, filter.gainDb / 40.0);
@@ -589,7 +589,7 @@ std::complex<double> evaluatePathResponse(
 	double frequencyHz,
 	double sampleRate)
 {
-	const double omega = 2.0 * kPi * frequencyHz / sampleRate;
+	const double omega = 2.0 * std::numbers::pi_v<double> * frequencyHz / sampleRate;
 	std::complex<double> response(1.0, 0.0);
 
 	for (const CompiledStage& stage : path.stages)
@@ -955,8 +955,7 @@ ValidationResult validate(const SubwooferRoutingState& state)
 				path.id,
 				termPointer + "/gainLinear");
 
-			if (physicalChannelIds.find(term.inputChannelId)
-				== physicalChannelIds.end())
+			if (!physicalChannelIds.contains(term.inputChannelId))
 			{
 				addDiagnostic(
 					result,
@@ -1285,8 +1284,7 @@ ValidationResult validate(const SubwooferRoutingState& state)
 				"The output target is duplicated.");
 		}
 
-		if (physicalChannelIds.find(output.targetChannelId)
-			== physicalChannelIds.end())
+		if (!physicalChannelIds.contains(output.targetChannelId))
 		{
 			addDiagnostic(
 				result,
@@ -1334,7 +1332,7 @@ ValidationResult validate(const SubwooferRoutingState& state)
 
 			matrixReferencedPathIds.insert(term.sourcePathId);
 
-			if (pathIndices.find(term.sourcePathId) == pathIndices.end())
+			if (!pathIndices.contains(term.sourcePathId))
 			{
 				addDiagnostic(
 					result,
@@ -1388,11 +1386,9 @@ ValidationResult validate(const SubwooferRoutingState& state)
 	for (const Path& path : state.paths)
 	{
 		const bool matrixReferenced =
-			matrixReferencedPathIds.find(path.id)
-			!= matrixReferencedPathIds.end();
+			matrixReferencedPathIds.contains(path.id);
 		const bool groupReferenced =
-			groupReferencedPathIds.find(path.id)
-			!= groupReferencedPathIds.end();
+			groupReferencedPathIds.contains(path.id);
 
 		if (path.kind == PathKind::SourceLfe)
 		{
@@ -1429,15 +1425,13 @@ ValidationResult validate(const SubwooferRoutingState& state)
 		for (const std::string& pathId : group.mainPathIds)
 		{
 			used = used
-				|| matrixReferencedPathIds.find(pathId)
-					!= matrixReferencedPathIds.end();
+				|| matrixReferencedPathIds.contains(pathId);
 		}
 
 		if (group.bassPathId.has_value())
 		{
 			used = used
-				|| matrixReferencedPathIds.find(*group.bassPathId)
-					!= matrixReferencedPathIds.end();
+				|| matrixReferencedPathIds.contains(*group.bassPathId);
 		}
 
 		if (!used)
@@ -1524,7 +1518,7 @@ ValidationResult validate(
 	{
 		const std::string& channelId = state.layout.channels[channelIndex].id;
 
-		if (deviceChannelIds.find(channelId) == deviceChannelIds.end())
+		if (!deviceChannelIds.contains(channelId))
 		{
 			addDiagnostic(
 				result,

--- a/SubwooferRoutingCore/src/Crossover.cpp
+++ b/SubwooferRoutingCore/src/Crossover.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "SubwooferRouting/Crossover.h"
+#include <numbers>
 
 #include <algorithm>
 #include <cmath>
@@ -12,7 +13,6 @@ namespace subroute
 namespace
 {
 
-constexpr double kPi = 3.14159265358979323846;
 
 // Relative tolerance for recognizing written values ("0.707", "80") as the
 // exact alignment constants.
@@ -35,7 +35,7 @@ std::vector<double> butterworthQs(int order)
 	for (int k = 0; k < order / 2; ++k)
 	{
 		const double theta =
-			kPi * (2.0 * k + 1.0) / (2.0 * order);
+			std::numbers::pi_v<double> * (2.0 * k + 1.0) / (2.0 * order);
 		result.push_back(1.0 / (2.0 * std::cos(theta)));
 	}
 	return result;

--- a/SubwooferRoutingCore/src/Json.cpp
+++ b/SubwooferRoutingCore/src/Json.cpp
@@ -1052,7 +1052,7 @@ private:
 				return false;
 			}
 
-			const bool duplicate = object.find(key) != object.end();
+			const bool duplicate = object.contains(key);
 
 			skipWhitespace();
 			if (offset_ == text_.size())

--- a/Tests/ApoHostProbe/ApoHostProbe.cpp
+++ b/Tests/ApoHostProbe/ApoHostProbe.cpp
@@ -35,6 +35,7 @@
 #include <audiomediatype.h>
 
 #include <cmath>
+#include <numbers>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -45,7 +46,6 @@
 
 namespace
 {
-const double pi = 3.14159265358979323846;
 
 struct Options
 {
@@ -316,7 +316,7 @@ int run(const Options& o, IAudioProcessingObjectRT* rt,
 	{
 		for (unsigned f = 0; f < o.frames; f++, sampleIndex++)
 		{
-			const double value = o.amplitude * std::sin(2.0 * pi * o.tone * (double)sampleIndex / (double)o.sampleRate);
+			const double value = o.amplitude * std::sin(2.0 * std::numbers::pi_v<double> * o.tone * (double)sampleIndex / (double)o.sampleRate);
 			for (unsigned c = 0; c < o.inputChannels; c++)
 				input[(size_t)f * o.inputChannels + c] = (SampleT)value;
 		}

--- a/Tests/AsioProbe/AsioProbe.cpp
+++ b/Tests/AsioProbe/AsioProbe.cpp
@@ -625,8 +625,8 @@ int wmain(int argc, wchar_t** argv)
 	IASIO* target = nullptr;
 	IFakeAsioControl* control = nullptr;
 	std::wstring targetClsid = L"{B7E3A9F4-52C1-4D0B-8A6E-1F9C3D5E7B21}";
-	const bool realDriver = a.target.rfind(L"clsid:", 0) == 0;
-	const bool wasapiTarget = a.target.rfind(L"wasapi:", 0) == 0;
+	const bool realDriver = a.target.starts_with(L"clsid:");
+	const bool wasapiTarget = a.target.starts_with(L"wasapi:");
 	// A target with a device behind it: no fake control, no pump, timed run.
 	const bool liveTarget = realDriver || wasapiTarget;
 	eapo::asio::WasapiExclusiveTarget* wasapi = nullptr;
@@ -634,7 +634,7 @@ int wmain(int argc, wchar_t** argv)
 	{
 		target = new FakeAsioDriver();
 	}
-	else if (a.target.rfind(L"dll:", 0) == 0)
+	else if (a.target.starts_with(L"dll:"))
 	{
 		target = loadFromDll(a.target.substr(4), CLSID_FakeAsio, targetModule);
 	}
@@ -714,7 +714,7 @@ int wmain(int argc, wchar_t** argv)
 		staticWrapper = new AsioWrapper(target, probeWrapperClsid, targetClsid, options, std::move(processor));
 		wrapper = staticWrapper;
 	}
-	else if (a.wrapper.rfind(L"dll:", 0) == 0)
+	else if (a.wrapper.starts_with(L"dll:"))
 	{
 		wrapper = wrapThroughDll(a.wrapper.substr(4), target, targetClsid, a, wrapperModule);
 	}

--- a/Tests/AudioRegressionTests/AudioRegressionTests.cpp
+++ b/Tests/AudioRegressionTests/AudioRegressionTests.cpp
@@ -9,6 +9,7 @@
 */
 
 #include <algorithm>
+#include <numbers>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -258,7 +259,7 @@ void ensureDirectory(const std::wstring& path)
 	{
 		start = 3;
 	}
-	else if (normalized.rfind(L"\\\\", 0) == 0)
+	else if (normalized.starts_with(L"\\\\"))
 	{
 		size_t serverEnd = normalized.find(L'\\', 2);
 		if (serverEnd == std::wstring::npos)
@@ -340,7 +341,7 @@ std::vector<float> generateSignal(SignalType type, unsigned sampleRate, unsigned
 			buf[c] = 1.0f;
 		break;
 	case SignalType::Sine1k: {
-		double w = 2.0 * 3.14159265358979323846 * 1000.0 / sampleRate;
+		double w = 2.0 * std::numbers::pi_v<double> * 1000.0 / sampleRate;
 		for (unsigned i = 0; i < frames; ++i) {
 			float s = (float)std::sin(w * i);
 			for (unsigned c = 0; c < channels; ++c)

--- a/Tests/CaptureProbe/CaptureProbe.cpp
+++ b/Tests/CaptureProbe/CaptureProbe.cpp
@@ -33,6 +33,7 @@
 
 #include <atomic>
 #include <cmath>
+#include <numbers>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -42,7 +43,6 @@
 
 namespace
 {
-const double pi = 3.14159265358979323846;
 
 struct Options
 {
@@ -514,7 +514,7 @@ void renderThread(RenderJob* job)
 			float* samples = reinterpret_cast<float*>(data);
 			for (UINT32 f = 0; f < frames; f++, sampleIndex++)
 			{
-				const float value = (float)(job->amplitude * std::sin(2.0 * pi * job->tone * (double)sampleIndex / (double)job->rate));
+				const float value = (float)(job->amplitude * std::sin(2.0 * std::numbers::pi_v<double> * job->tone * (double)sampleIndex / (double)job->rate));
 				for (unsigned c = 0; c < job->channels; c++)
 					samples[(size_t)f * job->channels + c] = value;
 			}
@@ -729,7 +729,7 @@ int wmain(int argc, wchar_t** argv)
 		const unsigned long long measureFrames = (unsigned long long)(o.seconds * rate);
 		std::vector<double> sumSquares(channels, 0.0);
 		unsigned long long seen = 0, counted = 0, silentPackets = 0;
-		const double coeff = 2.0 * std::cos(2.0 * pi * o.tone / (double)rate);
+		const double coeff = 2.0 * std::cos(2.0 * std::numbers::pi_v<double> * o.tone / (double)rate);
 		double s1 = 0.0, s2 = 0.0;
 		const DWORD deadline = GetTickCount() + (DWORD)((o.settle + o.seconds) * 1000.0) + 3000;
 		HRESULT captureError = S_OK;

--- a/Tests/EditorLogicTests/BiQuadWidthConversionTests.cpp
+++ b/Tests/EditorLogicTests/BiQuadWidthConversionTests.cpp
@@ -12,9 +12,9 @@
 	filter, quiet enough to miss and large enough to hear.
 */
 
-#define _USE_MATH_DEFINES
 
 #include <cmath>
+#include <numbers>
 #include <limits>
 
 #include "Editor/guis/BiQuadWidthConversion.h"
@@ -124,7 +124,7 @@ void testBiQuadWidthModesAndDefaults()
 	// A new all-pass starts at 0.707, not at the 10 the editors used to create.
 	// Q 10 at 1 kHz concentrates about 30 ms of group delay into a narrow band,
 	// which is a strange place to start a phase correction from.
-	expectTrue(std::abs(BiQuadWidth::defaultQ(BiQuad::ALL_PASS) - M_SQRT1_2) < 1e-12,
+	expectTrue(std::abs(BiQuadWidth::defaultQ(BiQuad::ALL_PASS) - std::numbers::sqrt2_v<double> / 2.0) < 1e-12,
 		QStringLiteral("a new all-pass starts at Q 0.707"));
 	// Peaking keeps its own default: this reform does not touch it.
 	expectTrue(BiQuadWidth::defaultQ(BiQuad::PEAKING) == 10.0,

--- a/Tests/EditorLogicTests/PhaseCurveTests.cpp
+++ b/Tests/EditorLogicTests/PhaseCurveTests.cpp
@@ -15,9 +15,9 @@
 */
 
 // Before anything that reaches <math.h>.
-#define _USE_MATH_DEFINES
 
 #include <cmath>
+#include <numbers>
 #include <complex>
 #include <limits>
 #include <memory>
@@ -58,7 +58,7 @@ std::shared_ptr<AnalysisResponse> biquadResponse(BiQuad::Type type, double freq,
 	auto response = emptyResponse();
 	for (size_t i = 0; i < response->bins.size(); i++)
 	{
-		const double omega = 2.0 * M_PI * response->frequencyOf(i) / SampleRate;
+		const double omega = 2.0 * std::numbers::pi_v<double> * response->frequencyOf(i) / SampleRate;
 		const std::complex<double> z1 = std::polar(1.0, -omega);
 		const std::complex<double> z2 = z1 * z1;
 		response->bins[i] = (b0 + b1 * z1 + b2 * z2) / (1.0 + a1 * z1 + a2 * z2);
@@ -218,7 +218,7 @@ void testPhaseAndGroupDelayOfAnAllPass()
 	const double widePeak = valueNearest(wide, request, 1000.0);
 	const double sharpPeak = valueNearest(sharp, request, 1000.0);
 	// 4Q / sin(w0) samples at Fc, converted to milliseconds.
-	const double omega0 = 2.0 * M_PI * 1000.0 / SampleRate;
+	const double omega0 = 2.0 * std::numbers::pi_v<double> * 1000.0 / SampleRate;
 	const double expectedWide = 4.0 * 0.707 / std::sin(omega0) / SampleRate * 1000.0;
 	expectTrue(std::abs(widePeak - expectedWide) < expectedWide * 0.02,
 		QStringLiteral("group delay at Fc matches 4Q/sin(w0) (expected %1 ms, got %2 ms)")

--- a/Tests/EngineOrchestrationTests/FakeRegistry.h
+++ b/Tests/EngineOrchestrationTests/FakeRegistry.h
@@ -295,13 +295,13 @@ public:
 		// throwing. The format check stays, because the real one runs splitKey
 		// before it ever looks for the key.
 		requireWellFormed(key);
-		return keys_.find(key) != keys_.end();
+		return keys_.contains(key);
 	}
 
 	bool valueExists(const std::wstring& key, const std::wstring& valuename) const override
 	{
 		const ValueMap& values = requireKey(key);
-		return values.find(valuename) != values.end();
+		return values.contains(valuename);
 	}
 
 	bool keyEmpty(const std::wstring& key) const override
@@ -352,7 +352,7 @@ public:
 	void createKey(const std::wstring& key) override
 	{
 		requireWellFormed(key);
-		if (deniedCreateKeys_.find(key) != deniedCreateKeys_.end())
+		if (deniedCreateKeys_.contains(key))
 			throw RegistryError(L"Error while creating registry key " + key + L": access is denied");
 		ensureKey(key);
 	}
@@ -440,7 +440,7 @@ private:
 		std::map<std::wstring, ValueMap, CaseInsensitiveLess>::const_iterator it = keys_.find(key);
 		if (it == keys_.end())
 			throw RegistryError(L"Error while opening registry key " + key + L": the system cannot find the file specified");
-		if (deniedReadKeys_.find(key) != deniedReadKeys_.end())
+		if (deniedReadKeys_.contains(key))
 			throw RegistryError(L"Error while opening registry key " + key + L": access is denied");
 		return it->second;
 	}
@@ -456,7 +456,7 @@ private:
 
 	void requireWritableValue(const std::wstring& key, const std::wstring& valuename) const
 	{
-		if (failedValueWrites_.find(key + L"\\" + valuename) != failedValueWrites_.end())
+		if (failedValueWrites_.contains(key + L"\\" + valuename))
 			throw RegistryError(L"Error while writing registry value " + key + L"\\" + valuename + L": access is denied");
 	}
 

--- a/Tests/HybridConvTests/AllPassTests.cpp
+++ b/Tests/HybridConvTests/AllPassTests.cpp
@@ -32,12 +32,8 @@
 	it, on the same shared function the new card calls.
 */
 
-// Before any header that reaches <math.h>: M_PI and M_SQRT2 are only declared
-// when this is defined at the point math.h is first processed, and <complex>
-// gets there on its own.
-#define _USE_MATH_DEFINES
-
 #include <cmath>
+#include <numbers>
 #include <complex>
 #include <cstring>
 #include <sstream>
@@ -83,7 +79,7 @@ BiQuad makeAllPass(double freq, double srate, double widthValue, bool isBandwidt
 
 std::complex<double> responseAt(const Coefficients& c, double freq, double srate)
 {
-	const double omega = 2.0 * M_PI * freq / srate;
+	const double omega = 2.0 * std::numbers::pi_v<double> * freq / srate;
 	const std::complex<double> z1 = std::polar(1.0, -omega);
 	const std::complex<double> z2 = z1 * z1;
 	return (c.b0 + c.b1 * z1 + c.b2 * z2) / (1.0 + c.a1 * z1 + c.a2 * z2);
@@ -91,7 +87,7 @@ std::complex<double> responseAt(const Coefficients& c, double freq, double srate
 
 double phaseDegreesAt(const Coefficients& c, double freq, double srate)
 {
-	return std::arg(responseAt(c, freq, srate)) * 180.0 / M_PI;
+	return std::arg(responseAt(c, freq, srate)) * 180.0 / std::numbers::pi_v<double>;
 }
 
 // Group delay in samples, differentiated in closed form.
@@ -110,7 +106,7 @@ double phaseDegreesAt(const Coefficients& c, double freq, double srate)
 double groupDelaySamplesAt(const Coefficients& c, double freq, double srate)
 {
 	const std::complex<double> j(0.0, 1.0);
-	const std::complex<double> z1 = std::polar(1.0, -2.0 * M_PI * freq / srate);
+	const std::complex<double> z1 = std::polar(1.0, -2.0 * std::numbers::pi_v<double> * freq / srate);
 	const std::complex<double> z2 = z1 * z1;
 
 	const std::complex<double> numerator = c.b0 + c.b1 * z1 + c.b2 * z2;
@@ -228,7 +224,7 @@ void testGroupDelayAtCenterMatchesTheClosedForm()
 			const double fc = 200.0;
 			const Coefficients c = coefficientsOf(makeAllPass(fc, srate, q, false));
 
-			const double omega0 = 2.0 * M_PI * fc / srate;
+			const double omega0 = 2.0 * std::numbers::pi_v<double> * fc / srate;
 			const double measured = groupDelaySamplesAt(c, fc, srate);
 			const double expected = 4.0 * q / std::sin(omega0);
 			std::ostringstream oss;
@@ -238,7 +234,7 @@ void testGroupDelayAtCenterMatchesTheClosedForm()
 
 			// The textbook 2Q/(pi*Fc) seconds only holds while w0 is small;
 			// at 200 Hz it is within a part in 10^4 at every rate here.
-			const double approxSeconds = 2.0 * q / (M_PI * fc);
+			const double approxSeconds = 2.0 * q / (std::numbers::pi_v<double> * fc);
 			harness.expect(std::abs(measured / srate - approxSeconds) < approxSeconds * 1e-3,
 				"the 2Q/(pi*Fc) approximation holds at low Fc, " + describe(srate, q));
 		}
@@ -423,7 +419,7 @@ void testBandwidthIsNotTheSameNumberAsQ()
 		/ groupDelaySamplesAt(asQ, fc, srate);
 	std::ostringstream oss;
 	oss << "rewriting BW Oct 1 as Q 1 changes the group delay at Fc by about 41% (ratio " << ratio << ")";
-	harness.expect(std::abs(ratio - M_SQRT2) < 0.01, oss.str());
+	harness.expect(std::abs(ratio - std::numbers::sqrt2_v<double>) < 0.01, oss.str());
 }
 
 // Two 1st-order sections at the same frequency, in series, are exactly one
@@ -518,7 +514,7 @@ void testFirstOrderAllPassBehaviour()
 				"1st-order phase approaches -180 deg at Nyquist and no further, " + label.str());
 
 			// Group delay at Fc, in samples, is (1 + K^2) / (2K).
-			const double K = std::tan(M_PI * fc / srate);
+			const double K = std::tan(std::numbers::pi_v<double> * fc / srate);
 			const double expected = (1.0 + K * K) / (2.0 * K);
 			const double measured = groupDelaySamplesAt(c, fc, srate);
 			std::ostringstream gd;

--- a/Tests/HybridConvTests/HilbertVelvetTests.cpp
+++ b/Tests/HybridConvTests/HilbertVelvetTests.cpp
@@ -10,6 +10,7 @@
 */
 
 #include <algorithm>
+#include <numbers>
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -26,7 +27,6 @@
 
 namespace
 {
-constexpr double Pi = 3.1415926535897932384626433832795;
 test::Harness harness("HilbertVelvetTests");
 
 std::complex<double> responseAt(const std::vector<double>& taps, double omega)
@@ -91,8 +91,8 @@ void testHilbertFirContract()
 	harness.expectTrue(maximumDirectionError < 1.0e-14,
 		"the two phase directions are exact sign inverses");
 
-	const std::complex<double> minusMid = responseAt(minus, Pi * 0.5);
-	const std::complex<double> plusMid = responseAt(plus, Pi * 0.5);
+	const std::complex<double> minusMid = responseAt(minus, std::numbers::pi_v<double> * 0.5);
+	const std::complex<double> plusMid = responseAt(plus, std::numbers::pi_v<double> * 0.5);
 	harness.expectTrue(std::abs(std::abs(minusMid) - 1.0) < 1.0e-12,
 		"Hilbert mid-band magnitude is normalized to 0 dB");
 	harness.expectTrue(minusMid.imag() < -0.999999999

--- a/Tests/HybridConvTests/SubwooferRoutingCompilerTests.cpp
+++ b/Tests/HybridConvTests/SubwooferRoutingCompilerTests.cpp
@@ -4,6 +4,7 @@
 #include "Tests/TestHarness.h"
 
 #include <cmath>
+#include <numbers>
 #include <complex>
 #include <string>
 #include <vector>
@@ -141,8 +142,7 @@ double evaluateMagnitudeDb(
 	double frequencyHz,
 	double sampleRate)
 {
-	const double pi = 3.141592653589793238462643383279502884;
-	const double omega = 2.0 * pi * frequencyHz / sampleRate;
+	const double omega = 2.0 * std::numbers::pi_v<double> * frequencyHz / sampleRate;
 	const std::complex<double> z1 = std::polar(1.0, -omega);
 	const std::complex<double> z2 = z1 * z1;
 	const std::complex<double> numerator =

--- a/Tests/TestVst3Plugin/TestVst3Plugin.cpp
+++ b/Tests/TestVst3Plugin/TestVst3Plugin.cpp
@@ -9,6 +9,7 @@
 #define INIT_CLASS_IID
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <numbers>
 
 #include <algorithm>
 #include <atomic>
@@ -522,7 +523,7 @@ public:
 			for (int32 sample = 0; sample < data.numSamples; ++sample)
 			{
 				const double value = state.gain * 0.05 * std::sin(
-					2.0 * 3.14159265358979323846 * 440.0
+					2.0 * std::numbers::pi_v<double> * 440.0
 					* static_cast<double>(tonePosition + sample) / setup.sampleRate);
 				for (int32 channel = 0; channel < 2; ++channel)
 				{

--- a/Tests/VstPreviewProbe/VstPreviewProbe.cpp
+++ b/Tests/VstPreviewProbe/VstPreviewProbe.cpp
@@ -41,6 +41,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <numbers>
 #include <mmdeviceapi.h>
 #include <Audioclient.h>
 #include <mmreg.h>
@@ -177,7 +178,7 @@ int runPluginProbe(const std::wstring& pluginPath, double seconds, float sampleR
 			for (int i = 0; i < blockFrames; i++)
 			{
 				const double sample = sineAmplitude
-					* std::sin(2.0 * 3.14159265358979323846 * sineFrequency * (position + i) / sampleRate);
+					* std::sin(2.0 * std::numbers::pi_v<double> * sineFrequency * (position + i) / sampleRate);
 				if (useDouble)
 					inputDouble[channel][i] = sample;
 				else
@@ -356,9 +357,9 @@ int runLoopbackProbe(double seconds)
 						// level meters settle into a motionless reading, and
 						// the panel-feed A/B keys on meter movement.
 						const double t = (renderedFrames + i) / sampleRate;
-						const double envelope = std::pow(std::sin(2.0 * 3.14159265358979323846 * 1.5 * t / 2.0), 2.0);
+						const double envelope = std::pow(std::sin(2.0 * std::numbers::pi_v<double> * 1.5 * t / 2.0), 2.0);
 						const float value = static_cast<float>(sineAmplitude * envelope
-							* std::sin(2.0 * 3.14159265358979323846 * sineFrequency * t));
+							* std::sin(2.0 * std::numbers::pi_v<double> * sineFrequency * t));
 						for (UINT32 channel = 0; channel < channelCount; channel++)
 							samples[i * channelCount + channel] = value;
 					}

--- a/asio/AsioRegistration.cpp
+++ b/asio/AsioRegistration.cpp
@@ -54,7 +54,7 @@ namespace eapo::asio
 		bool isWrapperEntry(const std::wstring& entryName)
 		{
 			const std::wstring tail(suffix);
-			return entryName.size() >= tail.size() && entryName.compare(entryName.size() - tail.size(), tail.size(), tail) == 0;
+			return entryName.ends_with(tail);
 		}
 
 		std::wstring wrapperClsidFor(const std::wstring& targetClsid)

--- a/asio/EngineHostCore.cpp
+++ b/asio/EngineHostCore.cpp
@@ -117,20 +117,21 @@ namespace eapo::asio
 				return true;
 			lane.planes.resize(channels);
 			lane.engine = std::make_unique<FilterEngine>();
-			EngineSetup setup;
-			setup.sampleRate = static_cast<float>(format.sampleRate);
-			setup.inputChannelCount = channels;
-			setup.realChannelCount = channels;
-			setup.outputChannelCount = channels;
-			setup.channelMask = 0;
-			setup.maxFrameCount = format.frames;
-			setup.customPath = options.configPath;
-			setup.preMix = false;
-			setup.capture = direction == Direction::Input;
-			setup.postMixInstalled = true;
-			setup.deviceName = format.deviceName;
-			setup.connectionName = L"ASIO";
-			setup.deviceGuid = format.deviceGuid;
+			EngineSetup setup{
+				.sampleRate = static_cast<float>(format.sampleRate),
+				.inputChannelCount = channels,
+				.realChannelCount = channels,
+				.outputChannelCount = channels,
+				.channelMask = 0,
+				.maxFrameCount = format.frames,
+				.customPath = options.configPath,
+				.preMix = false,
+				.capture = direction == Direction::Input,
+				.postMixInstalled = true,
+				.deviceName = format.deviceName,
+				.connectionName = L"ASIO",
+				.deviceGuid = format.deviceGuid
+			};
 			lane.engine->initialize(setup);
 			return true;
 		}

--- a/asio/InProcProcessor.cpp
+++ b/asio/InProcProcessor.cpp
@@ -53,20 +53,21 @@ namespace eapo::asio
 					lane.planes[c] = lane.storage.data() + static_cast<size_t>(c) * format.frames;
 
 				lane.engine = std::make_unique<FilterEngine>();
-				EngineSetup setup;
-				setup.sampleRate = static_cast<float>(format.sampleRate);
-				setup.inputChannelCount = channels;
-				setup.realChannelCount = channels;
-				setup.outputChannelCount = channels;
-				setup.channelMask = 0;
-				setup.maxFrameCount = format.frames;
-				setup.customPath = options.configPath;
-				setup.preMix = false;
-				setup.capture = direction == Direction::Input;
-				setup.postMixInstalled = true;
-				setup.deviceName = format.deviceName;
-				setup.connectionName = L"ASIO";
-				setup.deviceGuid = format.deviceGuid;
+				EngineSetup setup{
+					.sampleRate = static_cast<float>(format.sampleRate),
+					.inputChannelCount = channels,
+					.realChannelCount = channels,
+					.outputChannelCount = channels,
+					.channelMask = 0,
+					.maxFrameCount = format.frames,
+					.customPath = options.configPath,
+					.preMix = false,
+					.capture = direction == Direction::Input,
+					.postMixInstalled = true,
+					.deviceName = format.deviceName,
+					.connectionName = L"ASIO",
+					.deviceGuid = format.deviceGuid
+				};
 				lane.engine->initialize(setup);
 			}
 			catch (const std::exception& e)

--- a/asio/SampleCodec.cpp
+++ b/asio/SampleCodec.cpp
@@ -6,6 +6,7 @@
 
 #include "asio/SampleCodec.h"
 
+#include <bit>
 #include <cmath>
 #include <cstring>
 
@@ -171,7 +172,7 @@ namespace eapo::asio
 			for (unsigned i = 0; i < count; i++)
 			{
 				uint32_t raw = swap32(in[i]);
-				std::memcpy(&destination[i], &raw, sizeof(float));
+				destination[i] = std::bit_cast<float>(raw);
 			}
 		}
 
@@ -186,8 +187,7 @@ namespace eapo::asio
 			uint32_t* out = static_cast<uint32_t*>(destination);
 			for (unsigned i = 0; i < count; i++)
 			{
-				uint32_t raw;
-				std::memcpy(&raw, &source[i], sizeof(float));
+				uint32_t raw = std::bit_cast<uint32_t>(source[i]);
 				out[i] = swap32(raw);
 			}
 		}
@@ -201,8 +201,7 @@ namespace eapo::asio
 				uint64_t raw = in[i];
 				if (bigEndian)
 					raw = swap64(raw);
-				double value;
-				std::memcpy(&value, &raw, sizeof(double));
+				double value = std::bit_cast<double>(raw);
 				destination[i] = static_cast<float>(value);
 			}
 		}
@@ -214,8 +213,7 @@ namespace eapo::asio
 			for (unsigned i = 0; i < count; i++)
 			{
 				double value = source[i];
-				uint64_t raw;
-				std::memcpy(&raw, &value, sizeof(double));
+				uint64_t raw = std::bit_cast<uint64_t>(value);
 				out[i] = bigEndian ? swap64(raw) : raw;
 			}
 		}

--- a/audio/ChannelLayout.cpp
+++ b/audio/ChannelLayout.cpp
@@ -19,6 +19,9 @@
 
 #include "stdafx.h"
 #include <algorithm>
+#include <array>
+#include <string_view>
+#include <utility>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <Ks.h>
@@ -29,29 +32,22 @@
 
 using std::find;
 using std::to_wstring;
-using std::unordered_map;
 using std::vector;
 using std::wstring;
 
-unordered_map<wstring, int> ChannelLayout::channelNameToPosMap;
-unordered_map<int, wstring> ChannelLayout::channelPosToNameMap;
-// must come last, so that the static members are already initialized
-ChannelLayout ChannelLayout::instance;
-
-ChannelLayout::ChannelLayout()
+namespace
 {
-	channelNameToPosMap[L"L"] = SPEAKER_FRONT_LEFT;
-	channelNameToPosMap[L"R"] = SPEAKER_FRONT_RIGHT;
-	channelNameToPosMap[L"C"] = SPEAKER_FRONT_CENTER;
-	channelNameToPosMap[L"LFE"] = SPEAKER_LOW_FREQUENCY;
-	channelNameToPosMap[L"RL"] = SPEAKER_BACK_LEFT;
-	channelNameToPosMap[L"RR"] = SPEAKER_BACK_RIGHT;
-	channelNameToPosMap[L"RC"] = SPEAKER_BACK_CENTER;
-	channelNameToPosMap[L"SL"] = SPEAKER_SIDE_LEFT;
-	channelNameToPosMap[L"SR"] = SPEAKER_SIDE_RIGHT;
-
-	for (unordered_map<wstring, int>::iterator it = channelNameToPosMap.begin(); it != channelNameToPosMap.end(); it++)
-		channelPosToNameMap[it->second] = it->first;
+	constexpr std::array<std::pair<std::wstring_view, int>, 9> channelPositions{
+		std::pair{ std::wstring_view{ L"L" }, SPEAKER_FRONT_LEFT },
+		std::pair{ std::wstring_view{ L"R" }, SPEAKER_FRONT_RIGHT },
+		std::pair{ std::wstring_view{ L"C" }, SPEAKER_FRONT_CENTER },
+		std::pair{ std::wstring_view{ L"LFE" }, SPEAKER_LOW_FREQUENCY },
+		std::pair{ std::wstring_view{ L"RL" }, SPEAKER_BACK_LEFT },
+		std::pair{ std::wstring_view{ L"RR" }, SPEAKER_BACK_RIGHT },
+		std::pair{ std::wstring_view{ L"RC" }, SPEAKER_BACK_CENTER },
+		std::pair{ std::wstring_view{ L"SL" }, SPEAKER_SIDE_LEFT },
+		std::pair{ std::wstring_view{ L"SR" }, SPEAKER_SIDE_RIGHT }
+	};
 }
 
 int ChannelLayout::getDefaultChannelMask(int channelCount)
@@ -92,9 +88,10 @@ vector<wstring> ChannelLayout::getChannelNames(int channelCount, int channelMask
 		int channelPos = 1 << i;
 		if (channelMask & channelPos)
 		{
-			auto it = channelPosToNameMap.find(channelPos);
-			if (it != channelPosToNameMap.end())
-				channelNames.push_back(it->second);
+			auto it = std::find_if(channelPositions.begin(), channelPositions.end(),
+				[channelPos](const auto& entry) { return entry.second == channelPos; });
+			if (it != channelPositions.end())
+				channelNames.emplace_back(it->first.data(), it->first.size());
 			else
 				channelNames.push_back(to_wstring((unsigned long long)c));
 			c++;

--- a/audio/ChannelLayout.h
+++ b/audio/ChannelLayout.h
@@ -21,7 +21,6 @@
 
 #include <string>
 #include <vector>
-#include <unordered_map>
 
 class ChannelLayout
 {
@@ -29,11 +28,4 @@ public:
 	static int getDefaultChannelMask(int channelCount);
 	static std::vector<std::wstring> getChannelNames(int channelCount, int channelMask);
 	static int getChannelIndex(std::wstring word, const std::vector<std::wstring>& channelNames, bool allowAdditional = false);
-
-private:
-	ChannelLayout();
-	static ChannelLayout instance;
-
-	static std::unordered_map<std::wstring, int> channelNameToPosMap;
-	static std::unordered_map<int, std::wstring> channelPosToNameMap;
 };

--- a/devices/DeviceAPOInfo.h
+++ b/devices/DeviceAPOInfo.h
@@ -69,17 +69,7 @@ public:
 			exclusiveModeEq = false;
 		}
 
-		bool operator!=(const InstallState& other) const
-		{
-			return installPreMix != other.installPreMix
-				|| installPostMix != other.installPostMix
-				|| useOriginalAPOPreMix != other.useOriginalAPOPreMix
-				|| useOriginalAPOPostMix != other.useOriginalAPOPostMix
-				|| autoAdjust != other.autoAdjust
-				|| installMode != other.installMode
-				|| allowSilentBufferModification != other.allowSilentBufferModification
-				|| exclusiveModeEq != other.exclusiveModeEq;
-		}
+		bool operator==(const InstallState&) const = default;
 	};
 
 	// Every registry access this class makes goes through the injected port. The

--- a/devices/VoicemeeterAPOInfo.cpp
+++ b/devices/VoicemeeterAPOInfo.cpp
@@ -79,7 +79,7 @@ void VoicemeeterAPOInfo::prependInfos(vector<shared_ptr<AbstractAPOInfo>>& list,
 			outputCount = 1;
 
 		bool defaultDevice = false;
-		list.erase(remove_if(list.begin(), list.end(), [&defaultDevice](const shared_ptr<AbstractAPOInfo>& info) {
+		std::erase_if(list, [&defaultDevice](const shared_ptr<AbstractAPOInfo>& info) {
 			if (info->getDeviceName().find(L"VB-Audio VoiceMeeter") != wstring::npos)
 			{
 				if (info->isDefaultDevice())
@@ -89,7 +89,7 @@ void VoicemeeterAPOInfo::prependInfos(vector<shared_ptr<AbstractAPOInfo>>& list,
 			}
 
 			return false;
-			}), list.end());
+			});
 
 		bool anyInstalled = false;
 		for (unsigned i = 0; i < outputCount; i++)

--- a/engine/FilterEngine.Configuration.cpp
+++ b/engine/FilterEngine.Configuration.cpp
@@ -19,7 +19,6 @@
 
 #include "stdafx.h"
 #include "text/WideString.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <sstream>
 #include <fstream>

--- a/engine/FilterEngine.cpp
+++ b/engine/FilterEngine.cpp
@@ -20,8 +20,8 @@
 #include "stdafx.h"
 #include "text/WideString.h"
 #include "services/registry/RegistryPaths.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <numbers>
 #include <sstream>
 #include <fstream>
 #include <algorithm>
@@ -141,7 +141,7 @@ void FilterEngine::initialize(const EngineSetup& setup)
 		this->transitionCounter = 0;
 		this->transitionLength = (unsigned)(sampleRate / 100);
 		transitionFactorTable.resize(transitionLength);
-		const double scale = M_PI / static_cast<double>(transitionLength);
+		const double scale = std::numbers::pi_v<double> / static_cast<double>(transitionLength);
 		for (unsigned i = 0; i < transitionLength; i++)
 			transitionFactorTable[i] = 0.5 * (1.0 - std::cos(i * scale));
 

--- a/filters/BiQuad.cpp
+++ b/filters/BiQuad.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "stdafx.h"
+#include <numbers>
 #include "BiQuad.h"
 
 using std::log10;
@@ -31,7 +32,7 @@ BiQuad::BiQuad(Type type, double dbGain, double freq, double srate, double bandw
 		A = pow(10, dbGain / 40);
 	else
 		A = pow(10, dbGain / 20);
-	double omega = 2 * M_PI * freq / srate;
+	double omega = 2 * std::numbers::pi_v<double> * freq / srate;
 	double sn = sin(omega);
 	double cs = cos(omega);
 	double alpha;
@@ -41,7 +42,7 @@ BiQuad::BiQuad(Type type, double dbGain, double freq, double srate, double bandw
 	else if (type == LOW_SHELF || type == HIGH_SHELF) // S
 		alpha = sn / 2 * sqrt((A + 1 / A) * (1 / bandwidthOrQOrS - 1) + 2);
 	else // BW
-		alpha = sn * sinh(M_LN2 / 2 * bandwidthOrQOrS * omega / sn);
+		alpha = sn * sinh(std::numbers::ln2_v<double> / 2 * bandwidthOrQOrS * omega / sn);
 
 	double beta = 2 * sqrt(A) * alpha;
 
@@ -105,7 +106,7 @@ BiQuad::BiQuad(Type type, double dbGain, double freq, double srate, double bandw
 		// z = -c is inside the unit circle. At the very edges the pole reaches
 		// it, which is the same boundary behaviour every 2nd-order section
 		// here already has.
-		double K = tan(M_PI * freq / srate);
+		double K = tan(std::numbers::pi_v<double> * freq / srate);
 		double c = (K - 1) / (K + 1);
 		b0 = c;
 		b1 = 1;
@@ -155,7 +156,7 @@ BiQuad::BiQuad(Type type, double dbGain, double freq, double srate, double bandw
 
 double BiQuad::gainAt(double freq, double srate)
 {
-	double omega = 2 * M_PI * freq / srate;
+	double omega = 2 * std::numbers::pi_v<double> * freq / srate;
 	double sn = sin(omega / 2.0);
 	double phi = sn * sn;
 	double b0 = this->a0;

--- a/filters/BiQuad.h
+++ b/filters/BiQuad.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <climits>
 #include <string>

--- a/filters/BiQuadCommand.h
+++ b/filters/BiQuadCommand.h
@@ -55,7 +55,7 @@ struct BiQuadCommand
 // line cannot be reproduced from this struct alone, because BiQuadFilterFactory's
 // parser is intentionally lossy and normalizing:
 //   - A missing Q / BW / slope token is replaced by a synthesized default
-//     (M_SQRT1_2 for LP/HP/BP, 0.9 for shelves, 30 for notch), so "no token" and
+//     (1 / sqrt(2) for LP/HP/BP, 0.9 for shelves, 30 for notch), so "no token" and
 //     "a token whose value equals the default" collapse to identical fields.
 //   - LP/LPQ, HP/HPQ and LS/LSC all map to one BiQuad::Type; the spelling that
 //     was written is not recorded.

--- a/filters/BiQuadFilterFactory.cpp
+++ b/filters/BiQuadFilterFactory.cpp
@@ -20,8 +20,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "stdafx.h"
 #include "text/WideString.h"
 #include "parser/NumericText.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <numbers>
 #include <regex>
 #include <sstream>
 
@@ -95,7 +95,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 	wstring* errorOut)
 {
 	// starts-with check (rfind at position 0), the pre-C++20 idiom
-	if (command.rfind(L"Filter", 0) != 0)
+	if (!command.starts_with(L"Filter"))
 		return false;
 
 	// Collected reasons for a recognized-but-malformed line. They reach the
@@ -269,7 +269,7 @@ bool BiQuadFilterFactory::parseCommand(const wstring& command, wstring& paramete
 		}
 		else if (type == BiQuad::LOW_PASS || type == BiQuad::HIGH_PASS || type == BiQuad::BAND_PASS)
 		{
-			bandwidthOrQOrS = M_SQRT1_2;
+			bandwidthOrQOrS = std::numbers::sqrt2_v<double> / 2.0;
 		}
 		else if (type == BiQuad::LOW_SHELF || type == BiQuad::HIGH_SHELF)
 		{

--- a/filters/ExpressionCommand.h
+++ b/filters/ExpressionCommand.h
@@ -50,10 +50,7 @@ struct InlineExpression
 		// Literal text with escapes resolved, or the expression body.
 		std::wstring text;
 
-		bool operator==(const Segment& other) const
-		{
-			return isExpression == other.isExpression && text == other.text;
-		}
+		bool operator==(const Segment&) const = default;
 	};
 
 	// Splits parameters into segments: "\`" yields a literal backtick (the

--- a/filters/FilterFactoryRegistry.cpp
+++ b/filters/FilterFactoryRegistry.cpp
@@ -87,7 +87,7 @@ wstring FilterFactoryRegistry::canonicalCommand(const wstring& key)
 	// prefix here rather than comparing the first token is what keeps this
 	// function honest about what the engine will actually run.
 	static const wstring filterPrefix = L"Filter";
-	if (trimmedKey.rfind(filterPrefix, 0) == 0 && knownConfigCommands().count(filterPrefix) != 0)
+	if (trimmedKey.starts_with(filterPrefix) && knownConfigCommands().count(filterPrefix) != 0)
 		return filterPrefix;
 
 	// Every other factory compares the whole key for equality, so a trailing

--- a/filters/GraphicEQFilter.cpp
+++ b/filters/GraphicEQFilter.cpp
@@ -18,8 +18,8 @@
 */
 
 #include "stdafx.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <numbers>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -55,17 +55,7 @@ namespace
 		int sampleRate = 0;
 		unsigned filterLength = 0;
 
-		bool operator==(const EqIrCacheKey& o) const
-		{
-			if (sampleRate != o.sampleRate || filterLength != o.filterLength) return false;
-			if (nodes.size() != o.nodes.size()) return false;
-			for (size_t i = 0; i < nodes.size(); ++i)
-			{
-				if (nodes[i].freq != o.nodes[i].freq || nodes[i].dbGain != o.nodes[i].dbGain)
-					return false;
-			}
-			return true;
-		}
+		bool operator==(const EqIrCacheKey&) const = default;
 	};
 
 	struct EqIrCacheKeyHash
@@ -150,7 +140,7 @@ void GraphicEQFilter::initializeFilters(unsigned frameCount)
 
 		for (unsigned i = 0; i < filterLength; i++)
 		{
-			double factor = 0.5 * (1 + cos(2 * M_PI * i * 1.0 / (2 * filterLength)));
+			double factor = 0.5 * (1 + cos(2 * std::numbers::pi_v<double> * i * 1.0 / (2 * filterLength)));
 			timeData.get()[i][0] *= factor;
 			timeData.get()[i][1] *= factor;
 		}

--- a/filters/HilbertFilter.cpp
+++ b/filters/HilbertFilter.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "stdafx.h"
+#include <numbers>
 #include "HilbertFilter.h"
 
 #include <algorithm>
@@ -25,7 +26,6 @@ ConvolverMuteDiagnostics muteDiagnostics;
 
 namespace
 {
-constexpr double Pi = 3.1415926535897932384626433832795;
 
 double besselI0(double value)
 {
@@ -83,7 +83,7 @@ std::vector<double> designHilbertFir(int directionDegrees)
 		const double window = besselI0(beta
 			* std::sqrt(std::max(0.0, 1.0 - position * position)))
 			/ denominator;
-		taps[n] = sign * 2.0 * window / (Pi * static_cast<double>(k));
+		taps[n] = sign * 2.0 * window / (std::numbers::pi_v<double> * static_cast<double>(k));
 	}
 
 	// Pin the mid-band gain to unity. Windowing changes it by a small amount;
@@ -91,7 +91,7 @@ std::vector<double> designHilbertFir(int directionDegrees)
 	std::complex<double> response;
 	for (size_t n = 0; n < taps.size(); ++n)
 		response += taps[n] * std::exp(std::complex<double>(
-			0.0, -Pi * 0.5 * static_cast<double>(n)));
+			0.0, -std::numbers::pi_v<double> * 0.5 * static_cast<double>(n)));
 	const double gain = std::abs(response);
 	if (gain > 0.0)
 		for (double& tap : taps)
@@ -124,10 +124,9 @@ std::vector<std::wstring> HilbertFilter::initialize(float sampleRate,
 
 	// Aliases can resolve two different spellings to one physical channel.
 	// The phase-shifted role wins and the duplicate aligned role is dropped.
-	aligned.erase(std::remove_if(aligned.begin(), aligned.end(),
-		[this](int index) {
+	std::erase_if(aligned, [this](int index) {
 			return std::find(shifted.begin(), shifted.end(), index) != shifted.end();
-		}), aligned.end());
+		});
 
 	coefficients = designHilbertFir(command.directionDegrees);
 	if (!shifted.empty())

--- a/filters/IIRFilterFactory.cpp
+++ b/filters/IIRFilterFactory.cpp
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "stdafx.h"
 #include "text/WideString.h"
 #include "parser/NumericText.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <regex>
 #include <sstream>
@@ -66,7 +65,7 @@ bool IIRFilterFactory::parseCommand(const wstring& command, const wstring& param
 	};
 
 	// starts-with check (rfind at position 0), the pre-C++20 idiom
-	if (command.rfind(L"Filter", 0) != 0)
+	if (!command.starts_with(L"Filter"))
 		return false;
 
 	wsmatch match;

--- a/filters/IrCache.cpp
+++ b/filters/IrCache.cpp
@@ -57,10 +57,7 @@ namespace
 		unsigned long long mtime = 0;
 		int sampleRate = 0;
 
-		bool operator==(const IrCacheKey& o) const
-		{
-			return sampleRate == o.sampleRate && mtime == o.mtime && path == o.path;
-		}
+		bool operator==(const IrCacheKey&) const = default;
 	};
 
 	struct IrCacheKeyHash

--- a/filters/MultiConvolutionCommand.h
+++ b/filters/MultiConvolutionCommand.h
@@ -59,10 +59,7 @@ struct MultiConvolutionCommand
 		IrChannelRef(unsigned channel = 0, double factor = 1.0, bool isDecibel = false)
 			: channel(channel), factor(factor), isDecibel(isDecibel) {}
 
-		bool operator==(const IrChannelRef& other) const
-		{
-			return channel == other.channel && factor == other.factor && isDecibel == other.isDecibel;
-		}
+		bool operator==(const IrChannelRef&) const = default;
 	};
 
 	struct Mapping

--- a/filters/PreampFilter.cpp
+++ b/filters/PreampFilter.cpp
@@ -18,7 +18,6 @@
 */
 
 #include "stdafx.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "hwy/highway.h"

--- a/filters/VelvetCommand.cpp
+++ b/filters/VelvetCommand.cpp
@@ -32,8 +32,7 @@ bool suffixNumber(const std::wstring& source, const std::wstring& suffix,
 	const std::wstring lower = text::toLower(text);
 	if (!suffix.empty())
 	{
-		if (lower.size() < suffix.size()
-			|| lower.substr(lower.size() - suffix.size()) != suffix)
+		if (!lower.ends_with(suffix))
 			return false;
 		text.resize(text.size() - suffix.size());
 	}

--- a/filters/graphicEq/GainCurveIterator.h
+++ b/filters/graphicEq/GainCurveIterator.h
@@ -36,6 +36,8 @@ struct FilterNode
 	{
 		return freq < other.freq;
 	}
+
+	bool operator==(const FilterNode&) const = default;
 };
 
 class GainCurveIterator

--- a/filters/loudnessCorrection/LoudnessCorrectionFilter.cpp
+++ b/filters/loudnessCorrection/LoudnessCorrectionFilter.cpp
@@ -24,10 +24,8 @@
 
 #include <chrono>
 
-#ifndef _USE_MATH_DEFINES
-#define _USE_MATH_DEFINES
-#endif
 #include <math.h>
+#include <numbers>
 
 LoudnessCorrectionFilter::LoudnessCorrectionFilter(const FilterParameters& fParameters)
 	: _parameters(fParameters)
@@ -250,7 +248,7 @@ void LoudnessCorrectionFilter::upDateBiquadCoefficients(CoefficientSet& target, 
 	double A;
 	A = pow(10, dbGain / 40);
 
-	double omega = 2 * M_PI * freq / _sampleRate;
+	double omega = 2 * std::numbers::pi_v<double> * freq / _sampleRate;
 	double sn = sin(omega);
 	double cs = cos(omega);
 	double alpha;

--- a/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.cpp
+++ b/filters/loudnessCorrection/LoudnessCorrectionFilterFactory.cpp
@@ -18,7 +18,6 @@
 */
 
 #include "stdafx.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <regex>
 #include <sstream>

--- a/filters/velvet/VelvetProcessor.cpp
+++ b/filters/velvet/VelvetProcessor.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "stdafx.h"
+#include <numbers>
 #include "VelvetProcessor.h"
 
 #include <algorithm>
@@ -31,7 +32,6 @@ namespace velvet
 {
 namespace
 {
-constexpr double Pi = 3.1415926535897932384626433832795;
 
 std::uint64_t splitMix64(std::uint64_t& state) noexcept
 {
@@ -172,8 +172,8 @@ void Processor::processTyped(Sample* const* output, const Sample* const* input,
 		double newWeight = 0.0;
 		if (transitioning)
 		{
-			const double phase = transitionSamples <= 1 ? Pi * 0.5
-				: Pi * 0.5 * static_cast<double>(transitionPosition)
+			const double phase = transitionSamples <= 1 ? std::numbers::pi_v<double> * 0.5
+				: std::numbers::pi_v<double> * 0.5 * static_cast<double>(transitionPosition)
 					/ static_cast<double>(transitionSamples - 1);
 			oldWeight = std::cos(phase);
 			newWeight = std::sin(phase);

--- a/stdafx.h
+++ b/stdafx.h
@@ -17,8 +17,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#define _USE_MATH_DEFINES
 #include <cmath>
+#include <numbers>
 #include <climits>
 #include <cstdarg>
 #include <cstdio>


### PR DESCRIPTION
## What

The C++20 hygiene sweep closing the modern-C++ campaign: mechanical vocabulary upgrades over the verified inventory, zero behavior change. 58 files, +189/-252.

- **std::numbers** replaces every `M_PI`/`M_SQRT2`/`M_SQRT1_2`/`M_LN2` (38 uses), deletes all 19 `#define _USE_MATH_DEFINES` lines and their header-order traps, and collapses the duplicate hand-spelled pi constants onto one source of truth. `M_SQRT1_2` becomes `sqrt2_v<double> / 2.0` (division by two is exact, so the value is bit-identical). A repo scan shows none of the macros remain outside vendor code.
- **`contains()`** at the 19 verified sites where a find()/count() result was only a boolean (iterator-using sites untouched; 8 additional candidates found during the sweep were deliberately left for scope discipline and are listed in the worker report).
- **`std::erase`/`erase_if`** at 6 sites; the one `erase(unique(...))` has no C++20 shorthand and stays.
- **`starts_with`/`ends_with`** at 11 sites (the case-insensitive hand-rolled helper in FakeRegistry stays).
- **Defaulted comparisons**, surgically: `InstallState` gains `== = default` and loses its hand-written 8-field `!=` (the stale-field maintenance trap the audit flagged); `IrCacheKey`, `EqIrCacheKey`, `IrChannelRef`, `Segment` become defaulted; `FilterNode` gains `==` comparing freq *and* dbGain while its freq-only ordering `<` is untouched and no `<=>` is introduced anywhere; `MultiConvolutionCommand` itself stays manual (mutable serialization cache).
- **`std::bit_cast`** for the four scalar punning sites in SampleCodec (RT file; nothing else in it changed).
- **ChannelLayout** drops its two heap `unordered_map`s and global constructor (one map was written once and never read; the class was exposed to static-init-order) for a constexpr array with linear lookup at config-parse time. Case sensitivity and the SL/RL, SR/RR, SUB/LFE alias chain are unchanged.
- **Lambdas** replace the three `std::bind` sites.
- **Designated initializers** for the two duplicated 13-field `EngineSetup` blocks (declaration order verified).
- **Deliberately not done:** the raw `(void**)` COM out-params turned out to be manually-Released raw pointers, not `winutil::ComPtr` - converting them to `.put()` would change ownership, so category 9 shipped zero changes.

## Verification

- Implemented by the GPT worker against the pinned inventory; risk spots (SampleCodec, ChannelLayout, all six comparison operators, EngineSetup ordering) diff-reviewed line by line by the session driver; no stray files.
- Full dependency-ordered `/t:Rebuild` (19 projects) + Editor and DeviceSelector qmake clean rebuilds: 0 errors.
- 18,337 harness checks green across EditorLogicTests (3147), EngineOrchestrationTests (1317), HybridConvTests (13,249 incl. sub-harnesses), AsioTests (624 incl. sub-harnesses); AlignedMemory balance clean.
- **Local ASIO probe gate: all 8 runs bit-exact** (output, first-period and input SHA-256), pipelined-over-real-host on attempt 1 - the numbers and bit_cast changes provably did not move a single audio bit.
- No user-visible change, so no CHANGELOG entry. As a no-bump refactor the merge skips the build matrix; a workflow_dispatch full-matrix run follows the merge (its cross-variant audio comparison re-proves bit-exactness on every SIMD variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
